### PR TITLE
EN-3605 - heartbeat shard ID split into received and computed

### DIFF
--- a/api/node/routes_test.go
+++ b/api/node/routes_test.go
@@ -376,7 +376,7 @@ func TestHeartbeatstatus(t *testing.T) {
 			TimeStamp:       time.Now(),
 			MaxInactiveTime: heartbeat.Duration{Duration: 0},
 			IsActive:        true,
-			ShardID:         uint32(0),
+			ReceivedShardID: uint32(0),
 		},
 	}
 	facade := mock.Facade{

--- a/core/constants.go
+++ b/core/constants.go
@@ -70,7 +70,7 @@ const MetricCountAcceptedBlocks = "erd_count_accepted_blocks"
 const MetricNodeType = "erd_node_type"
 
 // MetricLiveValidatorNodes is the metric for monitoring live validators on the network
-const MetricLiveValidatorNodes = "erd_max_validator_nodes"
+const MetricLiveValidatorNodes = "erd_live_validator_nodes"
 
 // MetricConnectedNodes is the metric for monitoring total connected peers on the network
 const MetricConnectedNodes = "erd_connected_nodes"

--- a/facade/elrondNodeFacade_test.go
+++ b/facade/elrondNodeFacade_test.go
@@ -475,14 +475,14 @@ func TestElrondNodeFacade_GetHeartbeats(t *testing.T) {
 					TimeStamp:       time.Now(),
 					MaxInactiveTime: heartbeat.Duration{Duration: 0},
 					IsActive:        true,
-					ShardID:         uint32(0),
+					ReceivedShardID: uint32(0),
 				},
 				{
 					HexPublicKey:    "pk2",
 					TimeStamp:       time.Now(),
 					MaxInactiveTime: heartbeat.Duration{Duration: 0},
 					IsActive:        true,
-					ShardID:         uint32(0),
+					ReceivedShardID: uint32(0),
 				},
 			}
 		},

