### PR TITLE
Fixed bugs with fork choice and notarized meta blocks

### DIFF
--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -291,7 +291,9 @@ func (bp *baseProcessor) saveLastNotarizedHeader(shardId uint32, processedHdrs [
 		bp.lastNotarizedHdrs[shardId] = processedHdrs[i]
 	}
 
-	bp.finalNotarizedHdrs[shardId] = tmpLastNotarized
+	if tmpLastNotarized.GetNonce() != bp.lastNotarizedHdrs[shardId].GetNonce() {
+		bp.finalNotarizedHdrs[shardId] = tmpLastNotarized
+	}
 
 	return nil
 }

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -263,6 +263,13 @@ func (bp *baseProcessor) saveLastNotarizedHeader(shardId uint32, processedHdrs [
 		return processedHdrs[i].GetNonce() < processedHdrs[j].GetNonce()
 	})
 
+	if len(processedHdrs) > 0 {
+		log.Info(fmt.Sprintf("%d full processed metachain nonces for current header are between %d and %d\n",
+			len(processedHdrs),
+			processedHdrs[0].GetNonce(),
+			processedHdrs[len(processedHdrs)-1].GetNonce()))
+	}
+
 	for i := 0; i < len(processedHdrs); i++ {
 		errNotCritical := bp.checkHeaderTypeCorrect(shardId, processedHdrs[i])
 		if errNotCritical != nil {
@@ -272,6 +279,7 @@ func (bp *baseProcessor) saveLastNotarizedHeader(shardId uint32, processedHdrs [
 
 		errNotCritical = bp.isHdrConstructionValid(processedHdrs[i], bp.lastNotarizedHdrs[shardId])
 		if errNotCritical != nil {
+			log.Debug(errNotCritical.Error())
 			continue
 		}
 

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -264,8 +264,7 @@ func (bp *baseProcessor) saveLastNotarizedHeader(shardId uint32, processedHdrs [
 	})
 
 	if len(processedHdrs) > 0 {
-		log.Info(fmt.Sprintf("%d full processed metachain nonces for current header are between %d and %d\n",
-			len(processedHdrs),
+		log.Info(fmt.Sprintf("full processed metachain nonces for current header are between %d and %d\n",
 			processedHdrs[0].GetNonce(),
 			processedHdrs[len(processedHdrs)-1].GetNonce()))
 	}

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -264,7 +264,7 @@ func (bp *baseProcessor) saveLastNotarizedHeader(shardId uint32, processedHdrs [
 	})
 
 	if len(processedHdrs) > 0 {
-		log.Info(fmt.Sprintf("full processed metachain nonces for current header are between %d and %d\n",
+		log.Debug(fmt.Sprintf("full processed metachain nonces for current header are between %d and %d\n",
 			processedHdrs[0].GetNonce(),
 			processedHdrs[len(processedHdrs)-1].GetNonce()))
 	}

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -291,9 +291,7 @@ func (bp *baseProcessor) saveLastNotarizedHeader(shardId uint32, processedHdrs [
 		bp.lastNotarizedHdrs[shardId] = processedHdrs[i]
 	}
 
-	if tmpLastNotarized.GetNonce() != bp.lastNotarizedHdrs[shardId].GetNonce() {
-		bp.finalNotarizedHdrs[shardId] = tmpLastNotarized
-	}
+	bp.finalNotarizedHdrs[shardId] = tmpLastNotarized
 
 	return nil
 }

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -246,7 +246,7 @@ func (bp *baseProcessor) restoreLastNotarized() {
 	bp.mutNotarizedHdrs.Unlock()
 }
 
-func (bp *baseProcessor) saveLastNotarizedHeader(shardId uint32, processedHdrs []data.HeaderHandler) error {
+func (bp *baseProcessor) saveLastNotarizedHeader(shardId uint32, maxNonce uint64, processedHdrs []data.HeaderHandler) error {
 	bp.mutNotarizedHdrs.Lock()
 	defer bp.mutNotarizedHdrs.Unlock()
 
@@ -289,6 +289,10 @@ func (bp *baseProcessor) saveLastNotarizedHeader(shardId uint32, processedHdrs [
 
 	if bp.lastNotarizedHdrs[shardId].GetNonce() != tmpLastNotarized.GetNonce() {
 		bp.finalNotarizedHdrs[shardId] = tmpLastNotarized
+	}
+
+	if maxNonce > 0 && bp.lastNotarizedHdrs[shardId].GetNonce() != maxNonce {
+		return process.ErrSaveLastNotarizedBlock
 	}
 
 	return nil

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -269,6 +269,8 @@ func (bp *baseProcessor) saveLastNotarizedHeader(shardId uint32, processedHdrs [
 			processedHdrs[len(processedHdrs)-1].GetNonce()))
 	}
 
+	tmpLastNotarized := bp.lastNotarizedHdrs[shardId]
+
 	for i := 0; i < len(processedHdrs); i++ {
 		errNotCritical := bp.checkHeaderTypeCorrect(shardId, processedHdrs[i])
 		if errNotCritical != nil {
@@ -282,8 +284,11 @@ func (bp *baseProcessor) saveLastNotarizedHeader(shardId uint32, processedHdrs [
 			continue
 		}
 
-		bp.finalNotarizedHdrs[shardId] = bp.lastNotarizedHdrs[shardId]
 		bp.lastNotarizedHdrs[shardId] = processedHdrs[i]
+	}
+
+	if bp.lastNotarizedHdrs[shardId].GetNonce() != tmpLastNotarized.GetNonce() {
+		bp.finalNotarizedHdrs[shardId] = tmpLastNotarized
 	}
 
 	return nil

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -288,11 +288,6 @@ func isInTxHashes(searched []byte, list [][]byte) bool {
 	return false
 }
 
-func computeHash(data interface{}, marshalizer marshal.Marshalizer, hasher hashing.Hasher) []byte {
-	buff, _ := marshalizer.Marshal(data)
-	return hasher.Compute(string(buff))
-}
-
 type wrongBody struct {
 }
 
@@ -651,7 +646,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrLastNotSliceNotSet(t *testing.T) {
 	base.SetMarshalizer(&mock.MarshalizerMock{})
 	prHdrs := createShardProcessHeadersToSaveLastNoterized(10, &block.Header{}, mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	err := base.SaveLastNotarizedHeader(2, prHdrs)
+	err := base.SaveLastNotarizedHeader(2, 10, prHdrs)
 
 	assert.Equal(t, process.ErrNotarizedHdrsSliceIsNil, err)
 }
@@ -666,7 +661,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrLastNotShardIdMissmatch(t *testing.T)
 	_ = base.SetLastNotarizedHeadersSlice(createGenesisBlocks(shardCoordinator), true)
 	prHdrs := createShardProcessHeadersToSaveLastNoterized(10, &block.Header{}, mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	err := base.SaveLastNotarizedHeader(6, prHdrs)
+	err := base.SaveLastNotarizedHeader(6, 10, prHdrs)
 
 	assert.Equal(t, process.ErrShardIdMissmatch, err)
 }
@@ -687,7 +682,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrLastNotHdrNil(t *testing.T) {
 	_ = base.SetLastNotarizedHeadersSlice(genesisBlock, true)
 	prHdrs := createShardProcessHeadersToSaveLastNoterized(10, &block.Header{}, mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	err := base.SaveLastNotarizedHeader(shardId, prHdrs)
+	err := base.SaveLastNotarizedHeader(shardId, 10, prHdrs)
 
 	assert.Equal(t, process.ErrWrongTypeAssertion, err)
 }
@@ -708,7 +703,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrLastNotWrongTypeShard(t *testing.T) {
 	_ = base.SetLastNotarizedHeadersSlice(genesisBlock, true)
 	prHdrs := createShardProcessHeadersToSaveLastNoterized(10, &block.Header{}, mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	err := base.SaveLastNotarizedHeader(shardId, prHdrs)
+	err := base.SaveLastNotarizedHeader(shardId, 10, prHdrs)
 
 	assert.Equal(t, process.ErrWrongTypeAssertion, err)
 }
@@ -728,7 +723,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrLastNotWrongTypeMeta(t *testing.T) {
 	_ = base.SetLastNotarizedHeadersSlice(genesisBlock, true)
 	prHdrs := createMetaProcessHeadersToSaveLastNoterized(10, &block.Header{}, mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	err := base.SaveLastNotarizedHeader(sharding.MetachainShardId, prHdrs)
+	err := base.SaveLastNotarizedHeader(sharding.MetachainShardId, 10, prHdrs)
 
 	assert.Equal(t, process.ErrWrongTypeAssertion, err)
 }
@@ -745,7 +740,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrShardWrongProcessed(t *testing.T) {
 	prHdrs := createMetaProcessHeadersToSaveLastNoterized(highestNonce, &block.Header{}, mock.HasherMock{}, &mock.MarshalizerMock{})
 
 	shardId := uint32(0)
-	err := base.SaveLastNotarizedHeader(shardId, prHdrs)
+	err := base.SaveLastNotarizedHeader(shardId, 0, prHdrs)
 	assert.Nil(t, err)
 
 	lastNodesHdrs := base.LastNotarizedHdrs()
@@ -763,7 +758,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrMetaWrongProcessed(t *testing.T) {
 	highestNonce := uint64(10)
 	prHdrs := createShardProcessHeadersToSaveLastNoterized(highestNonce, &block.Header{}, mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	err := base.SaveLastNotarizedHeader(sharding.MetachainShardId, prHdrs)
+	err := base.SaveLastNotarizedHeader(sharding.MetachainShardId, 0, prHdrs)
 	assert.Nil(t, err)
 
 	lastNodesHdrs := base.LastNotarizedHdrs()
@@ -786,7 +781,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrShardGood(t *testing.T) {
 	shardId := uint32(0)
 	prHdrs := createShardProcessHeadersToSaveLastNoterized(highestNonce, genesisBlcks[shardId], hasher, marshalizer)
 
-	err := base.SaveLastNotarizedHeader(shardId, prHdrs)
+	err := base.SaveLastNotarizedHeader(shardId, highestNonce, prHdrs)
 	assert.Nil(t, err)
 
 	lastNodesHdrs := base.LastNotarizedHdrs()
@@ -808,7 +803,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrMetaGood(t *testing.T) {
 	highestNonce := uint64(10)
 	prHdrs := createMetaProcessHeadersToSaveLastNoterized(highestNonce, genesisBlcks[sharding.MetachainShardId], hasher, marshalizer)
 
-	err := base.SaveLastNotarizedHeader(sharding.MetachainShardId, prHdrs)
+	err := base.SaveLastNotarizedHeader(sharding.MetachainShardId, highestNonce, prHdrs)
 	assert.Nil(t, err)
 
 	lastNodesHdrs := base.LastNotarizedHdrs()

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -226,6 +226,13 @@ func initMetaDataPool() *mock.MetaPoolsHolderStub {
 			}
 			return cs
 		},
+		ShardHeadersNoncesCalled: func() dataRetriever.Uint64Cacher {
+			cs := &mock.Uint64CacherStub{}
+			cs.RemoveCalled = func(u uint64) {
+
+			}
+			return cs
+		},
 	}
 	return mdp
 }
@@ -646,7 +653,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrLastNotSliceNotSet(t *testing.T) {
 	base.SetMarshalizer(&mock.MarshalizerMock{})
 	prHdrs := createShardProcessHeadersToSaveLastNoterized(10, &block.Header{}, mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	err := base.SaveLastNotarizedHeader(2, 10, prHdrs)
+	err := base.SaveLastNotarizedHeader(2, prHdrs)
 
 	assert.Equal(t, process.ErrNotarizedHdrsSliceIsNil, err)
 }
@@ -661,7 +668,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrLastNotShardIdMissmatch(t *testing.T)
 	_ = base.SetLastNotarizedHeadersSlice(createGenesisBlocks(shardCoordinator), true)
 	prHdrs := createShardProcessHeadersToSaveLastNoterized(10, &block.Header{}, mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	err := base.SaveLastNotarizedHeader(6, 10, prHdrs)
+	err := base.SaveLastNotarizedHeader(6, prHdrs)
 
 	assert.Equal(t, process.ErrShardIdMissmatch, err)
 }
@@ -682,7 +689,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrLastNotHdrNil(t *testing.T) {
 	_ = base.SetLastNotarizedHeadersSlice(genesisBlock, true)
 	prHdrs := createShardProcessHeadersToSaveLastNoterized(10, &block.Header{}, mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	err := base.SaveLastNotarizedHeader(shardId, 10, prHdrs)
+	err := base.SaveLastNotarizedHeader(shardId, prHdrs)
 
 	assert.Equal(t, process.ErrWrongTypeAssertion, err)
 }
@@ -703,7 +710,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrLastNotWrongTypeShard(t *testing.T) {
 	_ = base.SetLastNotarizedHeadersSlice(genesisBlock, true)
 	prHdrs := createShardProcessHeadersToSaveLastNoterized(10, &block.Header{}, mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	err := base.SaveLastNotarizedHeader(shardId, 10, prHdrs)
+	err := base.SaveLastNotarizedHeader(shardId, prHdrs)
 
 	assert.Equal(t, process.ErrWrongTypeAssertion, err)
 }
@@ -723,7 +730,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrLastNotWrongTypeMeta(t *testing.T) {
 	_ = base.SetLastNotarizedHeadersSlice(genesisBlock, true)
 	prHdrs := createMetaProcessHeadersToSaveLastNoterized(10, &block.Header{}, mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	err := base.SaveLastNotarizedHeader(sharding.MetachainShardId, 10, prHdrs)
+	err := base.SaveLastNotarizedHeader(sharding.MetachainShardId, prHdrs)
 
 	assert.Equal(t, process.ErrWrongTypeAssertion, err)
 }
@@ -740,8 +747,8 @@ func TestBaseProcessor_SaveLastNoterizedHdrShardWrongProcessed(t *testing.T) {
 	prHdrs := createMetaProcessHeadersToSaveLastNoterized(highestNonce, &block.Header{}, mock.HasherMock{}, &mock.MarshalizerMock{})
 
 	shardId := uint32(0)
-	err := base.SaveLastNotarizedHeader(shardId, 0, prHdrs)
-	assert.Nil(t, err)
+	err := base.SaveLastNotarizedHeader(shardId, prHdrs)
+	assert.Equal(t, process.ErrWrongTypeAssertion, err)
 
 	lastNodesHdrs := base.LastNotarizedHdrs()
 	assert.Equal(t, uint64(0), lastNodesHdrs[shardId].GetNonce())
@@ -758,8 +765,8 @@ func TestBaseProcessor_SaveLastNoterizedHdrMetaWrongProcessed(t *testing.T) {
 	highestNonce := uint64(10)
 	prHdrs := createShardProcessHeadersToSaveLastNoterized(highestNonce, &block.Header{}, mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	err := base.SaveLastNotarizedHeader(sharding.MetachainShardId, 0, prHdrs)
-	assert.Nil(t, err)
+	err := base.SaveLastNotarizedHeader(sharding.MetachainShardId, prHdrs)
+	assert.Equal(t, process.ErrWrongTypeAssertion, err)
 
 	lastNodesHdrs := base.LastNotarizedHdrs()
 	assert.Equal(t, uint64(0), lastNodesHdrs[sharding.MetachainShardId].GetNonce())
@@ -781,7 +788,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrShardGood(t *testing.T) {
 	shardId := uint32(0)
 	prHdrs := createShardProcessHeadersToSaveLastNoterized(highestNonce, genesisBlcks[shardId], hasher, marshalizer)
 
-	err := base.SaveLastNotarizedHeader(shardId, highestNonce, prHdrs)
+	err := base.SaveLastNotarizedHeader(shardId, prHdrs)
 	assert.Nil(t, err)
 
 	lastNodesHdrs := base.LastNotarizedHdrs()
@@ -803,7 +810,7 @@ func TestBaseProcessor_SaveLastNoterizedHdrMetaGood(t *testing.T) {
 	highestNonce := uint64(10)
 	prHdrs := createMetaProcessHeadersToSaveLastNoterized(highestNonce, genesisBlcks[sharding.MetachainShardId], hasher, marshalizer)
 
-	err := base.SaveLastNotarizedHeader(sharding.MetachainShardId, highestNonce, prHdrs)
+	err := base.SaveLastNotarizedHeader(sharding.MetachainShardId, prHdrs)
 	assert.Nil(t, err)
 
 	lastNodesHdrs := base.LastNotarizedHdrs()

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -53,8 +53,8 @@ func (sp *shardProcessor) CreateMiniBlocks(noShards uint32, maxTxInBlock int, ro
 	return sp.createMiniBlocks(noShards, maxTxInBlock, round, haveTime)
 }
 
-func (sp *shardProcessor) GetProcessedMetaBlocksFromPool(body block.Body) ([]data.HeaderHandler, error) {
-	return sp.getProcessedMetaBlocksFromPool(body)
+func (sp *shardProcessor) GetProcessedMetaBlocksFromPool(body block.Body, header *block.Header) ([]data.HeaderHandler, error) {
+	return sp.getProcessedMetaBlocksFromPool(body, header)
 }
 
 func (sp *shardProcessor) RemoveProcessedMetablocksFromPool(processedMetaHdrs []data.HeaderHandler) error {

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -53,8 +53,8 @@ func (sp *shardProcessor) CreateMiniBlocks(noShards uint32, maxTxInBlock int, ro
 	return sp.createMiniBlocks(noShards, maxTxInBlock, round, haveTime)
 }
 
-func (sp *shardProcessor) GetProcessedMetaBlocksFromPool(body block.Body, maxNonce uint64) ([]data.HeaderHandler, error) {
-	return sp.getProcessedMetaBlocksFromPool(body, maxNonce)
+func (sp *shardProcessor) GetProcessedMetaBlocksFromPool(body block.Body, header *block.Header) ([]data.HeaderHandler, error) {
+	return sp.getProcessedMetaBlocksFromPool(body, header)
 }
 
 func (sp *shardProcessor) RemoveProcessedMetablocksFromPool(processedMetaHdrs []data.HeaderHandler) error {
@@ -156,8 +156,8 @@ func NewBaseProcessor(shardCord sharding.Coordinator) *baseProcessor {
 	return &baseProcessor{shardCoordinator: shardCord}
 }
 
-func (bp *baseProcessor) SaveLastNotarizedHeader(shardId uint32, maxNonce uint64, processedHdrs []data.HeaderHandler) error {
-	return bp.saveLastNotarizedHeader(shardId, maxNonce, processedHdrs)
+func (bp *baseProcessor) SaveLastNotarizedHeader(shardId uint32, processedHdrs []data.HeaderHandler) error {
+	return bp.saveLastNotarizedHeader(shardId, processedHdrs)
 }
 
 func (sp *shardProcessor) CheckHeaderBodyCorrelation(hdr *block.Header, body block.Body) error {

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -156,8 +156,8 @@ func NewBaseProcessor(shardCord sharding.Coordinator) *baseProcessor {
 	return &baseProcessor{shardCoordinator: shardCord}
 }
 
-func (bp *baseProcessor) SaveLastNotarizedHeader(shardId uint32, processedHdrs []data.HeaderHandler) error {
-	return bp.saveLastNotarizedHeader(shardId, processedHdrs)
+func (bp *baseProcessor) SaveLastNotarizedHeader(shardId uint32, maxNonce uint64, processedHdrs []data.HeaderHandler) error {
+	return bp.saveLastNotarizedHeader(shardId, maxNonce, processedHdrs)
 }
 
 func (sp *shardProcessor) CheckHeaderBodyCorrelation(hdr *block.Header, body block.Body) error {

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -53,8 +53,8 @@ func (sp *shardProcessor) CreateMiniBlocks(noShards uint32, maxTxInBlock int, ro
 	return sp.createMiniBlocks(noShards, maxTxInBlock, round, haveTime)
 }
 
-func (sp *shardProcessor) GetProcessedMetaBlocksFromPool(body block.Body, header *block.Header) ([]data.HeaderHandler, error) {
-	return sp.getProcessedMetaBlocksFromPool(body, header)
+func (sp *shardProcessor) GetProcessedMetaBlocksFromPool(body block.Body, maxNonce uint64) ([]data.HeaderHandler, error) {
+	return sp.getProcessedMetaBlocksFromPool(body, maxNonce)
 }
 
 func (sp *shardProcessor) RemoveProcessedMetablocksFromPool(processedMetaHdrs []data.HeaderHandler) error {

--- a/process/block/interceptors/metachainHeaderInterceptor.go
+++ b/process/block/interceptors/metachainHeaderInterceptor.go
@@ -42,13 +42,13 @@ func NewMetachainHeaderInterceptor(
 		return nil, process.ErrNilMarshalizer
 	}
 	if metachainHeaders == nil {
-		return nil, process.ErrNilMetachainHeadersDataPool
+		return nil, process.ErrNilMetaHeadersDataPool
 	}
 	if metachainHeadersNonces == nil {
-		return nil, process.ErrNilMetachainHeadersNoncesDataPool
+		return nil, process.ErrNilMetaHeadersNoncesDataPool
 	}
 	if storer == nil {
-		return nil, process.ErrNilMetachainHeadersStorage
+		return nil, process.ErrNilMetaHeadersStorage
 	}
 	if multiSigVerifier == nil {
 		return nil, process.ErrNilMultiSigVerifier

--- a/process/block/interceptors/metachainHeaderInterceptor_test.go
+++ b/process/block/interceptors/metachainHeaderInterceptor_test.go
@@ -53,7 +53,7 @@ func TestNewMetachainHeaderInterceptor_NilMetachainHeadersShouldErr(t *testing.T
 		&mock.ChronologyValidatorStub{},
 	)
 
-	assert.Equal(t, process.ErrNilMetachainHeadersDataPool, err)
+	assert.Equal(t, process.ErrNilMetaHeadersDataPool, err)
 	assert.Nil(t, mhi)
 }
 
@@ -73,7 +73,7 @@ func TestNewMetachainHeaderInterceptor_NilMetachainHeadersNoncesShouldErr(t *tes
 		&mock.ChronologyValidatorStub{},
 	)
 
-	assert.Equal(t, process.ErrNilMetachainHeadersNoncesDataPool, err)
+	assert.Equal(t, process.ErrNilMetaHeadersNoncesDataPool, err)
 	assert.Nil(t, mhi)
 }
 
@@ -93,7 +93,7 @@ func TestNewMetachainHeaderInterceptor_NilMetachainStorerShouldErr(t *testing.T)
 		&mock.ChronologyValidatorStub{},
 	)
 
-	assert.Equal(t, process.ErrNilMetachainHeadersStorage, err)
+	assert.Equal(t, process.ErrNilMetaHeadersStorage, err)
 	assert.Nil(t, mhi)
 }
 

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -291,6 +291,11 @@ func (mp *metaProcessor) RestoreBlockIntoPools(headerHandler data.HeaderHandler,
 
 		headerPool.Put([]byte(hdrHash), &hdr)
 
+		err = mp.store.GetStorer(dataRetriever.BlockHeaderUnit).Remove([]byte(hdrHash))
+		if err != nil {
+			return err
+		}
+
 		shardMBHeaderCounterMutex.Lock()
 		shardMBHeadersTotalProcessed -= len(hdr.MiniBlockHeaders)
 		shardMBHeaderCounterMutex.Unlock()

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -541,7 +541,9 @@ func (mp *metaProcessor) createLastNotarizedHdrs(header *block.MetaBlock) error 
 	}
 
 	for i := uint32(0); i < mp.shardCoordinator.NumberOfShards(); i++ {
-		mp.finalNotarizedHdrs[i] = tmpNotedHdrs[i]
+		if tmpNotedHdrs[i].GetNonce() != mp.lastNotarizedHdrs[i].GetNonce() {
+			mp.finalNotarizedHdrs[i] = tmpNotedHdrs[i]
+		}
 	}
 
 	return nil

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -271,6 +271,11 @@ func (mp *metaProcessor) RestoreBlockIntoPools(headerHandler data.HeaderHandler,
 		return process.ErrNilHeadersDataPool
 	}
 
+	headerNoncesPool := mp.dataPool.ShardHeadersNonces()
+	if headerNoncesPool == nil {
+		return process.ErrNilHeadersNoncesDataPool
+	}
+
 	hdrHashes := make([][]byte, 0)
 	for i := 0; i < len(header.ShardInfo); i++ {
 		shardData := header.ShardInfo[i]
@@ -292,6 +297,7 @@ func (mp *metaProcessor) RestoreBlockIntoPools(headerHandler data.HeaderHandler,
 		}
 
 		headerPool.Put([]byte(hdrHash), &hdr)
+		headerNoncesPool.Put(hdr.Nonce, &hdr)
 
 		err = mp.store.GetStorer(dataRetriever.BlockHeaderUnit).Remove([]byte(hdrHash))
 		if err != nil {

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -541,9 +541,7 @@ func (mp *metaProcessor) createLastNotarizedHdrs(header *block.MetaBlock) error 
 	}
 
 	for i := uint32(0); i < mp.shardCoordinator.NumberOfShards(); i++ {
-		if tmpNotedHdrs[i].GetNonce() != mp.lastNotarizedHdrs[i].GetNonce() {
-			mp.finalNotarizedHdrs[i] = tmpNotedHdrs[i]
-		}
+		mp.finalNotarizedHdrs[i] = tmpNotedHdrs[i]
 	}
 
 	return nil

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -349,7 +349,7 @@ func (mp *metaProcessor) processBlockHeaders(header *block.MetaBlock, round uint
 	}
 
 	if len(msg) > 0 {
-		log.Info(fmt.Sprintf("the following miniblocks hashes were successfully processed:%s\n", msg))
+		log.Debug(fmt.Sprintf("the following miniblocks hashes were successfully processed:%s\n", msg))
 	}
 
 	return nil
@@ -894,7 +894,7 @@ func (mp *metaProcessor) createShardInfo(
 		return shardInfo, nil
 	}
 
-	log.Info(fmt.Sprintf("time elapsed to ordered %d hdrs: %v sec\n", len(orderedHdrs), timeAfter.Sub(timeBefore).Seconds()))
+	log.Debug(fmt.Sprintf("time elapsed to ordered %d hdrs: %v sec\n", len(orderedHdrs), timeAfter.Sub(timeBefore).Seconds()))
 
 	if err != nil {
 		return nil, err

--- a/process/block/metablock_test.go
+++ b/process/block/metablock_test.go
@@ -1642,10 +1642,8 @@ func TestMetaProcessor_RestoreBlockIntoPoolsShouldWork(t *testing.T) {
 	hdrHash := []byte("hdr_hash1")
 
 	store := &mock.ChainStorerMock{
-		GetAllCalled: func(unitType dataRetriever.UnitType, keys [][]byte) (map[string][]byte, error) {
-			m := make(map[string][]byte, 0)
-			m[string(hdrHash)] = buffHdr
-			return m, nil
+		GetCalled: func(unitType dataRetriever.UnitType, key []byte) ([]byte, error) {
+			return buffHdr, nil
 		},
 		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
 			return &mock.StorerStub{

--- a/process/block/metablock_test.go
+++ b/process/block/metablock_test.go
@@ -1647,6 +1647,13 @@ func TestMetaProcessor_RestoreBlockIntoPoolsShouldWork(t *testing.T) {
 			m[string(hdrHash)] = buffHdr
 			return m, nil
 		},
+		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
+			return &mock.StorerStub{
+				RemoveCalled: func(key []byte) error {
+					return nil
+				},
+			}
+		},
 	}
 
 	mp, _ := blproc.NewMetaProcessor(

--- a/process/block/preprocess/transactions.go
+++ b/process/block/preprocess/transactions.go
@@ -187,6 +187,11 @@ func (txs *transactions) RestoreTxBlockIntoPools(
 			}
 
 			txs.txPool.AddData([]byte(txHash), &tx, strCache)
+
+			err = txs.storage.GetStorer(dataRetriever.TransactionUnit).Remove([]byte(txHash))
+			if err != nil {
+				return txsRestored, err
+			}
 		}
 
 		buff, err := txs.marshalizer.Marshal(miniBlock)
@@ -196,6 +201,12 @@ func (txs *transactions) RestoreTxBlockIntoPools(
 
 		miniBlockHash := txs.hasher.Compute(string(buff))
 		miniBlockPool.Put(miniBlockHash, miniBlock)
+
+		err = txs.storage.GetStorer(dataRetriever.MiniBlockUnit).Remove(miniBlockHash)
+		if err != nil {
+			return txsRestored, err
+		}
+
 		if miniBlock.SenderShardID != txs.shardCoordinator.SelfId() {
 			miniBlockHashes[i] = miniBlockHash
 		}

--- a/process/block/preprocess/transactions.go
+++ b/process/block/preprocess/transactions.go
@@ -504,16 +504,17 @@ func (txs *transactions) CreateAndProcessMiniBlock(sndShardId, dstShardId uint32
 	orderedTxes, orderedTxHashes, err := txs.getTxs(txStore)
 	timeAfter := time.Now()
 
+	if err != nil {
+		log.Info(err.Error())
+		return nil, err
+	}
+
 	if !haveTime() {
 		log.Info(fmt.Sprintf("time is up after ordered %d txs in %v sec\n", len(orderedTxes), timeAfter.Sub(timeBefore).Seconds()))
 		return nil, process.ErrTimeIsOut
 	}
 
-	log.Info(fmt.Sprintf("time elapsed to ordered %d txs: %v sec\n", len(orderedTxes), timeAfter.Sub(timeBefore).Seconds()))
-
-	if err != nil {
-		log.Debug(fmt.Sprintf("when trying to order txs: %s", err.Error()))
-	}
+	log.Debug(fmt.Sprintf("time elapsed to ordered %d txs: %v sec\n", len(orderedTxes), timeAfter.Sub(timeBefore).Seconds()))
 
 	miniBlock := &block.MiniBlock{}
 	miniBlock.SenderShardID = sndShardId

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/block/preprocess"
 	"github.com/ElrondNetwork/elrond-go/sharding"
-	"github.com/pkg/errors"
 )
 
 const maxTransactionsInBlock = 15000
@@ -509,9 +508,9 @@ func (sp *shardProcessor) CommitBlock(
 	log.Info(fmt.Sprintf("last notarized block nonce from metachain is %d\n",
 		sp.lastNotarizedHdrs[sharding.MetachainShardId].GetNonce()))
 
-	if maxNonce > 0 && sp.lastNotarizedHdrs[sharding.MetachainShardId].GetNonce() != maxNonce {
-		return errors.New("error")
-	}
+	//if maxNonce > 0 && sp.lastNotarizedHdrs[sharding.MetachainShardId].GetNonce() != maxNonce {
+	//	return errors.New("error")
+	//}
 
 	errNotCritical = sp.removeProcessedMetablocksFromPool(processedMetaHdrs)
 	if errNotCritical != nil {
@@ -1219,11 +1218,11 @@ func (sp *shardProcessor) createAndProcessCrossMiniBlocksDstMe(
 
 		maxTxRemaining := uint32(maxTxInBlock) - nrTxAdded
 
-		if len(hdr.GetMiniBlockHeadersWithDst(sp.shardCoordinator.SelfId())) == 0 {
-			usedMetaHdrsHashes = append(usedMetaHdrsHashes, orderedMetaBlocks[i].hash)
-			lastMetaHdr = hdr
-			continue
-		}
+		//if len(hdr.GetMiniBlockHeadersWithDst(sp.shardCoordinator.SelfId())) == 0 {
+		//	usedMetaHdrsHashes = append(usedMetaHdrsHashes, orderedMetaBlocks[i].hash)
+		//	lastMetaHdr = hdr
+		//	continue
+		//}
 
 		currMBProcessed, currTxsAdded, hdrProcessFinished := sp.createAndprocessMiniBlocksFromHeader(hdr, maxTxRemaining, round, haveTime)
 
@@ -1231,9 +1230,9 @@ func (sp *shardProcessor) createAndProcessCrossMiniBlocksDstMe(
 		miniBlocks = append(miniBlocks, currMBProcessed...)
 		nrTxAdded = nrTxAdded + currTxsAdded
 
-		if currTxsAdded > 0 {
-			usedMetaHdrsHashes = append(usedMetaHdrsHashes, orderedMetaBlocks[i].hash)
-		}
+		//if currTxsAdded > 0 {
+		usedMetaHdrsHashes = append(usedMetaHdrsHashes, orderedMetaBlocks[i].hash)
+		//}
 
 		if !hdrProcessFinished {
 			break

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -531,8 +531,8 @@ func (sp *shardProcessor) CommitBlock(
 	return nil
 }
 
-// getMaxNonce returns the maximum nonce of meta blocks included in the given shard header
-func (sp *shardProcessor) getMaxNonce(header *block.Header) uint64 {
+// getMaxNonceInMetaBlocksUsed returns the maximum nonce of meta blocks included in the given shard header
+func (sp *shardProcessor) getMaxNonceInMetaBlocksUsed(header *block.Header) uint64 {
 	maxNonce := uint64(0)
 	for _, hash := range header.MetaBlockHashes {
 		metaBlock, _ := sp.dataPool.MetaBlocks().Peek(hash)
@@ -564,7 +564,7 @@ func (sp *shardProcessor) getProcessedMetaBlocksFromPool(body block.Body, header
 		return nil, process.ErrNilBlockHeader
 	}
 
-	maxNonce := sp.getMaxNonce(header)
+	maxNonce := sp.getMaxNonceInMetaBlocksUsed(header)
 
 	log.Info(fmt.Sprintf("the highest metachain block nonce used in shard header with nonce %d is %d\n",
 		header.Nonce,

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -525,7 +525,7 @@ func (sp *shardProcessor) CommitBlock(
 	lastNotarizedNonce := sp.lastNotarizedHdrs[sharding.MetachainShardId].GetNonce()
 	sp.mutNotarizedHdrs.RUnlock()
 
-	log.Info(fmt.Sprintf("last notarized block nonce from metachain is %d and max nonce used in current header is %d\n",
+	log.Debug(fmt.Sprintf("last notarized block nonce from metachain is %d and max nonce used in current header is %d\n",
 		lastNotarizedNonce,
 		maxNonce))
 
@@ -627,7 +627,7 @@ func (sp *shardProcessor) getProcessedMetaBlocksFromPool(body block.Body, maxNon
 		miniBlockHashes[i] = mbHash
 	}
 
-	log.Info(fmt.Sprintf("cross nini blocks in body: %d\n", len(miniBlockHashes)))
+	log.Debug(fmt.Sprintf("cross nini blocks in body: %d\n", len(miniBlockHashes)))
 
 	processedMetaHdrs := make([]data.HeaderHandler, 0)
 	for _, metaBlockKey := range sp.dataPool.MetaBlocks().Keys() {
@@ -647,7 +647,7 @@ func (sp *shardProcessor) getProcessedMetaBlocksFromPool(body block.Body, maxNon
 			continue
 		}
 
-		log.Info(fmt.Sprintf("meta header nonce: %d\n", hdr.Nonce))
+		log.Debug(fmt.Sprintf("meta header nonce: %d\n", hdr.Nonce))
 
 		crossMiniBlockHashes := hdr.GetMiniBlockHeadersWithDst(sp.shardCoordinator.SelfId())
 		for key := range miniBlockHashes {
@@ -660,7 +660,7 @@ func (sp *shardProcessor) getProcessedMetaBlocksFromPool(body block.Body, maxNon
 			delete(miniBlockHashes, key)
 		}
 
-		log.Info(fmt.Sprintf("cross mini blocks in meta header: %d\n", len(crossMiniBlockHashes)))
+		log.Debug(fmt.Sprintf("cross mini blocks in meta header: %d\n", len(crossMiniBlockHashes)))
 
 		processedAll := true
 		for key := range crossMiniBlockHashes {
@@ -1317,7 +1317,7 @@ func (sp *shardProcessor) createMiniBlocks(
 		log.Info(err.Error())
 	}
 
-	log.Info(fmt.Sprintf("processed %d miniblocks and %d txs with destination in self shard\n", len(destMeMiniBlocks), txs))
+	log.Debug(fmt.Sprintf("processed %d miniblocks and %d txs with destination in self shard\n", len(destMeMiniBlocks), txs))
 
 	if len(destMeMiniBlocks) > 0 {
 		miniBlocks = append(miniBlocks, destMeMiniBlocks...)

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -3199,7 +3199,7 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock, 0)
 	assert.Nil(t, err)
 
-	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, processedMetaHdrs)
+	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, 0, processedMetaHdrs)
 	assert.Nil(t, err)
 
 	err = sp.RemoveProcessedMetablocksFromPool(processedMetaHdrs)
@@ -3216,7 +3216,7 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	processedMetaHdrs, err = sp.GetProcessedMetaBlocksFromPool(shardBlock, 46)
 	assert.Equal(t, nil, err)
 
-	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, processedMetaHdrs)
+	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, 0, processedMetaHdrs)
 	assert.Nil(t, err)
 
 	err = sp.RemoveProcessedMetablocksFromPool(processedMetaHdrs)
@@ -3233,7 +3233,7 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	processedMetaHdrs, err = sp.GetProcessedMetaBlocksFromPool(shardBlock, 46)
 	assert.Nil(t, err)
 
-	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, processedMetaHdrs)
+	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, 46, processedMetaHdrs)
 	assert.Nil(t, err)
 
 	err = sp.RemoveProcessedMetablocksFromPool(processedMetaHdrs)
@@ -3382,7 +3382,7 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNotAllMBFinished(t *tes
 	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock, 46)
 	assert.Nil(t, err)
 
-	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, processedMetaHdrs)
+	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, 45, processedMetaHdrs)
 	assert.Nil(t, err)
 
 	err = sp.RemoveProcessedMetablocksFromPool(processedMetaHdrs)
@@ -3508,7 +3508,7 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrAllMBFinished(t *testin
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(processedMetaHdrs))
 
-	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, processedMetaHdrs)
+	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, 46, processedMetaHdrs)
 	assert.Nil(t, err)
 
 	err = sp.RemoveProcessedMetablocksFromPool(processedMetaHdrs)

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -2892,6 +2892,13 @@ func TestShardProcessor_RestoreBlockIntoPoolsShouldWork(t *testing.T) {
 			m[string(txHash)] = buffTx
 			return m, nil
 		},
+		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
+			return &mock.StorerStub{
+				RemoveCalled: func(key []byte) error {
+					return nil
+				},
+			}
+		},
 	}
 
 	sp, _ := blproc.NewShardProcessor(

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -2777,12 +2777,6 @@ func TestShardProcessor_GetProcessedMetaBlockFromPoolShouldWork(t *testing.T) {
 		createDummyMetaBlock(destShardId, destShards[2], miniblockHashes[4], miniblockHashes[5]),
 	)
 
-	//hashes := make([][]byte, 0)
-	//hashes = append(hashes, mb1Hash)
-	//hashes = append(hashes, mb2Hash)
-	//hashes = append(hashes, mb3Hash)
-	//blockHeader := &block.Header{MetaBlockHashes: hashes}
-
 	shardCoordinator := mock.NewMultipleShardsCoordinatorMock()
 	shardCoordinator.CurrentShard = destShardId
 	shardCoordinator.SetNoShards(destShardId + 1)
@@ -3201,8 +3195,6 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	shardHdr := &block.Header{Round: 15}
 	shardBlock := block.Body{}
 
-	//shardHeader := &block.Header{}
-
 	// test header not in pool and defer called
 	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock, 0)
 	assert.Nil(t, err)
@@ -3221,10 +3213,6 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	// wrong header type in pool and defer called
 	dataPool.MetaBlocks().Put(currHash, shardHdr)
 
-	//hashes := make([][]byte, 0)
-	//hashes = append(hashes, currHash)
-	//shardHeader = &block.Header{MetaBlockHashes: hashes}
-
 	processedMetaHdrs, err = sp.GetProcessedMetaBlocksFromPool(shardBlock, 46)
 	assert.Equal(t, nil, err)
 
@@ -3241,11 +3229,6 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	// put headers in pool
 	dataPool.MetaBlocks().Put(currHash, currHdr)
 	dataPool.MetaBlocks().Put(prevHash, prevHdr)
-
-	//hashes = make([][]byte, 0)
-	//hashes = append(hashes, currHash)
-	//hashes = append(hashes, prevHash)
-	//shardHeader = &block.Header{MetaBlockHashes: hashes}
 
 	processedMetaHdrs, err = sp.GetProcessedMetaBlocksFromPool(shardBlock, 46)
 	assert.Nil(t, err)
@@ -3396,11 +3379,6 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNotAllMBFinished(t *tes
 	dataPool.MetaBlocks().Put(currHash, currHdr)
 	dataPool.MetaBlocks().Put(prevHash, prevHdr)
 
-	//hashes := make([][]byte, 0)
-	//hashes = append(hashes, currHash)
-	//hashes = append(hashes, prevHash)
-	//shardHeader := &block.Header{MetaBlockHashes: hashes}
-
 	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock, 46)
 	assert.Nil(t, err)
 
@@ -3525,12 +3503,6 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrAllMBFinished(t *testin
 	dataPool.MetaBlocks().Put(currHash, currHdr)
 	dataPool.MetaBlocks().Put(prevHash, prevHdr)
 	dataPool.MetaBlocks().Put([]byte("shouldNotRemove"), &block.MetaBlock{Nonce: 47})
-
-	//hashes := make([][]byte, 0)
-	//hashes = append(hashes, currHash)
-	//hashes = append(hashes, prevHash)
-	//hashes = append(hashes, []byte("shouldNotRemove"))
-	//shardHeader := &block.Header{MetaBlockHashes: hashes}
 
 	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock, 47)
 	assert.Nil(t, err)

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -2827,7 +2827,7 @@ func TestShardProcessor_GetProcessedMetaBlockFromPoolShouldWork(t *testing.T) {
 	assert.False(t, (metaBlock3Recov.(data.HeaderHandler)).GetMiniBlockProcessed(miniblockHashes[5]))
 }
 
-func TestBlockProcessor_RestoreBlockIntoPoolsShouldErrNilBlockChain(t *testing.T) {
+func TestBlockProcessor_RestoreBlockIntoPoolsShouldErrNilBlockHeader(t *testing.T) {
 	t.Parallel()
 	tdp := initDataPool([]byte("tx_hash1"))
 
@@ -2848,7 +2848,7 @@ func TestBlockProcessor_RestoreBlockIntoPoolsShouldErrNilBlockChain(t *testing.T
 	)
 	err := be.RestoreBlockIntoPools(nil, nil)
 	assert.NotNil(t, err)
-	assert.Equal(t, process.ErrNilTxBlockBody, err)
+	assert.Equal(t, process.ErrNilBlockHeader, err)
 }
 
 func TestBlockProcessor_RestoreBlockIntoPoolsShouldErrNilTxBlockBody(t *testing.T) {
@@ -2870,7 +2870,7 @@ func TestBlockProcessor_RestoreBlockIntoPoolsShouldErrNilTxBlockBody(t *testing.
 		&mock.RequestHandlerMock{},
 	)
 
-	err := sp.RestoreBlockIntoPools(nil, nil)
+	err := sp.RestoreBlockIntoPools(&block.Header{}, nil)
 	assert.NotNil(t, err)
 	assert.Equal(t, err, process.ErrNilTxBlockBody)
 }
@@ -2939,7 +2939,7 @@ func TestShardProcessor_RestoreBlockIntoPoolsShouldWork(t *testing.T) {
 		metablockHeader,
 	)
 
-	err := sp.RestoreBlockIntoPools(nil, body)
+	err := sp.RestoreBlockIntoPools(&block.Header{}, body)
 
 	miniblockFromPool, _ := dataPool.MiniBlocks().Get(miniblockHash)
 	txFromPool, _ := dataPool.Transactions().SearchFirstData(txHash)

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -2777,11 +2777,11 @@ func TestShardProcessor_GetProcessedMetaBlockFromPoolShouldWork(t *testing.T) {
 		createDummyMetaBlock(destShardId, destShards[2], miniblockHashes[4], miniblockHashes[5]),
 	)
 
-	hashes := make([][]byte, 0)
-	hashes = append(hashes, mb1Hash)
-	hashes = append(hashes, mb2Hash)
-	hashes = append(hashes, mb3Hash)
-	blockHeader := &block.Header{MetaBlockHashes: hashes}
+	//hashes := make([][]byte, 0)
+	//hashes = append(hashes, mb1Hash)
+	//hashes = append(hashes, mb2Hash)
+	//hashes = append(hashes, mb3Hash)
+	//blockHeader := &block.Header{MetaBlockHashes: hashes}
 
 	shardCoordinator := mock.NewMultipleShardsCoordinatorMock()
 	shardCoordinator.CurrentShard = destShardId
@@ -2814,7 +2814,7 @@ func TestShardProcessor_GetProcessedMetaBlockFromPoolShouldWork(t *testing.T) {
 	//create block body with first 3 miniblocks from miniblocks var
 	blockBody := block.Body{miniblocks[0], miniblocks[1], miniblocks[2]}
 
-	_, err := bp.GetProcessedMetaBlocksFromPool(blockBody, blockHeader)
+	_, err := bp.GetProcessedMetaBlocksFromPool(blockBody, 0)
 
 	assert.Nil(t, err)
 	//check WasMiniBlockProcessed for remaining metablocks
@@ -3201,10 +3201,10 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	shardHdr := &block.Header{Round: 15}
 	shardBlock := block.Body{}
 
-	shardHeader := &block.Header{}
+	//shardHeader := &block.Header{}
 
 	// test header not in pool and defer called
-	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock, shardHeader)
+	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock, 0)
 	assert.Nil(t, err)
 
 	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, processedMetaHdrs)
@@ -3221,11 +3221,11 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	// wrong header type in pool and defer called
 	dataPool.MetaBlocks().Put(currHash, shardHdr)
 
-	hashes := make([][]byte, 0)
-	hashes = append(hashes, currHash)
-	shardHeader = &block.Header{MetaBlockHashes: hashes}
+	//hashes := make([][]byte, 0)
+	//hashes = append(hashes, currHash)
+	//shardHeader = &block.Header{MetaBlockHashes: hashes}
 
-	processedMetaHdrs, err = sp.GetProcessedMetaBlocksFromPool(shardBlock, shardHeader)
+	processedMetaHdrs, err = sp.GetProcessedMetaBlocksFromPool(shardBlock, 46)
 	assert.Equal(t, nil, err)
 
 	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, processedMetaHdrs)
@@ -3242,12 +3242,12 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	dataPool.MetaBlocks().Put(currHash, currHdr)
 	dataPool.MetaBlocks().Put(prevHash, prevHdr)
 
-	hashes = make([][]byte, 0)
-	hashes = append(hashes, currHash)
-	hashes = append(hashes, prevHash)
-	shardHeader = &block.Header{MetaBlockHashes: hashes}
+	//hashes = make([][]byte, 0)
+	//hashes = append(hashes, currHash)
+	//hashes = append(hashes, prevHash)
+	//shardHeader = &block.Header{MetaBlockHashes: hashes}
 
-	processedMetaHdrs, err = sp.GetProcessedMetaBlocksFromPool(shardBlock, shardHeader)
+	processedMetaHdrs, err = sp.GetProcessedMetaBlocksFromPool(shardBlock, 46)
 	assert.Nil(t, err)
 
 	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, processedMetaHdrs)
@@ -3396,12 +3396,12 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNotAllMBFinished(t *tes
 	dataPool.MetaBlocks().Put(currHash, currHdr)
 	dataPool.MetaBlocks().Put(prevHash, prevHdr)
 
-	hashes := make([][]byte, 0)
-	hashes = append(hashes, currHash)
-	hashes = append(hashes, prevHash)
-	shardHeader := &block.Header{MetaBlockHashes: hashes}
+	//hashes := make([][]byte, 0)
+	//hashes = append(hashes, currHash)
+	//hashes = append(hashes, prevHash)
+	//shardHeader := &block.Header{MetaBlockHashes: hashes}
 
-	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock, shardHeader)
+	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock, 46)
 	assert.Nil(t, err)
 
 	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, processedMetaHdrs)
@@ -3526,13 +3526,13 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrAllMBFinished(t *testin
 	dataPool.MetaBlocks().Put(prevHash, prevHdr)
 	dataPool.MetaBlocks().Put([]byte("shouldNotRemove"), &block.MetaBlock{Nonce: 47})
 
-	hashes := make([][]byte, 0)
-	hashes = append(hashes, currHash)
-	hashes = append(hashes, prevHash)
-	hashes = append(hashes, []byte("shouldNotRemove"))
-	shardHeader := &block.Header{MetaBlockHashes: hashes}
+	//hashes := make([][]byte, 0)
+	//hashes = append(hashes, currHash)
+	//hashes = append(hashes, prevHash)
+	//hashes = append(hashes, []byte("shouldNotRemove"))
+	//shardHeader := &block.Header{MetaBlockHashes: hashes}
 
-	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock, shardHeader)
+	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock, 47)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(processedMetaHdrs))
 

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -2777,6 +2777,12 @@ func TestShardProcessor_GetProcessedMetaBlockFromPoolShouldWork(t *testing.T) {
 		createDummyMetaBlock(destShardId, destShards[2], miniblockHashes[4], miniblockHashes[5]),
 	)
 
+	hashes := make([][]byte, 0)
+	hashes = append(hashes, mb1Hash)
+	hashes = append(hashes, mb2Hash)
+	hashes = append(hashes, mb3Hash)
+	blockHeader := &block.Header{MetaBlockHashes: hashes}
+
 	shardCoordinator := mock.NewMultipleShardsCoordinatorMock()
 	shardCoordinator.CurrentShard = destShardId
 	shardCoordinator.SetNoShards(destShardId + 1)
@@ -2808,7 +2814,7 @@ func TestShardProcessor_GetProcessedMetaBlockFromPoolShouldWork(t *testing.T) {
 	//create block body with first 3 miniblocks from miniblocks var
 	blockBody := block.Body{miniblocks[0], miniblocks[1], miniblocks[2]}
 
-	_, err := bp.GetProcessedMetaBlocksFromPool(blockBody)
+	_, err := bp.GetProcessedMetaBlocksFromPool(blockBody, blockHeader)
 
 	assert.Nil(t, err)
 	//check WasMiniBlockProcessed for remaining metablocks
@@ -3188,8 +3194,10 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	shardHdr := &block.Header{Round: 15}
 	shardBlock := block.Body{}
 
+	shardHeader := &block.Header{}
+
 	// test header not in pool and defer called
-	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock)
+	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock, shardHeader)
 	assert.Nil(t, err)
 
 	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, processedMetaHdrs)
@@ -3206,7 +3214,11 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	// wrong header type in pool and defer called
 	dataPool.MetaBlocks().Put(currHash, shardHdr)
 
-	processedMetaHdrs, err = sp.GetProcessedMetaBlocksFromPool(shardBlock)
+	hashes := make([][]byte, 0)
+	hashes = append(hashes, currHash)
+	shardHeader = &block.Header{MetaBlockHashes: hashes}
+
+	processedMetaHdrs, err = sp.GetProcessedMetaBlocksFromPool(shardBlock, shardHeader)
 	assert.Equal(t, nil, err)
 
 	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, processedMetaHdrs)
@@ -3223,7 +3235,12 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	dataPool.MetaBlocks().Put(currHash, currHdr)
 	dataPool.MetaBlocks().Put(prevHash, prevHdr)
 
-	processedMetaHdrs, err = sp.GetProcessedMetaBlocksFromPool(shardBlock)
+	hashes = make([][]byte, 0)
+	hashes = append(hashes, currHash)
+	hashes = append(hashes, prevHash)
+	shardHeader = &block.Header{MetaBlockHashes: hashes}
+
+	processedMetaHdrs, err = sp.GetProcessedMetaBlocksFromPool(shardBlock, shardHeader)
 	assert.Nil(t, err)
 
 	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, processedMetaHdrs)
@@ -3372,7 +3389,12 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNotAllMBFinished(t *tes
 	dataPool.MetaBlocks().Put(currHash, currHdr)
 	dataPool.MetaBlocks().Put(prevHash, prevHdr)
 
-	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock)
+	hashes := make([][]byte, 0)
+	hashes = append(hashes, currHash)
+	hashes = append(hashes, prevHash)
+	shardHeader := &block.Header{MetaBlockHashes: hashes}
+
+	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock, shardHeader)
 	assert.Nil(t, err)
 
 	err = sp.SaveLastNotarizedHeader(sharding.MetachainShardId, processedMetaHdrs)
@@ -3497,7 +3519,13 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrAllMBFinished(t *testin
 	dataPool.MetaBlocks().Put(prevHash, prevHdr)
 	dataPool.MetaBlocks().Put([]byte("shouldNotRemove"), &block.MetaBlock{Nonce: 47})
 
-	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock)
+	hashes := make([][]byte, 0)
+	hashes = append(hashes, currHash)
+	hashes = append(hashes, prevHash)
+	hashes = append(hashes, []byte("shouldNotRemove"))
+	shardHeader := &block.Header{MetaBlockHashes: hashes}
+
+	processedMetaHdrs, err := sp.GetProcessedMetaBlocksFromPool(shardBlock, shardHeader)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(processedMetaHdrs))
 

--- a/process/constants.go
+++ b/process/constants.go
@@ -26,5 +26,5 @@ const (
 
 const ShardBlockFinality = 1
 const MetaBlockFinality = 1
-const BlockFinality = 1
+const ForkBlockFinality = 1
 const MaxHeaderRequestsAllowed = 10

--- a/process/constants.go
+++ b/process/constants.go
@@ -26,4 +26,5 @@ const (
 
 const ShardBlockFinality = 1
 const MetaBlockFinality = 1
+const BlockFinality = 1
 const MaxHeaderRequestsAllowed = 10

--- a/process/errors.go
+++ b/process/errors.go
@@ -136,17 +136,17 @@ var ErrNilMessenger = errors.New("nil Messenger")
 // ErrNilTxDataPool signals that a nil transaction pool has been provided
 var ErrNilTxDataPool = errors.New("nil transaction data pool")
 
-// ErrNilHeadersDataPool signals that a nil header pool has been provided
+// ErrNilHeadersDataPool signals that a nil headers pool has been provided
 var ErrNilHeadersDataPool = errors.New("nil headers data pool")
 
-// ErrNilMetachainHeadersDataPool signals that a nil metachain header pool has been provided
-var ErrNilMetachainHeadersDataPool = errors.New("nil metachain headers data pool")
+// ErrNilMetaHeadersDataPool signals that a nil metachain header pool has been provided
+var ErrNilMetaHeadersDataPool = errors.New("nil meta headers data pool")
 
 // ErrNilHeadersNoncesDataPool signals that a nil header - nonce cache
 var ErrNilHeadersNoncesDataPool = errors.New("nil headers nonces cache")
 
-//ErrNilMetachainHeadersNoncesDataPool signals a nil metachain header - nonce cache
-var ErrNilMetachainHeadersNoncesDataPool = errors.New("nil metachain headers nonces cache")
+//ErrNilMetaHeadersNoncesDataPool signals a nil metachain header - nonce cache
+var ErrNilMetaHeadersNoncesDataPool = errors.New("nil meta headers nonces cache")
 
 // ErrNilCacher signals that a nil cache has been provided
 var ErrNilCacher = errors.New("nil cacher")
@@ -211,8 +211,8 @@ var ErrNilHeadersStorage = errors.New("nil headers storage")
 // ErrNilHeadersNonceHashStorage signals that a nil header nonce hash storage has been provided
 var ErrNilHeadersNonceHashStorage = errors.New("nil headers nonce hash storage")
 
-// ErrNilMetachainHeadersStorage signals that a nil metachain header storage has been provided
-var ErrNilMetachainHeadersStorage = errors.New("nil metachain headers storage")
+// ErrNilMetaHeadersStorage signals that a nil metachain header storage has been provided
+var ErrNilMetaHeadersStorage = errors.New("nil meta headers storage")
 
 // ErrNilBlockBodyStorage signals that a nil block body storage has been provided
 var ErrNilBlockBodyStorage = errors.New("nil block body storage")

--- a/process/errors.go
+++ b/process/errors.go
@@ -372,6 +372,3 @@ var ErrNilScrDataPool = errors.New("smart contract result pool is nil")
 
 // ErrNilScrStorage signals that smart contract storage is nil
 var ErrNilScrStorage = errors.New("smart contract result storage is nil")
-
-// ErrSaveLastNotarizedBlock signals that save of last notarized block has been failed
-var ErrSaveLastNotarizedBlock = errors.New("save of last notarized block failed")

--- a/process/errors.go
+++ b/process/errors.go
@@ -372,3 +372,6 @@ var ErrNilScrDataPool = errors.New("smart contract result pool is nil")
 
 // ErrNilScrStorage signals that smart contract storage is nil
 var ErrNilScrStorage = errors.New("smart contract result storage is nil")
+
+// ErrSaveLastNotarizedBlock signals that save of last notarized block has been failed
+var ErrSaveLastNotarizedBlock = errors.New("save of last notarized block failed")

--- a/process/interface.go
+++ b/process/interface.go
@@ -29,12 +29,13 @@ type SmartContractProcessor interface {
 	ProcessSmartContractResult(scr *smartContractResult.SmartContractResult) error
 }
 
+// PreProcessor is the main interface for pre processor engine
 type PreProcessor interface {
 	CreateBlockStarted()
 	IsDataPrepared(requestedTxs int, haveTime func() time.Duration) error
 
 	RemoveTxBlockFromPools(body block.Body, miniBlockPool storage.Cacher) error
-	RestoreTxBlockIntoPools(body block.Body, miniBlockHashes map[int][]byte, miniBlockPool storage.Cacher) (int, error)
+	RestoreTxBlockIntoPools(body block.Body, miniBlockPool storage.Cacher) (int, map[int][]byte, error)
 	SaveTxBlockToStorage(body block.Body) error
 
 	ProcessBlockTransactions(body block.Body, round uint32, haveTime func() time.Duration) error

--- a/process/sync/basicForkDetector.go
+++ b/process/sync/basicForkDetector.go
@@ -113,6 +113,9 @@ func (bfd *basicForkDetector) checkBlockValidity(header data.HeaderHandler, stat
 	if int32(header.GetRound()) > bfd.rounder.Index() {
 		return ErrHigherRoundInBlock
 	}
+	if int32(header.GetRound()) < bfd.rounder.Index()-process.BlockFinality {
+		return ErrLowerRoundInBlock
+	}
 	if int64(roundDif) < nonceDif {
 		return ErrHigherNonceInBlock
 	}

--- a/process/sync/basicForkDetector.go
+++ b/process/sync/basicForkDetector.go
@@ -113,7 +113,7 @@ func (bfd *basicForkDetector) checkBlockValidity(header data.HeaderHandler, stat
 	if int32(header.GetRound()) > bfd.rounder.Index() {
 		return ErrHigherRoundInBlock
 	}
-	if int32(header.GetRound()) < bfd.rounder.Index()-process.BlockFinality {
+	if int32(header.GetRound()) < bfd.rounder.Index()-process.ForkBlockFinality {
 		return ErrLowerRoundInBlock
 	}
 	if int64(roundDif) < nonceDif {

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -668,7 +668,7 @@ func (boot *ShardBootstrap) rollback(header *block.Header) error {
 	}
 
 	boot.cleanCachesOnRollback(header, headerStore, headerNonceHashStore)
-	errNotCritical := boot.blkExecutor.RestoreBlockIntoPools(nil, body)
+	errNotCritical := boot.blkExecutor.RestoreBlockIntoPools(header, body)
 	if errNotCritical != nil {
 		log.Info(errNotCritical.Error())
 	}


### PR DESCRIPTION
Fork choice detected (After more than 12 sec of latency in which one proposer tried to write on disk and then to broadcast the valid block with nonce n, the network already proposed another block with the same nonce n, and also the next proposer broadcast the block with nonce n + 1. Before the rest of the network to sync this block with nonce n + 1, they also received the block with nonce n from the slow proposer. Because they didn't sync yet the block with nonce n + 1 and the final block is still n - 1 (as k finality is 1) they will start a fork choice on the block with nonce n (as they have now two block with nonce n but with different round inside). As the rule is that when two VALID blocks have the same nonce, the one with the lower round will be selected, they will try to request the first block with nonce n. The problem is that the only one who got this block is the slower proposer, but because he also received the new block with nonce n + 1 which has been broadcast by the proposer of that round,  this caused a fail of validity when it verified it against his own block with nonce n, and for this reason he considered that he is also on the fork and rolled back to the final block with nonce n - 1, and removed its own proposed block with nonce n. From now nobody will have this block anymore and all the network is stuck, as nobody can resolve the request of this first block with nonce n. The solution for this case is that nobody from network should accept blocks, even they are valid, with the round inside them, lower than the current round - k finality. In this case any slow proposer has time (its round + next one) to broadcast the block to the network as this block to be taken into consideration.

Problem with the meta blocks which are added into node's shard pool but not notarized until the first cross shard transaction will happen. (this will cause that if there are many meta headers not notarized between two cross shard transactions with destination in node's shard, there is no enough time (in 4 seconds) to compute the validity checks for all of them and for this reason no more cross shard txs could be validated form that point (all will remain in state pending).The solution is that all the hashes from the validated metablocks, until that point, to be added in the creation of each shard block even if there are no cross shard transactions with destination in self shard. In this way the pool is emptied each round and the validation of the next cross shard transaction has to be fast as there are no many meta headers remained to be validated.