### PR TITLE
bugfix for stuck go routines writing on a chan in basePreProcess

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -86,7 +86,7 @@
         Size = 100000
         Type = "LRU"
     [UnsignedTransactionStorage.DB]
-        FilePath = "SmartContractResult"
+        FilePath = "UnsignedTransactions"
         Type = "LvlDBSerial"
         BatchDelaySeconds = 15
         MaxBatchSize = 30000

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -323,6 +323,7 @@ func startNode(ctx *cli.Context, log *logger.Logger, version string) error {
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 	log.Info(fmt.Sprintf("Starting node with version %s\n", version))
+	log.Info(fmt.Sprintf("Process ID: %d\n", os.Getpid()))
 
 	configurationFileName := ctx.GlobalString(configurationFile.Name)
 	generalConfig, err := loadMainConfig(configurationFileName, log)
@@ -835,7 +836,7 @@ func initLogFileAndStatsMonitor(config *config.Config, pubKey crypto.PublicKey, 
 
 	hexPublicKey := core.GetTrimmedPk(hex.EncodeToString(publicKey))
 	err = log.ApplyOptions(
-		logger.WithFileRotation(hexPublicKey,  filepath.Join(workingDir, defaultLogPath), "log"),
+		logger.WithFileRotation(hexPublicKey, filepath.Join(workingDir, defaultLogPath), "log"),
 		logger.WithStderrRedirect(),
 	)
 	if err != nil {

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -236,7 +236,7 @@ func main() {
 	app := cli.NewApp()
 	cli.AppHelpTemplate = nodeHelpTemplate
 	app.Name = "Elrond Node CLI App"
-	app.Version = "v1.0.8"
+	app.Version = "v1.0.9"
 	app.Usage = "This is the entry point for starting a new Elrond node - the app will start after the genesis timestamp"
 	app.Flags = []cli.Flag{
 		genesisFile,

--- a/process/block/preprocess/basePreProcess.go
+++ b/process/block/preprocess/basePreProcess.go
@@ -145,7 +145,6 @@ func (bpp *basePreProcess) baseReceivedTransaction(
 	txPool dataRetriever.ShardedDataCacherNotifier,
 ) bool {
 	forBlock.mutTxsForBlock.Lock()
-	defer forBlock.mutTxsForBlock.Unlock()
 
 	if forBlock.missingTxs > 0 {
 		txInfoForHash := forBlock.txHashAndInfo[string(txHash)]
@@ -157,9 +156,12 @@ func (bpp *basePreProcess) baseReceivedTransaction(
 				forBlock.missingTxs--
 			}
 		}
+		missingTxs := forBlock.missingTxs
+		forBlock.mutTxsForBlock.Unlock()
 
-		return forBlock.missingTxs == 0
+		return missingTxs == 0
 	}
+	forBlock.mutTxsForBlock.Unlock()
 
 	return false
 }

--- a/process/block/preprocess/basePreProcess.go
+++ b/process/block/preprocess/basePreProcess.go
@@ -144,9 +144,9 @@ func (bpp *basePreProcess) baseReceivedTransaction(
 	forBlock *txsForBlock,
 	txPool dataRetriever.ShardedDataCacherNotifier,
 ) bool {
-	currMissingTxs := 0
-
 	forBlock.mutTxsForBlock.Lock()
+	defer forBlock.mutTxsForBlock.Unlock()
+
 	if forBlock.missingTxs > 0 {
 		txInfoForHash := forBlock.txHashAndInfo[string(txHash)]
 		if txInfoForHash != nil && txInfoForHash.txShardInfo != nil &&
@@ -158,11 +158,10 @@ func (bpp *basePreProcess) baseReceivedTransaction(
 			}
 		}
 
-		currMissingTxs = forBlock.missingTxs
+		return forBlock.missingTxs == 0
 	}
-	forBlock.mutTxsForBlock.Unlock()
 
-	return currMissingTxs == 0
+	return false
 }
 
 // getTransactionFromPool gets the transaction from a given shard id and a given transaction hash


### PR DESCRIPTION
fixed a bug in preprocessor when a new tx is intercepted. It should write on received chan only if it was requested.
added process ID in main.go