### PR TITLE
Feat/en 1334 send miniblock to destination

### DIFF
--- a/consensus/spos/mock/blockProcessorMock.go
+++ b/consensus/spos/mock/blockProcessorMock.go
@@ -9,17 +9,17 @@ import (
 
 // BlockProcessorMock mocks the implementation for a blockProcessor
 type BlockProcessorMock struct {
-	ProcessBlockCalled            func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler, haveTime func() time.Duration) error
-	CommitBlockCalled             func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler) error
-	RevertAccountStateCalled      func()
-	CreateGenesisBlockCalled      func(balances map[string]*big.Int) (rootHash []byte, err error)
-	CreateBlockCalled             func(round int32, haveTime func() bool) (data.BodyHandler, error)
-	RemoveBlockInfoFromPoolCalled func(body data.BodyHandler) error
-	GetRootHashCalled             func() []byte
-	SetOnRequestTransactionCalled func(f func(destShardID uint32, txHash []byte))
-	CheckBlockValidityCalled      func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler) bool
-	CreateBlockHeaderCalled       func(body data.BodyHandler) (data.HeaderHandler, error)
-	MarshalizedDataForCrossShardCalled func(body data.BodyHandler) (map[uint32][]byte, error)
+	ProcessBlockCalled                 func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler, haveTime func() time.Duration) error
+	CommitBlockCalled                  func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler) error
+	RevertAccountStateCalled           func()
+	CreateGenesisBlockCalled           func(balances map[string]*big.Int) (rootHash []byte, err error)
+	CreateBlockCalled                  func(round int32, haveTime func() bool) (data.BodyHandler, error)
+	RemoveBlockInfoFromPoolCalled      func(body data.BodyHandler) error
+	GetRootHashCalled                  func() []byte
+	SetOnRequestTransactionCalled      func(f func(destShardID uint32, txHash []byte))
+	CheckBlockValidityCalled           func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler) bool
+	CreateBlockHeaderCalled            func(body data.BodyHandler) (data.HeaderHandler, error)
+	MarshalizedDataForCrossShardCalled func(body data.BodyHandler) (map[uint32][][]byte, error)
 }
 
 // SetOnRequestTransaction mocks setting request transaction call back function
@@ -71,6 +71,6 @@ func (blProcMock BlockProcessorMock) CreateBlockHeader(body data.BodyHandler) (d
 	return blProcMock.CreateBlockHeaderCalled(body)
 }
 
