### PR TITLE
core: fix filename trimming

### DIFF
--- a/core/trimmers.go
+++ b/core/trimmers.go
@@ -3,7 +3,7 @@ package core
 // GetTrimmedPk returns a trimmed string to the pkPrefixSize value
 func GetTrimmedPk(pk string) string {
 	if len(pk) > pkPrefixSize {
-		pk = pk[:pkPrefixSize] + "..."
+		pk = pk[:pkPrefixSize]
 	}
 
 	return pk

--- a/core/trimmers_test.go
+++ b/core/trimmers_test.go
@@ -10,7 +10,7 @@ import (
 func TestSubroundStartRound_GetPkToDisplayShouldTrim(t *testing.T) {
 	pk := "1234567891234"
 	pkToDisplay := core.GetTrimmedPk(pk)
-	assert.Equal(t, "123456789123...", pkToDisplay)
+	assert.Equal(t, "123456789123", pkToDisplay)
 }
 
 func TestSubroundStartRound_GetPkToDisplayShouldNotTrim(t *testing.T) {


### PR DESCRIPTION
on windows the "..." in filename are not ok