### PR TITLE
Recreate trie and request shard headers missing

### DIFF
--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -997,6 +997,10 @@ func (mp *metaProcessor) CreateBlockHeader(bodyHandler data.BodyHandler, round u
 		RandSeed:     make([]byte, 0),
 	}
 
+	defer func() {
+		go mp.checkAndRequestIfShardHeadersMissing(round)
+	}()
+
 	shardInfo, err := mp.createShardInfo(maxHeadersInBlock, round, haveTime)
 	if err != nil {
 		return nil, err
@@ -1011,8 +1015,6 @@ func (mp *metaProcessor) CreateBlockHeader(bodyHandler data.BodyHandler, round u
 	header.PeerInfo = peerInfo
 	header.RootHash = mp.getRootHash()
 	header.TxCount = getTxCount(shardInfo)
-
-	go mp.checkAndRequestIfShardHeadersMissing(header.Round)
 
 	return header, nil
 }

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -1272,7 +1272,9 @@ func (sp *shardProcessor) CreateBlockHeader(bodyHandler data.BodyHandler, round 
 		RandSeed:         make([]byte, 0),
 	}
 
-	go sp.checkAndRequestIfMetaHeadersMissing(header.GetRound())
+	defer func() {
+		go sp.checkAndRequestIfMetaHeadersMissing(round)
+	}()
 
 	if bodyHandler == nil {
 		return header, nil

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -111,13 +111,14 @@ func (boot *baseBootstrap) loadBlocks(
 		}
 
 		if err == nil {
+			err = boot.accounts.RecreateTrie(boot.blkc.GetCurrentBlockHeader().GetRootHash())
+			if err != nil {
+				lastBlocksToSkip++
+				continue
+			}
+
 			break
 		}
-	}
-
-	err = boot.accounts.RecreateTrie(boot.blkc.GetCurrentBlockHeader().GetRootHash())
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/process/sync/shardblock_test.go
+++ b/process/sync/shardblock_test.go
@@ -2734,6 +2734,7 @@ func TestBootstrap_LoadBlocksShouldErrBoostrapFromStorageWhenBlocksAreNotValid(t
 func TestBootstrap_LoadBlocksShouldErrWhenRecreateTrieFail(t *testing.T) {
 	t.Parallel()
 
+	wasCalled := false
 	errExpected := errors.New("error to recreate trie")
 	uint64Converter := uint64ByteSlice.NewBigEndianConverter()
 	pools := &mock.PoolsHolderStub{}
@@ -2778,6 +2779,7 @@ func TestBootstrap_LoadBlocksShouldErrWhenRecreateTrieFail(t *testing.T) {
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
 	account := &mock.AccountsStub{
 		RecreateTrieCalled: func(rootHash []byte) error {
+			wasCalled = true
 			return errExpected
 		},
 	}
@@ -2814,7 +2816,8 @@ func TestBootstrap_LoadBlocksShouldErrWhenRecreateTrieFail(t *testing.T) {
 		getBlockBody,
 	)
 
-	assert.Equal(t, errExpected, err)
+	assert.True(t, wasCalled)
+	assert.Equal(t, process.ErrBoostrapFromStorage, err)
 }
 
 func TestBootstrap_LoadBlocksShouldWorkAfterRemoveInvalidBlocks(t *testing.T) {


### PR DESCRIPTION
* Fixed bug in boostrap from storage when recreate trie fails
* Fixed bug in CreateBlockHeader when checkAndRequestIfShardHeadersMissing was not called in every situation and with wrong round