-func (blProcMock BlockProcessorMock) MarshalizedDataForCrossShard(body data.BodyHandler) (map[uint32][]byte, error) {
+func (blProcMock BlockProcessorMock) MarshalizedDataForCrossShard(body data.BodyHandler) (map[uint32][][]byte, error) {
 	return blProcMock.MarshalizedDataForCrossShardCalled(body)
 }

--- a/data/block/block.go
+++ b/data/block/block.go
@@ -2,6 +2,7 @@ package block
 
 import (
 	"fmt"
+	"github.com/ElrondNetwork/elrond-go-sandbox/data"
 	"io"
 
 	"github.com/ElrondNetwork/elrond-go-sandbox/data/block/capnp"
@@ -430,15 +431,15 @@ func (h *Header) SetTimeStamp(ts uint64) {
 }
 
 // IntegrityAndValidity checks if data is valid
-func (b Body) IntegrityAndValidity() bool {
+func (b Body) IntegrityAndValidity() error {
 	if len(b) == 0 {
-		return false
+		return data.ErrBlockBodyEmpty
 	}
 
 	for i := 0; i < len(b); i++ {
 		if len(b[i].TxHashes) == 0 {
-			return false
+			return data.ErrMiniBlockEmpty
 		}
 	}
-	return true
+	return nil
 }

--- a/data/block/block_test.go
+++ b/data/block/block_test.go
@@ -2,7 +2,7 @@ package block_test
 
 import (
 	"bytes"
-	"fmt"
+	"github.com/ElrondNetwork/elrond-go-sandbox/data"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go-sandbox/data/block"
@@ -305,10 +305,10 @@ func TestBody_IntegrityAndValidityNil(t *testing.T) {
 
 	body := block.Body{}
 	body = nil
-	assert.Equal(t, false, body.IntegrityAndValidity())
+	assert.Equal(t, data.ErrBlockBodyEmpty, body.IntegrityAndValidity())
 }
 
-func TestBody_IntegrityAndValidityMiniNil(t *testing.T) {
+func TestBody_IntegrityAndValidityEmptyMiniblockShouldThrowException(t *testing.T) {
 	t.Parallel()
 
 	txHash0 := []byte("txHash0")
@@ -323,7 +323,7 @@ func TestBody_IntegrityAndValidityMiniNil(t *testing.T) {
 	body = append(body, &mb0)
 	body = append(body, &mb1)
 
-	assert.Equal(t, false, body.IntegrityAndValidity())
+	assert.Equal(t, data.ErrMiniBlockEmpty, body.IntegrityAndValidity())
 }
 
 func TestBody_IntegrityAndValidityOK(t *testing.T) {
@@ -338,14 +338,5 @@ func TestBody_IntegrityAndValidityOK(t *testing.T) {
 	body := make(block.Body, 0)
 	body = append(body, &mb0)
 
-	assert.Equal(t, true, body.IntegrityAndValidity())
-}
-
-func Test_test(t *testing.T) {
-	var list []string
-	list = nil
-
-	for i := range list {
-		fmt.Println("entered ", i)
-	}
+	assert.Equal(t, nil, body.IntegrityAndValidity())
 }

--- a/data/block/metaBlock.go
+++ b/data/block/metaBlock.go
@@ -393,6 +393,6 @@ func (m *MetaBlock) SetTimeStamp(ts uint64) {
 }
 
 // IntegrityAndValidity return true as block is nil for metablock.
-func (mb *MetaBlockBody) IntegrityAndValidity() bool {
-	return true
+func (mb *MetaBlockBody) IntegrityAndValidity() error {
+	return nil
 }

--- a/data/errors.go
+++ b/data/errors.go
@@ -45,3 +45,9 @@ var ErrInvalidHeaderType = errors.New("invalid header type")
 
 // ErrInvalidBodyType signals an invalid header pointer was provided
 var ErrInvalidBodyType = errors.New("invalid body type")
+
+// ErrBlockBodyEmpty signals that block body is empty
+var ErrBlockBodyEmpty = errors.New("block body empty")
+
+// ErrMiniBlockEmpty signals that mini block is empty
+var ErrMiniBlockEmpty = errors.New("mini block is empty")

--- a/data/interface.go
+++ b/data/interface.go
@@ -106,7 +106,7 @@ type HeaderHandler interface {
 // BodyHandler interface for a block body
 type BodyHandler interface {
 	// checks the integrity and validity of the block
-	IntegrityAndValidity() bool
+	IntegrityAndValidity() error
 }
 
 // StorageService is the interface for blockChain storage unit provided services

--- a/node/errors.go
+++ b/node/errors.go
@@ -78,6 +78,3 @@ var ErrNilBlockHeader = errors.New("block header is nil")
 
 // ErrNilTxBlockBody is raised when a valid tx block body is expected but nil was used
 var ErrNilTxBlockBody = errors.New("tx block body is nil")
-
-// ErrNotValidBlockBody is raised when a block body is not valid
-var ErrNotValidBlockBody = errors.New("block body not valid")

--- a/node/mock/blockProcessorStub.go
+++ b/node/mock/blockProcessorStub.go
@@ -9,16 +9,16 @@ import (
 
 // BlockProcessorStub mocks the implementation for a blockProcessor
 type BlockProcessorStub struct {
-	ProcessBlockCalled            func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler, haveTime func() time.Duration) error
-	CommitBlockCalled             func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler) error
-	RevertAccountStateCalled      func()
-	CreateGenesisBlockCalled      func(balances map[string]*big.Int) (rootHash []byte, err error)
-	CreateBlockCalled             func(round int32, haveTime func() bool) (data.BodyHandler, error)
-	RemoveBlockInfoFromPoolCalled func(body data.BodyHandler) error
-	GetRootHashCalled             func() []byte
-	SetOnRequestTransactionCalled func(f func(destShardID uint32, txHash []byte))
-	CheckBlockValidityCalled      func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler) bool
-	MarshalizedDataForCrossShardCalled func(body data.BodyHandler) (map[uint32][]byte, error)
+	ProcessBlockCalled                 func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler, haveTime func() time.Duration) error
+	CommitBlockCalled                  func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler) error
+	RevertAccountStateCalled           func()
+	CreateGenesisBlockCalled           func(balances map[string]*big.Int) (rootHash []byte, err error)
+	CreateBlockCalled                  func(round int32, haveTime func() bool) (data.BodyHandler, error)
+	RemoveBlockInfoFromPoolCalled      func(body data.BodyHandler) error
+	GetRootHashCalled                  func() []byte
+	SetOnRequestTransactionCalled      func(f func(destShardID uint32, txHash []byte))
+	CheckBlockValidityCalled           func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler) bool
+	MarshalizedDataForCrossShardCalled func(body data.BodyHandler) (map[uint32][][]byte, error)
 }
 
 // ProcessBlock mocks pocessing a block
@@ -65,6 +65,6 @@ func (bps BlockProcessorStub) CreateBlockHeader(body data.BodyHandler) (data.Hea
 	panic("implement me")
 }
 
-func (blProcMock BlockProcessorStub) MarshalizedDataForCrossShard(body data.BodyHandler) (map[uint32][]byte, error) {
+func (blProcMock BlockProcessorStub) MarshalizedDataForCrossShard(body data.BodyHandler) (map[uint32][][]byte, error) {
 	return blProcMock.MarshalizedDataForCrossShardCalled(body)
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -923,8 +923,8 @@ func getMessenger() *mock.MessengerStub {
 func TestNode_BroadcastBlockShouldFailWhenTxBlockBodyNil(t *testing.T) {
 	n, _ := node.NewNode()
 	messenger := getMessenger()
-	bp := &mock.BlockProcessorStub{MarshalizedDataForCrossShardCalled: func(body data.BodyHandler) (bytes map[uint32][]byte, e error) {
-		return make(map[uint32][]byte, 1), nil
+	bp := &mock.BlockProcessorStub{MarshalizedDataForCrossShardCalled: func(body data.BodyHandler) (bytes map[uint32][][]byte, e error) {
+		return make(map[uint32][][]byte, 1), nil
 	}}
 
 	_ = n.ApplyOptions(
@@ -951,8 +951,8 @@ func TestNode_BroadcastBlockShouldFailWhenMarshalTxBlockBodyErr(t *testing.T) {
 
 		return []byte("marshalized ok"), nil
 	}
-	bp := &mock.BlockProcessorStub{MarshalizedDataForCrossShardCalled: func(body data.BodyHandler) (bytes map[uint32][]byte, e error) {
-		return make(map[uint32][]byte, 1), nil
+	bp := &mock.BlockProcessorStub{MarshalizedDataForCrossShardCalled: func(body data.BodyHandler) (bytes map[uint32][][]byte, e error) {
+		return make(map[uint32][][]byte, 1), nil
 	}}
 
 	_ = n.ApplyOptions(
@@ -977,14 +977,14 @@ func TestNode_BroadcastBlockShouldFailWhenMarshalTxBlockBodyErr(t *testing.T) {
 type wrongBody struct {
 }
 
-func (wr wrongBody) IntegrityAndValidity() bool {
-	return true
+func (wr wrongBody) IntegrityAndValidity() error {
+	return nil
 }
 
 func TestNode_BroadcastBlockShouldFailWhenBlockIsNotGoodType(t *testing.T) {
 	n, _ := node.NewNode()
 	messenger := getMessenger()
-	bp := &mock.BlockProcessorStub{MarshalizedDataForCrossShardCalled: func(body data.BodyHandler) (bytes map[uint32][]byte, e error) {
+	bp := &mock.BlockProcessorStub{MarshalizedDataForCrossShardCalled: func(body data.BodyHandler) (bytes map[uint32][][]byte, e error) {
 		return nil, process.ErrWrongTypeAssertion
 	}}
 	_ = n.ApplyOptions(
@@ -1002,8 +1002,8 @@ func TestNode_BroadcastBlockShouldFailWhenBlockIsNotGoodType(t *testing.T) {
 func TestNode_BroadcastBlockShouldFailWhenHeaderNil(t *testing.T) {
 	n, _ := node.NewNode()
 	messenger := getMessenger()
-	bp := &mock.BlockProcessorStub{MarshalizedDataForCrossShardCalled: func(body data.BodyHandler) (bytes map[uint32][]byte, e error) {
-		return make(map[uint32][]byte, 1), nil
+	bp := &mock.BlockProcessorStub{MarshalizedDataForCrossShardCalled: func(body data.BodyHandler) (bytes map[uint32][][]byte, e error) {
+		return make(map[uint32][][]byte, 1), nil
 	}}
 	_ = n.ApplyOptions(
 		node.WithMessenger(messenger),
@@ -1040,8 +1040,8 @@ func TestNode_BroadcastBlockShouldFailWhenMarshalHeaderErr(t *testing.T) {
 		return []byte("marshalized ok"), nil
 	}
 
-	bp := &mock.BlockProcessorStub{MarshalizedDataForCrossShardCalled: func(body data.BodyHandler) (bytes map[uint32][]byte, e error) {
-		return make(map[uint32][]byte, 1), nil
+	bp := &mock.BlockProcessorStub{MarshalizedDataForCrossShardCalled: func(body data.BodyHandler) (bytes map[uint32][][]byte, e error) {
+		return make(map[uint32][][]byte, 1), nil
 	}}
 
 	_ = n.ApplyOptions(
@@ -1064,11 +1064,11 @@ func TestNode_BroadcastBlockShouldFailWhenMarshalHeaderErr(t *testing.T) {
 	assert.Equal(t, err, err2)
 }
 
-func TestNode_BroadcastBlockShouldWork(t *testing.T) {
+func TestNode_BroadcastBlockShouldWorkWithOneShard(t *testing.T) {
 	n, _ := node.NewNode()
 	messenger := getMessenger()
-	bp := &mock.BlockProcessorStub{MarshalizedDataForCrossShardCalled: func(body data.BodyHandler) (bytes map[uint32][]byte, e error) {
-		return make(map[uint32][]byte, 0), nil
+	bp := &mock.BlockProcessorStub{MarshalizedDataForCrossShardCalled: func(body data.BodyHandler) (bytes map[uint32][][]byte, e error) {
+		return make(map[uint32][][]byte, 0), nil
 	}}
 	_ = n.ApplyOptions(
 		node.WithMessenger(messenger),
@@ -1085,6 +1085,45 @@ func TestNode_BroadcastBlockShouldWork(t *testing.T) {
 
 	body := make(block.Body, 0)
 	body = append(body, &mb0)
+
+	err := n.BroadcastBlock(body, &block.Header{})
+	assert.Nil(t, err)
+}
+
+func TestNode_BroadcastBlockShouldWorkMultiShard(t *testing.T) {
+	n, _ := node.NewNode()
+	messenger := getMessenger()
+	bp := &mock.BlockProcessorStub{MarshalizedDataForCrossShardCalled: func(body data.BodyHandler) (bytes map[uint32][][]byte, e error) {
+		return make(map[uint32][][]byte, 0), nil
+	}}
+	_ = n.ApplyOptions(
+		node.WithMessenger(messenger),
+		node.WithMarshalizer(mock.MarshalizerMock{}),
+		node.WithShardCoordinator(mock.NewOneShardCoordinatorMock()),
+		node.WithBlockProcessor(bp),
+	)
+
+	txHash0 := []byte("txHash0")
+	mb0 := block.MiniBlock{
+		ShardID:  0,
+		TxHashes: [][]byte{[]byte(txHash0)},
+	}
+
+	txHash1 := []byte("txHash1")
+	mb1 := block.MiniBlock{
+		ShardID:  1,
+		TxHashes: [][]byte{[]byte(txHash1)},
+	}
+
+	body := make(block.Body, 0)
+	body = append(body, &mb0)
+	body = append(body, &mb0)
+	body = append(body, &mb0)
+	body = append(body, &mb1)
+	body = append(body, &mb1)
+	body = append(body, &mb1)
+	body = append(body, &mb1)
+	body = append(body, &mb1)
 
 	err := n.BroadcastBlock(body, &block.Header{})
 	assert.Nil(t, err)

--- a/process/block/process.go
+++ b/process/block/process.go
@@ -704,7 +704,6 @@ func (bp *blockProcessor) waitForTxHashes(waitTime time.Duration) error {
 }
 
 func (bp *blockProcessor) displayBlockchain(blockHeader *block.Header, txBlockBody block.Body) {
-
 	if blockHeader == nil || txBlockBody == nil {
 		return
 	}
@@ -963,7 +962,6 @@ func (bp *blockProcessor) getTxsFromPool(shardId uint32) int {
 
 // CheckBlockValidity method checks if the given block is valid
 func (bp *blockProcessor) CheckBlockValidity(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler) bool {
-
 	if header == nil {
 		log.Info(process.ErrNilBlockHeader.Error())
 		return false
@@ -1027,12 +1025,12 @@ func (bp *blockProcessor) CheckBlockValidity(blockChain data.ChainHandler, heade
 }
 
 // MarshalizedDataForCrossShard prepares underlying data into a marshalized object according to destination
-func (bp *blockProcessor) MarshalizedDataForCrossShard(body data.BodyHandler) (map[uint32]([]byte), error) {
+func (bp *blockProcessor) MarshalizedDataForCrossShard(body data.BodyHandler) (map[uint32][][]byte, error) {
 	if body == nil {
 		return nil, process.ErrNilMiniBlocks
 	}
 
-	mrsData := make(map[uint32][]byte)
+	mrsData := make(map[uint32][][]byte)
 	blockBody, ok := body.(block.Body)
 
 	if !ok {
@@ -1046,7 +1044,7 @@ func (bp *blockProcessor) MarshalizedDataForCrossShard(body data.BodyHandler) (m
 			return nil, process.ErrMarshalWithoutSuccess
 		}
 		if shardId != bp.shardCoordinator.SelfId() {
-			mrsData[shardId] = buff
+			mrsData[shardId] = append(mrsData[shardId], buff)
 		}
 	}
 

--- a/process/block/process_test.go
+++ b/process/block/process_test.go
@@ -1949,6 +1949,8 @@ func TestBlockProcessor_MarshalizedDataForCrossShardShouldWork(t *testing.T) {
 	body := make(block.Body, 0)
 	body = append(body, &mb0)
 	body = append(body, &mb1)
+	body = append(body, &mb0)
+	body = append(body, &mb1)
 
 	marshal := &mock.MarshalizerMock{
 		false,
@@ -1974,14 +1976,15 @@ func TestBlockProcessor_MarshalizedDataForCrossShardShouldWork(t *testing.T) {
 	_, found := msh[0]
 	assert.Equal(t, false, found)
 	m1, _ := marshal.Marshal(mb1)
-	assert.Equal(t, m1, msh[1])
+	assert.Equal(t, m1, msh[1][0])
+	assert.Equal(t, m1, msh[1][1])
 }
 
 type wrongBody struct {
 }
 
-func (wr wrongBody) IntegrityAndValidity() bool {
-	return true
+func (wr wrongBody) IntegrityAndValidity() error {
+	return nil
 }
 
 func TestBlockProcessor_MarshalizedDataWrongType(t *testing.T) {

--- a/process/interface.go
+++ b/process/interface.go
@@ -31,7 +31,7 @@ type BlockProcessor interface {
 	RemoveBlockInfoFromPool(body data.BodyHandler) error
 	CheckBlockValidity(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler) bool
 	CreateBlockHeader(body data.BodyHandler) (data.HeaderHandler, error)
-	MarshalizedDataForCrossShard(body data.BodyHandler) (map[uint32][]byte, error)
+	MarshalizedDataForCrossShard(body data.BodyHandler) (map[uint32][][]byte, error)
 }
 
 // Checker provides functionality to checks the integrity and validity of a data structure

--- a/process/mock/blockProcessorMock.go
+++ b/process/mock/blockProcessorMock.go
@@ -19,7 +19,7 @@ type BlockProcessorMock struct {
 	SetOnRequestTransactionCalled      func(f func(destShardID uint32, txHash []byte))
 	CheckBlockValidityCalled           func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler) bool
 	CreateBlockHeaderCalled            func(body data.BodyHandler) (data.HeaderHandler, error)
-	MarshalizedDataForCrossShardCalled func(body data.BodyHandler) (map[uint32][]byte, error)
+	MarshalizedDataForCrossShardCalled func(body data.BodyHandler) (map[uint32][][]byte, error)
 }
 
 func (bpm *BlockProcessorMock) ProcessBlock(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler, haveTime func() time.Duration) error {
@@ -59,6 +59,6 @@ func (blProcMock BlockProcessorMock) CreateBlockHeader(body data.BodyHandler) (d
 	return blProcMock.CreateBlockHeaderCalled(body)
 }
 
-func (blProcMock BlockProcessorMock) MarshalizedDataForCrossShard(body data.BodyHandler) (map[uint32][]byte, error) {
+func (blProcMock BlockProcessorMock) MarshalizedDataForCrossShard(body data.BodyHandler) (map[uint32][][]byte, error) {
 	return blProcMock.MarshalizedDataForCrossShardCalled(body)
 }


### PR DESCRIPTION
Added new function to node to send miniblocks in specific topic towards destination shard. Added function in blockprocessor to create the marshalized data to send in case of crosshard communication.