### PR TITLE
bug/EN-2897-Root-state-does-not-match

### DIFF
--- a/consensus/mock/forkDetectorMock.go
+++ b/consensus/mock/forkDetectorMock.go
@@ -6,12 +6,12 @@ import (
 )
 
 type ForkDetectorMock struct {
-	AddHeaderCalled                       func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
-	RemoveHeadersCalled                   func(nonce uint64, hash []byte)
-	CheckForkCalled                       func() (bool, uint64)
-	GetHighestFinalBlockNonceCalled       func() uint64
-	ProbableHighestNonceCalled            func() uint64
-	ResetProbableHighestNonceIfNeedCalled func()
+	AddHeaderCalled                         func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
+	RemoveHeadersCalled                     func(nonce uint64, hash []byte)
+	CheckForkCalled                         func() (bool, uint64)
+	GetHighestFinalBlockNonceCalled         func() uint64
+	ProbableHighestNonceCalled              func() uint64
+	ResetProbableHighestNonceIfNeededCalled func()
 }
 
 func (fdm *ForkDetectorMock) AddHeader(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error {
@@ -34,6 +34,6 @@ func (fdm *ForkDetectorMock) ProbableHighestNonce() uint64 {
 	return fdm.ProbableHighestNonceCalled()
 }
 
-func (fdm *ForkDetectorMock) ResetProbableHighestNonceIfNeed() {
-	fdm.ResetProbableHighestNonceIfNeedCalled()
+func (fdm *ForkDetectorMock) ResetProbableHighestNonceIfNeeded() {
+	fdm.ResetProbableHighestNonceIfNeededCalled()
 }

--- a/consensus/mock/forkDetectorMock.go
+++ b/consensus/mock/forkDetectorMock.go
@@ -6,11 +6,12 @@ import (
 )
 
 type ForkDetectorMock struct {
-	AddHeaderCalled                 func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
-	RemoveHeadersCalled             func(nonce uint64, hash []byte)
-	CheckForkCalled                 func() (bool, uint64)
-	GetHighestFinalBlockNonceCalled func() uint64
-	ProbableHighestNonceCalled      func() uint64
+	AddHeaderCalled                       func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
+	RemoveHeadersCalled                   func(nonce uint64, hash []byte)
+	CheckForkCalled                       func() (bool, uint64)
+	GetHighestFinalBlockNonceCalled       func() uint64
+	ProbableHighestNonceCalled            func() uint64
+	ResetProbableHighestNonceIfNeedCalled func()
 }
 
 func (fdm *ForkDetectorMock) AddHeader(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error {
@@ -31,4 +32,8 @@ func (fdm *ForkDetectorMock) GetHighestFinalBlockNonce() uint64 {
 
 func (fdm *ForkDetectorMock) ProbableHighestNonce() uint64 {
 	return fdm.ProbableHighestNonceCalled()
+}
+
+func (fdm *ForkDetectorMock) ResetProbableHighestNonceIfNeed() {
+	fdm.ResetProbableHighestNonceIfNeedCalled()
 }

--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -384,7 +384,7 @@ func (wrk *Worker) Extend(subroundId int) {
 		time.Sleep(time.Millisecond)
 	}
 
-	log.Info(fmt.Sprintf("account state is reverted to snapshot\n"))
+	log.Debug(fmt.Sprintf("account state is reverted to snapshot\n"))
 
 	wrk.blockProcessor.RevertAccountState()
 }

--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -384,6 +384,8 @@ func (wrk *Worker) Extend(subroundId int) {
 		time.Sleep(time.Millisecond)
 	}
 
+	log.Info(fmt.Sprintf("account state is reverted to snapshot\n"))
+
 	wrk.blockProcessor.RevertAccountState()
 }
 

--- a/integrationTests/mock/forkDetectorMock.go
+++ b/integrationTests/mock/forkDetectorMock.go
@@ -7,12 +7,12 @@ import (
 
 // ForkDetectorMock is a mock implementation for the ForkDetector interface
 type ForkDetectorMock struct {
-	AddHeaderCalled                       func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
-	RemoveHeadersCalled                   func(nonce uint64, hash []byte)
-	CheckForkCalled                       func() (bool, uint64)
-	GetHighestFinalBlockNonceCalled       func() uint64
-	ProbableHighestNonceCalled            func() uint64
-	ResetProbableHighestNonceIfNeedCalled func()
+	AddHeaderCalled                         func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
+	RemoveHeadersCalled                     func(nonce uint64, hash []byte)
+	CheckForkCalled                         func() (bool, uint64)
+	GetHighestFinalBlockNonceCalled         func() uint64
+	ProbableHighestNonceCalled              func() uint64
+	ResetProbableHighestNonceIfNeededCalled func()
 }
 
 // AddHeader is a mock implementation for AddHeader
@@ -40,6 +40,6 @@ func (f *ForkDetectorMock) ProbableHighestNonce() uint64 {
 	return f.ProbableHighestNonceCalled()
 }
 
-func (fdm *ForkDetectorMock) ResetProbableHighestNonceIfNeed() {
-	fdm.ResetProbableHighestNonceIfNeedCalled()
+func (fdm *ForkDetectorMock) ResetProbableHighestNonceIfNeeded() {
+	fdm.ResetProbableHighestNonceIfNeededCalled()
 }

--- a/integrationTests/mock/forkDetectorMock.go
+++ b/integrationTests/mock/forkDetectorMock.go
@@ -7,11 +7,12 @@ import (
 
 // ForkDetectorMock is a mock implementation for the ForkDetector interface
 type ForkDetectorMock struct {
-	AddHeaderCalled                 func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
-	RemoveHeadersCalled             func(nonce uint64, hash []byte)
-	CheckForkCalled                 func() (bool, uint64)
-	GetHighestFinalBlockNonceCalled func() uint64
-	ProbableHighestNonceCalled      func() uint64
+	AddHeaderCalled                       func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
+	RemoveHeadersCalled                   func(nonce uint64, hash []byte)
+	CheckForkCalled                       func() (bool, uint64)
+	GetHighestFinalBlockNonceCalled       func() uint64
+	ProbableHighestNonceCalled            func() uint64
+	ResetProbableHighestNonceIfNeedCalled func()
 }
 
 // AddHeader is a mock implementation for AddHeader
@@ -37,4 +38,8 @@ func (f *ForkDetectorMock) GetHighestFinalBlockNonce() uint64 {
 // GetProbableHighestNonce is a mock implementation for GetProbableHighestNonce
 func (f *ForkDetectorMock) ProbableHighestNonce() uint64 {
 	return f.ProbableHighestNonceCalled()
+}
+
+func (fdm *ForkDetectorMock) ResetProbableHighestNonceIfNeed() {
+	fdm.ResetProbableHighestNonceIfNeedCalled()
 }

--- a/node/mock/forkDetectorMock.go
+++ b/node/mock/forkDetectorMock.go
@@ -7,12 +7,12 @@ import (
 
 // ForkDetectorMock is a mock implementation for the ForkDetector interface
 type ForkDetectorMock struct {
-	AddHeaderCalled                       func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
-	RemoveHeadersCalled                   func(nonce uint64, hash []byte)
-	CheckForkCalled                       func() (bool, uint64)
-	GetHighestFinalBlockNonceCalled       func() uint64
-	ProbableHighestNonceCalled            func() uint64
-	ResetProbableHighestNonceIfNeedCalled func()
+	AddHeaderCalled                         func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
+	RemoveHeadersCalled                     func(nonce uint64, hash []byte)
+	CheckForkCalled                         func() (bool, uint64)
+	GetHighestFinalBlockNonceCalled         func() uint64
+	ProbableHighestNonceCalled              func() uint64
+	ResetProbableHighestNonceIfNeededCalled func()
 }
 
 // AddHeader is a mock implementation for AddHeader
@@ -40,6 +40,6 @@ func (f *ForkDetectorMock) ProbableHighestNonce() uint64 {
 	return f.ProbableHighestNonceCalled()
 }
 
-func (fdm *ForkDetectorMock) ResetProbableHighestNonceIfNeed() {
-	fdm.ResetProbableHighestNonceIfNeedCalled()
+func (fdm *ForkDetectorMock) ResetProbableHighestNonceIfNeeded() {
+	fdm.ResetProbableHighestNonceIfNeededCalled()
 }

--- a/node/mock/forkDetectorMock.go
+++ b/node/mock/forkDetectorMock.go
@@ -7,11 +7,12 @@ import (
 
 // ForkDetectorMock is a mock implementation for the ForkDetector interface
 type ForkDetectorMock struct {
-	AddHeaderCalled                 func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
-	RemoveHeadersCalled             func(nonce uint64, hash []byte)
-	CheckForkCalled                 func() (bool, uint64)
-	GetHighestFinalBlockNonceCalled func() uint64
-	ProbableHighestNonceCalled      func() uint64
+	AddHeaderCalled                       func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
+	RemoveHeadersCalled                   func(nonce uint64, hash []byte)
+	CheckForkCalled                       func() (bool, uint64)
+	GetHighestFinalBlockNonceCalled       func() uint64
+	ProbableHighestNonceCalled            func() uint64
+	ResetProbableHighestNonceIfNeedCalled func()
 }
 
 // AddHeader is a mock implementation for AddHeader
@@ -37,4 +38,8 @@ func (f *ForkDetectorMock) GetHighestFinalBlockNonce() uint64 {
 // ProbableHighestNonce is a mock implementation for GetProbableHighestNonce
 func (f *ForkDetectorMock) ProbableHighestNonce() uint64 {
 	return f.ProbableHighestNonceCalled()
+}
+
+func (fdm *ForkDetectorMock) ResetProbableHighestNonceIfNeed() {
+	fdm.ResetProbableHighestNonceIfNeedCalled()
 }

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -99,7 +99,8 @@ func (bp *baseProcessor) checkBlockValidity(
 				return nil
 			}
 
-			log.Info(fmt.Sprintf("hash not match: local block hash is empty and node received block with previous hash %s\n",
+			log.Info(fmt.Sprintf("hash not match: local block hash is %s and node received block with previous hash %s\n",
+				core.ToB64(chainHandler.GetGenesisHeaderHash()),
 				core.ToB64(headerHandler.GetPrevHash())))
 
 			return process.ErrInvalidBlockHash

--- a/process/interface.go
+++ b/process/interface.go
@@ -113,6 +113,7 @@ type ForkDetector interface {
 	CheckFork() (bool, uint64)
 	GetHighestFinalBlockNonce() uint64
 	ProbableHighestNonce() uint64
+	ResetProbableHighestNonceIfNeed()
 }
 
 // InterceptorsContainer defines an interceptors holder data type with basic functionality

--- a/process/interface.go
+++ b/process/interface.go
@@ -113,7 +113,7 @@ type ForkDetector interface {
 	CheckFork() (bool, uint64)
 	GetHighestFinalBlockNonce() uint64
 	ProbableHighestNonce() uint64
-	ResetProbableHighestNonceIfNeed()
+	ResetProbableHighestNonceIfNeeded()
 }
 
 // InterceptorsContainer defines an interceptors holder data type with basic functionality

--- a/process/mock/forkDetectorMock.go
+++ b/process/mock/forkDetectorMock.go
@@ -6,12 +6,12 @@ import (
 )
 
 type ForkDetectorMock struct {
-	AddHeaderCalled                       func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
-	RemoveHeadersCalled                   func(nonce uint64, hash []byte)
-	CheckForkCalled                       func() (bool, uint64)
-	GetHighestFinalBlockNonceCalled       func() uint64
-	ProbableHighestNonceCalled            func() uint64
-	ResetProbableHighestNonceIfNeedCalled func()
+	AddHeaderCalled                         func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
+	RemoveHeadersCalled                     func(nonce uint64, hash []byte)
+	CheckForkCalled                         func() (bool, uint64)
+	GetHighestFinalBlockNonceCalled         func() uint64
+	ProbableHighestNonceCalled              func() uint64
+	ResetProbableHighestNonceIfNeededCalled func()
 }
 
 func (fdm *ForkDetectorMock) AddHeader(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error {
@@ -34,6 +34,6 @@ func (fdm *ForkDetectorMock) ProbableHighestNonce() uint64 {
 	return fdm.ProbableHighestNonceCalled()
 }
 
-func (fdm *ForkDetectorMock) ResetProbableHighestNonceIfNeed() {
-	fdm.ResetProbableHighestNonceIfNeedCalled()
+func (fdm *ForkDetectorMock) ResetProbableHighestNonceIfNeeded() {
+	fdm.ResetProbableHighestNonceIfNeededCalled()
 }

--- a/process/mock/forkDetectorMock.go
+++ b/process/mock/forkDetectorMock.go
@@ -6,11 +6,12 @@ import (
 )
 
 type ForkDetectorMock struct {
-	AddHeaderCalled                 func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
-	RemoveHeadersCalled             func(nonce uint64, hash []byte)
-	CheckForkCalled                 func() (bool, uint64)
-	GetHighestFinalBlockNonceCalled func() uint64
-	ProbableHighestNonceCalled      func() uint64
+	AddHeaderCalled                       func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error
+	RemoveHeadersCalled                   func(nonce uint64, hash []byte)
+	CheckForkCalled                       func() (bool, uint64)
+	GetHighestFinalBlockNonceCalled       func() uint64
+	ProbableHighestNonceCalled            func() uint64
+	ResetProbableHighestNonceIfNeedCalled func()
 }
 
 func (fdm *ForkDetectorMock) AddHeader(header data.HeaderHandler, hash []byte, state process.BlockHeaderState) error {
@@ -31,4 +32,8 @@ func (fdm *ForkDetectorMock) GetHighestFinalBlockNonce() uint64 {
 
 func (fdm *ForkDetectorMock) ProbableHighestNonce() uint64 {
 	return fdm.ProbableHighestNonceCalled()
+}
+
+func (fdm *ForkDetectorMock) ResetProbableHighestNonceIfNeed() {
+	fdm.ResetProbableHighestNonceIfNeedCalled()
 }

--- a/process/sync/basicForkDetector.go
+++ b/process/sync/basicForkDetector.go
@@ -355,8 +355,8 @@ func (bfd *basicForkDetector) ProbableHighestNonce() uint64 {
 // is received so the node will act as synchronized
 func (bfd *basicForkDetector) ResetProbableHighestNonceIfNeeded() {
 	//TODO: This mechanism should be improved to avoid the situation when a malicious group of 2/3 + 1 from a
-	// consensus group size, could keep all the shard in sync mode, by creating fakes block higher than current commited
-	// block + 1 which could not be verified by hash - prev hash and only by rand seed - prev random seed
+	// consensus group size, could keep all the shard in sync mode, by creating fake blocks higher than current
+	// committed block + 1, which could not be verified by hash -> prev hash and only by rand seed -> prev random seed
 	bfd.mutFork.Lock()
 	roundsWithoutReceivedBlock := bfd.rounder.Index() - bfd.fork.lastBlockRound
 	if roundsWithoutReceivedBlock > maxRoundsToWait {

--- a/process/sync/basicForkDetector.go
+++ b/process/sync/basicForkDetector.go
@@ -351,9 +351,9 @@ func (bfd *basicForkDetector) ProbableHighestNonce() uint64 {
 	return probableHighestNonce
 }
 
-// ResetProbableHighestNonceIfNeed resets the probableHighestNonce to checkpoint if after maxRoundsToWait nothing
+// ResetProbableHighestNonceIfNeeded resets the probableHighestNonce to checkpoint if after maxRoundsToWait nothing
 // is received so the node will act as synchronized
-func (bfd *basicForkDetector) ResetProbableHighestNonceIfNeed() {
+func (bfd *basicForkDetector) ResetProbableHighestNonceIfNeeded() {
 	bfd.mutFork.Lock()
 	roundsWithoutReceivedBlock := bfd.rounder.Index() - bfd.fork.lastBlockRound
 	if roundsWithoutReceivedBlock > maxRoundsToWait {

--- a/process/sync/basicForkDetector.go
+++ b/process/sync/basicForkDetector.go
@@ -354,6 +354,9 @@ func (bfd *basicForkDetector) ProbableHighestNonce() uint64 {
 // ResetProbableHighestNonceIfNeeded resets the probableHighestNonce to checkpoint if after maxRoundsToWait nothing
 // is received so the node will act as synchronized
 func (bfd *basicForkDetector) ResetProbableHighestNonceIfNeeded() {
+	//TODO: This mechanism should be improved to avoid the situation when a malicious group of 2/3 + 1 from a
+	// consensus group size, could keep all the shard in sync mode, by creating fakes block higher than current commited
+	// block + 1 which could not be verified by hash - prev hash and only by rand seed - prev random seed
 	bfd.mutFork.Lock()
 	roundsWithoutReceivedBlock := bfd.rounder.Index() - bfd.fork.lastBlockRound
 	if roundsWithoutReceivedBlock > maxRoundsToWait {

--- a/process/sync/basicForkDetector_test.go
+++ b/process/sync/basicForkDetector_test.go
@@ -444,7 +444,7 @@ func TestBasicForkDetector_ResetProbableHighestNonce(t *testing.T) {
 	assert.Equal(t, uint64(11), bfd.ProbableHighestNonce())
 
 	rounderMock.RoundIndex = 22
-	bfd.ResetProbableHighestNonceIfNeed()
+	bfd.ResetProbableHighestNonceIfNeeded()
 	assert.Equal(t, uint64(10), bfd.ProbableHighestNonce())
 }
 

--- a/process/sync/basicForkDetector_test.go
+++ b/process/sync/basicForkDetector_test.go
@@ -428,8 +428,23 @@ func TestBasicForkDetector_ProbableHighestNonce(t *testing.T) {
 	rounderMock.RoundIndex = 16
 	_ = bfd.AddHeader(&block.Header{PubKeysBitmap: []byte("X"), Nonce: 11, Round: 15}, []byte("hash3"), process.BHReceived)
 	assert.Equal(t, uint64(11), bfd.ProbableHighestNonce())
+}
+
+func TestBasicForkDetector_ResetProbableHighestNonce(t *testing.T) {
+	t.Parallel()
+	rounderMock := &mock.RounderMock{}
+	bfd, _ := sync.NewBasicForkDetector(rounderMock)
+
+	rounderMock.RoundIndex = 15
+	_ = bfd.AddHeader(&block.Header{PubKeysBitmap: []byte("X"), Nonce: 10, Round: 14}, []byte("hash3"), process.BHProcessed)
+	assert.Equal(t, uint64(10), bfd.ProbableHighestNonce())
+
+	rounderMock.RoundIndex = 16
+	_ = bfd.AddHeader(&block.Header{PubKeysBitmap: []byte("X"), Nonce: 11, Round: 15}, []byte("hash3"), process.BHReceived)
+	assert.Equal(t, uint64(11), bfd.ProbableHighestNonce())
 
 	rounderMock.RoundIndex = 22
+	bfd.ResetProbableHighestNonceIfNeed()
 	assert.Equal(t, uint64(10), bfd.ProbableHighestNonce())
 }
 

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -397,7 +397,7 @@ func (boot *MetaBootstrap) SyncBlock() error {
 
 	hdr, err := boot.getHeaderRequestingIfMissing(nonce)
 	if err != nil {
-		boot.forkDetector.ResetProbableHighestNonceIfNeed()
+		boot.forkDetector.ResetProbableHighestNonceIfNeeded()
 		return err
 	}
 

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -397,6 +397,7 @@ func (boot *MetaBootstrap) SyncBlock() error {
 
 	hdr, err := boot.getHeaderRequestingIfMissing(nonce)
 	if err != nil {
+		boot.forkDetector.ResetProbableHighestNonceIfNeed()
 		return err
 	}
 

--- a/process/sync/metablock_test.go
+++ b/process/sync/metablock_test.go
@@ -754,7 +754,7 @@ func TestMetaBootstrap_ShouldReturnTimeIsOutWhenMissingHeader(t *testing.T) {
 	forkDetector.ProbableHighestNonceCalled = func() uint64 {
 		return 100
 	}
-	forkDetector.ResetProbableHighestNonceIfNeedCalled = func() {
+	forkDetector.ResetProbableHighestNonceIfNeededCalled = func() {
 	}
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()

--- a/process/sync/metablock_test.go
+++ b/process/sync/metablock_test.go
@@ -754,6 +754,8 @@ func TestMetaBootstrap_ShouldReturnTimeIsOutWhenMissingHeader(t *testing.T) {
 	forkDetector.ProbableHighestNonceCalled = func() uint64 {
 		return 100
 	}
+	forkDetector.ResetProbableHighestNonceIfNeedCalled = func() {
+	}
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
 	account := &mock.AccountsStub{}

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -509,7 +509,7 @@ func (boot *ShardBootstrap) SyncBlock() error {
 
 	hdr, err := boot.getHeaderRequestingIfMissing(nonce)
 	if err != nil {
-		boot.forkDetector.ResetProbableHighestNonceIfNeed()
+		boot.forkDetector.ResetProbableHighestNonceIfNeeded()
 		return err
 	}
 

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -509,6 +509,7 @@ func (boot *ShardBootstrap) SyncBlock() error {
 
 	hdr, err := boot.getHeaderRequestingIfMissing(nonce)
 	if err != nil {
+		boot.forkDetector.ResetProbableHighestNonceIfNeed()
 		return err
 	}
 

--- a/process/sync/shardblock_test.go
+++ b/process/sync/shardblock_test.go
@@ -980,7 +980,7 @@ func TestBootstrap_ShouldReturnTimeIsOutWhenMissingHeader(t *testing.T) {
 	forkDetector.ProbableHighestNonceCalled = func() uint64 {
 		return 100
 	}
-	forkDetector.ResetProbableHighestNonceIfNeedCalled = func() {
+	forkDetector.ResetProbableHighestNonceIfNeededCalled = func() {
 	}
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
@@ -1236,7 +1236,7 @@ func TestBootstrap_SyncShouldSyncOneBlock(t *testing.T) {
 	forkDetector.ProbableHighestNonceCalled = func() uint64 {
 		return 2
 	}
-	forkDetector.ResetProbableHighestNonceIfNeedCalled = func() {
+	forkDetector.ResetProbableHighestNonceIfNeededCalled = func() {
 	}
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()

--- a/process/sync/shardblock_test.go
+++ b/process/sync/shardblock_test.go
@@ -249,7 +249,8 @@ func createForkDetector(removedNonce uint64, remFlags *removedFlags) process.For
 		},
 		ProbableHighestNonceCalled: func() uint64 {
 			return uint64(0)
-		}}
+		},
+	}
 }
 
 func initBlockchain() *mock.BlockChainMock {

--- a/process/sync/shardblock_test.go
+++ b/process/sync/shardblock_test.go
@@ -249,8 +249,7 @@ func createForkDetector(removedNonce uint64, remFlags *removedFlags) process.For
 		},
 		ProbableHighestNonceCalled: func() uint64 {
 			return uint64(0)
-		},
-	}
+		}}
 }
 
 func initBlockchain() *mock.BlockChainMock {
@@ -981,6 +980,8 @@ func TestBootstrap_ShouldReturnTimeIsOutWhenMissingHeader(t *testing.T) {
 	forkDetector.ProbableHighestNonceCalled = func() uint64 {
 		return 100
 	}
+	forkDetector.ResetProbableHighestNonceIfNeedCalled = func() {
+	}
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
 	account := &mock.AccountsStub{}
@@ -1234,6 +1235,8 @@ func TestBootstrap_SyncShouldSyncOneBlock(t *testing.T) {
 	}
 	forkDetector.ProbableHighestNonceCalled = func() uint64 {
 		return 2
+	}
+	forkDetector.ResetProbableHighestNonceIfNeedCalled = func() {
 	}
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
@@ -1496,7 +1499,8 @@ func TestBootstrap_ShouldSyncShouldReturnFalseWhenCurrentBlockIsNilAndRoundIndex
 		},
 		ProbableHighestNonceCalled: func() uint64 {
 			return 0
-		}}
+		},
+	}
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
 	account := &mock.AccountsStub{}


### PR DESCRIPTION
Because of the fallback mechanism from ForkDetector which set after n(5) rounds, in which no block is received, the node state from not sync to sync, just to force the node to try to propose the next block it could damage the state. If in the same time when the node is stucked in processBlock or commitBlock called from SyncBlock, the node will enter in createBlockBody from consensus as a proposer it will dirty the account state.