### PR TITLE
Fixed bug in bnworker when round is canceled for the node.

### DIFF
--- a/consensus/spos/bn/export_test.go
+++ b/consensus/spos/bn/export_test.go
@@ -235,6 +235,10 @@ func (wrk *worker) SetConsensusStateChangedChannels(consensusStateChangedChannel
 	wrk.consensusStateChangedChannels = consensusStateChangedChannels
 }
 
+func (wrk *worker) CheckSelfState(cnsDta *consensus.Message) error {
+	return wrk.checkSelfState(cnsDta)
+}
+
 // subroundStartRound
 
 type SubroundStartRound *subroundStartRound

--- a/consensus/spos/errors.go
+++ b/consensus/spos/errors.go
@@ -114,3 +114,6 @@ var ErrMessageForPastRound = errors.New("message is for past round")
 
 // ErrInvalidSignature is raised when signature is invalid
 var ErrInvalidSignature = errors.New("signature is invalid")
+
+// ErrMessageFromItself is raised when a message from itself is received
+var ErrMessageFromItself = errors.New("message is from itself")


### PR DESCRIPTION
 In this case each received message would not been broadcast to the other peers.