### PR TITLE
Add pprof routes to node when enabled by flag

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/api/transaction"
 	"github.com/ElrondNetwork/elrond-go/api/vmValues"
 	"github.com/gin-contrib/cors"
+	"github.com/gin-contrib/pprof"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/gin-gonic/gin/json"
@@ -32,6 +33,7 @@ type prometheus struct {
 // MainApiHandler interface defines methods that can be used from `elrondFacade` context variable
 type MainApiHandler interface {
 	RestApiPort() string
+	PprofEnabled() bool
 	PrometheusMonitoring() bool
 	PrometheusJoinURL() string
 	PrometheusNetworkID() string
@@ -108,6 +110,9 @@ func registerRoutes(ws *gin.Engine, elrondFacade middleware.ElrondHandler) {
 		nodeRoutes.GET("/metrics", gin.WrapH(promhttp.Handler()))
 	}
 
+	if apiHandler.PprofEnabled() {
+		pprof.Register(ws)
+	}
 }
 
 func registerValidators() error {

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -122,6 +122,17 @@ VERSION:
 		Value: 0,
 	}
 	// profileMode defines a flag for profiling the binary
+	// If enabled, it will open the pprof routes over the default gin rest webserver.
+	// There are several routes that will be available for profiling (profiling can be analyzed with: go tool pprof):
+	//  /debug/pprof/ (can be accessed in the browser, will list the available options)
+	//  /debug/pprof/goroutine
+	//  /debug/pprof/heap
+	//  /debug/pprof/threadcreate
+	//  /debug/pprof/block
+	//  /debug/pprof/mutex
+	//  /debug/pprof/profile (CPU profile)
+	//  /debug/pprof/trace?seconds=5 (CPU trace) -> being a trace, can be analyzed with: go tool trace
+	// Usage: go tool pprof http(s)://ip.of.the.server/debug/pprof/xxxxx
 	profileMode = cli.BoolFlag{
 		Name:  "profile-mode",
 		Usage: "Boolean profiling mode option. If set to true, the /debug/pprof routes will be available on the node for profiling the application.",

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -39,7 +39,6 @@ import (
 	"github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/ElrondNetwork/elrond-vm/iele/elrond/node/endpoint"
 	"github.com/google/gops/agent"
-	"github.com/pkg/profile"
 	"github.com/urfave/cli"
 )
 
@@ -123,10 +122,9 @@ VERSION:
 		Value: 0,
 	}
 	// profileMode defines a flag for profiling the binary
-	profileMode = cli.StringFlag{
+	profileMode = cli.BoolFlag{
 		Name:  "profile-mode",
-		Usage: "Profiling mode. Available options: cpu, mem, mutex, block",
-		Value: "",
+		Usage: "Boolean profiling mode option. If set to true, the /debug/pprof routes will be available on the node for profiling the application.",
 	}
 	// txSignSkIndex defines a flag that specifies the 0-th based index of the private key to be used from initialBalancesSk.pem file
 	txSignSkIndex = cli.IntFlag{
@@ -305,22 +303,6 @@ func getSuite(config *config.Config) (crypto.Suite, error) {
 func startNode(ctx *cli.Context, log *logger.Logger, version string) error {
 	logLevel := ctx.GlobalString(logLevel.Name)
 	log.SetLevel(logLevel)
-
-	profileMode := ctx.GlobalString(profileMode.Name)
-	switch profileMode {
-	case "cpu":
-		p := profile.Start(profile.CPUProfile, profile.ProfilePath("."), profile.NoShutdownHook)
-		defer p.Stop()
-	case "mem":
-		p := profile.Start(profile.MemProfile, profile.ProfilePath("."), profile.NoShutdownHook)
-		defer p.Stop()
-	case "mutex":
-		p := profile.Start(profile.MutexProfile, profile.ProfilePath("."), profile.NoShutdownHook)
-		defer p.Stop()
-	case "block":
-		p := profile.Start(profile.BlockProfile, profile.ProfilePath("."), profile.NoShutdownHook)
-		defer p.Stop()
-	}
 
 	enableGopsIfNeeded(ctx, log)
 
@@ -565,6 +547,7 @@ func startNode(ctx *cli.Context, log *logger.Logger, version string) error {
 
 	efConfig := &config.FacadeConfig{
 		RestApiPort:       ctx.GlobalString(restApiPort.Name),
+		PprofEnabled:      ctx.GlobalBool(profileMode.Name),
 		Prometheus:        ctx.GlobalBool(usePrometheus.Name) && prometheusURLAvailable,
 		PrometheusJoinURL: prometheusJoinUrl,
 		PrometheusJobName: generalConfig.GeneralSettings.NetworkID,

--- a/config/config.go
+++ b/config/config.go
@@ -176,6 +176,7 @@ type ElasticSearchConfig struct {
 // FacadeConfig will hold different configuration option that will be passed to the main ElrondFacade
 type FacadeConfig struct {
 	RestApiPort       string
+	PprofEnabled      bool
 	Prometheus        bool
 	PrometheusJoinURL string
 	PrometheusJobName string

--- a/facade/elrondNodeFacade.go
+++ b/facade/elrondNodeFacade.go
@@ -232,3 +232,8 @@ func (ef *ElrondNodeFacade) GetHeartbeats() ([]heartbeat.PubKeyHeartbeat, error)
 func (ef *ElrondNodeFacade) GetVmValue(address string, funcName string, argsBuff ...[]byte) ([]byte, error) {
 	return ef.apiResolver.GetVmValue(address, funcName, argsBuff...)
 }
+
+// PprofEnabled returns if profiling mode should be active or not on the application
+func (ef *ElrondNodeFacade) PprofEnabled() bool {
+	return ef.config.PprofEnabled
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f
 	github.com/elastic/go-elasticsearch/v7 v7.1.0
 	github.com/gin-contrib/cors v0.0.0-20190301062745-f9e10995c85a
+	github.com/gin-contrib/pprof v1.2.0
 	github.com/gin-gonic/gin v1.3.0
 	github.com/glycerine/go-capnproto v0.0.0-20190118050403-2d07de3aa7fc
 	github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gin-contrib/cors v0.0.0-20190301062745-f9e10995c85a h1:zBycVvXa03SIX+jdMv8wGu9TMDMWdN8EhaR1FoeKHNo=
 github.com/gin-contrib/cors v0.0.0-20190301062745-f9e10995c85a/go.mod h1:pL2kNE+DgDU+eQ+dary5bX0Z6LPP8nR6Mqs1iejILw4=
+github.com/gin-contrib/pprof v1.2.0 h1:tmuopx+/U4t4ImlPfWDpMcZF0x+egx0iA10e4/rR+PE=
+github.com/gin-contrib/pprof v1.2.0/go.mod h1:gOv+/B5pK9Hm3wuppCDM+WUwmGff5bwenVHS9/qpYYk=
 github.com/gin-contrib/sse v0.0.0-20170109093832-22d885f9ecc7 h1:AzN37oI0cOS+cougNAV9szl6CVoj2RYwzS3DpUQNtlY=
 github.com/gin-contrib/sse v0.0.0-20170109093832-22d885f9ecc7/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-gonic/gin v1.3.0 h1:kCmZyPklC0gVdL728E6Aj20uYBJV93nj/TkwBTKhFbs=
@@ -405,6 +407,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181221143128-b4a75ba826a6/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181228144115-9a3f9b0469bb/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Added pprof routes over gin. It can be used with pprof tool:
https://golang.org/pkg/net/http/pprof/
https://jvns.ca/blog/2017/09/24/profiling-go-with-pprof/