### PR TITLE
Bug/en 2838 delete from branch node correctly

### DIFF
--- a/data/trie/branchNode.go
+++ b/data/trie/branchNode.go
@@ -436,15 +436,9 @@ func (bn *branchNode) delete(key []byte, db data.DBWriteCacher, marshalizer mars
 		if err != nil {
 			return false, nil, err
 		}
-		if childPos != 16 {
-			newNode := bn.reduceNode(pos)
-			return true, newNode, nil
-		}
-		child := bn.children[pos]
-		if child, ok := child.(*leafNode); ok {
-			return true, newLeafNode([]byte{byte(pos)}, child.Value), nil
-		}
 
+		newNode := bn.children[pos].reduceNode(pos)
+		return true, newNode, nil
 	}
 
 	bn.dirty = dirty
@@ -452,10 +446,7 @@ func (bn *branchNode) delete(key []byte, db data.DBWriteCacher, marshalizer mars
 }
 
 func (bn *branchNode) reduceNode(pos int) node {
-	if child, ok := bn.children[pos].(*leafNode); ok {
-		return newLeafNode(concat([]byte{byte(pos)}, child.Key...), child.Value)
-	}
-	return newExtensionNode([]byte{byte(pos)}, bn.children[pos])
+	return newExtensionNode([]byte{byte(pos)}, bn)
 }
 
 func getChildPosition(n *branchNode) (nrOfChildren int, childPos int) {

--- a/data/trie/branchNode.go
+++ b/data/trie/branchNode.go
@@ -438,10 +438,12 @@ func (bn *branchNode) delete(key []byte, db data.DBWriteCacher, marshalizer mars
 		}
 
 		newNode := bn.children[pos].reduceNode(pos)
+
 		return true, newNode, nil
 	}
 
 	bn.dirty = dirty
+
 	return true, bn, nil
 }
 

--- a/data/trie/branchNode_test.go
+++ b/data/trie/branchNode_test.go
@@ -679,7 +679,7 @@ func TestBranchNode_reduceNode(t *testing.T) {
 	bn := newBranchNode()
 	bn.children = children
 	ln := newLeafNode([]byte{2, 100, 111, 103}, []byte("dog"))
-	node := bn.reduceNode(2)
+	node := bn.children[2].reduceNode(2)
 	assert.Equal(t, ln, node)
 }
 
