### PR TITLE
Fixed stream reset and peer is not directly connected errors

### DIFF
--- a/dataRetriever/resolvers/topicResolverSender/export_test.go
+++ b/dataRetriever/resolvers/topicResolverSender/export_test.go
@@ -5,20 +5,14 @@ import (
 	"github.com/ElrondNetwork/elrond-go/p2p"
 )
 
-func SelectRandomPeers(
-	connectedPeers []p2p.PeerID,
-	excludedConnectedPeers []p2p.PeerID,
-	peersToSend int,
-	randomizer dataRetriever.IntRandomizer,
-) ([]p2p.PeerID, error) {
-
-	return selectRandomPeers(connectedPeers, excludedConnectedPeers, peersToSend, randomizer)
-}
-
 func MakeDiffList(
 	allConnectedPeers []p2p.PeerID,
 	excludedConnectedPeers []p2p.PeerID,
 ) []p2p.PeerID {
 
 	return makeDiffList(allConnectedPeers, excludedConnectedPeers)
+}
+
+func FisherYatesShuffle(indexes []int, randomizer dataRetriever.IntRandomizer) ([]int, error) {
+	return fisherYatesShuffle(indexes, randomizer)
 }

--- a/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
+++ b/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
@@ -90,10 +90,11 @@ func (trs *topicResolverSender) SendOnRequestTopic(rd *dataRetriever.RequestData
 		peer := diffList[idx]
 
 		err = trs.messenger.SendToConnectedPeer(topicToSendRequest, buff, peer)
-		if err == nil {
-			msgSentCounter++
+		if err != nil {
+			continue
 		}
 
+		msgSentCounter++
 		if msgSentCounter == NumPeersToQuery {
 			break
 		}

--- a/p2p/libp2p/export_test.go
+++ b/p2p/libp2p/export_test.go
@@ -1,6 +1,7 @@
 package libp2p
 
 import (
+	"github.com/ElrondNetwork/elrond-go/storage/lrucache"
 	"github.com/libp2p/go-libp2p-core/connmgr"
 	"github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/whyrusleeping/timecache"
@@ -26,4 +27,8 @@ func (ds *directSender) SeenMessages() *timecache.TimeCache {
 
 func (ds *directSender) Counter() uint64 {
 	return ds.counter
+}
+
+func (mh *MutexHolder) Mutexes() *lrucache.LRUCache {
+	return mh.mutexes
 }

--- a/p2p/libp2p/mutexHolder.go
+++ b/p2p/libp2p/mutexHolder.go
@@ -1,0 +1,50 @@
+package libp2p
+
+import (
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go/storage/lrucache"
+)
+
+// MutexHolder holds a cache of mutexes: pairs of (key, *sync.Mutex)
+type MutexHolder struct {
+	//generalMutex is used to assure access to the already concurrent safe lrucache is being serialized
+	generalMutex sync.Mutex
+	mutexes      *lrucache.LRUCache
+}
+
+// NewMutexHolder creates a new instance of MutexHolder with specified capacity.
+func NewMutexHolder(mutexesCapacity int) (*MutexHolder, error) {
+	mh := &MutexHolder{}
+	var err error
+	mh.mutexes, err = lrucache.NewCache(mutexesCapacity)
+	if err != nil {
+		return nil, err
+	}
+
+	return mh, nil
+}
+
+// Get returns a mutex for the provided key. If the key was not found, it will create a new mutex, save it in the
+// cache and returns it.
+func (mh *MutexHolder) Get(key string) *sync.Mutex {
+	mh.generalMutex.Lock()
+	defer mh.generalMutex.Unlock()
+
+	sliceKey := []byte(key)
+	val, ok := mh.mutexes.Get(sliceKey)
+	if !ok {
+		newMutex := &sync.Mutex{}
+		mh.mutexes.Put(sliceKey, newMutex)
+		return newMutex
+	}
+
+	mutex, ok := val.(*sync.Mutex)
+	if !ok {
+		newMutex := &sync.Mutex{}
+		mh.mutexes.Put(sliceKey, newMutex)
+		return newMutex
+	}
+
+	return mutex
+}

--- a/p2p/libp2p/mutexHolder.go
+++ b/p2p/libp2p/mutexHolder.go
@@ -8,7 +8,7 @@ import (
 
 // MutexHolder holds a cache of mutexes: pairs of (key, *sync.Mutex)
 type MutexHolder struct {
-	//generalMutex is used to assure access to the already concurrent safe lrucache is being serialized
+	//generalMutex is used to serialize the access to the already concurrent safe lrucache
 	generalMutex sync.Mutex
 	mutexes      *lrucache.LRUCache
 }

--- a/p2p/libp2p/mutexHolder_test.go
+++ b/p2p/libp2p/mutexHolder_test.go
@@ -1,0 +1,73 @@
+package libp2p_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/p2p/libp2p"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMutexHolder_InvalidCapacityShouldErr(t *testing.T) {
+	t.Parallel()
+
+	mh, err := libp2p.NewMutexHolder(-1)
+
+	assert.Nil(t, mh)
+	assert.NotNil(t, err)
+}
+
+func TestNewMutexHolder_InvalidCapacityShouldWork(t *testing.T) {
+	t.Parallel()
+
+	mh, err := libp2p.NewMutexHolder(10)
+
+	assert.NotNil(t, mh)
+	assert.Nil(t, err)
+}
+
+func TestMutexHolder_MutexNotFoundShouldCreate(t *testing.T) {
+	t.Parallel()
+
+	mh, _ := libp2p.NewMutexHolder(10)
+	key := "key"
+	mut := mh.Get(key)
+
+	assert.NotNil(t, mut)
+	assert.Equal(t, 1, mh.Mutexes().Len())
+	addedMutex, _ := mh.Mutexes().Get([]byte(key))
+	//pointer testing to not have the situation of creating new mutexes for each getMutex call
+	assert.True(t, mut == addedMutex)
+}
+
+func TestMutexHolder_OtherObjectInCacheShouldRewriteWithNewMutexAndReturn(t *testing.T) {
+	t.Parallel()
+
+	mh, _ := libp2p.NewMutexHolder(10)
+	key := "key"
+	mh.Mutexes().Put([]byte(key), "not a mutex value")
+	mut := mh.Get(key)
+
+	assert.NotNil(t, mut)
+	assert.Equal(t, 1, mh.Mutexes().Len())
+	addedMutex, _ := mh.Mutexes().Get([]byte(key))
+	//pointer testing to not have the situation of creating new mutexes for each getMutex call
+	assert.True(t, mut == addedMutex)
+}
+
+func TestMutexHolder_MutexFoundShouldReturnIt(t *testing.T) {
+	t.Parallel()
+
+	mh, _ := libp2p.NewMutexHolder(10)
+	key := "key"
+	mut := &sync.Mutex{}
+	mh.Mutexes().Put([]byte(key), mut)
+	mutRecov := mh.Get(key)
+
+	assert.NotNil(t, mutRecov)
+	assert.Equal(t, 1, mh.Mutexes().Len())
+	addedMutex, _ := mh.Mutexes().Get([]byte(key))
+	//pointer testing to not have the situation of creating new mutexes for each getMutex call
+	assert.True(t, mut == addedMutex)
+	assert.True(t, mut == mutRecov)
+}

--- a/p2p/libp2p/netMessenger.go
+++ b/p2p/libp2p/netMessenger.go
@@ -452,9 +452,7 @@ func (netMes *networkMessenger) UnregisterMessageProcessor(topic string) error {
 
 // SendToConnectedPeer sends a direct message to a connected peer
 func (netMes *networkMessenger) SendToConnectedPeer(topic string, buff []byte, peerID p2p.PeerID) error {
-	netMes.ds.SendAsync(topic, buff, peerID)
-
-	return nil
+	return netMes.ds.Send(topic, buff, peerID)
 }
 
 func (netMes *networkMessenger) directMessageHandler(message p2p.MessageP2P) error {

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -72,7 +72,7 @@ type Messenger interface {
 	// to and listening to.
 	Addresses() []string
 
-	// Explicitly connect to a specific peer with a known address (note that the
+	// ConnectToPeer explicitly connect to a specific peer with a known address (note that the
 	// address contains the peer ID). This function is usually not called
 	// manually, because any underlying implementation of the Messenger interface
 	// should be keeping connections to peers open.
@@ -137,7 +137,7 @@ type Messenger interface {
 	// message, blocking until sending is completed.
 	BroadcastOnChannelBlocking(channel string, topic string, buff []byte)
 
-	// BroadcastOnChannelBlocking asynchronously sends a message on a given topic
+	// BroadcastOnChannel asynchronously sends a message on a given topic
 	// through a specified channel.
 	BroadcastOnChannel(channel string, topic string, buff []byte)
 
@@ -174,7 +174,6 @@ type ChannelLoadBalancer interface {
 type DirectSender interface {
 	NextSeqno(counter *uint64) []byte
 	Send(topic string, buff []byte, peer PeerID) error
-	SendAsync(topic string, buff []byte, peer PeerID)
 }
 
 // PeerDiscoveryFactory defines the factory for peer discoverer implementation


### PR DESCRIPTION
Direct sender fixed, stream reset issue should not appear
TopicResolverSender tries to send the request to the next peer if a send to a peer fails.