### PR TITLE
feat/EN 2404 tx hash return on send tx route

### DIFF
--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -23,7 +23,7 @@ type Facade struct {
 	GetAccountHandler                              func(address string) (*state.Account, error)
 	GenerateTransactionHandler                     func(sender string, receiver string, value *big.Int, code string) (*transaction.Transaction, error)
 	GetTransactionHandler                          func(hash string) (*transaction.Transaction, error)
-	SendTransactionHandler                         func(nonce uint64, sender string, receiver string, value *big.Int, code string, signature []byte) (*transaction.Transaction, error)
+	SendTransactionHandler                         func(nonce uint64, sender string, receiver string, value *big.Int, code string, signature []byte) (string, error)
 	GenerateAndSendBulkTransactionsHandler         func(destination string, value *big.Int, nrTransactions uint64) error
 	GenerateAndSendBulkTransactionsOneByOneHandler func(destination string, value *big.Int, nrTransactions uint64) error
 	RecentNotarizedBlocksHandler                   func(maxShardHeadersNum int) ([]*external.BlockHeader, error)
@@ -99,7 +99,7 @@ func (f *Facade) GetTransaction(hash string) (*transaction.Transaction, error) {
 }
 
 // SendTransaction is the mock implementation of a handler's SendTransaction method
-func (f *Facade) SendTransaction(nonce uint64, sender string, receiver string, value *big.Int, code string, signature []byte) (*transaction.Transaction, error) {
+func (f *Facade) SendTransaction(nonce uint64, sender string, receiver string, value *big.Int, code string, signature []byte) (string, error) {
 	return f.SendTransactionHandler(nonce, sender, receiver, value, code, signature)
 }
 

--- a/api/transaction/routes.go
+++ b/api/transaction/routes.go
@@ -14,7 +14,7 @@ import (
 // TxService interface defines methods that can be used from `elrondFacade` context variable
 type TxService interface {
 	GenerateTransaction(sender string, receiver string, value *big.Int, code string) (*transaction.Transaction, error)
-	SendTransaction(nonce uint64, sender string, receiver string, value *big.Int, code string, signature []byte) (*transaction.Transaction, error)
+	SendTransaction(nonce uint64, sender string, receiver string, value *big.Int, code string, signature []byte) (string, error)
 	GetTransaction(hash string) (*transaction.Transaction, error)
 	GenerateAndSendBulkTransactions(string, *big.Int, uint64) error
 	GenerateAndSendBulkTransactionsOneByOne(string, *big.Int, uint64) error
@@ -119,13 +119,13 @@ func SendTransaction(c *gin.Context) {
 		return
 	}
 
-	tx, err := ef.SendTransaction(gtx.Nonce, gtx.Sender, gtx.Receiver, gtx.Value, gtx.Data, signature)
+	txHash, err := ef.SendTransaction(gtx.Nonce, gtx.Sender, gtx.Receiver, gtx.Value, gtx.Data, signature)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("%s: %s", errors.ErrTxGenerationFailed.Error(), err.Error())})
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"transaction": txResponseFromTransaction(tx)})
+	c.JSON(http.StatusOK, gin.H{"txHash": txHash})
 }
 
 // GenerateAndSendBulkTransactions generates multipleTransactions

--- a/facade/elrondNodeFacade.go
+++ b/facade/elrondNodeFacade.go
@@ -115,7 +115,7 @@ func (ef *ElrondNodeFacade) SendTransaction(
 	value *big.Int,
 	transactionData string,
 	signature []byte,
-) (*transaction.Transaction, error) {
+) (string, error) {
 
 	return ef.node.SendTransaction(nonce, senderHex, receiverHex, value, transactionData, signature)
 }

