### PR TITLE
bugs/fix-elasticsearch-crash-when-error

### DIFF
--- a/core/indexer/elasticsearch.go
+++ b/core/indexer/elasticsearch.go
@@ -297,6 +297,7 @@ func (ei *elasticIndexer) saveTransactions(
 		res, err := ei.db.Bulk(bytes.NewReader(buff.Bytes()), ei.db.Bulk.WithIndex(txIndex))
 		if err != nil {
 			ei.logger.Warn("error indexing bulk of transactions")
+			continue
 		}
 		if res.IsError() {
 			ei.logger.Warn(res.String())
@@ -438,6 +439,7 @@ func (ei *elasticIndexer) UpdateTPS(tpsBenchmark statistics.TPSBenchmark) {
 		res, err := ei.db.Bulk(bytes.NewReader(buff.Bytes()), ei.db.Bulk.WithIndex(tpsIndex))
 		if err != nil {
 			ei.logger.Warn("error indexing tps information")
+			continue
 		}
 		if res.IsError() {
 			fmt.Println(res.String())

--- a/core/indexer/errors.go
+++ b/core/indexer/errors.go
@@ -4,17 +4,14 @@ import (
 	"errors"
 )
 
-// ErrCannotCreateIndex signals that we could not creeate an elasticsearch index
+// ErrCannotCreateIndex signals that we could not create an elasticsearch index
 var ErrCannotCreateIndex = errors.New("cannot create elasitc index")
 
-// ErrHeaderTypeAssertion signals that we could not convert to a header
-var ErrHeaderTypeAssertion = errors.New("elasticsearch - header type assertion failed")
-
-// ErrCannotCreateIndex signals that we could not creeate an elasticsearch index
+// ErrBodyTypeAssertion signals that we could not create an elasticsearch index
 var ErrBodyTypeAssertion = errors.New("elasticsearch - body type assertion failed")
 
-// ErrCannotCreateIndex signals that we could not creeate an elasticsearch index
+// ErrNoHeader signals that we could not create an elasticsearch index
 var ErrNoHeader = errors.New("elasticsearch - no header")
 
-// ErrCannotCreateIndex signals that we could not creeate an elasticsearch index
+// ErrNoMiniblocks signals that we could not create an elasticsearch index
 var ErrNoMiniblocks = errors.New("elasticsearch - no miniblocks")

--- a/core/indexer/interface.go
+++ b/core/indexer/interface.go
@@ -6,8 +6,8 @@ import (
 	"github.com/ElrondNetwork/elrond-go-sandbox/data/transaction"
 )
 
-// Indexer is an interface for saving node specific data to other storages.
-// This could be an elasticsearch intex, a MySql database or any other external services.
+// Indexer is an interface for saving node specific data to other storage.
+// This could be an elasticsearch index, a MySql database or any other external services.
 type Indexer interface {
 	SaveBlock(body data.BodyHandler, header data.HeaderHandler, txPool map[string]*transaction.Transaction)
 	UpdateTPS(tpsBenchmark statistics.TPSBenchmark)


### PR DESCRIPTION
core/indexer:
 - bugfix: when an error occurs in saveTransactions or buildTransactionBulks the code will not break
 - updated comments and typos fixes
 - removed unused error var