### PR TITLE
bugfix/make transaction coordinator call processors in strict order when processing miniblocks

### DIFF
--- a/process/coordinator/process_test.go
+++ b/process/coordinator/process_test.go
@@ -1443,7 +1443,7 @@ func TestShardProcessor_ProcessMiniBlockCompleteWithOkTxsShouldExecuteThemAndNot
 	haveTime := func() bool {
 		return true
 	}
-	preproc := tc.getPreprocessor(block.TxBlock)
+	preproc := tc.getPreProcessor(block.TxBlock)
 	err = tc.processCompleteMiniBlock(preproc, &miniBlock, 0, haveTime)
 
 	assert.Nil(t, err)
@@ -1547,7 +1547,7 @@ func TestShardProcessor_ProcessMiniBlockCompleteWithErrorWhileProcessShouldCallR
 	haveTime := func() bool {
 		return true
 	}
-	preproc := tc.getPreprocessor(block.TxBlock)
+	preproc := tc.getPreProcessor(block.TxBlock)
 	err = tc.processCompleteMiniBlock(preproc, &miniBlock, 0, haveTime)
 
 	assert.Equal(t, process.ErrHigherNonceInTransaction, err)

--- a/process/coordinator/process_test.go
+++ b/process/coordinator/process_test.go
@@ -434,12 +434,12 @@ func TestTransactionCoordinator_CreateBlockStarted(t *testing.T) {
 
 	tc.CreateBlockStarted()
 
-	tc.mutPreprocessor.Lock()
-	for _, value := range tc.txPreprocessors {
+	tc.mutPreProcessor.Lock()
+	for _, value := range tc.txPreProcessors {
 		txs := value.GetAllCurrentUsedTxs()
 		assert.Equal(t, 0, len(txs))
 	}
-	tc.mutPreprocessor.Unlock()
+	tc.mutPreProcessor.Unlock()
 }
 
 func TestTransactionCoordinator_CreateMarshalizedDataNilBody(t *testing.T) {

--- a/process/errors.go
+++ b/process/errors.go
@@ -405,3 +405,6 @@ var ErrNilPreProcessorsContainer = errors.New("preprocessors container is nil")
 
 // ErrUnknownBlockType signals that block type is not correct
 var ErrUnknownBlockType = errors.New("block type is unknown")
+
+// ErrMissingPreProcessor signals that required pre processor is missing
+var ErrMissingPreProcessor = errors.New("pre processor is missing")


### PR DESCRIPTION
There was a TODO in the code that it should be investigated if processing with multiple different processors can be done in parallel or not. The order in which the transactions for a selected account has to be processed are strict - increasing nonce one by one - , so the parallel processing would make this impossible. 
Furthermore, there is an undefined behavior if the same account is updated from 2 different places at the same time - both of them want to update the value. First they got the account from the trie with the initial balance, do some calculations and both save - for example both add 5 to the balance, because of parallel execution the balance of the account will be initial + 5, but it should be initial + 5 + 5.
Another problem is both processors wants to save into the same data field, it depends which one was called faster.  Multiple nodes might reach to different state roothashes because the order was different.