--- a/facade/elrondNodeFacade_test.go
+++ b/facade/elrondNodeFacade_test.go
@@ -393,9 +393,9 @@ func TestElrondNodeFacade_SetSyncer(t *testing.T) {
 func TestElrondNodeFacade_SendTransaction(t *testing.T) {
 	called := 0
 	node := &mock.NodeMock{}
-	node.SendTransactionHandler = func(nonce uint64, sender string, receiver string, amount *big.Int, code string, signature []byte) (i *transaction.Transaction, e error) {
+	node.SendTransactionHandler = func(nonce uint64, sender string, receiver string, amount *big.Int, code string, signature []byte) (string, error) {
 		called++
-		return nil, nil
+		return "", nil
 	}
 	ef := createElrondNodeFacadeWithMockResolver(node)
 	ef.SendTransaction(1, "test", "test", big.NewInt(0), "code", []byte{})

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -34,7 +34,7 @@ type NodeWrapper interface {
 	GenerateTransaction(senderHex string, receiverHex string, amount *big.Int, code string) (*transaction.Transaction, error)
 
 	//SendTransaction will send a new transaction on the topic channel
-	SendTransaction(nonce uint64, senderHex string, receiverHex string, value *big.Int, transactionData string, signature []byte) (*transaction.Transaction, error)
+	SendTransaction(nonce uint64, senderHex string, receiverHex string, value *big.Int, transactionData string, signature []byte) (string, error)
 
 	//GetTransaction gets the transaction
 	GetTransaction(hash string) (*transaction.Transaction, error)

--- a/facade/mock/nodeMock.go
+++ b/facade/mock/nodeMock.go
@@ -19,7 +19,7 @@ type NodeMock struct {
 	GetBalanceHandler                              func(address string) (*big.Int, error)
 	GenerateTransactionHandler                     func(sender string, receiver string, amount *big.Int, code string) (*transaction.Transaction, error)
 	GetTransactionHandler                          func(hash string) (*transaction.Transaction, error)
-	SendTransactionHandler                         func(nonce uint64, sender string, receiver string, amount *big.Int, code string, signature []byte) (*transaction.Transaction, error)
+	SendTransactionHandler                         func(nonce uint64, sender string, receiver string, amount *big.Int, code string, signature []byte) (string, error)
 	GetAccountHandler                              func(address string) (*state.Account, error)
 	GetCurrentPublicKeyHandler                     func() string
 	GenerateAndSendBulkTransactionsHandler         func(destination string, value *big.Int, nrTransactions uint64) error
@@ -67,7 +67,7 @@ func (nm *NodeMock) GetTransaction(hash string) (*transaction.Transaction, error
 	return nm.GetTransactionHandler(hash)
 }
 
-func (nm *NodeMock) SendTransaction(nonce uint64, sender string, receiver string, value *big.Int, transactionData string, signature []byte) (*transaction.Transaction, error) {
+func (nm *NodeMock) SendTransaction(nonce uint64, sender string, receiver string, value *big.Int, transactionData string, signature []byte) (string, error) {
 	return nm.SendTransactionHandler(nonce, sender, receiver, value, transactionData, signature)
 }
 

--- a/integrationTests/frontend/wallet/txInterception_test.go
+++ b/integrationTests/frontend/wallet/txInterception_test.go
@@ -71,7 +71,12 @@ func testInterceptedTxFromFrontendGeneratedParams(
 
 	chDone := make(chan struct{})
 
+	var err error
+	txHexHash := ""
+
 	dPool.Transactions().RegisterHandler(func(key []byte) {
+		assert.Equal(t, txHexHash, hex.EncodeToString(key))
+
 		dataRecovered, _ := dPool.Transactions().SearchFirstData(key)
 		assert.NotNil(t, dataRecovered)
 
@@ -102,7 +107,8 @@ func testInterceptedTxFromFrontendGeneratedParams(
 		dataBuff, _ := hex.DecodeString(frontendData)
 		data = string(dataBuff)
 	}
-	n.SendTransaction(frontendNonce, frontendSenderHex, frontendReceiverHex, frontendValue, data, sig)
+	txHexHash, err = n.SendTransaction(frontendNonce, frontendSenderHex, frontendReceiverHex, frontendValue, data, sig)
+	assert.Nil(t, err)
 
 	select {
 	case <-chDone:


### PR DESCRIPTION
api/transaction:
 - adapted /transaction/send route to return the resulting hash

facade, node:
 - adapted SendTransaction to return the resulting hash

integrationTests/wallet:
 - added check for resulting tx hash to match received tx hash