--- a/node/heartbeat/hearbeatMessageInfo.go
+++ b/node/heartbeat/hearbeatMessageInfo.go
@@ -16,7 +16,8 @@ type heartbeatMessageInfo struct {
 	getTimeHandler     func() time.Time
 	timeStamp          time.Time
 	isActive           bool
-	shardID            uint32
+	receivedShardID    uint32
+	computedShardID    uint32
 	versionNumber      string
 	nodeDisplayName    string
 	isValidator        bool
@@ -37,6 +38,7 @@ func newHeartbeatMessageInfo(
 		maxDurationPeerUnresponsive: maxDurationPeerUnresponsive,
 		maxInactiveTime:             Duration{0},
 		isActive:                    false,
+		receivedShardID:             uint32(0),
 		timeStamp:                   emptyTimestamp,
 		lastUptimeDowntime:          time.Now(),
 		totalUpTime:                 Duration{0},
@@ -81,7 +83,7 @@ func (hbmi *heartbeatMessageInfo) updateUpAndDownTime() {
 func (hbmi *heartbeatMessageInfo) HeartbeatReceived(shardID uint32, version string, nodeDisplayName string) {
 	crtTime := hbmi.getTimeHandler()
 	hbmi.updateFields()
-	hbmi.shardID = shardID
+	hbmi.receivedShardID = shardID
 	hbmi.updateMaxInactiveTimeDuration()
 	hbmi.timeStamp = crtTime
 	hbmi.versionNumber = version

--- a/node/heartbeat/hearbeatMessageInfo.go
+++ b/node/heartbeat/hearbeatMessageInfo.go
@@ -80,10 +80,12 @@ func (hbmi *heartbeatMessageInfo) updateUpAndDownTime() {
 }
 
 // HeartbeatReceived processes a new message arrived from a peer
-func (hbmi *heartbeatMessageInfo) HeartbeatReceived(shardID uint32, version string, nodeDisplayName string) {
+func (hbmi *heartbeatMessageInfo) HeartbeatReceived(computedShardID, receivedshardID uint32, version string,
+	nodeDisplayName string) {
 	crtTime := hbmi.getTimeHandler()
 	hbmi.updateFields()
-	hbmi.receivedShardID = shardID
+	hbmi.computedShardID = computedShardID
+	hbmi.receivedShardID = receivedshardID
 	hbmi.updateMaxInactiveTimeDuration()
 	hbmi.timeStamp = crtTime
 	hbmi.versionNumber = version

--- a/node/heartbeat/hearbeatMessageInfo_test.go
+++ b/node/heartbeat/hearbeatMessageInfo_test.go
@@ -42,14 +42,14 @@ func TestHeartbeatMessageInfo_HeartbeatReceivedShouldUpdate(t *testing.T) {
 
 	hbmi.HeartbeatReceived(uint32(0), "v0.1", "undefined")
 	assert.NotEqual(t, emptyTimestamp, hbmi.timeStamp)
-	assert.Equal(t, uint32(0), hbmi.shardID)
+	assert.Equal(t, uint32(0), hbmi.receivedShardID)
 
 	hbmi.HeartbeatReceived(uint32(1), "v0.1", "undefined")
 	assert.NotEqual(t, emptyTimestamp, hbmi.timeStamp)
-	assert.Equal(t, uint32(1), hbmi.shardID)
+	assert.Equal(t, uint32(1), hbmi.receivedShardID)
 }
 
-func TestHeartbeatMessageInfo_HeartbeatSweepShouldUpdate(t *testing.T) {
+func TestHeartbeatMessageInfo_HeartbeatUpdateFieldsShouldWork(t *testing.T) {
 	t.Parallel()
 
 	hbmi, _ := newHeartbeatMessageInfo(time.Duration(1), false)

--- a/node/heartbeat/hearbeatMessageInfo_test.go
+++ b/node/heartbeat/hearbeatMessageInfo_test.go
@@ -40,11 +40,11 @@ func TestHeartbeatMessageInfo_HeartbeatReceivedShouldUpdate(t *testing.T) {
 
 	assert.Equal(t, emptyTimestamp, hbmi.timeStamp)
 
-	hbmi.HeartbeatReceived(uint32(0), "v0.1", "undefined")
+	hbmi.HeartbeatReceived(uint32(0), uint32(0), "v0.1", "undefined")
 	assert.NotEqual(t, emptyTimestamp, hbmi.timeStamp)
 	assert.Equal(t, uint32(0), hbmi.receivedShardID)
 
-	hbmi.HeartbeatReceived(uint32(1), "v0.1", "undefined")
+	hbmi.HeartbeatReceived(uint32(0), uint32(1), "v0.1", "undefined")
 	assert.NotEqual(t, emptyTimestamp, hbmi.timeStamp)
 	assert.Equal(t, uint32(1), hbmi.receivedShardID)
 }
@@ -63,7 +63,7 @@ func TestHeartbeatMessageInfo_HeartbeatUpdateFieldsShouldWork(t *testing.T) {
 
 	assert.Equal(t, emptyTimestamp, hbmi.timeStamp)
 
-	hbmi.HeartbeatReceived(uint32(3), "v0.1", "undefined")
+	hbmi.HeartbeatReceived(uint32(0), uint32(3), "v0.1", "undefined")
 	assert.NotEqual(t, emptyTimestamp, hbmi.timeStamp)
 }
 
@@ -82,8 +82,8 @@ func TestHeartbeatMessageInfo_HeartbeatShouldUpdateUpTime(t *testing.T) {
 	assert.Equal(t, emptyTimestamp, hbmi.timeStamp)
 
 	// send heartbeat twice in order to calculate the duration between thm
-	hbmi.HeartbeatReceived(uint32(1), "v0.1", "undefined")
-	hbmi.HeartbeatReceived(uint32(2), "v0.1", "undefined")
+	hbmi.HeartbeatReceived(uint32(0), uint32(1), "v0.1", "undefined")
+	hbmi.HeartbeatReceived(uint32(0), uint32(2), "v0.1", "undefined")
 
 	assert.True(t, hbmi.totalUpTime.Duration > time.Duration(0))
 	assert.NotEqual(t, emptyTimestamp, hbmi.timeStamp)

--- a/node/heartbeat/heartbeat.go
+++ b/node/heartbeat/heartbeat.go
@@ -9,7 +9,7 @@ type Heartbeat struct {
 	Payload         []byte
 	Pubkey          []byte
 	Signature       []byte
-	ShardID         uint32
+	ReceivedShardID uint32
 	VersionNumber   string
 	NodeDisplayName string
 }
@@ -20,11 +20,11 @@ type PubKeyHeartbeat struct {
 	TimeStamp       time.Time `json:"timeStamp"`
 	MaxInactiveTime Duration  `json:"maxInactiveTime"`
 	IsActive        bool      `json:"isActive"`
-	//TODO should have 2 fields for this: receivedShardID and computedShardID
-	ShardID         uint32   `json:"shardID"`
-	TotalUpTime     Duration `json:"totalUpTime"`
-	TotalDownTime   Duration `json:"totalDownTime"`
-	VersionNumber   string   `json:"versionNumber"`
-	IsValidator     bool     `json:"isValidator"`
-	NodeDisplayName string   `json:"nodeDisplayName"`
+	ReceivedShardID uint32    `json:"receivedShardID"`
+	ComputedShardID uint32    `json:"computedShardID"`
+	TotalUpTime     Duration  `json:"totalUpTime"`
+	TotalDownTime   Duration  `json:"totalDownTime"`
+	VersionNumber   string    `json:"versionNumber"`
+	IsValidator     bool      `json:"isValidator"`
+	NodeDisplayName string    `json:"nodeDisplayName"`
 }

--- a/node/heartbeat/heartbeat.go
+++ b/node/heartbeat/heartbeat.go
@@ -9,7 +9,7 @@ type Heartbeat struct {
 	Payload         []byte
 	Pubkey          []byte
 	Signature       []byte
-	ReceivedShardID uint32
+	ShardID         uint32
 	VersionNumber   string
 	NodeDisplayName string
 }

--- a/node/heartbeat/monitor.go
+++ b/node/heartbeat/monitor.go
@@ -66,7 +66,7 @@ func NewMonitor(
 				return nil, err
 			}
 
-			mhbi.shardID = shardId
+			mhbi.computedShardID = shardId
 			mon.heartbeatMessages[pubkey] = mhbi
 		}
 	}
@@ -121,7 +121,7 @@ func (m *Monitor) ProcessReceivedMessage(message p2p.MessageP2P) error {
 			m.heartbeatMessages[string(hb.Pubkey)] = pe
 		}
 
-		pe.HeartbeatReceived(hb.ShardID, hb.VersionNumber, hb.NodeDisplayName)
+		pe.HeartbeatReceived(hb.ReceivedShardID, hb.VersionNumber, hb.NodeDisplayName)
 		m.updateAllHeartbeatMessages()
 	}(message, hbRecv)
 
@@ -175,7 +175,8 @@ func (m *Monitor) GetHeartbeats() []PubKeyHeartbeat {
 			TimeStamp:       v.timeStamp,
 			MaxInactiveTime: v.maxInactiveTime,
 			IsActive:        v.isActive,
-			ShardID:         v.shardID,
+			ReceivedShardID: v.receivedShardID,
+			ComputedShardID: v.computedShardID,
 			TotalUpTime:     v.totalUpTime,
 			TotalDownTime:   v.totalDownTime,
 			VersionNumber:   v.versionNumber,

--- a/node/heartbeat/monitor.go
+++ b/node/heartbeat/monitor.go
@@ -121,11 +121,18 @@ func (m *Monitor) ProcessReceivedMessage(message p2p.MessageP2P) error {
 			m.heartbeatMessages[string(hb.Pubkey)] = pe
 		}
 
-		pe.HeartbeatReceived(hb.ReceivedShardID, hb.VersionNumber, hb.NodeDisplayName)
+		computedShardID := m.computeShardID(string(hb.Pubkey))
+		pe.HeartbeatReceived(computedShardID, hb.ShardID, hb.VersionNumber, hb.NodeDisplayName)
 		m.updateAllHeartbeatMessages()
 	}(message, hbRecv)
 
 	return nil
+}
+
+func (m *Monitor) computeShardID(pubkey string) uint32 {
+	// TODO : the shard ID will be recomputed at the end of an epoch / beginning of a new one.
+	//  For the moment, just return the initial computed shard ID
+	return m.heartbeatMessages[pubkey].computedShardID
 }
 
 func (m *Monitor) verifySignature(hbRecv *Heartbeat) error {

--- a/node/heartbeat/monitor.go
+++ b/node/heartbeat/monitor.go
@@ -25,6 +25,7 @@ type Monitor struct {
 	marshalizer                 marshal.Marshalizer
 	heartbeatMessages           map[string]*heartbeatMessageInfo
 	mutHeartbeatMessages        sync.RWMutex
+	mutShardIdComputation       sync.RWMutex
 	appStatusHandler            core.AppStatusHandler
 }
 
@@ -132,6 +133,8 @@ func (m *Monitor) ProcessReceivedMessage(message p2p.MessageP2P) error {
 func (m *Monitor) computeShardID(pubkey string) uint32 {
 	// TODO : the shard ID will be recomputed at the end of an epoch / beginning of a new one.
 	//  For the moment, just return the initial computed shard ID
+	m.mutShardIdComputation.RLock()
+	defer m.mutShardIdComputation.RUnlock()
 	return m.heartbeatMessages[pubkey].computedShardID
 }
 

--- a/node/heartbeat/monitor_test.go
+++ b/node/heartbeat/monitor_test.go
@@ -100,7 +100,7 @@ func TestNewMonitor_ShouldComputeShardId(t *testing.T) {
 		1: {"pk1"},
 	}
 
-	maxDuration := 1 * time.Millisecond
+	maxDuration := time.Millisecond
 	mon, err := heartbeat.NewMonitor(
 		&mock.SinglesignMock{},
 		&mock.KeyGenMock{},

--- a/node/heartbeat/monitor_test.go
+++ b/node/heartbeat/monitor_test.go
@@ -99,11 +99,13 @@ func TestNewMonitor_ShouldComputeShardId(t *testing.T) {
 		0: {"pk0"},
 		1: {"pk1"},
 	}
+
+	maxDuration := 1 * time.Millisecond
 	mon, err := heartbeat.NewMonitor(
 		&mock.SinglesignMock{},
 		&mock.KeyGenMock{},
 		&mock.MarshalizerMock{},
-		1,
+		maxDuration,
 		pksPerShards,
 	)
 
@@ -323,7 +325,7 @@ func TestMonitor_ProcessReceivedMessageWithNewShardID(t *testing.T) {
 				var rcvdHb heartbeat.Heartbeat
 				_ = json.Unmarshal(buff, &rcvdHb)
 				(obj.(*heartbeat.Heartbeat)).Pubkey = rcvdHb.Pubkey
-				(obj.(*heartbeat.Heartbeat)).ReceivedShardID = rcvdHb.ReceivedShardID
+				(obj.(*heartbeat.Heartbeat)).ShardID = rcvdHb.ShardID
 				return nil
 			},
 		},
@@ -333,8 +335,8 @@ func TestMonitor_ProcessReceivedMessageWithNewShardID(t *testing.T) {
 
 	// First send from pk1 from shard 0
 	hb := &heartbeat.Heartbeat{
-		Pubkey:          pubKey,
-		ReceivedShardID: uint32(0),
+		Pubkey:  pubKey,
+		ShardID: uint32(0),
 	}
 
 	buffToSend, err := json.Marshal(hb)
@@ -352,8 +354,8 @@ func TestMonitor_ProcessReceivedMessageWithNewShardID(t *testing.T) {
 
 	// now we send a new heartbeat which will contain a new shard id
 	hb = &heartbeat.Heartbeat{
-		Pubkey:          pubKey,
-		ReceivedShardID: uint32(1),
+		Pubkey:  pubKey,
+		ShardID: uint32(1),
 	}
 
 	buffToSend, err = json.Marshal(hb)
@@ -393,7 +395,7 @@ func TestMonitor_ProcessReceivedMessageShouldSetPeerInactive(t *testing.T) {
 				var rcvdHb heartbeat.Heartbeat
 				_ = json.Unmarshal(buff, &rcvdHb)
 				(obj.(*heartbeat.Heartbeat)).Pubkey = rcvdHb.Pubkey
-				(obj.(*heartbeat.Heartbeat)).ReceivedShardID = rcvdHb.ReceivedShardID
+				(obj.(*heartbeat.Heartbeat)).ShardID = rcvdHb.ShardID
 				return nil
 			},
 		},

--- a/node/heartbeat/sender.go
+++ b/node/heartbeat/sender.go
@@ -36,19 +36,15 @@ func NewSender(
 	if peerMessenger == nil {
 		return nil, ErrNilMessenger
 	}
-
 	if singleSigner == nil {
 		return nil, ErrNilSingleSigner
 	}
-
 	if privKey == nil {
 		return nil, ErrNilPrivateKey
 	}
-
 	if marshalizer == nil {
 		return nil, ErrNilMarshalizer
 	}
-
 	if shardCoordinator == nil {
 		return nil, ErrNilShardCoordinator
 	}
@@ -72,7 +68,7 @@ func (s *Sender) SendHeartbeat() error {
 
 	hb := &Heartbeat{
 		Payload:         []byte(fmt.Sprintf("%v", time.Now())),
-		ReceivedShardID: s.shardCoordinator.SelfId(),
+		ShardID:         s.shardCoordinator.SelfId(),
 		VersionNumber:   s.versionNumber,
 		NodeDisplayName: s.nodeDisplayName,
 	}

--- a/node/heartbeat/sender.go
+++ b/node/heartbeat/sender.go
@@ -36,16 +36,22 @@ func NewSender(
 	if peerMessenger == nil {
 		return nil, ErrNilMessenger
 	}
+
 	if singleSigner == nil {
 		return nil, ErrNilSingleSigner
 	}
+
 	if privKey == nil {
 		return nil, ErrNilPrivateKey
 	}
+
 	if marshalizer == nil {
 		return nil, ErrNilMarshalizer
 	}
-	//TODO add test for shardCoordinator
+
+	if shardCoordinator == nil {
+		return nil, ErrNilShardCoordinator
+	}
 
 	sender := &Sender{
 		peerMessenger:    peerMessenger,
@@ -66,7 +72,7 @@ func (s *Sender) SendHeartbeat() error {
 
 	hb := &Heartbeat{
 		Payload:         []byte(fmt.Sprintf("%v", time.Now())),
-		ShardID:         s.shardCoordinator.SelfId(),
+		ReceivedShardID: s.shardCoordinator.SelfId(),
 		VersionNumber:   s.versionNumber,
 		NodeDisplayName: s.nodeDisplayName,
 	}

--- a/node/heartbeat/sender_test.go
+++ b/node/heartbeat/sender_test.go
@@ -49,6 +49,24 @@ func TestNewSender_NilSingleSignerShouldErr(t *testing.T) {
 	assert.Equal(t, heartbeat.ErrNilSingleSigner, err)
 }
 
+func TestNewSender_NilShardCoordinatorShouldErr(t *testing.T) {
+	t.Parallel()
+
+	sender, err := heartbeat.NewSender(
+		&mock.MessengerStub{},
+		&mock.SinglesignStub{},
+		&mock.PrivateKeyStub{},
+		&mock.MarshalizerMock{},
+		"",
+		nil,
+		"v0.1",
+		"undefined",
+	)
+
+	assert.Nil(t, sender)
+	assert.Equal(t, heartbeat.ErrNilShardCoordinator, err)
+}
+
 func TestNewSender_NilPrivateKeyShouldErr(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Heartbeat shard ID divided into received shard id and computed shard id in order to enable checking the validity of this information