@@ -706,6 +706,78 @@ func TestBranchNode_isEmptyOrNil(t *testing.T) {
 
 	bn = nil
 	assert.Equal(t, ErrNilNode, bn.isEmptyOrNil())
+}
+
+func TestReduceBranchNodeWithExtensionNodeChildShouldWork(t *testing.T) {
+	tr := newEmptyTrie()
+	expectedTr := newEmptyTrie()
+
+	expectedTr.Update([]byte("dog"), []byte("dog"))
+	expectedTr.Update([]byte("doll"), []byte("doll"))
+
+	tr.Update([]byte("dog"), []byte("dog"))
+	tr.Update([]byte("doll"), []byte("doll"))
+	tr.Update([]byte("wolf"), []byte("wolf"))
+	tr.Delete([]byte("wolf"))
+
+	expectedHash, _ := expectedTr.Root()
+	hash, _ := tr.Root()
+
+	assert.Equal(t, expectedHash, hash)
+}
+
+func TestReduceBranchNodeWithBranchNodeChildShouldWork(t *testing.T) {
+	tr := newEmptyTrie()
+	expectedTr := newEmptyTrie()
+
+	expectedTr.Update([]byte("dog"), []byte("puppy"))
+	expectedTr.Update([]byte("dogglesworth"), []byte("cat"))
+
+	tr.Update([]byte("doe"), []byte("reindeer"))
+	tr.Update([]byte("dog"), []byte("puppy"))
+	tr.Update([]byte("dogglesworth"), []byte("cat"))
+	tr.Delete([]byte("doe"))
+
+	expectedHash, _ := expectedTr.Root()
+	hash, _ := tr.Root()
+
+	assert.Equal(t, expectedHash, hash)
+}
+
+func TestReduceBranchNodeWithLeafNodeChildShouldWork(t *testing.T) {
+	tr := newEmptyTrie()
+	expectedTr := newEmptyTrie()
+
+	expectedTr.Update([]byte("doe"), []byte("reindeer"))
+	expectedTr.Update([]byte("dogglesworth"), []byte("cat"))
+
+	tr.Update([]byte("doe"), []byte("reindeer"))
+	tr.Update([]byte("dog"), []byte("puppy"))
+	tr.Update([]byte("dogglesworth"), []byte("cat"))
+	tr.Delete([]byte("dog"))
+
+	expectedHash, _ := expectedTr.Root()
+	hash, _ := tr.Root()
+
+	assert.Equal(t, expectedHash, hash)
+}
+
+func TestReduceBranchNodeWithLeafNodeValueShouldWork(t *testing.T) {
+	tr := newEmptyTrie()
+	expectedTr := newEmptyTrie()
+
+	expectedTr.Update([]byte("doe"), []byte("reindeer"))
+	expectedTr.Update([]byte("dog"), []byte("puppy"))
+
+	tr.Update([]byte("doe"), []byte("reindeer"))
+	tr.Update([]byte("dog"), []byte("puppy"))
+	tr.Update([]byte("dogglesworth"), []byte("cat"))
+	tr.Delete([]byte("dogglesworth"))
+
+	expectedHash, _ := expectedTr.Root()
+	hash, _ := tr.Root()
+
+	assert.Equal(t, expectedHash, hash)
 }
 
 func newEmptyTrie() data.Trie {

--- a/data/trie/branchNode_test.go
+++ b/data/trie/branchNode_test.go
@@ -709,6 +709,7 @@ func TestBranchNode_isEmptyOrNil(t *testing.T) {
 }
 
 func TestReduceBranchNodeWithExtensionNodeChildShouldWork(t *testing.T) {
+	t.Parallel()
 	tr := newEmptyTrie()
 	expectedTr := newEmptyTrie()
 
@@ -727,6 +728,7 @@ func TestReduceBranchNodeWithExtensionNodeChildShouldWork(t *testing.T) {
 }
 
 func TestReduceBranchNodeWithBranchNodeChildShouldWork(t *testing.T) {
+	t.Parallel()
 	tr := newEmptyTrie()
 	expectedTr := newEmptyTrie()
 
@@ -745,6 +747,7 @@ func TestReduceBranchNodeWithBranchNodeChildShouldWork(t *testing.T) {
 }
 
 func TestReduceBranchNodeWithLeafNodeChildShouldWork(t *testing.T) {
+	t.Parallel()
 	tr := newEmptyTrie()
 	expectedTr := newEmptyTrie()
 
@@ -763,6 +766,7 @@ func TestReduceBranchNodeWithLeafNodeChildShouldWork(t *testing.T) {
 }
 
 func TestReduceBranchNodeWithLeafNodeValueShouldWork(t *testing.T) {
+	t.Parallel()
 	tr := newEmptyTrie()
 	expectedTr := newEmptyTrie()
 

--- a/data/trie/patriciaMerkleTrie.go
+++ b/data/trie/patriciaMerkleTrie.go
@@ -140,7 +140,7 @@ func (tr *patriciaMerkleTrie) Prove(key []byte) ([][]byte, error) {
 		return nil, err
 	}
 
-	for len(hexKey) >= 0 {
+	for {
 		encNode, err := node.getEncodedNode(tr.marshalizer)
 		if err != nil {
 			return nil, err
@@ -155,7 +155,6 @@ func (tr *patriciaMerkleTrie) Prove(key []byte) ([][]byte, error) {
 			return proof, nil
 		}
 	}
-	return nil, ErrNodeNotFound
 }
 
 // VerifyProof checks Merkle proofs.


### PR DESCRIPTION
The issue appeared when you had a branchNode that had only 2 children, a leafNode and an extensionNode. If you deleted the leafNode, then the branchNode should have been replaced with an extensionNode leading directly to the child of the extensionNode, but the bug was that the branchNode was replaced with an extensionNode leading to the extensionNode, which is an incorrect type of construction.

To resolve this, I changed the reduceNode method accordingly, and changed the way that it was called.