### PR TITLE
Bug/en 3214 fix bug in "Has" method from nonceSyncMapCacher

### DIFF
--- a/dataRetriever/dataPool/nonceSyncMapCacher.go
+++ b/dataRetriever/dataPool/nonceSyncMapCacher.go
@@ -119,7 +119,11 @@ func (nspc *nonceSyncMapCacher) RemoveShardId(nonce uint64, shardId uint32) {
 		return
 	}
 
-	syncMap := val.(*ShardIdHashSyncMap)
+	syncMap, ok := val.(*ShardIdHashSyncMap)
+	if !ok {
+		return
+	}
+
 	syncMap.Delete(shardId)
 }
 
@@ -143,9 +147,19 @@ func (nspc *nonceSyncMapCacher) callAddedDataHandlers(nonce uint64, shardId uint
 	nspc.mutAddedDataHandlers.RUnlock()
 }
 
-// Has returns true if a map is found for provided nonce
-func (nspc *nonceSyncMapCacher) Has(nonce uint64) bool {
-	_, ok := nspc.cacher.Peek(nspc.nonceConverter.ToByteSlice(nonce))
+// Has returns true if a map is found for provided nonce ans shardId
+func (nspc *nonceSyncMapCacher) Has(nonce uint64, shardId uint32) bool {
+	val, ok := nspc.cacher.Peek(nspc.nonceConverter.ToByteSlice(nonce))
+	if !ok {
+		return false
+	}
 
-	return ok
+	syncMap, ok := val.(*ShardIdHashSyncMap)
+	if !ok {
+		return false
+	}
+
+	_, exists := syncMap.Load(shardId)
+
+	return exists
 }

--- a/dataRetriever/dataPool/nonceSyncMapCacher_test.go
+++ b/dataRetriever/dataPool/nonceSyncMapCacher_test.go
@@ -462,7 +462,7 @@ func TestNonceSyncMapCacher_HasNotFoundShouldRetFalse(t *testing.T) {
 	nsmc, _ := dataPool.NewNonceSyncMapCacher(cacher, nonceConverter)
 
 	inexistentNonce := uint64(67)
-	has := nsmc.Has(inexistentNonce)
+	has := nsmc.Has(inexistentNonce, 0)
 
 	assert.False(t, has)
 }
@@ -475,8 +475,10 @@ func TestNonceSyncMapCacher_HasFoundShouldRetTrue(t *testing.T) {
 	nsmc, _ := dataPool.NewNonceSyncMapCacher(cacher, nonceConverter)
 
 	nonce := uint64(67)
-	nsmc.Merge(nonce, &dataPool.ShardIdHashSyncMap{})
-	has := nsmc.Has(nonce)
+	syncMap := &dataPool.ShardIdHashSyncMap{}
+	syncMap.Store(0, []byte("X"))
+	nsmc.Merge(nonce, syncMap)
+	has := nsmc.Has(nonce, 0)
 
 	assert.True(t, has)
 }

--- a/dataRetriever/interface.go
+++ b/dataRetriever/interface.go
@@ -173,7 +173,7 @@ type Uint64SyncMapCacher interface {
 	RemoveNonce(nonce uint64)
 	RemoveShardId(nonce uint64, shardId uint32)
 	RegisterHandler(handler func(nonce uint64, shardId uint32, value []byte))
-	Has(nonce uint64) bool
+	Has(nonce uint64, shardId uint32) bool
 }
 
 // PoolsHolder defines getters for data pools

--- a/dataRetriever/mock/uint64SyncMapCacherStub.go
+++ b/dataRetriever/mock/uint64SyncMapCacherStub.go
@@ -11,7 +11,7 @@ type Uint64SyncMapCacherStub struct {
 	RemoveNonceCalled     func(nonce uint64)
 	RemoveShardIdCalled   func(nonce uint64, shardId uint32)
 	RegisterHandlerCalled func(handler func(nonce uint64, shardId uint32, value []byte))
-	HasCalled             func(nonce uint64) bool
+	HasCalled             func(nonce uint64, shardId uint32) bool
 }
 
 func (usmcs *Uint64SyncMapCacherStub) Clear() {
@@ -34,8 +34,8 @@ func (usmcs *Uint64SyncMapCacherStub) RegisterHandler(handler func(nonce uint64,
 	usmcs.RegisterHandlerCalled(handler)
 }
 
-func (usmcs *Uint64SyncMapCacherStub) Has(nonce uint64) bool {
-	return usmcs.HasCalled(nonce)
+func (usmcs *Uint64SyncMapCacherStub) Has(nonce uint64, shardId uint32) bool {
+	return usmcs.HasCalled(nonce, shardId)
 }
 
 func (usmcs *Uint64SyncMapCacherStub) RemoveShardId(nonce uint64, shardId uint32) {

--- a/integrationTests/consensus/consensus_test.go
+++ b/integrationTests/consensus/consensus_test.go
@@ -49,7 +49,7 @@ func initNodesAndTest(numNodes, consensusSize, numInvalid uint32, roundTime uint
 		for i := uint32(0); i < numInvalid; i++ {
 			nodes[i].blkProcessor.ProcessBlockCalled = func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler, haveTime func() time.Duration) error {
 				fmt.Println("process block invalid ", header.GetRound(), header.GetNonce(), getPkEncoded(nodes[i].pk))
-				return process.ErrInvalidBlockHash
+				return process.ErrBlockHashDoesNotMatch
 			}
 			nodes[i].blkProcessor.CreateBlockHeaderCalled = func(body data.BodyHandler, round uint32, haveTime func() bool) (handler data.HeaderHandler, e error) {
 				return nil, process.ErrAccountStateDirty

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -211,7 +211,7 @@ func (bp *baseProcessor) isHdrConstructionValid(currHdr, prevHdr data.HeaderHand
 	}
 
 	if !bytes.Equal(currHdr.GetPrevHash(), prevHeaderHash) {
-		return process.ErrInvalidBlockHash
+		return process.ErrInvalidNotarizedBlockHash
 	}
 
 	return nil

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -103,7 +103,7 @@ func (bp *baseProcessor) checkBlockValidity(
 				core.ToB64(chainHandler.GetGenesisHeaderHash()),
 				core.ToB64(headerHandler.GetPrevHash())))
 
-			return process.ErrInvalidBlockHash
+			return process.ErrBlockHashDoesNotMatch
 		}
 
 		log.Info(fmt.Sprintf("nonce not match: local block nonce is 0 and node received block with nonce %d\n",
@@ -128,7 +128,7 @@ func (bp *baseProcessor) checkBlockValidity(
 		log.Info(fmt.Sprintf("hash not match: local block hash is %s and node received block with previous hash %s\n",
 			core.ToB64(prevHeaderHash), core.ToB64(headerHandler.GetPrevHash())))
 
-		return process.ErrInvalidBlockHash
+		return process.ErrBlockHashDoesNotMatch
 	}
 
 	if bodyHandler != nil {
@@ -211,7 +211,7 @@ func (bp *baseProcessor) isHdrConstructionValid(currHdr, prevHdr data.HeaderHand
 	}
 
 	if !bytes.Equal(currHdr.GetPrevHash(), prevHeaderHash) {
-		return process.ErrInvalidNotarizedBlockHash
+		return process.ErrNotarizedBlockHashDoesNotMatch
 	}
 
 	return nil

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -333,7 +333,7 @@ func TestBlockProcessor_CheckBlockValidity(t *testing.T) {
 	hdr.TimeStamp = 0
 	hdr.PrevHash = []byte("X")
 	err := bp.CheckBlockValidity(blkc, hdr, body)
-	assert.Equal(t, process.ErrInvalidBlockHash, err)
+	assert.Equal(t, process.ErrBlockHashDoesNotMatch, err)
 
 	hdr.PrevHash = []byte("")
 	err = bp.CheckBlockValidity(blkc, hdr, body)
@@ -356,7 +356,7 @@ func TestBlockProcessor_CheckBlockValidity(t *testing.T) {
 	hdr.Nonce = 2
 	hdr.PrevHash = []byte("X")
 	err = bp.CheckBlockValidity(blkc, hdr, body)
-	assert.Equal(t, process.ErrInvalidBlockHash, err)
+	assert.Equal(t, process.ErrBlockHashDoesNotMatch, err)
 
 	hdr.Nonce = 3
 	hdr.PrevHash = []byte("")

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -112,7 +112,7 @@ func initDataPool(testHash []byte) *mock.PoolsHolderStub {
 		HeadersNoncesCalled: func() dataRetriever.Uint64SyncMapCacher {
 			return &mock.Uint64SyncMapCacherStub{
 				MergeCalled: func(u uint64, syncMap dataRetriever.ShardIdHashMap) {},
-				HasCalled: func(nonce uint64) bool {
+				HasCalled: func(nonce uint64, shardId uint32) bool {
 					return true
 				},
 			}

--- a/process/block/metablock_test.go
+++ b/process/block/metablock_test.go
@@ -2237,7 +2237,7 @@ func TestMetaProcessor_IsHdrConstructionValid(t *testing.T) {
 	prevHdr.RandSeed = currRandSeed
 	currHdr.PrevHash = []byte("wronghash")
 	err = mp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrInvalidBlockHash)
+	assert.Equal(t, err, process.ErrInvalidNotarizedBlockHash)
 
 	currHdr.PrevHash = prevHash
 	prevHdr.RootHash = []byte("prevRootHash")

--- a/process/block/metablock_test.go
+++ b/process/block/metablock_test.go
@@ -409,7 +409,7 @@ func TestMetaProcessor_ProcessWithHeaderNotCorrectPrevHashShouldErr(t *testing.T
 
 	body := &block.MetaBlockBody{}
 	err := mp.ProcessBlock(blkc, hdr, body, haveTime)
-	assert.Equal(t, process.ErrInvalidBlockHash, err)
+	assert.Equal(t, process.ErrBlockHashDoesNotMatch, err)
 }
 
 func TestMetaProcessor_ProcessBlockWithErrOnVerifyStateRootCallShouldRevertState(t *testing.T) {
@@ -2237,7 +2237,7 @@ func TestMetaProcessor_IsHdrConstructionValid(t *testing.T) {
 	prevHdr.RandSeed = currRandSeed
 	currHdr.PrevHash = []byte("wronghash")
 	err = mp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrInvalidNotarizedBlockHash)
+	assert.Equal(t, err, process.ErrNotarizedBlockHashDoesNotMatch)
 
 	currHdr.PrevHash = prevHash
 	prevHdr.RootHash = []byte("prevRootHash")

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -881,7 +881,7 @@ func (sp *shardProcessor) receivedMetaBlock(metaBlockHash []byte) {
 func (sp *shardProcessor) requestFinalMissingHeaders() uint32 {
 	requestedBlockHeaders := uint32(0)
 	for i := sp.currHighestMetaHdrNonce + 1; i <= sp.currHighestMetaHdrNonce+uint64(sp.metaBlockFinality); i++ {
-		if !sp.dataPool.HeadersNonces().Has(i) {
+		if !sp.dataPool.HeadersNonces().Has(i, sharding.MetachainShardId) {
 			requestedBlockHeaders++
 			go sp.onRequestHeaderHandlerByNonce(sharding.MetachainShardId, i)
 		}

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -3619,7 +3619,7 @@ func TestShardProcessor_IsHdrConstructionValid(t *testing.T) {
 	prevHdr.RandSeed = currRandSeed
 	currHdr.PrevHash = []byte("wronghash")
 	err = sp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrInvalidBlockHash)
+	assert.Equal(t, err, process.ErrInvalidNotarizedBlockHash)
 
 	currHdr.PrevHash = prevHash
 	prevHdr.RootHash = []byte("prevRootHash")

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -789,7 +789,7 @@ func TestShardProcessor_ProcessWithHeaderNotCorrectPrevHashShouldErr(t *testing.
 		},
 	}
 	err := sp.ProcessBlock(blkc, hdr, body, haveTime)
-	assert.Equal(t, process.ErrInvalidBlockHash, err)
+	assert.Equal(t, process.ErrBlockHashDoesNotMatch, err)
 }
 
 func TestShardProcessor_ProcessBlockWithErrOnProcessBlockTransactionsCallShouldRevertState(t *testing.T) {
@@ -3619,7 +3619,7 @@ func TestShardProcessor_IsHdrConstructionValid(t *testing.T) {
 	prevHdr.RandSeed = currRandSeed
 	currHdr.PrevHash = []byte("wronghash")
 	err = sp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrInvalidNotarizedBlockHash)
+	assert.Equal(t, err, process.ErrNotarizedBlockHashDoesNotMatch)
 
 	currHdr.PrevHash = prevHash
 	prevHdr.RootHash = []byte("prevRootHash")

--- a/process/coordinator/process_test.go
+++ b/process/coordinator/process_test.go
@@ -90,7 +90,7 @@ func initDataPool(testHash []byte) *mock.PoolsHolderStub {
 		HeadersNoncesCalled: func() dataRetriever.Uint64SyncMapCacher {
 			return &mock.Uint64SyncMapCacherStub{
 				MergeCalled: func(u uint64, hashMap dataRetriever.ShardIdHashMap) {},
-				HasCalled: func(nonce uint64) bool {
+				HasCalled: func(nonce uint64, shardId uint32) bool {
 					return true
 				},
 			}

--- a/process/errors.go
+++ b/process/errors.go
@@ -94,6 +94,9 @@ var ErrWrongNonceInBlock = errors.New("wrong nonce in block")
 // ErrInvalidBlockHash signals the hash of the block is not matching with the previous one
 var ErrInvalidBlockHash = errors.New("invalid block hash")
 
+// ErrInvalidNotarizedBlockHash signals the hash of the notarized block is not matching with the previous one
+var ErrInvalidNotarizedBlockHash = errors.New("invalid notarized block hash")
+
 // ErrMissingTransaction signals that one transaction is missing
 var ErrMissingTransaction = errors.New("missing transaction")
 

--- a/process/errors.go
+++ b/process/errors.go
@@ -91,11 +91,11 @@ var ErrNilRootHash = errors.New("root hash is nil")
 // ErrWrongNonceInBlock signals the nonce in block is different than expected nonce
 var ErrWrongNonceInBlock = errors.New("wrong nonce in block")
 
-// ErrInvalidBlockHash signals the hash of the block is not matching with the previous one
-var ErrInvalidBlockHash = errors.New("invalid block hash")
+// ErrBlockHashDoesNotMatch signals the hash of the block is not matching with the previous one
+var ErrBlockHashDoesNotMatch = errors.New("block hash does not match")
 
-// ErrInvalidNotarizedBlockHash signals the hash of the notarized block is not matching with the previous one
-var ErrInvalidNotarizedBlockHash = errors.New("invalid notarized block hash")
+// ErrNotarizedBlockHashDoesNotMatch signals the hash of the notarized block is not matching with the previous one
+var ErrNotarizedBlockHashDoesNotMatch = errors.New("notarized block hash does not match")
 
 // ErrMissingTransaction signals that one transaction is missing
 var ErrMissingTransaction = errors.New("missing transaction")

--- a/process/mock/uint64SyncMapCacherStub.go
+++ b/process/mock/uint64SyncMapCacherStub.go
@@ -11,7 +11,7 @@ type Uint64SyncMapCacherStub struct {
 	RemoveNonceCalled     func(nonce uint64)
 	RemoveShardIdCalled   func(nonce uint64, shardId uint32)
 	RegisterHandlerCalled func(handler func(nonce uint64, shardId uint32, value []byte))
-	HasCalled             func(nonce uint64) bool
+	HasCalled             func(nonce uint64, shardId uint32) bool
 }
 
 func (usmcs *Uint64SyncMapCacherStub) Clear() {
@@ -34,8 +34,8 @@ func (usmcs *Uint64SyncMapCacherStub) RegisterHandler(handler func(nonce uint64,
 	usmcs.RegisterHandlerCalled(handler)
 }
 
-func (usmcs *Uint64SyncMapCacherStub) Has(nonce uint64) bool {
-	return usmcs.HasCalled(nonce)
+func (usmcs *Uint64SyncMapCacherStub) Has(nonce uint64, shardId uint32) bool {
+	return usmcs.HasCalled(nonce, shardId)
 }
 
 func (usmcs *Uint64SyncMapCacherStub) RemoveShardId(nonce uint64, shardId uint32) {

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/data/state"
 	"github.com/ElrondNetwork/elrond-go/data/typeConverters/uint64ByteSlice"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
-	"github.com/ElrondNetwork/elrond-go/dataRetriever/dataPool"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -365,17 +364,6 @@ func (boot *MetaBootstrap) syncBlocks() {
 func (boot *MetaBootstrap) doJobOnSyncBlockFail(hdr *block.MetaBlock, err error) {
 	if err == process.ErrTimeIsOut {
 		boot.requestsWithTimeout++
-	}
-
-	if err == process.ErrInvalidBlockHash {
-		prevHdr, errNotCritical := boot.getHeaderWithHashRequestingIfMissing(hdr.GetPrevHash())
-		if errNotCritical != nil {
-			log.Info(errNotCritical.Error())
-		} else {
-			syncMap := &dataPool.ShardIdHashSyncMap{}
-			syncMap.Store(prevHdr.GetShardID(), hdr.GetPrevHash())
-			boot.headersNonces.Merge(prevHdr.GetNonce(), syncMap)
-		}
 	}
 
 	isForkDetected := err != process.ErrTimeIsOut || boot.requestsWithTimeout >= process.MaxRequestsWithTimeoutAllowed

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -381,7 +381,7 @@ func (boot *MetaBootstrap) doJobOnSyncBlockFail(hdr *block.MetaBlock, err error)
 	// The below section of code fixed a situation when all peers would have replaced in their headerNonceHash pool a
 	// good/used header in their blockchain construction, with a wrong/unused header on which they didn't construct,
 	// but which came after a late broadcast from a valid proposer.
-	if err == process.ErrInvalidBlockHash {
+	if err == process.ErrBlockHashDoesNotMatch {
 		prevHdr, errNotCritical := boot.getHeaderWithHashRequestingIfMissing(hdr.GetPrevHash())
 		if errNotCritical != nil {
 			log.Info(errNotCritical.Error())

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/data/state"
 	"github.com/ElrondNetwork/elrond-go/data/typeConverters/uint64ByteSlice"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever/dataPool"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -364,6 +365,17 @@ func (boot *MetaBootstrap) syncBlocks() {
 func (boot *MetaBootstrap) doJobOnSyncBlockFail(hdr *block.MetaBlock, err error) {
 	if err == process.ErrTimeIsOut {
 		boot.requestsWithTimeout++
+	}
+
+	if err == process.ErrInvalidBlockHash {
+		prevHdr, errNotCritical := boot.getHeaderWithHashRequestingIfMissing(hdr.GetPrevHash())
+		if errNotCritical != nil {
+			log.Info(errNotCritical.Error())
+		} else {
+			syncMap := &dataPool.ShardIdHashSyncMap{}
+			syncMap.Store(prevHdr.GetShardID(), hdr.GetPrevHash())
+			boot.headersNonces.Merge(prevHdr.GetNonce(), syncMap)
+		}
 	}
 
 	isForkDetected := err != process.ErrTimeIsOut || boot.requestsWithTimeout >= process.MaxRequestsWithTimeoutAllowed

--- a/process/sync/metablock_test.go
+++ b/process/sync/metablock_test.go
@@ -1074,7 +1074,7 @@ func TestMetaBootstrap_SyncBlockShouldReturnErrorWhenProcessBlockFailed(t *testi
 		mock.SyncTimerMock{})
 
 	ebm.ProcessBlockCalled = func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler, haveTime func() time.Duration) error {
-		return process.ErrInvalidBlockHash
+		return process.ErrBlockHashDoesNotMatch
 	}
 
 	bs, _ := sync.NewMetaBootstrap(
@@ -1095,7 +1095,7 @@ func TestMetaBootstrap_SyncBlockShouldReturnErrorWhenProcessBlockFailed(t *testi
 
 	err := bs.SyncBlock()
 
-	assert.Equal(t, process.ErrInvalidBlockHash, err)
+	assert.Equal(t, process.ErrBlockHashDoesNotMatch, err)
 }
 
 func TestMetaBootstrap_ShouldSyncShouldReturnFalseWhenCurrentBlockIsNilAndRoundIndexIsZero(t *testing.T) {

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/data/state"
 	"github.com/ElrondNetwork/elrond-go/data/typeConverters/uint64ByteSlice"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
-	"github.com/ElrondNetwork/elrond-go/dataRetriever/dataPool"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -476,17 +475,6 @@ func (boot *ShardBootstrap) syncBlocks() {
 func (boot *ShardBootstrap) doJobOnSyncBlockFail(hdr *block.Header, err error) {
 	if err == process.ErrTimeIsOut {
 		boot.requestsWithTimeout++
-	}
-
-	if err == process.ErrInvalidBlockHash {
-		prevHdr, errNotCritical := boot.getHeaderWithHashRequestingIfMissing(hdr.GetPrevHash())
-		if errNotCritical != nil {
-			log.Info(errNotCritical.Error())
-		} else {
-			syncMap := &dataPool.ShardIdHashSyncMap{}
-			syncMap.Store(prevHdr.GetShardID(), hdr.GetPrevHash())
-			boot.headersNonces.Merge(prevHdr.GetNonce(), syncMap)
-		}
 	}
 
 	isForkDetected := err != process.ErrTimeIsOut || boot.requestsWithTimeout >= process.MaxRequestsWithTimeoutAllowed

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/data/state"
 	"github.com/ElrondNetwork/elrond-go/data/typeConverters/uint64ByteSlice"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever/dataPool"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -475,6 +476,17 @@ func (boot *ShardBootstrap) syncBlocks() {
 func (boot *ShardBootstrap) doJobOnSyncBlockFail(hdr *block.Header, err error) {
 	if err == process.ErrTimeIsOut {
 		boot.requestsWithTimeout++
+	}
+
+	if err == process.ErrInvalidBlockHash {
+		prevHdr, errNotCritical := boot.getHeaderWithHashRequestingIfMissing(hdr.GetPrevHash())
+		if errNotCritical != nil {
+			log.Info(errNotCritical.Error())
+		} else {
+			syncMap := &dataPool.ShardIdHashSyncMap{}
+			syncMap.Store(prevHdr.GetShardID(), hdr.GetPrevHash())
+			boot.headersNonces.Merge(prevHdr.GetNonce(), syncMap)
+		}
 	}
 
 	isForkDetected := err != process.ErrTimeIsOut || boot.requestsWithTimeout >= process.MaxRequestsWithTimeoutAllowed

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -492,7 +492,7 @@ func (boot *ShardBootstrap) doJobOnSyncBlockFail(hdr *block.Header, err error) {
 	// The below section of code fixed a situation when all peers would have replaced in their headerNonceHash pool a
 	// good/used header in their blockchain construction, with a wrong/unused header on which they didn't construct,
 	// but which came after a late broadcast from a valid proposer.
-	if err == process.ErrInvalidBlockHash {
+	if err == process.ErrBlockHashDoesNotMatch {
 		prevHdr, errNotCritical := boot.getHeaderWithHashRequestingIfMissing(hdr.GetPrevHash())
 		if errNotCritical != nil {
 			log.Info(errNotCritical.Error())

--- a/process/sync/shardblock_test.go
+++ b/process/sync/shardblock_test.go
@@ -1488,7 +1488,7 @@ func TestBootstrap_SyncBlockShouldReturnErrorWhenProcessBlockFailed(t *testing.T
 		mock.SyncTimerMock{})
 
 	ebm.ProcessBlockCalled = func(blockChain data.ChainHandler, header data.HeaderHandler, body data.BodyHandler, haveTime func() time.Duration) error {
-		return process.ErrInvalidBlockHash
+		return process.ErrBlockHashDoesNotMatch
 	}
 
 	bs, _ := sync.NewShardBootstrap(
@@ -1508,7 +1508,7 @@ func TestBootstrap_SyncBlockShouldReturnErrorWhenProcessBlockFailed(t *testing.T
 	)
 
 	err := bs.SyncBlock()
-	assert.Equal(t, process.ErrInvalidBlockHash, err)
+	assert.Equal(t, process.ErrBlockHashDoesNotMatch, err)
 }
 
 func TestBootstrap_ShouldSyncShouldReturnFalseWhenCurrentBlockIsNilAndRoundIndexIsZero(t *testing.T) {


### PR DESCRIPTION
* Fixed "Has" method from nonceSyncMapCacher
* ErrInvalidBlockHash has been split in two different errors (one for current shard blocks and one for notarized blocks) to help debugging