### PR TITLE
En 3609 bugfix interceptors should not broadcast when a direct msg has been received

### DIFF
--- a/consensus/mock/sposWorkerMock.go
+++ b/consensus/mock/sposWorkerMock.go
@@ -29,7 +29,7 @@ func (sposWorkerMock *SposWorkerMock) RemoveAllReceivedMessagesCalls() {
 	sposWorkerMock.RemoveAllReceivedMessagesCallsCalled()
 }
 
-func (sposWorkerMock *SposWorkerMock) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (sposWorkerMock *SposWorkerMock) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	return sposWorkerMock.ProcessReceivedMessageCalled(message)
 }
 

--- a/consensus/spos/interface.go
+++ b/consensus/spos/interface.go
@@ -76,7 +76,7 @@ type WorkerHandler interface {
 	//RemoveAllReceivedMessagesCalls removes all the functions handlers
 	RemoveAllReceivedMessagesCalls()
 	//ProcessReceivedMessage method redirects the received message to the channel which should handle it
-	ProcessReceivedMessage(message p2p.MessageP2P) error
+	ProcessReceivedMessage(message p2p.MessageP2P, broadcastHandler func(buffToSend []byte)) error
 	//Extend does an extension for the subround with subroundId
 	Extend(subroundId int)
 	//GetConsensusStateChangedChannel gets the channel for the consensusStateChanged

--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -210,7 +210,7 @@ func (wrk *Worker) getCleanedList(cnsDataList []*consensus.Message) []*consensus
 }
 
 // ProcessReceivedMessage method redirects the received message to the channel which should handle it
-func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	if message == nil {
 		return ErrNilMessage
 	}

--- a/consensus/spos/worker_test.go
+++ b/consensus/spos/worker_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const roundTimeDuration = time.Duration(100 * time.Millisecond)
+const roundTimeDuration = 100 * time.Millisecond
 
 func initWorker() *spos.Worker {
 	blockProcessor := &mock.BlockProcessorMock{
@@ -659,7 +659,7 @@ func TestWorker_ProcessReceivedMessageTxBlockBodyShouldRetNil(t *testing.T) {
 	)
 	buff, _ := wrk.Marshalizer().Marshal(cnsMsg)
 	time.Sleep(time.Second)
-	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff})
+	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff}, nil)
 
 	assert.Nil(t, err)
 }
@@ -683,7 +683,7 @@ func TestWorker_ProcessReceivedMessageHeaderShouldRetNil(t *testing.T) {
 	)
 	buff, _ := wrk.Marshalizer().Marshal(cnsMsg)
 	time.Sleep(time.Second)
-	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff})
+	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff}, nil)
 
 	assert.Nil(t, err)
 }
@@ -691,7 +691,7 @@ func TestWorker_ProcessReceivedMessageHeaderShouldRetNil(t *testing.T) {
 func TestWorker_ProcessReceivedMessageNilMessageShouldErr(t *testing.T) {
 	t.Parallel()
 	wrk := *initWorker()
-	err := wrk.ProcessReceivedMessage(nil)
+	err := wrk.ProcessReceivedMessage(nil, nil)
 	time.Sleep(time.Second)
 
 	assert.Equal(t, 0, len(wrk.ReceivedMessages()[bn.MtBlockBody]))
@@ -701,7 +701,7 @@ func TestWorker_ProcessReceivedMessageNilMessageShouldErr(t *testing.T) {
 func TestWorker_ProcessReceivedMessageNilMessageDataFieldShouldErr(t *testing.T) {
 	t.Parallel()
 	wrk := *initWorker()
-	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{})
+	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{}, nil)
 	time.Sleep(time.Second)
 
 	assert.Equal(t, 0, len(wrk.ReceivedMessages()[bn.MtBlockBody]))
@@ -723,7 +723,7 @@ func TestWorker_ProcessReceivedMessageNodeNotInEligibleListShouldErr(t *testing.
 		0,
 	)
 	buff, _ := wrk.Marshalizer().Marshal(cnsMsg)
-	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff})
+	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff}, nil)
 	time.Sleep(time.Second)
 
 	assert.Equal(t, 0, len(wrk.ReceivedMessages()[bn.MtBlockBody]))
@@ -745,7 +745,7 @@ func TestWorker_ProcessReceivedMessageMessageIsForPastRoundShouldErr(t *testing.
 		-1,
 	)
 	buff, _ := wrk.Marshalizer().Marshal(cnsMsg)
-	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff})
+	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff}, nil)
 	time.Sleep(time.Second)
 
 	assert.Equal(t, 0, len(wrk.ReceivedMessages()[bn.MtBlockBody]))
@@ -767,7 +767,7 @@ func TestWorker_ProcessReceivedMessageInvalidSignatureShouldErr(t *testing.T) {
 		0,
 	)
 	buff, _ := wrk.Marshalizer().Marshal(cnsMsg)
-	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff})
+	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff}, nil)
 	time.Sleep(time.Second)
 
 	assert.Equal(t, 0, len(wrk.ReceivedMessages()[bn.MtBlockBody]))
@@ -789,7 +789,7 @@ func TestWorker_ProcessReceivedMessageReceivedMessageIsFromSelfShouldRetNilAndNo
 		0,
 	)
 	buff, _ := wrk.Marshalizer().Marshal(cnsMsg)
-	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff})
+	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff}, nil)
 	time.Sleep(time.Second)
 
 	assert.Equal(t, 0, len(wrk.ReceivedMessages()[bn.MtBlockBody]))
@@ -812,7 +812,7 @@ func TestWorker_ProcessReceivedMessageWhenRoundIsCanceledShouldRetNilAndNotProce
 		0,
 	)
 	buff, _ := wrk.Marshalizer().Marshal(cnsMsg)
-	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff})
+	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff}, nil)
 	time.Sleep(time.Second)
 
 	assert.Equal(t, 0, len(wrk.ReceivedMessages()[bn.MtBlockBody]))
@@ -834,7 +834,7 @@ func TestWorker_ProcessReceivedMessageOkValsShouldWork(t *testing.T) {
 		0,
 	)
 	buff, _ := wrk.Marshalizer().Marshal(cnsMsg)
-	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff})
+	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff}, nil)
 	time.Sleep(time.Second)
 
 	assert.Equal(t, 1, len(wrk.ReceivedMessages()[bn.MtBlockHeader]))
@@ -1411,7 +1411,7 @@ func TestWorker_BroadcastUnnotarisedBlocksShouldNotBroadcastWhenMaxRoundGapIsNot
 		},
 	}
 
-	wrk.ConsensusState().RoundIndex = int64(roundIndex)
+	wrk.ConsensusState().RoundIndex = roundIndex
 	wrk.SetBlockTracker(blockTracker)
 	wrk.SetForkDetector(forkDetector)
 	bmm := &mock.BroadcastMessengerMock{
@@ -1421,11 +1421,11 @@ func TestWorker_BroadcastUnnotarisedBlocksShouldNotBroadcastWhenMaxRoundGapIsNot
 		},
 	}
 	wrk.SetBroadcastMessenger(bmm)
-	wrk.BlockTracker().SetBlockBroadcastRound(header.Nonce, int64(roundIndex-spos.MaxRoundsGap))
+	wrk.BlockTracker().SetBlockBroadcastRound(header.Nonce, roundIndex-spos.MaxRoundsGap)
 
 	wrk.BroadcastUnnotarisedBlocks()
 	assert.False(t, headerHasBeenBroadcast)
-	assert.Equal(t, int64(roundIndex-spos.MaxRoundsGap), wrk.BlockTracker().BlockBroadcastRound(header.Nonce))
+	assert.Equal(t, roundIndex-spos.MaxRoundsGap, wrk.BlockTracker().BlockBroadcastRound(header.Nonce))
 }
 
 func TestWorker_BroadcastUnnotarisedBlocksShouldErrWhenBroadcastHeaderFails(t *testing.T) {
@@ -1457,7 +1457,7 @@ func TestWorker_BroadcastUnnotarisedBlocksShouldErrWhenBroadcastHeaderFails(t *t
 		},
 	}
 
-	wrk.ConsensusState().RoundIndex = int64(roundIndex)
+	wrk.ConsensusState().RoundIndex = roundIndex
 	wrk.SetBlockTracker(blockTracker)
 	wrk.SetForkDetector(forkDetector)
 	bmm := &mock.BroadcastMessengerMock{
@@ -1467,11 +1467,11 @@ func TestWorker_BroadcastUnnotarisedBlocksShouldErrWhenBroadcastHeaderFails(t *t
 		},
 	}
 	wrk.SetBroadcastMessenger(bmm)
-	wrk.BlockTracker().SetBlockBroadcastRound(header.Nonce, int64(roundIndex-spos.MaxRoundsGap-1))
+	wrk.BlockTracker().SetBlockBroadcastRound(header.Nonce, roundIndex-spos.MaxRoundsGap-1)
 
 	wrk.BroadcastUnnotarisedBlocks()
 	assert.NotNil(t, err)
-	assert.Equal(t, int64(roundIndex-spos.MaxRoundsGap-1), wrk.BlockTracker().BlockBroadcastRound(header.Nonce))
+	assert.Equal(t, roundIndex-spos.MaxRoundsGap-1, wrk.BlockTracker().BlockBroadcastRound(header.Nonce))
 }
 
 func TestWorker_BroadcastUnnotarisedBlocksShouldBroadcast(t *testing.T) {
@@ -1503,7 +1503,7 @@ func TestWorker_BroadcastUnnotarisedBlocksShouldBroadcast(t *testing.T) {
 		},
 	}
 
-	wrk.ConsensusState().RoundIndex = int64(roundIndex)
+	wrk.ConsensusState().RoundIndex = roundIndex
 	wrk.SetBlockTracker(blockTracker)
 	wrk.SetForkDetector(forkDetector)
 	bmm := &mock.BroadcastMessengerMock{
@@ -1513,7 +1513,7 @@ func TestWorker_BroadcastUnnotarisedBlocksShouldBroadcast(t *testing.T) {
 		},
 	}
 	wrk.SetBroadcastMessenger(bmm)
-	wrk.BlockTracker().SetBlockBroadcastRound(header.Nonce, int64(roundIndex-spos.MaxRoundsGap-1))
+	wrk.BlockTracker().SetBlockBroadcastRound(header.Nonce, roundIndex-spos.MaxRoundsGap-1)
 
 	wrk.BroadcastUnnotarisedBlocks()
 	assert.True(t, headerHasBeenBroadcast)

--- a/dataRetriever/interface.go
+++ b/dataRetriever/interface.go
@@ -42,7 +42,7 @@ const (
 // Resolver defines what a data resolver should do
 type Resolver interface {
 	RequestDataFromHash(hash []byte) error
-	ProcessReceivedMessage(message p2p.MessageP2P) error
+	ProcessReceivedMessage(message p2p.MessageP2P, broadcastHandler func(buffToSend []byte)) error
 }
 
 // HeaderResolver defines what a block header resolver should do

--- a/dataRetriever/mock/hashSliceResolverStub.go
+++ b/dataRetriever/mock/hashSliceResolverStub.go
@@ -16,7 +16,7 @@ func (hsrs *HashSliceResolverStub) RequestDataFromHash(hash []byte) error {
 	return errNotImplemented
 }
 
-func (hsrs *HashSliceResolverStub) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (hsrs *HashSliceResolverStub) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	if hsrs.ProcessReceivedMessageCalled != nil {
 		return hsrs.ProcessReceivedMessageCalled(message)
 	}

--- a/dataRetriever/mock/headerResolverStub.go
+++ b/dataRetriever/mock/headerResolverStub.go
@@ -21,7 +21,7 @@ func (hrs *HeaderResolverStub) RequestDataFromHash(hash []byte) error {
 	return errNotImplemented
 }
 
-func (hrs *HeaderResolverStub) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (hrs *HeaderResolverStub) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	if hrs.ProcessReceivedMessageCalled != nil {
 		return hrs.ProcessReceivedMessageCalled(message)
 	}

--- a/dataRetriever/mock/resolverStub.go
+++ b/dataRetriever/mock/resolverStub.go
@@ -6,13 +6,13 @@ import (
 
 type ResolverStub struct {
 	RequestDataFromHashCalled    func(hash []byte) error
-	ProcessReceivedMessageCalled func(message p2p.MessageP2P) error
+	ProcessReceivedMessageCalled func(message p2p.MessageP2P, broadcastHandler func(buffToSend []byte)) error
 }
 
 func (rs *ResolverStub) RequestDataFromHash(hash []byte) error {
 	return rs.RequestDataFromHashCalled(hash)
 }
 
-func (rs *ResolverStub) ProcessReceivedMessage(message p2p.MessageP2P) error {
-	return rs.ProcessReceivedMessageCalled(message)
+func (rs *ResolverStub) ProcessReceivedMessage(message p2p.MessageP2P, broadcastHandler func(buffToSend []byte)) error {
+	return rs.ProcessReceivedMessageCalled(message, broadcastHandler)
 }

--- a/dataRetriever/resolvers/genericBlockBodyResolver.go
+++ b/dataRetriever/resolvers/genericBlockBodyResolver.go
@@ -53,7 +53,7 @@ func NewGenericBlockBodyResolver(
 
 // ProcessReceivedMessage will be the callback func from the p2p.Messenger and will be called each time a new message was received
 // (for the topic this validator was registered to, usually a request topic)
-func (gbbRes *GenericBlockBodyResolver) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (gbbRes *GenericBlockBodyResolver) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	rd := &dataRetriever.RequestData{}
 	err := rd.Unmarshal(gbbRes.marshalizer, message)
 	if err != nil {

--- a/dataRetriever/resolvers/genericBlockBodyResolver_test.go
+++ b/dataRetriever/resolvers/genericBlockBodyResolver_test.go
@@ -97,7 +97,7 @@ func TestNewGenericBlockBodyResolver_ProcessReceivedMessageNilValueShouldErr(t *
 		&mock.MarshalizerMock{},
 	)
 
-	err := gbbRes.ProcessReceivedMessage(createRequestMsg(dataRetriever.HashType, nil))
+	err := gbbRes.ProcessReceivedMessage(createRequestMsg(dataRetriever.HashType, nil), nil)
 	assert.Equal(t, dataRetriever.ErrNilValue, err)
 }
 
@@ -111,7 +111,7 @@ func TestGenericBlockBodyResolver_ProcessReceivedMessageWrongTypeShouldErr(t *te
 		&mock.MarshalizerMock{},
 	)
 
-	err := gbbRes.ProcessReceivedMessage(createRequestMsg(dataRetriever.NonceType, make([]byte, 0)))
+	err := gbbRes.ProcessReceivedMessage(createRequestMsg(dataRetriever.NonceType, make([]byte, 0)), nil)
 	assert.Equal(t, dataRetriever.ErrInvalidRequestType, err)
 }
 
@@ -153,9 +153,10 @@ func TestGenericBlockBodyResolver_ProcessReceivedMessageFoundInPoolShouldRetValA
 		marshalizer,
 	)
 
-	err := gbbRes.ProcessReceivedMessage(createRequestMsg(
-		dataRetriever.HashArrayType,
-		requestedBuff))
+	err := gbbRes.ProcessReceivedMessage(
+		createRequestMsg(dataRetriever.HashArrayType, requestedBuff),
+		nil,
+	)
 
 	assert.Nil(t, err)
 	assert.True(t, wasResolved)
@@ -203,9 +204,10 @@ func TestGenericBlockBodyResolver_ProcessReceivedMessageFoundInPoolMarshalizerFa
 		marshalizer,
 	)
 
-	err := gbbRes.ProcessReceivedMessage(createRequestMsg(
-		dataRetriever.HashArrayType,
-		requestedBuff))
+	err := gbbRes.ProcessReceivedMessage(
+		createRequestMsg(dataRetriever.HashArrayType, requestedBuff),
+		nil,
+	)
 
 	assert.Equal(t, errExpected, err)
 
@@ -247,9 +249,10 @@ func TestGenericBlockBodyResolver_ProcessReceivedMessageNotFoundInPoolShouldRetF
 		marshalizer,
 	)
 
-	err := gbbRes.ProcessReceivedMessage(createRequestMsg(
-		dataRetriever.HashType,
-		requestedBuff))
+	err := gbbRes.ProcessReceivedMessage(
+		createRequestMsg(dataRetriever.HashType, requestedBuff),
+		nil,
+	)
 
 	assert.Nil(t, err)
 	assert.True(t, wasResolved)
@@ -289,9 +292,10 @@ func TestGenericBlockBodyResolver_ProcessReceivedMessageMissingDataShouldNotSend
 		marshalizer,
 	)
 
-	_ = gbbRes.ProcessReceivedMessage(createRequestMsg(
-		dataRetriever.HashType,
-		requestedBuff))
+	_ = gbbRes.ProcessReceivedMessage(
+		createRequestMsg(dataRetriever.HashType, requestedBuff),
+		nil,
+	)
 
 	assert.False(t, wasSent)
 }

--- a/dataRetriever/resolvers/headerResolver.go
+++ b/dataRetriever/resolvers/headerResolver.go
@@ -72,7 +72,7 @@ func NewHeaderResolver(
 
 // ProcessReceivedMessage will be the callback func from the p2p.Messenger and will be called each time a new message was received
 // (for the topic this validator was registered to, usually a request topic)
-func (hdrRes *HeaderResolver) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (hdrRes *HeaderResolver) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	rd, err := hdrRes.parseReceivedMessage(message)
 	if err != nil {
 		return err

--- a/dataRetriever/resolvers/headerResolver_test.go
+++ b/dataRetriever/resolvers/headerResolver_test.go
@@ -166,7 +166,7 @@ func TestHeaderResolver_ProcessReceivedMessageNilValueShouldErr(t *testing.T) {
 		mock.NewNonceHashConverterMock(),
 	)
 
-	err := hdrRes.ProcessReceivedMessage(createRequestMsg(dataRetriever.NonceType, nil))
+	err := hdrRes.ProcessReceivedMessage(createRequestMsg(dataRetriever.NonceType, nil), nil)
 	assert.Equal(t, dataRetriever.ErrNilValue, err)
 }
 
@@ -183,7 +183,7 @@ func TestHeaderResolver_ProcessReceivedMessageRequestUnknownTypeShouldErr(t *tes
 		mock.NewNonceHashConverterMock(),
 	)
 
-	err := hdrRes.ProcessReceivedMessage(createRequestMsg(254, make([]byte, 0)))
+	err := hdrRes.ProcessReceivedMessage(createRequestMsg(254, make([]byte, 0)), nil)
 	assert.Equal(t, dataRetriever.ErrResolveTypeUnknown, err)
 
 }
@@ -223,7 +223,7 @@ func TestHeaderResolver_ValidateRequestHashTypeFoundInHdrPoolShouldSearchAndSend
 		mock.NewNonceHashConverterMock(),
 	)
 
-	err := hdrRes.ProcessReceivedMessage(createRequestMsg(dataRetriever.HashType, requestedData))
+	err := hdrRes.ProcessReceivedMessage(createRequestMsg(dataRetriever.HashType, requestedData), nil)
 	assert.Nil(t, err)
 	assert.True(t, searchWasCalled)
 	assert.True(t, sendWasCalled)
@@ -270,7 +270,7 @@ func TestHeaderResolver_ProcessReceivedMessageRequestHashTypeFoundInHdrPoolMarsh
 		mock.NewNonceHashConverterMock(),
 	)
 
-	err := hdrRes.ProcessReceivedMessage(createRequestMsg(dataRetriever.HashType, requestedData))
+	err := hdrRes.ProcessReceivedMessage(createRequestMsg(dataRetriever.HashType, requestedData), nil)
 	assert.Equal(t, errExpected, err)
 }
 
@@ -315,7 +315,7 @@ func TestHeaderResolver_ProcessReceivedMessageRequestRetFromStorageShouldRetValA
 		mock.NewNonceHashConverterMock(),
 	)
 
-	err := hdrRes.ProcessReceivedMessage(createRequestMsg(dataRetriever.HashType, requestedData))
+	err := hdrRes.ProcessReceivedMessage(createRequestMsg(dataRetriever.HashType, requestedData), nil)
 	assert.Nil(t, err)
 	assert.True(t, wasGotFromStorage)
 	assert.True(t, wasSent)
@@ -338,7 +338,7 @@ func TestHeaderResolver_ProcessReceivedMessageRequestNonceTypeInvalidSliceShould
 		mock.NewNonceHashConverterMock(),
 	)
 
-	err := hdrRes.ProcessReceivedMessage(createRequestMsg(dataRetriever.NonceType, []byte("aaa")))
+	err := hdrRes.ProcessReceivedMessage(createRequestMsg(dataRetriever.NonceType, []byte("aaa")), nil)
 	assert.Equal(t, dataRetriever.ErrInvalidNonceByteSlice, err)
 }
 
@@ -375,9 +375,10 @@ func TestHeaderResolver_ProcessReceivedMessageRequestNonceTypeNotFoundInHdrNonce
 		nonceConverter,
 	)
 
-	err := hdrRes.ProcessReceivedMessage(createRequestMsg(
-		dataRetriever.NonceType,
-		nonceConverter.ToByteSlice(requestedNonce)))
+	err := hdrRes.ProcessReceivedMessage(
+		createRequestMsg(dataRetriever.NonceType, nonceConverter.ToByteSlice(requestedNonce)),
+		nil,
+	)
 	assert.Nil(t, err)
 	assert.False(t, wasSent)
 }
@@ -438,9 +439,10 @@ func TestHeaderResolver_ProcessReceivedMessageRequestNonceTypeFoundInHdrNoncePoo
 		nonceConverter,
 	)
 
-	err := hdrRes.ProcessReceivedMessage(createRequestMsg(
-		dataRetriever.NonceType,
-		nonceConverter.ToByteSlice(requestedNonce)))
+	err := hdrRes.ProcessReceivedMessage(
+		createRequestMsg(dataRetriever.NonceType, nonceConverter.ToByteSlice(requestedNonce)),
+		nil,
+	)
 
 	assert.Nil(t, err)
 	assert.True(t, wasResolved)
@@ -508,9 +510,10 @@ func TestHeaderResolver_ProcessReceivedMessageRequestNonceTypeFoundInHdrNoncePoo
 		nonceConverter,
 	)
 
-	err := hdrRes.ProcessReceivedMessage(createRequestMsg(
-		dataRetriever.NonceType,
-		nonceConverter.ToByteSlice(requestedNonce)))
+	err := hdrRes.ProcessReceivedMessage(
+		createRequestMsg(dataRetriever.NonceType, nonceConverter.ToByteSlice(requestedNonce)),
+		nil,
+	)
 
 	assert.Nil(t, err)
 	assert.True(t, wasResolved)
@@ -575,9 +578,10 @@ func TestHeaderResolver_ProcessReceivedMessageRequestNonceTypeFoundInHdrNoncePoo
 		nonceConverter,
 	)
 
-	err := hdrRes.ProcessReceivedMessage(createRequestMsg(
-		dataRetriever.NonceType,
-		nonceConverter.ToByteSlice(requestedNonce)))
+	err := hdrRes.ProcessReceivedMessage(
+		createRequestMsg(dataRetriever.NonceType, nonceConverter.ToByteSlice(requestedNonce)),
+		nil,
+	)
 
 	assert.Equal(t, errExpected, err)
 }

--- a/dataRetriever/resolvers/transactionResolver.go
+++ b/dataRetriever/resolvers/transactionResolver.go
@@ -57,7 +57,7 @@ func NewTxResolver(
 
 // ProcessReceivedMessage will be the callback func from the p2p.Messenger and will be called each time a new message was received
 // (for the topic this validator was registered to, usually a request topic)
-func (txRes *TxResolver) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (txRes *TxResolver) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	rd := &dataRetriever.RequestData{}
 	err := rd.Unmarshal(txRes.marshalizer, message)
 	if err != nil {

--- a/dataRetriever/resolvers/transactionResolver_test.go
+++ b/dataRetriever/resolvers/transactionResolver_test.go
@@ -121,7 +121,7 @@ func TestTxResolver_ProcessReceivedMessageNilMessageShouldErr(t *testing.T) {
 		&mock.DataPackerStub{},
 	)
 
-	err := txRes.ProcessReceivedMessage(nil)
+	err := txRes.ProcessReceivedMessage(nil, nil)
 
 	assert.Equal(t, dataRetriever.ErrNilMessage, err)
 }
@@ -143,7 +143,7 @@ func TestTxResolver_ProcessReceivedMessageWrongTypeShouldErr(t *testing.T) {
 
 	msg := &mock.P2PMessageMock{DataField: data}
 
-	err := txRes.ProcessReceivedMessage(msg)
+	err := txRes.ProcessReceivedMessage(msg, nil)
 
 	assert.Equal(t, dataRetriever.ErrRequestTypeNotImplemented, err)
 }
@@ -165,7 +165,7 @@ func TestTxResolver_ProcessReceivedMessageNilValueShouldErr(t *testing.T) {
 
 	msg := &mock.P2PMessageMock{DataField: data}
 
-	err := txRes.ProcessReceivedMessage(msg)
+	err := txRes.ProcessReceivedMessage(msg, nil)
 
 	assert.Equal(t, dataRetriever.ErrNilValue, err)
 }
@@ -206,7 +206,7 @@ func TestTxResolver_ProcessReceivedMessageFoundInTxPoolShouldSearchAndSend(t *te
 
 	msg := &mock.P2PMessageMock{DataField: data}
 
-	err := txRes.ProcessReceivedMessage(msg)
+	err := txRes.ProcessReceivedMessage(msg, nil)
 
 	assert.Nil(t, err)
 	assert.True(t, searchWasCalled)
@@ -251,7 +251,7 @@ func TestTxResolver_ProcessReceivedMessageFoundInTxPoolMarshalizerFailShouldRetN
 
 	msg := &mock.P2PMessageMock{DataField: data}
 
-	err := txRes.ProcessReceivedMessage(msg)
+	err := txRes.ProcessReceivedMessage(msg, nil)
 
 	assert.Equal(t, errExpected, err)
 }
@@ -299,7 +299,7 @@ func TestTxResolver_ProcessReceivedMessageFoundInTxStorageShouldRetValAndSend(t 
 
 	msg := &mock.P2PMessageMock{DataField: data}
 
-	err := txRes.ProcessReceivedMessage(msg)
+	err := txRes.ProcessReceivedMessage(msg, nil)
 
 	assert.Nil(t, err)
 	assert.True(t, searchWasCalled)
@@ -340,7 +340,7 @@ func TestTxResolver_ProcessReceivedMessageFoundInTxStorageCheckRetError(t *testi
 
 	msg := &mock.P2PMessageMock{DataField: data}
 
-	err := txRes.ProcessReceivedMessage(msg)
+	err := txRes.ProcessReceivedMessage(msg, nil)
 
 	assert.Equal(t, errExpected, err)
 
@@ -399,7 +399,7 @@ func TestTxResolver_ProcessReceivedMessageRequestedTwoSmallTransactionsShouldCal
 
 	msg := &mock.P2PMessageMock{DataField: data}
 
-	err := txRes.ProcessReceivedMessage(msg)
+	err := txRes.ProcessReceivedMessage(msg, nil)
 
 	assert.Nil(t, err)
 	assert.True(t, sendSliceWasCalled)

--- a/integrationTests/consensus/consensus_test.go
+++ b/integrationTests/consensus/consensus_test.go
@@ -140,7 +140,7 @@ func runFullConsensusTest(t *testing.T, consensusType string) {
 
 	// delay for bootstrapping and topic announcement
 	fmt.Println("Start consensus...")
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Second)
 
 	nonceForRoundMap := make(map[uint64]uint64)
 	totalCalled := 0
@@ -196,7 +196,7 @@ func runConsensusWithNotEnoughValidators(t *testing.T, consensusType string) {
 
 	// delay for bootstrapping and topic announcement
 	fmt.Println("Start consensus...")
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Second)
 
 	nonceForRoundMap := make(map[uint64]uint64)
 	totalCalled := 0

--- a/integrationTests/mock/headerResolverMock.go
+++ b/integrationTests/mock/headerResolverMock.go
@@ -17,7 +17,7 @@ func (hrm *HeaderResolverMock) RequestDataFromHash(hash []byte) error {
 	return hrm.RequestDataFromHashCalled(hash)
 }
 
-func (hrm *HeaderResolverMock) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (hrm *HeaderResolverMock) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	if hrm.ProcessReceivedMessageCalled == nil {
 		return nil
 	}

--- a/integrationTests/mock/miniBlocksResolverMock.go
+++ b/integrationTests/mock/miniBlocksResolverMock.go
@@ -20,7 +20,7 @@ func (hrm *MiniBlocksResolverMock) RequestDataFromHashArray(hashes [][]byte) err
 	return hrm.RequestDataFromHashArrayCalled(hashes)
 }
 
-func (hrm *MiniBlocksResolverMock) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (hrm *MiniBlocksResolverMock) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	return hrm.ProcessReceivedMessageCalled(message)
 }
 

--- a/integrationTests/p2p/peerDiscovery/messageProcessor.go
+++ b/integrationTests/p2p/peerDiscovery/messageProcessor.go
@@ -21,7 +21,7 @@ func NewMessageProcessor(chanDone chan struct{}, requiredVal []byte) *MessagePro
 	}
 }
 
-func (mp *MessageProcesssor) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (mp *MessageProcesssor) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	if bytes.Equal(mp.RequiredValue, message.Data()) {
 		mp.mutDataReceived.Lock()
 		mp.wasDataReceived = true

--- a/integrationTests/p2p/pubsub/peerReceivingMessages_test.go
+++ b/integrationTests/p2p/pubsub/peerReceivingMessages_test.go
@@ -20,15 +20,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var durationBootstrapingTime = time.Duration(time.Second * 2)
-var durationTest = time.Duration(time.Second * 30)
+var durationBootstrapingTime = time.Second * 2
+var durationTest = time.Second * 30
 var randezVous = "elrondRandezVous"
 
 type messageProcessorStub struct {
 	ProcessReceivedMessageCalled func(message p2p.MessageP2P) error
 }
 
-func (mps *messageProcessorStub) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (mps *messageProcessorStub) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	return mps.ProcessReceivedMessageCalled(message)
 }
 
@@ -73,12 +73,12 @@ func TestPeerReceivesTheSameMessageMultipleTimesShouldNotHappen(t *testing.T) {
 	defer func() {
 		for i := 0; i < noOfPeers; i++ {
 			if peers[i] != nil {
-				peers[i].Close()
+				_ = peers[i].Close()
 			}
 		}
 
 		if advertiser != nil {
-			advertiser.Close()
+			_ = advertiser.Close()
 		}
 	}()
 
@@ -92,9 +92,9 @@ func TestPeerReceivesTheSameMessageMultipleTimesShouldNotHappen(t *testing.T) {
 	for i := 0; i < noOfPeers; i++ {
 		idx := i
 		mapMessages[idx] = make(map[string]struct{})
-		peers[idx].CreateTopic(testTopic, true)
+		_ = peers[idx].CreateTopic(testTopic, true)
 
-		peers[idx].RegisterMessageProcessor(testTopic, &messageProcessorStub{
+		_ = peers[idx].RegisterMessageProcessor(testTopic, &messageProcessorStub{
 			ProcessReceivedMessageCalled: func(message p2p.MessageP2P) error {
 				time.Sleep(time.Second)
 
@@ -115,9 +115,9 @@ func TestPeerReceivesTheSameMessageMultipleTimesShouldNotHappen(t *testing.T) {
 	}
 
 	//Step 4. Call bootstrap on all peers
-	advertiser.Bootstrap()
+	_ = advertiser.Bootstrap()
 	for _, p := range peers {
-		p.Bootstrap()
+		_ = p.Bootstrap()
 	}
 	waitForBootstrapAndShowConnected(peers)
 

--- a/node/heartbeat/monitor.go
+++ b/node/heartbeat/monitor.go
@@ -86,7 +86,7 @@ func (m *Monitor) SetAppStatusHandler(ash core.AppStatusHandler) error {
 
 // ProcessReceivedMessage satisfies the p2p.MessageProcessor interface so it can be called
 // by the p2p subsystem each time a new heartbeat message arrives
-func (m *Monitor) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (m *Monitor) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	if message == nil {
 		return ErrNilMessage
 	}

--- a/node/heartbeat/monitor_test.go
+++ b/node/heartbeat/monitor_test.go
@@ -105,7 +105,7 @@ func TestMonitor_ProcessReceivedMessageNilMessageShouldErr(t *testing.T) {
 		map[uint32][]string{0: {"pk1"}},
 	)
 
-	err := mon.ProcessReceivedMessage(nil)
+	err := mon.ProcessReceivedMessage(nil, nil)
 
 	assert.Equal(t, heartbeat.ErrNilMessage, err)
 }
@@ -121,7 +121,7 @@ func TestMonitor_ProcessReceivedMessageNilDataShouldErr(t *testing.T) {
 		map[uint32][]string{0: {"pk1"}},
 	)
 
-	err := mon.ProcessReceivedMessage(&mock.P2PMessageStub{})
+	err := mon.ProcessReceivedMessage(&mock.P2PMessageStub{}, nil)
 
 	assert.Equal(t, heartbeat.ErrNilDataToProcess, err)
 }
@@ -143,7 +143,7 @@ func TestMonitor_ProcessReceivedMessageMarshalFailsShouldErr(t *testing.T) {
 		map[uint32][]string{0: {"pk1"}},
 	)
 
-	err := mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: []byte("")})
+	err := mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: []byte("")}, nil)
 
 	assert.Equal(t, errExpected, err)
 }
@@ -169,7 +169,7 @@ func TestMonitor_ProcessReceivedMessageWrongPubkeyShouldErr(t *testing.T) {
 		map[uint32][]string{0: {"pk1"}},
 	)
 
-	err := mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: []byte("")})
+	err := mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: []byte("")}, nil)
 
 	assert.Equal(t, errExpected, err)
 }
@@ -199,7 +199,7 @@ func TestMonitor_ProcessReceivedMessageVerifyFailsShouldErr(t *testing.T) {
 		map[uint32][]string{0: {"pk1"}},
 	)
 
-	err := mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: []byte("")})
+	err := mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: []byte("")}, nil)
 
 	assert.Equal(t, errExpected, err)
 }
@@ -230,7 +230,7 @@ func TestMonitor_ProcessReceivedMessageShouldWork(t *testing.T) {
 		map[uint32][]string{0: {pubKey}},
 	)
 
-	err := mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: []byte("")})
+	err := mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: []byte("")}, nil)
 	assert.Nil(t, err)
 
 	//a delay is mandatory for the go routine to finish its job
@@ -267,7 +267,7 @@ func TestMonitor_ProcessReceivedMessageWithNewPublicKey(t *testing.T) {
 		map[uint32][]string{0: {"pk2"}},
 	)
 
-	err := mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: []byte("")})
+	err := mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: []byte("")}, nil)
 	assert.Nil(t, err)
 
 	//a delay is mandatory for the go routine to finish its job
@@ -317,7 +317,7 @@ func TestMonitor_ProcessReceivedMessageWithNewShardID(t *testing.T) {
 	buffToSend, err := json.Marshal(hb)
 	assert.Nil(t, err)
 
-	err = mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: buffToSend})
+	err = mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: buffToSend}, nil)
 	assert.Nil(t, err)
 
 	//a delay is mandatory for the go routine to finish its job
@@ -337,7 +337,7 @@ func TestMonitor_ProcessReceivedMessageWithNewShardID(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	err = mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: buffToSend})
+	err = mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: buffToSend}, nil)
 
 	time.Sleep(1 * time.Second)
 
@@ -412,6 +412,6 @@ func sendHbMessageFromPubKey(pubKey string, mon *heartbeat.Monitor) error {
 		Pubkey: []byte(pubKey),
 	}
 	buffToSend, _ := json.Marshal(hb)
-	err := mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: buffToSend})
+	err := mon.ProcessReceivedMessage(&mock.P2PMessageStub{DataField: buffToSend}, nil)
 	return err
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1236,7 +1236,7 @@ func TestNode_StartHeartbeatShouldWorkAndCanCallProcessMessage(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, registeredHandler)
 
-	err = registeredHandler.ProcessReceivedMessage(nil)
+	err = registeredHandler.ProcessReceivedMessage(nil, nil)
 	assert.NotNil(t, err)
 	assert.Contains(t, "nil message", err.Error())
 }

--- a/p2p/example/libp2p/chatAdvertiser/main.go
+++ b/p2p/example/libp2p/chatAdvertiser/main.go
@@ -60,7 +60,7 @@ func main() {
 	// libp2p.New constructs a new libp2p Host. Other options can be added
 	// here.
 	host, err := libp2p.New(ctx,
-		libp2p.ListenAddrs([]multiaddr.Multiaddr(make([]multiaddr.Multiaddr, 0))...),
+		libp2p.ListenAddrs(make([]multiaddr.Multiaddr, 0)...),
 	)
 	if err != nil {
 		panic(err)

--- a/p2p/example/libp2p/internalBroadcastSpeedMeasure/main.go
+++ b/p2p/example/libp2p/internalBroadcastSpeedMeasure/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	_ = mes1.RegisterMessageProcessor("test1",
 		&mock.MessageProcessorStub{
-			ProcessMessageCalled: func(message p2p.MessageP2P) error {
+			ProcessMessageCalled: func(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 				atomic.AddInt64(&bytesReceived1, int64(len(message.Data())))
 
 				return nil
@@ -49,7 +49,7 @@ func main() {
 		})
 
 	_ = mes1.RegisterMessageProcessor("test2", &mock.MessageProcessorStub{
-		ProcessMessageCalled: func(message p2p.MessageP2P) error {
+		ProcessMessageCalled: func(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 			atomic.AddInt64(&bytesReceived2, int64(len(message.Data())))
 
 			return nil
@@ -57,7 +57,7 @@ func main() {
 	})
 
 	_ = mes1.RegisterMessageProcessor("test3", &mock.MessageProcessorStub{
-		ProcessMessageCalled: func(message p2p.MessageP2P) error {
+		ProcessMessageCalled: func(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 			atomic.AddInt64(&bytesReceived3, int64(len(message.Data())))
 
 			return nil

--- a/p2p/libp2p/discovery/kadDhtDiscoverer.go
+++ b/p2p/libp2p/discovery/kadDhtDiscoverer.go
@@ -9,7 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p-kad-dht"
 )
 
-var peerDiscoveryTimeout = time.Duration(time.Second * 10)
+var peerDiscoveryTimeout = time.Second * 10
 var noOfQueries = 1
 
 const kadDhtName = "kad-dht discovery"
@@ -86,7 +86,7 @@ func (kdd *KadDhtDiscoverer) connectToInitialAndBootstrap() {
 	cfg := dht.BootstrapConfig{
 		Period:  kdd.refreshInterval,
 		Queries: noOfQueries,
-		Timeout: time.Duration(peerDiscoveryTimeout),
+		Timeout: peerDiscoveryTimeout,
 	}
 
 	ctx := kdd.contextProvider.Context()

--- a/p2p/libp2p/discovery/kadDhtDiscoverer_test.go
+++ b/p2p/libp2p/discovery/kadDhtDiscoverer_test.go
@@ -29,7 +29,7 @@ func TestNewKadDhtPeerDiscoverer_ShouldSetValues(t *testing.T) {
 //------- Bootstrap
 
 func TestKadDhtPeerDiscoverer_BootstrapCalledWithoutContextAppliedShouldErr(t *testing.T) {
-	interval := time.Second * 1
+	interval := time.Second
 
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 	err := kdd.Bootstrap()
@@ -38,7 +38,7 @@ func TestKadDhtPeerDiscoverer_BootstrapCalledWithoutContextAppliedShouldErr(t *t
 }
 
 func TestKadDhtPeerDiscoverer_BootstrapCalledOnceShouldWork(t *testing.T) {
-	interval := time.Second * 1
+	interval := time.Second
 
 	h := createDummyHost()
 	ctx, _ := libp2p.NewLibp2pContext(context.Background(), h)
@@ -55,7 +55,7 @@ func TestKadDhtPeerDiscoverer_BootstrapCalledOnceShouldWork(t *testing.T) {
 }
 
 func TestKadDhtPeerDiscoverer_BootstrapCalledTwiceShouldErr(t *testing.T) {
-	interval := time.Second * 1
+	interval := time.Second
 
 	h := createDummyHost()
 	ctx, _ := libp2p.NewLibp2pContext(context.Background(), h)
@@ -76,7 +76,7 @@ func TestKadDhtPeerDiscoverer_BootstrapCalledTwiceShouldErr(t *testing.T) {
 //------- connectToOnePeerFromInitialPeersList
 
 func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersListNilListShouldRetWithChanFull(t *testing.T) {
-	interval := time.Second * 1
+	interval := time.Second
 
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 	lctx, _ := libp2p.NewLibp2pContext(context.Background(), &mock.ConnectableHostStub{})
@@ -88,7 +88,7 @@ func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersListNilListShouldR
 }
 
 func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersListEmptyListShouldRetWithChanFull(t *testing.T) {
-	interval := time.Second * 1
+	interval := time.Second
 
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 	lctx, _ := libp2p.NewLibp2pContext(context.Background(), &mock.ConnectableHostStub{})
@@ -100,7 +100,7 @@ func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersListEmptyListShoul
 }
 
 func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersOnePeerShouldTryToConnect(t *testing.T) {
-	interval := time.Second * 1
+	interval := time.Second
 
 	peerID := "peer"
 
@@ -131,7 +131,7 @@ func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersOnePeerShouldTryTo
 }
 
 func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersOnePeerShouldTryToConnectContinously(t *testing.T) {
-	interval := time.Second * 1
+	interval := time.Second
 
 	peerID := "peer"
 	wasConnectCalled := int32(0)
@@ -170,7 +170,7 @@ func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersOnePeerShouldTryTo
 }
 
 func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersTwoPeersShouldAlternate(t *testing.T) {
-	interval := time.Second * 1
+	interval := time.Second
 
 	peerID1 := "peer1"
 	peerID2 := "peer2"
@@ -223,7 +223,7 @@ func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersTwoPeersShouldAlte
 //------- ApplyContext
 
 func TestKadDhtPeerDiscoverer_ApplyContextNilProviderShouldErr(t *testing.T) {
-	interval := time.Second * 1
+	interval := time.Second
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 
 	err := kdd.ApplyContext(nil)
@@ -232,7 +232,7 @@ func TestKadDhtPeerDiscoverer_ApplyContextNilProviderShouldErr(t *testing.T) {
 }
 
 func TestKadDhtPeerDiscoverer_ApplyContextWrongProviderShouldErr(t *testing.T) {
-	interval := time.Second * 1
+	interval := time.Second
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 
 	err := kdd.ApplyContext(&mock.ContextProviderMock{})
@@ -242,7 +242,7 @@ func TestKadDhtPeerDiscoverer_ApplyContextWrongProviderShouldErr(t *testing.T) {
 
 func TestKadDhtPeerDiscoverer_ApplyContextShouldWork(t *testing.T) {
 	ctx, _ := libp2p.NewLibp2pContext(context.Background(), &mock.ConnectableHostStub{})
-	interval := time.Second * 1
+	interval := time.Second
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 
 	err := kdd.ApplyContext(ctx)

--- a/p2p/libp2p/discovery/kadDhtDiscoverer_test.go
+++ b/p2p/libp2p/discovery/kadDhtDiscoverer_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestNewKadDhtPeerDiscoverer_ShouldSetValues(t *testing.T) {
 	initialPeersList := []string{"peer1", "peer2"}
-	interval := time.Duration(time.Second * 4)
+	interval := time.Second * 4
 	randezVous := "randez vous"
 
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, randezVous, initialPeersList)
@@ -29,7 +29,7 @@ func TestNewKadDhtPeerDiscoverer_ShouldSetValues(t *testing.T) {
 //------- Bootstrap
 
 func TestKadDhtPeerDiscoverer_BootstrapCalledWithoutContextAppliedShouldErr(t *testing.T) {
-	interval := time.Duration(time.Second * 1)
+	interval := time.Second * 1
 
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 	err := kdd.Bootstrap()
@@ -38,24 +38,24 @@ func TestKadDhtPeerDiscoverer_BootstrapCalledWithoutContextAppliedShouldErr(t *t
 }
 
 func TestKadDhtPeerDiscoverer_BootstrapCalledOnceShouldWork(t *testing.T) {
-	interval := time.Duration(time.Second * 1)
+	interval := time.Second * 1
 
 	h := createDummyHost()
 	ctx, _ := libp2p.NewLibp2pContext(context.Background(), h)
 
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 	defer func() {
-		h.Close()
+		_ = h.Close()
 	}()
 
-	kdd.ApplyContext(ctx)
+	_ = kdd.ApplyContext(ctx)
 	err := kdd.Bootstrap()
 
 	assert.Nil(t, err)
 }
 
 func TestKadDhtPeerDiscoverer_BootstrapCalledTwiceShouldErr(t *testing.T) {
-	interval := time.Duration(time.Second * 1)
+	interval := time.Second * 1
 
 	h := createDummyHost()
 	ctx, _ := libp2p.NewLibp2pContext(context.Background(), h)
@@ -63,10 +63,10 @@ func TestKadDhtPeerDiscoverer_BootstrapCalledTwiceShouldErr(t *testing.T) {
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 
 	defer func() {
-		h.Close()
+		_ = h.Close()
 	}()
 
-	kdd.ApplyContext(ctx)
+	_ = kdd.ApplyContext(ctx)
 	_ = kdd.Bootstrap()
 	err := kdd.Bootstrap()
 
@@ -76,11 +76,11 @@ func TestKadDhtPeerDiscoverer_BootstrapCalledTwiceShouldErr(t *testing.T) {
 //------- connectToOnePeerFromInitialPeersList
 
 func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersListNilListShouldRetWithChanFull(t *testing.T) {
-	interval := time.Duration(time.Second * 1)
+	interval := time.Second * 1
 
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 	lctx, _ := libp2p.NewLibp2pContext(context.Background(), &mock.ConnectableHostStub{})
-	kdd.ApplyContext(lctx)
+	_ = kdd.ApplyContext(lctx)
 
 	chanDone := kdd.ConnectToOnePeerFromInitialPeersList(time.Second, nil)
 
@@ -88,11 +88,11 @@ func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersListNilListShouldR
 }
 
 func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersListEmptyListShouldRetWithChanFull(t *testing.T) {
-	interval := time.Duration(time.Second * 1)
+	interval := time.Second * 1
 
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 	lctx, _ := libp2p.NewLibp2pContext(context.Background(), &mock.ConnectableHostStub{})
-	kdd.ApplyContext(lctx)
+	_ = kdd.ApplyContext(lctx)
 
 	chanDone := kdd.ConnectToOnePeerFromInitialPeersList(time.Second, make([]string, 0))
 
@@ -100,7 +100,7 @@ func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersListEmptyListShoul
 }
 
 func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersOnePeerShouldTryToConnect(t *testing.T) {
-	interval := time.Duration(time.Second * 1)
+	interval := time.Second * 1
 
 	peerID := "peer"
 
@@ -118,7 +118,7 @@ func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersOnePeerShouldTryTo
 
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 	lctx, _ := libp2p.NewLibp2pContext(context.Background(), uhs)
-	kdd.ApplyContext(lctx)
+	_ = kdd.ApplyContext(lctx)
 
 	chanDone := kdd.ConnectToOnePeerFromInitialPeersList(time.Second, []string{peerID})
 
@@ -131,7 +131,7 @@ func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersOnePeerShouldTryTo
 }
 
 func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersOnePeerShouldTryToConnectContinously(t *testing.T) {
-	interval := time.Duration(time.Second * 1)
+	interval := time.Second * 1
 
 	peerID := "peer"
 	wasConnectCalled := int32(0)
@@ -157,7 +157,7 @@ func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersOnePeerShouldTryTo
 
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 	lctx, _ := libp2p.NewLibp2pContext(context.Background(), uhs)
-	kdd.ApplyContext(lctx)
+	_ = kdd.ApplyContext(lctx)
 
 	chanDone := kdd.ConnectToOnePeerFromInitialPeersList(time.Millisecond*10, []string{peerID})
 
@@ -170,7 +170,7 @@ func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersOnePeerShouldTryTo
 }
 
 func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersTwoPeersShouldAlternate(t *testing.T) {
-	interval := time.Duration(time.Second * 1)
+	interval := time.Second * 1
 
 	peerID1 := "peer1"
 	peerID2 := "peer2"
@@ -209,7 +209,7 @@ func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersTwoPeersShouldAlte
 
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 	lctx, _ := libp2p.NewLibp2pContext(context.Background(), uhs)
-	kdd.ApplyContext(lctx)
+	_ = kdd.ApplyContext(lctx)
 
 	chanDone := kdd.ConnectToOnePeerFromInitialPeersList(time.Millisecond*10, []string{peerID1, peerID2})
 
@@ -223,7 +223,7 @@ func TestKadDhtPeerDiscoverer_ConnectToOnePeerFromInitialPeersTwoPeersShouldAlte
 //------- ApplyContext
 
 func TestKadDhtPeerDiscoverer_ApplyContextNilProviderShouldErr(t *testing.T) {
-	interval := time.Duration(time.Second * 1)
+	interval := time.Second * 1
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 
 	err := kdd.ApplyContext(nil)
@@ -232,7 +232,7 @@ func TestKadDhtPeerDiscoverer_ApplyContextNilProviderShouldErr(t *testing.T) {
 }
 
 func TestKadDhtPeerDiscoverer_ApplyContextWrongProviderShouldErr(t *testing.T) {
-	interval := time.Duration(time.Second * 1)
+	interval := time.Second * 1
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 
 	err := kdd.ApplyContext(&mock.ContextProviderMock{})
@@ -242,7 +242,7 @@ func TestKadDhtPeerDiscoverer_ApplyContextWrongProviderShouldErr(t *testing.T) {
 
 func TestKadDhtPeerDiscoverer_ApplyContextShouldWork(t *testing.T) {
 	ctx, _ := libp2p.NewLibp2pContext(context.Background(), &mock.ConnectableHostStub{})
-	interval := time.Duration(time.Second * 1)
+	interval := time.Second * 1
 	kdd := discovery.NewKadDhtPeerDiscoverer(interval, "", nil)
 
 	err := kdd.ApplyContext(ctx)

--- a/p2p/libp2p/discovery/mdnsDiscoverer_test.go
+++ b/p2p/libp2p/discovery/mdnsDiscoverer_test.go
@@ -28,7 +28,7 @@ func createDummyHost() libp2p2.ConnectableHost {
 
 func TestNewMdnsDiscoverer_ShouldSetValues(t *testing.T) {
 	serviceTag := "srvcTag"
-	interval := time.Duration(time.Second * 4)
+	interval := time.Second * 4
 
 	mdns := discovery.NewMdnsPeerDiscoverer(interval, serviceTag)
 
@@ -40,7 +40,7 @@ func TestNewMdnsDiscoverer_ShouldSetValues(t *testing.T) {
 
 func TestMdnsPeerDiscoverer_BootstrapCalledWithoutContextAppliedShouldErr(t *testing.T) {
 	serviceTag := "srvcTag"
-	interval := time.Duration(time.Second * 1)
+	interval := time.Second * 1
 
 	mdns := discovery.NewMdnsPeerDiscoverer(interval, serviceTag)
 	err := mdns.Bootstrap()
@@ -52,17 +52,17 @@ func TestMdnsPeerDiscoverer_BootstrapCalledOnceShouldWork(t *testing.T) {
 	//TODO delete skip when mdns library is concurrent safe
 	t.Skip("mdns library is not concurrent safe (yet)")
 	serviceTag := "srvcTag"
-	interval := time.Duration(time.Second * 1)
+	interval := time.Second * 1
 
 	h := createDummyHost()
 	ctx, _ := libp2p2.NewLibp2pContext(context.Background(), h)
 
 	mdns := discovery.NewMdnsPeerDiscoverer(interval, serviceTag)
 	defer func() {
-		h.Close()
+		_ = h.Close()
 	}()
 
-	mdns.ApplyContext(ctx)
+	_ = mdns.ApplyContext(ctx)
 	err := mdns.Bootstrap()
 
 	assert.Nil(t, err)
@@ -72,7 +72,7 @@ func TestMdnsPeerDiscoverer_BootstrapCalledTwiceShouldErr(t *testing.T) {
 	//TODO delete skip when mdns library is concurrent safe
 	t.Skip("mdns library is not concurrent safe (yet)")
 	serviceTag := "srvcTag"
-	interval := time.Duration(time.Second * 1)
+	interval := time.Second * 1
 
 	h := createDummyHost()
 	ctx, _ := libp2p2.NewLibp2pContext(context.Background(), h)
@@ -80,10 +80,10 @@ func TestMdnsPeerDiscoverer_BootstrapCalledTwiceShouldErr(t *testing.T) {
 	mdns := discovery.NewMdnsPeerDiscoverer(interval, serviceTag)
 
 	defer func() {
-		h.Close()
+		_ = h.Close()
 	}()
 
-	mdns.ApplyContext(ctx)
+	_ = mdns.ApplyContext(ctx)
 	_ = mdns.Bootstrap()
 	err := mdns.Bootstrap()
 
@@ -93,7 +93,7 @@ func TestMdnsPeerDiscoverer_BootstrapCalledTwiceShouldErr(t *testing.T) {
 //------- ApplyContext
 
 func TestMdnsPeerDiscoverer_ApplyContextNilProviderShouldErr(t *testing.T) {
-	mdns := discovery.NewMdnsPeerDiscoverer(time.Duration(time.Second*1), "srvcTag")
+	mdns := discovery.NewMdnsPeerDiscoverer(time.Second*1, "srvcTag")
 
 	err := mdns.ApplyContext(nil)
 
@@ -103,7 +103,7 @@ func TestMdnsPeerDiscoverer_ApplyContextNilProviderShouldErr(t *testing.T) {
 func TestMdnsPeerDiscoverer_ApplyContextWrongProviderShouldErr(t *testing.T) {
 	//TODO delete skip when mdns library is concurrent safe
 	t.Skip("mdns library is not concurrent safe (yet)")
-	mdns := discovery.NewMdnsPeerDiscoverer(time.Duration(time.Second*1), "srvcTag")
+	mdns := discovery.NewMdnsPeerDiscoverer(time.Second*1, "srvcTag")
 
 	err := mdns.ApplyContext(&mock.ContextProviderMock{})
 
@@ -114,7 +114,7 @@ func TestMdnsPeerDiscoverer_ApplyContextShouldWork(t *testing.T) {
 	//TODO delete skip when mdns library is concurrent safe
 	t.Skip("mdns library is not concurrent safe (yet)")
 	ctx, _ := libp2p2.NewLibp2pContext(context.Background(), &mock.ConnectableHostStub{})
-	mdns := discovery.NewMdnsPeerDiscoverer(time.Duration(time.Second*1), "srvcTag")
+	mdns := discovery.NewMdnsPeerDiscoverer(time.Second*1, "srvcTag")
 
 	err := mdns.ApplyContext(ctx)
 
@@ -148,7 +148,7 @@ func TestNetworkMessenger_HandlePeerFoundNotFoundShouldTryToConnect(t *testing.T
 	}
 
 	ctx, _ := libp2p2.NewLibp2pContext(context.Background(), mockHost)
-	mdns := discovery.NewMdnsPeerDiscoverer(time.Duration(time.Second*1), "srvcTag")
+	mdns := discovery.NewMdnsPeerDiscoverer(time.Second*1, "srvcTag")
 	_ = mdns.ApplyContext(ctx)
 
 	mdns.HandlePeerFound(newPeerInfo)
@@ -188,7 +188,7 @@ func TestNetworkMessenger_HandlePeerFoundPeerFoundShouldNotTryToConnect(t *testi
 	}
 
 	ctx, _ := libp2p2.NewLibp2pContext(context.Background(), mockHost)
-	mdns := discovery.NewMdnsPeerDiscoverer(time.Duration(time.Second*1), "srvcTag")
+	mdns := discovery.NewMdnsPeerDiscoverer(time.Second*1, "srvcTag")
 	_ = mdns.ApplyContext(ctx)
 
 	mdns.HandlePeerFound(newPeerInfo)

--- a/p2p/libp2p/discovery/mdnsDiscoverer_test.go
+++ b/p2p/libp2p/discovery/mdnsDiscoverer_test.go
@@ -40,7 +40,7 @@ func TestNewMdnsDiscoverer_ShouldSetValues(t *testing.T) {
 
 func TestMdnsPeerDiscoverer_BootstrapCalledWithoutContextAppliedShouldErr(t *testing.T) {
 	serviceTag := "srvcTag"
-	interval := time.Second * 1
+	interval := time.Second
 
 	mdns := discovery.NewMdnsPeerDiscoverer(interval, serviceTag)
 	err := mdns.Bootstrap()
@@ -52,7 +52,7 @@ func TestMdnsPeerDiscoverer_BootstrapCalledOnceShouldWork(t *testing.T) {
 	//TODO delete skip when mdns library is concurrent safe
 	t.Skip("mdns library is not concurrent safe (yet)")
 	serviceTag := "srvcTag"
-	interval := time.Second * 1
+	interval := time.Second
 
 	h := createDummyHost()
 	ctx, _ := libp2p2.NewLibp2pContext(context.Background(), h)
@@ -72,7 +72,7 @@ func TestMdnsPeerDiscoverer_BootstrapCalledTwiceShouldErr(t *testing.T) {
 	//TODO delete skip when mdns library is concurrent safe
 	t.Skip("mdns library is not concurrent safe (yet)")
 	serviceTag := "srvcTag"
-	interval := time.Second * 1
+	interval := time.Second
 
 	h := createDummyHost()
 	ctx, _ := libp2p2.NewLibp2pContext(context.Background(), h)
@@ -93,7 +93,7 @@ func TestMdnsPeerDiscoverer_BootstrapCalledTwiceShouldErr(t *testing.T) {
 //------- ApplyContext
 
 func TestMdnsPeerDiscoverer_ApplyContextNilProviderShouldErr(t *testing.T) {
-	mdns := discovery.NewMdnsPeerDiscoverer(time.Second*1, "srvcTag")
+	mdns := discovery.NewMdnsPeerDiscoverer(time.Second, "srvcTag")
 
 	err := mdns.ApplyContext(nil)
 
@@ -103,7 +103,7 @@ func TestMdnsPeerDiscoverer_ApplyContextNilProviderShouldErr(t *testing.T) {
 func TestMdnsPeerDiscoverer_ApplyContextWrongProviderShouldErr(t *testing.T) {
 	//TODO delete skip when mdns library is concurrent safe
 	t.Skip("mdns library is not concurrent safe (yet)")
-	mdns := discovery.NewMdnsPeerDiscoverer(time.Second*1, "srvcTag")
+	mdns := discovery.NewMdnsPeerDiscoverer(time.Second, "srvcTag")
 
 	err := mdns.ApplyContext(&mock.ContextProviderMock{})
 
@@ -114,7 +114,7 @@ func TestMdnsPeerDiscoverer_ApplyContextShouldWork(t *testing.T) {
 	//TODO delete skip when mdns library is concurrent safe
 	t.Skip("mdns library is not concurrent safe (yet)")
 	ctx, _ := libp2p2.NewLibp2pContext(context.Background(), &mock.ConnectableHostStub{})
-	mdns := discovery.NewMdnsPeerDiscoverer(time.Second*1, "srvcTag")
+	mdns := discovery.NewMdnsPeerDiscoverer(time.Second, "srvcTag")
 
 	err := mdns.ApplyContext(ctx)
 
@@ -148,7 +148,7 @@ func TestNetworkMessenger_HandlePeerFoundNotFoundShouldTryToConnect(t *testing.T
 	}
 
 	ctx, _ := libp2p2.NewLibp2pContext(context.Background(), mockHost)
-	mdns := discovery.NewMdnsPeerDiscoverer(time.Second*1, "srvcTag")
+	mdns := discovery.NewMdnsPeerDiscoverer(time.Second, "srvcTag")
 	_ = mdns.ApplyContext(ctx)
 
 	mdns.HandlePeerFound(newPeerInfo)
@@ -188,7 +188,7 @@ func TestNetworkMessenger_HandlePeerFoundPeerFoundShouldNotTryToConnect(t *testi
 	}
 
 	ctx, _ := libp2p2.NewLibp2pContext(context.Background(), mockHost)
-	mdns := discovery.NewMdnsPeerDiscoverer(time.Second*1, "srvcTag")
+	mdns := discovery.NewMdnsPeerDiscoverer(time.Second, "srvcTag")
 	_ = mdns.ApplyContext(ctx)
 
 	mdns.HandlePeerFound(newPeerInfo)

--- a/p2p/libp2p/issues_test.go
+++ b/p2p/libp2p/issues_test.go
@@ -52,11 +52,11 @@ func TestIssueEN898_StreamResetError(t *testing.T) {
 	mes2 := createMessenger(23101)
 
 	defer func() {
-		mes1.Close()
-		mes2.Close()
+		_ = mes1.Close()
+		_ = mes2.Close()
 	}()
 
-	mes1.ConnectToPeer(getConnectableAddress(mes2))
+	_ = mes1.ConnectToPeer(getConnectableAddress(mes2))
 
 	topic := "test topic"
 
@@ -74,9 +74,9 @@ func TestIssueEN898_StreamResetError(t *testing.T) {
 	smallPacketReceived := &atomic.Value{}
 	smallPacketReceived.Store(false)
 
-	mes2.CreateTopic(topic, false)
-	mes2.RegisterMessageProcessor(topic, &mock.MessageProcessorStub{
-		ProcessMessageCalled: func(message p2p.MessageP2P) error {
+	_ = mes2.CreateTopic(topic, false)
+	_ = mes2.RegisterMessageProcessor(topic, &mock.MessageProcessorStub{
+		ProcessMessageCalled: func(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 			if bytes.Equal(message.Data(), largePacket) {
 				largePacketReceived.Store(true)
 			}
@@ -90,12 +90,12 @@ func TestIssueEN898_StreamResetError(t *testing.T) {
 	})
 
 	fmt.Println("sending the large packet...")
-	mes1.SendToConnectedPeer(topic, largePacket, mes2.ID())
+	_ = mes1.SendToConnectedPeer(topic, largePacket, mes2.ID())
 
 	time.Sleep(time.Second)
 
 	fmt.Println("sending the small packet...")
-	mes1.SendToConnectedPeer(topic, smallPacket, mes2.ID())
+	_ = mes1.SendToConnectedPeer(topic, smallPacket, mes2.ID())
 
 	time.Sleep(time.Second)
 

--- a/p2p/libp2p/libp2pConnectionMonitor.go
+++ b/p2p/libp2p/libp2pConnectionMonitor.go
@@ -14,7 +14,7 @@ var ThresholdMinimumConnectedPeers = 3
 
 // DurationBetweenReconnectAttempts is used as to not call reconnecter.ReconnectToNetwork() to often
 // when there are a lot of peers disconnecting and reconnection to initial nodes succeed
-var DurationBetweenReconnectAttempts = time.Duration(time.Second * 5)
+var DurationBetweenReconnectAttempts = time.Second * 5
 
 type libp2pConnectionMonitor struct {
 	chDoReconnect chan struct{}

--- a/p2p/libp2p/libp2pConnectionMonitor_test.go
+++ b/p2p/libp2p/libp2pConnectionMonitor_test.go
@@ -11,11 +11,11 @@ import (
 
 func init() {
 	ThresholdMinimumConnectedPeers = 3
-	DurationBetweenReconnectAttempts = time.Duration(time.Millisecond)
+	DurationBetweenReconnectAttempts = time.Millisecond
 }
 
-var durTimeoutWaiting = time.Duration(time.Second * 2)
-var durStartGoRoutine = time.Duration(time.Second)
+var durTimeoutWaiting = time.Second * 2
+var durStartGoRoutine = time.Second
 
 func TestNewLibp2pConnectionMonitor_WithNilReconnecterShouldWork(t *testing.T) {
 	t.Parallel()

--- a/p2p/libp2p/memMessenger.go
+++ b/p2p/libp2p/memMessenger.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/p2p/loadBalancer"
 	"github.com/libp2p/go-libp2p-core/connmgr"
 	libp2pCrypto "github.com/libp2p/go-libp2p-core/crypto"
-	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p/p2p/net/mock"
 )
 
@@ -34,7 +33,7 @@ func NewMemoryMessenger(
 		return nil, err
 	}
 
-	lctx, err := NewLibp2pContext(ctx, NewConnectableHost(host.Host(h)))
+	lctx, err := NewLibp2pContext(ctx, NewConnectableHost(h))
 	if err != nil {
 		log.LogIfError(h.Close())
 		return nil, err

--- a/p2p/loadBalancer/outgoingChannelLoadBalancer_test.go
+++ b/p2p/loadBalancer/outgoingChannelLoadBalancer_test.go
@@ -235,7 +235,7 @@ func TestOutgoingChannelLoadBalancer_CollectOneElementFromChannelsShouldWork(t *
 
 	oclb := loadBalancer.NewOutgoingChannelLoadBalancer()
 
-	oclb.AddChannel("test")
+	_ = oclb.AddChannel("test")
 
 	obj1 := &p2p.SendableData{Topic: "test"}
 	obj2 := &p2p.SendableData{Topic: "default"}

--- a/p2p/memp2p/memp2p.go
+++ b/p2p/memp2p/memp2p.go
@@ -358,9 +358,7 @@ func (messenger *Messenger) ReceiveMessage(topic string, message p2p.MessageP2P,
 		}
 	}
 
-	err := validator.ProcessReceivedMessage(message, handler)
-
-	return err
+	return validator.ProcessReceivedMessage(message, handler)
 }
 
 // Close disconnects this Messenger from the network it was connected to.

--- a/p2p/memp2p/memp2p_test.go
+++ b/p2p/memp2p/memp2p_test.go
@@ -41,7 +41,7 @@ func TestInitializingNetworkwith4Peers(t *testing.T) {
 	expectedAddresses := []string{"/memp2p/Peer1", "/memp2p/Peer2", "/memp2p/Peer3", "/memp2p/Peer4"}
 	assert.Equal(t, expectedAddresses, network.ListAddresses())
 
-	peer1.Close()
+	_ = peer1.Close()
 	peerIDs := network.PeerIDs()
 	peersMap := network.Peers()
 	assert.Equal(t, 3, len(peerIDs))

--- a/p2p/mock/messageProcessorStub.go
+++ b/p2p/mock/messageProcessorStub.go
@@ -5,9 +5,9 @@ import (
 )
 
 type MessageProcessorStub struct {
-	ProcessMessageCalled func(message p2p.MessageP2P) error
+	ProcessMessageCalled func(message p2p.MessageP2P, broadcastHandler func(buffToSend []byte)) error
 }
 
-func (mps *MessageProcessorStub) ProcessReceivedMessage(message p2p.MessageP2P) error {
-	return mps.ProcessMessageCalled(message)
+func (mps *MessageProcessorStub) ProcessReceivedMessage(message p2p.MessageP2P, broadcastHandler func(buffToSend []byte)) error {
+	return mps.ProcessMessageCalled(message, broadcastHandler)
 }

--- a/p2p/mock/mockMessageProcessor.go
+++ b/p2p/mock/mockMessageProcessor.go
@@ -16,7 +16,7 @@ func NewMockMessageProcessor(peer p2p.PeerID) *MockMessageProcessor {
 	return &processor
 }
 
-func (processor *MockMessageProcessor) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (processor *MockMessageProcessor) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	fmt.Printf("Message received by %s from %s: %s\n", string(processor.Peer), string(message.Peer()), string(message.Data()))
 	return nil
 }

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -11,13 +11,7 @@ import (
 // All implementations that will be called from Messenger implementation will need to satisfy this interface
 // If the function returns a non nil value, the received message will not be propagated to its connected peers
 type MessageProcessor interface {
-	ProcessReceivedMessage(message MessageP2P) error
-}
-
-// BroadcastCallbackHandler will be implemented by those message processor instances that need to send back
-// a subset of received message (after filtering occurs)
-type BroadcastCallbackHandler interface {
-	SetBroadcastCallback(callback func(buffToSend []byte))
+	ProcessReceivedMessage(message MessageP2P, broadcastHandler func(buffToSend []byte)) error
 }
 
 // SendableData represents the struct used in data throttler implementation

--- a/process/block/interceptors/headerInterceptor.go
+++ b/process/block/interceptors/headerInterceptor.go
@@ -112,7 +112,7 @@ func (hi *HeaderInterceptor) ParseReceivedMessage(message p2p.MessageP2P) (*bloc
 
 // ProcessReceivedMessage will be the callback func from the p2p.Messenger and will be called each time a new message was received
 // (for the topic this validator was registered to)
-func (hi *HeaderInterceptor) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (hi *HeaderInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	hdrIntercepted, err := hi.ParseReceivedMessage(message)
 	if err != nil {
 		return err

--- a/process/block/interceptors/headerInterceptor_test.go
+++ b/process/block/interceptors/headerInterceptor_test.go
@@ -417,7 +417,7 @@ func TestHeaderInterceptor_ProcessReceivedMessageNilMessageShouldErr(t *testing.
 		&mock.ChronologyValidatorStub{},
 	)
 
-	assert.Equal(t, process.ErrNilMessage, hi.ProcessReceivedMessage(nil))
+	assert.Equal(t, process.ErrNilMessage, hi.ProcessReceivedMessage(nil, nil))
 }
 
 func TestHeaderInterceptor_ProcessReceivedMessageValsOkShouldWork(t *testing.T) {
@@ -491,7 +491,7 @@ func TestHeaderInterceptor_ProcessReceivedMessageValsOkShouldWork(t *testing.T) 
 		chanDone <- struct{}{}
 	}()
 
-	assert.Nil(t, hi.ProcessReceivedMessage(msg))
+	assert.Nil(t, hi.ProcessReceivedMessage(msg, nil))
 	select {
 	case <-chanDone:
 	case <-time.After(durTimeout):
@@ -560,7 +560,7 @@ func TestHeaderInterceptor_ProcessReceivedMessageTestHdrNonces(t *testing.T) {
 		}
 	}
 
-	assert.Nil(t, hi.ProcessReceivedMessage(msg))
+	assert.Nil(t, hi.ProcessReceivedMessage(msg, nil))
 	select {
 	case <-chanDone:
 	case <-time.After(durTimeout):
@@ -632,7 +632,7 @@ func TestHeaderInterceptor_ProcessReceivedMessageIsNotValidShouldNotAdd(t *testi
 		return false, false
 	}
 
-	assert.Nil(t, hi.ProcessReceivedMessage(msg))
+	assert.Nil(t, hi.ProcessReceivedMessage(msg, nil))
 	select {
 	case <-chanDone:
 		assert.Fail(t, "should have not add block in pool")
@@ -707,6 +707,6 @@ func TestHeaderInterceptor_ProcessReceivedMessageNotForCurrentShardShouldNotAdd(
 		return false, false
 	}
 
-	assert.Nil(t, hi.ProcessReceivedMessage(msg))
+	assert.Nil(t, hi.ProcessReceivedMessage(msg, nil))
 
 }

--- a/process/block/interceptors/metachainHeaderInterceptor.go
+++ b/process/block/interceptors/metachainHeaderInterceptor.go
@@ -79,7 +79,7 @@ func NewMetachainHeaderInterceptor(
 
 // ProcessReceivedMessage will be the callback func from the p2p.Messenger and will be called each time a new message was received
 // (for the topic this validator was registered to)
-func (mhi *MetachainHeaderInterceptor) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (mhi *MetachainHeaderInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	err := mhi.checkMessage(message)
 	if err != nil {
 		return err

--- a/process/block/interceptors/metachainHeaderInterceptor_test.go
+++ b/process/block/interceptors/metachainHeaderInterceptor_test.go
@@ -202,7 +202,7 @@ func TestMetachainHeaderInterceptor_ProcessReceivedMessageNilMessageShouldErr(t 
 		&mock.ChronologyValidatorStub{},
 	)
 
-	assert.Equal(t, process.ErrNilMessage, mhi.ProcessReceivedMessage(nil))
+	assert.Equal(t, process.ErrNilMessage, mhi.ProcessReceivedMessage(nil, nil))
 }
 
 func TestMetachainHeaderInterceptor_ProcessReceivedMessageNilDataToProcessShouldErr(t *testing.T) {
@@ -224,7 +224,7 @@ func TestMetachainHeaderInterceptor_ProcessReceivedMessageNilDataToProcessShould
 
 	msg := &mock.P2PMessageMock{}
 
-	assert.Equal(t, process.ErrNilDataToProcess, mhi.ProcessReceivedMessage(msg))
+	assert.Equal(t, process.ErrNilDataToProcess, mhi.ProcessReceivedMessage(msg, nil))
 }
 
 func TestMetachainHeaderInterceptor_ProcessReceivedMessageMarshalizerErrorsAtUnmarshalingShouldErr(t *testing.T) {
@@ -253,7 +253,7 @@ func TestMetachainHeaderInterceptor_ProcessReceivedMessageMarshalizerErrorsAtUnm
 		DataField: make([]byte, 0),
 	}
 
-	assert.Equal(t, errMarshalizer, mhi.ProcessReceivedMessage(msg))
+	assert.Equal(t, errMarshalizer, mhi.ProcessReceivedMessage(msg, nil))
 }
 
 func TestMetachainHeaderInterceptor_ProcessReceivedMessageSanityCheckFailedShouldErr(t *testing.T) {
@@ -285,7 +285,7 @@ func TestMetachainHeaderInterceptor_ProcessReceivedMessageSanityCheckFailedShoul
 		DataField: buff,
 	}
 
-	assert.Equal(t, process.ErrNilPubKeysBitmap, mhi.ProcessReceivedMessage(msg))
+	assert.Equal(t, process.ErrNilPubKeysBitmap, mhi.ProcessReceivedMessage(msg, nil))
 }
 
 func TestMetachainHeaderInterceptor_ProcessReceivedMessageValsOkShouldWork(t *testing.T) {
@@ -365,7 +365,7 @@ func TestMetachainHeaderInterceptor_ProcessReceivedMessageValsOkShouldWork(t *te
 		chanDone <- struct{}{}
 	}()
 
-	assert.Nil(t, mhi.ProcessReceivedMessage(msg))
+	assert.Nil(t, mhi.ProcessReceivedMessage(msg, nil))
 	select {
 	case <-chanDone:
 	case <-time.After(durTimeout):
@@ -442,7 +442,7 @@ func TestMetachainHeaderInterceptor_ProcessReceivedMessageIsNotValidShouldNotAdd
 		})
 	}
 
-	assert.Nil(t, mhi.ProcessReceivedMessage(msg))
+	assert.Nil(t, mhi.ProcessReceivedMessage(msg, nil))
 	select {
 	case <-chanDone:
 		assert.Fail(t, "should have not add block in pool")

--- a/process/block/interceptors/peerBlockBodyInterceptor.go
+++ b/process/block/interceptors/peerBlockBodyInterceptor.go
@@ -57,7 +57,7 @@ func NewPeerBlockBodyInterceptor(
 
 // ProcessReceivedMessage will be the callback func from the p2p.Messenger and will be called each time a new message was received
 // (for the topic this validator was registered to)
-func (pbbi *PeerBlockBodyInterceptor) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (pbbi *PeerBlockBodyInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	err := pbbi.checkMessage(message)
 	if err != nil {
 		return err

--- a/process/block/interceptors/peerBlockBodyInterceptors_test.go
+++ b/process/block/interceptors/peerBlockBodyInterceptors_test.go
@@ -64,7 +64,7 @@ func TestPeerBlockBodyInterceptor_ProcessReceivedMessageNilMessageShouldErr(t *t
 		mock.HasherMock{},
 		mock.NewOneShardCoordinatorMock())
 
-	assert.Equal(t, process.ErrNilMessage, pbbi.ProcessReceivedMessage(nil))
+	assert.Equal(t, process.ErrNilMessage, pbbi.ProcessReceivedMessage(nil, nil))
 }
 
 func TestPeerBlockBodyInterceptor_ProcessReceivedMessageNilMessageDataShouldErr(t *testing.T) {
@@ -82,7 +82,7 @@ func TestPeerBlockBodyInterceptor_ProcessReceivedMessageNilMessageDataShouldErr(
 
 	msg := &mock.P2PMessageMock{}
 
-	assert.Equal(t, process.ErrNilDataToProcess, pbbi.ProcessReceivedMessage(msg))
+	assert.Equal(t, process.ErrNilDataToProcess, pbbi.ProcessReceivedMessage(msg, nil))
 }
 
 func TestPeerBlockBodyInterceptor_ValidateMarshalizerErrorsAtUnmarshalingShouldErr(t *testing.T) {
@@ -108,7 +108,7 @@ func TestPeerBlockBodyInterceptor_ValidateMarshalizerErrorsAtUnmarshalingShouldE
 		DataField: make([]byte, 0),
 	}
 
-	assert.Equal(t, errMarshalizer, pbbi.ProcessReceivedMessage(msg))
+	assert.Equal(t, errMarshalizer, pbbi.ProcessReceivedMessage(msg, nil))
 }
 
 func TestPeerBlockBodyInterceptor_ProcessReceivedMessageBlockShouldWork(t *testing.T) {
@@ -147,7 +147,7 @@ func TestPeerBlockBodyInterceptor_ProcessReceivedMessageBlockShouldWork(t *testi
 		return true, false
 	}
 
-	assert.Nil(t, pbbi.ProcessReceivedMessage(msg))
+	assert.Nil(t, pbbi.ProcessReceivedMessage(msg, nil))
 	select {
 	case <-chanDone:
 	case <-time.After(durTimeout):
@@ -191,7 +191,7 @@ func TestPeerBlockBodyInterceptor_ProcessReceivedMessageIsInStorageShouldNotAdd(
 		return true, false
 	}
 
-	assert.Nil(t, pbbi.ProcessReceivedMessage(msg))
+	assert.Nil(t, pbbi.ProcessReceivedMessage(msg, nil))
 	select {
 	case <-chanDone:
 		assert.Fail(t, "should have not add block in pool")

--- a/process/block/interceptors/txBlockBodyInterceptor.go
+++ b/process/block/interceptors/txBlockBodyInterceptor.go
@@ -58,7 +58,7 @@ func NewTxBlockBodyInterceptor(
 
 // ProcessReceivedMessage will be the callback func from the p2p.Messenger and will be called each time a new message was received
 // (for the topic this validator was registered to)
-func (tbbi *TxBlockBodyInterceptor) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (tbbi *TxBlockBodyInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	err := tbbi.checkMessage(message)
 	if err != nil {
 		return err

--- a/process/block/interceptors/txBlockBodyInterceptors_test.go
+++ b/process/block/interceptors/txBlockBodyInterceptors_test.go
@@ -130,7 +130,7 @@ func TestTxBlockBodyInterceptor_ProcessReceivedMessageNilMessageShouldErr(t *tes
 		mock.HasherMock{},
 		mock.NewOneShardCoordinatorMock())
 
-	assert.Equal(t, process.ErrNilMessage, tbbi.ProcessReceivedMessage(nil))
+	assert.Equal(t, process.ErrNilMessage, tbbi.ProcessReceivedMessage(nil, nil))
 }
 
 func TestTxBlockBodyInterceptor_ProcessReceivedMessageNilMessageDataShouldErr(t *testing.T) {
@@ -148,7 +148,7 @@ func TestTxBlockBodyInterceptor_ProcessReceivedMessageNilMessageDataShouldErr(t 
 
 	msg := &mock.P2PMessageMock{}
 
-	assert.Equal(t, process.ErrNilDataToProcess, tbbi.ProcessReceivedMessage(msg))
+	assert.Equal(t, process.ErrNilDataToProcess, tbbi.ProcessReceivedMessage(msg, nil))
 }
 
 func TestTxBlockBodyInterceptor_ProcessReceivedMessageMarshalizerErrorsAtUnmarshalingShouldErr(t *testing.T) {
@@ -174,7 +174,7 @@ func TestTxBlockBodyInterceptor_ProcessReceivedMessageMarshalizerErrorsAtUnmarsh
 		DataField: make([]byte, 0),
 	}
 
-	assert.Equal(t, errMarshalizer, tbbi.ProcessReceivedMessage(msg))
+	assert.Equal(t, errMarshalizer, tbbi.ProcessReceivedMessage(msg, nil))
 }
 
 func TestTxBlockBodyInterceptor_ProcessReceivedMessageBlockShouldWork(t *testing.T) {
@@ -219,7 +219,7 @@ func TestTxBlockBodyInterceptor_ProcessReceivedMessageBlockShouldWork(t *testing
 		return false, false
 	}
 
-	assert.Nil(t, tbbi.ProcessReceivedMessage(msg))
+	assert.Nil(t, tbbi.ProcessReceivedMessage(msg, nil))
 	select {
 	case <-chanDone:
 	case <-time.After(durTimeout):

--- a/process/interceptors/common.go
+++ b/process/interceptors/common.go
@@ -21,7 +21,7 @@ func preProcessMesage(throttler process.InterceptorThrottler, message p2p.Messag
 		return nil
 	}
 
-	throttler.StartToProcess()
+	throttler.StartProcessing()
 	return nil
 }
 

--- a/process/interceptors/common_test.go
+++ b/process/interceptors/common_test.go
@@ -56,7 +56,7 @@ func TestPreProcessMessage_CanProcessReturnsNilAndCallsStartProcessing(t *testin
 		CanProcessCalled: func() bool {
 			return true
 		},
-		StartToProcessCalled: func() {
+		StartProcessingCalled: func() {
 			startProcessingCalled = true
 		},
 	}

--- a/process/interceptors/multiDataInterceptor.go
+++ b/process/interceptors/multiDataInterceptor.go
@@ -62,11 +62,11 @@ func (mdi *MultiDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P) 
 	multiDataBuff := make([][]byte, 0)
 	err = mdi.marshalizer.Unmarshal(&multiDataBuff, message.Data())
 	if err != nil {
-		mdi.throttler.EndProcess()
+		mdi.throttler.EndProcessing()
 		return err
 	}
 	if len(multiDataBuff) == 0 {
-		mdi.throttler.EndProcess()
+		mdi.throttler.EndProcessing()
 		return process.ErrNoDataInMessage
 	}
 
@@ -76,7 +76,7 @@ func (mdi *MultiDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P) 
 	wgProcess.Add(len(multiDataBuff))
 	go func() {
 		wgProcess.Wait()
-		mdi.throttler.EndProcess()
+		mdi.throttler.EndProcessing()
 	}()
 
 	for _, dataBuff := range multiDataBuff {

--- a/process/interceptors/multiDataInterceptor.go
+++ b/process/interceptors/multiDataInterceptor.go
@@ -13,11 +13,10 @@ var log = logger.DefaultLogger()
 
 // MultiDataInterceptor is used for intercepting packed multi data
 type MultiDataInterceptor struct {
-	marshalizer              marshal.Marshalizer
-	factory                  process.InterceptedDataFactory
-	processor                process.InterceptorProcessor
-	throttler                process.InterceptorThrottler
-	broadcastCallbackHandler func(buffToSend []byte)
+	marshalizer marshal.Marshalizer
+	factory     process.InterceptedDataFactory
+	processor   process.InterceptorProcessor
+	throttler   process.InterceptorThrottler
 }
 
 // NewMultiDataInterceptor hooks a new interceptor for packed multi data
@@ -53,7 +52,7 @@ func NewMultiDataInterceptor(
 
 // ProcessReceivedMessage is the callback func from the p2p.Messenger and will be called each time a new message was received
 // (for the topic this validator was registered to)
-func (mdi *MultiDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (mdi *MultiDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, broadcastHandler func(buffToSend []byte)) error {
 	err := preProcessMesage(mdi.throttler, message)
 	if err != nil {
 		return err
@@ -113,15 +112,10 @@ func (mdi *MultiDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P) 
 			return err
 		}
 
-		if mdi.broadcastCallbackHandler != nil {
-			mdi.broadcastCallbackHandler(buffToSend)
+		if broadcastHandler != nil {
+			broadcastHandler(buffToSend)
 		}
 	}
 
 	return lastErrEncountered
-}
-
-// SetBroadcastCallback sets the callback method to broadcast validated data
-func (mdi *MultiDataInterceptor) SetBroadcastCallback(callback func(buffToSend []byte)) {
-	mdi.broadcastCallbackHandler = callback
 }

--- a/process/interceptors/multiDataInterceptor_test.go
+++ b/process/interceptors/multiDataInterceptor_test.go
@@ -95,7 +95,7 @@ func TestMultiDataInterceptor_ProcessReceivedMessageNilMessageShouldErr(t *testi
 		&mock.InterceptorThrottlerStub{},
 	)
 
-	err := mdi.ProcessReceivedMessage(nil)
+	err := mdi.ProcessReceivedMessage(nil, nil)
 
 	assert.Equal(t, process.ErrNilMessage, err)
 }
@@ -118,7 +118,7 @@ func TestMultiDataInterceptor_ProcessReceivedMessageUnmarshalFailsShouldErr(t *t
 	msg := &mock.P2PMessageMock{
 		DataField: []byte("data to be processed"),
 	}
-	err := mdi.ProcessReceivedMessage(msg)
+	err := mdi.ProcessReceivedMessage(msg, nil)
 
 	assert.Equal(t, errExpeced, err)
 }
@@ -140,7 +140,7 @@ func TestMultiDataInterceptor_ProcessReceivedMessageUnmarshalReturnsEmptySliceSh
 	msg := &mock.P2PMessageMock{
 		DataField: []byte("data to be processed"),
 	}
-	err := mdi.ProcessReceivedMessage(msg)
+	err := mdi.ProcessReceivedMessage(msg, nil)
 
 	assert.Equal(t, process.ErrNoDataInMessage, err)
 }
@@ -167,15 +167,15 @@ func TestMultiDataInterceptor_ProcessReceivedCreateFailsShouldNotResend(t *testi
 		createMockInterceptorStub(&checkCalledNum, &processCalledNum),
 		createMockThrottler(&throttlerStartNum, &throttlerEndNum),
 	)
-	mdi.SetBroadcastCallback(func(buffToSend []byte) {
+	bradcastCallback := func(buffToSend []byte) {
 		atomic.AddInt32(&broadcastNum, 1)
-	})
+	}
 
 	dataField, _ := marshalizer.Marshal(buffData)
 	msg := &mock.P2PMessageMock{
 		DataField: dataField,
 	}
-	err := mdi.ProcessReceivedMessage(msg)
+	err := mdi.ProcessReceivedMessage(msg, bradcastCallback)
 
 	time.Sleep(time.Second)
 
@@ -223,7 +223,7 @@ func TestMultiDataInterceptor_ProcessReceivedPartiallyCorrectDataShouldSendOnlyC
 		createMockInterceptorStub(&checkCalledNum, &processCalledNum),
 		createMockThrottler(&throttlerStartNum, &throttlerEndNum),
 	)
-	mdi.SetBroadcastCallback(func(buffToSend []byte) {
+	bradcastCallback := func(buffToSend []byte) {
 		unmarshalledBuffs := make([][]byte, 0)
 		err := marshalizer.Unmarshal(&unmarshalledBuffs, buffToSend)
 		if err != nil {
@@ -237,13 +237,13 @@ func TestMultiDataInterceptor_ProcessReceivedPartiallyCorrectDataShouldSendOnlyC
 		}
 
 		atomic.AddInt32(&broadcastNum, 1)
-	})
+	}
 
 	dataField, _ := marshalizer.Marshal(buffData)
 	msg := &mock.P2PMessageMock{
 		DataField: dataField,
 	}
-	err := mdi.ProcessReceivedMessage(msg)
+	err := mdi.ProcessReceivedMessage(msg, bradcastCallback)
 
 	time.Sleep(time.Second)
 
@@ -289,7 +289,7 @@ func TestMultiDataInterceptor_ProcessReceivedMessageNotValidShouldErrAndNotProce
 	msg := &mock.P2PMessageMock{
 		DataField: dataField,
 	}
-	err := mdi.ProcessReceivedMessage(msg)
+	err := mdi.ProcessReceivedMessage(msg, nil)
 
 	time.Sleep(time.Second)
 
@@ -333,7 +333,7 @@ func TestMultiDataInterceptor_ProcessReceivedMessageIsAddressedToOtherShardShoul
 	msg := &mock.P2PMessageMock{
 		DataField: dataField,
 	}
-	err := mdi.ProcessReceivedMessage(msg)
+	err := mdi.ProcessReceivedMessage(msg, nil)
 
 	time.Sleep(time.Second)
 
@@ -377,7 +377,7 @@ func TestMultiDataInterceptor_ProcessReceivedMessageOkMessageShouldRetNil(t *tes
 	msg := &mock.P2PMessageMock{
 		DataField: dataField,
 	}
-	err := mdi.ProcessReceivedMessage(msg)
+	err := mdi.ProcessReceivedMessage(msg, nil)
 
 	time.Sleep(time.Second)
 

--- a/process/interceptors/singleDataInterceptor.go
+++ b/process/interceptors/singleDataInterceptor.go
@@ -51,18 +51,18 @@ func (sdi *SingleDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P)
 
 	interceptedData, err := sdi.factory.Create(message.Data())
 	if err != nil {
-		sdi.throttler.EndProcess()
+		sdi.throttler.EndProcessing()
 		return err
 	}
 
 	err = interceptedData.CheckValidity()
 	if err != nil {
-		sdi.throttler.EndProcess()
+		sdi.throttler.EndProcessing()
 		return err
 	}
 
 	if !interceptedData.IsForMyShard() {
-		sdi.throttler.EndProcess()
+		sdi.throttler.EndProcessing()
 		log.Debug("intercepted data is for other shards")
 		return nil
 	}
@@ -71,7 +71,7 @@ func (sdi *SingleDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P)
 	wgProcess.Add(1)
 	go func() {
 		wgProcess.Wait()
-		sdi.throttler.EndProcess()
+		sdi.throttler.EndProcessing()
 	}()
 
 	go processInterceptedData(sdi.processor, interceptedData, wgProcess)

--- a/process/interceptors/singleDataInterceptor.go
+++ b/process/interceptors/singleDataInterceptor.go
@@ -9,10 +9,9 @@ import (
 
 // SingleDataInterceptor is used for intercepting packed multi data
 type SingleDataInterceptor struct {
-	factory                  process.InterceptedDataFactory
-	processor                process.InterceptorProcessor
-	throttler                process.InterceptorThrottler
-	broadcastCallbackHandler func(buffToSend []byte)
+	factory   process.InterceptedDataFactory
+	processor process.InterceptorProcessor
+	throttler process.InterceptorThrottler
 }
 
 // NewSingleDataInterceptor hooks a new interceptor for single data
@@ -43,7 +42,7 @@ func NewSingleDataInterceptor(
 
 // ProcessReceivedMessage is the callback func from the p2p.Messenger and will be called each time a new message was received
 // (for the topic this validator was registered to)
-func (sdi *SingleDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (sdi *SingleDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	err := preProcessMesage(sdi.throttler, message)
 	if err != nil {
 		return err

--- a/process/interceptors/singleDataInterceptor_test.go
+++ b/process/interceptors/singleDataInterceptor_test.go
@@ -36,12 +36,12 @@ func createMockThrottler(throttlerStartNum *int32, throttlerEndNum *int32) proce
 		CanProcessCalled: func() bool {
 			return true
 		},
-		StartToProcessCalled: func() {
+		StartProcessingCalled: func() {
 			if throttlerStartNum != nil {
 				atomic.AddInt32(throttlerStartNum, 1)
 			}
 		},
-		EndProcessCalled: func() {
+		EndProcessingCalled: func() {
 			if throttlerEndNum != nil {
 				atomic.AddInt32(throttlerEndNum, 1)
 			}
@@ -132,8 +132,8 @@ func TestSingleDataInterceptor_ProcessReceivedMessageFactoryCreationErrorShouldE
 			CanProcessCalled: func() bool {
 				return true
 			},
-			StartToProcessCalled: func() {},
-			EndProcessCalled:     func() {},
+			StartProcessingCalled: func() {},
+			EndProcessingCalled:   func() {},
 		},
 	)
 

--- a/process/interceptors/singleDataInterceptor_test.go
+++ b/process/interceptors/singleDataInterceptor_test.go
@@ -112,7 +112,7 @@ func TestSingleDataInterceptor_ProcessReceivedMessageNilMessageShouldErr(t *test
 		&mock.InterceptorThrottlerStub{},
 	)
 
-	err := sdi.ProcessReceivedMessage(nil)
+	err := sdi.ProcessReceivedMessage(nil, nil)
 
 	assert.Equal(t, process.ErrNilMessage, err)
 }
@@ -140,7 +140,7 @@ func TestSingleDataInterceptor_ProcessReceivedMessageFactoryCreationErrorShouldE
 	msg := &mock.P2PMessageMock{
 		DataField: []byte("data to be processed"),
 	}
-	err := sdi.ProcessReceivedMessage(msg)
+	err := sdi.ProcessReceivedMessage(msg, nil)
 
 	assert.Equal(t, errExpected, err)
 }
@@ -175,7 +175,7 @@ func TestSingleDataInterceptor_ProcessReceivedMessageIsNotValidShouldNotCallProc
 	msg := &mock.P2PMessageMock{
 		DataField: []byte("data to be processed"),
 	}
-	err := sdi.ProcessReceivedMessage(msg)
+	err := sdi.ProcessReceivedMessage(msg, nil)
 
 	time.Sleep(time.Second)
 
@@ -215,7 +215,7 @@ func TestSingleDataInterceptor_ProcessReceivedMessageIsNotForCurrentShardShouldN
 	msg := &mock.P2PMessageMock{
 		DataField: []byte("data to be processed"),
 	}
-	err := sdi.ProcessReceivedMessage(msg)
+	err := sdi.ProcessReceivedMessage(msg, nil)
 
 	time.Sleep(time.Second)
 
@@ -255,7 +255,7 @@ func TestSingleDataInterceptor_ProcessReceivedMessageShouldWork(t *testing.T) {
 	msg := &mock.P2PMessageMock{
 		DataField: []byte("data to be processed"),
 	}
-	err := sdi.ProcessReceivedMessage(msg)
+	err := sdi.ProcessReceivedMessage(msg, nil)
 
 	time.Sleep(time.Second)
 

--- a/process/interface.go
+++ b/process/interface.go
@@ -61,8 +61,8 @@ type InterceptorProcessor interface {
 // InterceptorThrottler can
 type InterceptorThrottler interface {
 	CanProcess() bool
-	StartToProcess()
-	EndProcess()
+	StartProcessing()
+	EndProcessing()
 }
 
 // TransactionCoordinator is an interface to coordinate transaction processing using multiple processors

--- a/process/interface.go
+++ b/process/interface.go
@@ -259,7 +259,7 @@ type VirtualMachinesContainerFactory interface {
 // Interceptor defines what a data interceptor should do
 // It should also adhere to the p2p.MessageProcessor interface so it can wire to a p2p.Messenger
 type Interceptor interface {
-	ProcessReceivedMessage(message p2p.MessageP2P) error
+	ProcessReceivedMessage(message p2p.MessageP2P, broadcastHandler func(buffToSend []byte)) error
 }
 
 // MessageHandler defines the functionality needed by structs to send data to other peers

--- a/process/mock/headerResolverMock.go
+++ b/process/mock/headerResolverMock.go
@@ -14,7 +14,7 @@ func (hrm *HeaderResolverMock) RequestDataFromHash(hash []byte) error {
 	return hrm.RequestDataFromHashCalled(hash)
 }
 
-func (hrm *HeaderResolverMock) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (hrm *HeaderResolverMock) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	return hrm.ProcessReceivedMessageCalled(message)
 }
 

--- a/process/mock/interceptorStub.go
+++ b/process/mock/interceptorStub.go
@@ -5,9 +5,9 @@ import (
 )
 
 type InterceptorStub struct {
-	ProcessReceivedMessageCalled func(message p2p.MessageP2P) error
+	ProcessReceivedMessageCalled func(message p2p.MessageP2P, broadcastHandler func(buffToSend []byte)) error
 }
 
-func (is *InterceptorStub) ProcessReceivedMessage(message p2p.MessageP2P) error {
-	return is.ProcessReceivedMessageCalled(message)
+func (is *InterceptorStub) ProcessReceivedMessage(message p2p.MessageP2P, broadcastHandler func(buffToSend []byte)) error {
+	return is.ProcessReceivedMessageCalled(message, broadcastHandler)
 }

--- a/process/mock/interceptorThrottlerStub.go
+++ b/process/mock/interceptorThrottlerStub.go
@@ -1,19 +1,19 @@
 package mock
 
 type InterceptorThrottlerStub struct {
-	CanProcessCalled     func() bool
-	StartToProcessCalled func()
-	EndProcessCalled     func()
+	CanProcessCalled      func() bool
+	StartProcessingCalled func()
+	EndProcessingCalled   func()
 }
 
 func (its InterceptorThrottlerStub) CanProcess() bool {
 	return its.CanProcessCalled()
 }
 
-func (its InterceptorThrottlerStub) StartToProcess() {
-	its.StartToProcessCalled()
+func (its InterceptorThrottlerStub) StartProcessing() {
+	its.StartProcessingCalled()
 }
 
-func (its InterceptorThrottlerStub) EndProcess() {
-	its.EndProcessCalled()
+func (its InterceptorThrottlerStub) EndProcessing() {
+	its.EndProcessingCalled()
 }

--- a/process/mock/miniBlocksResolverMock.go
+++ b/process/mock/miniBlocksResolverMock.go
@@ -20,7 +20,7 @@ func (hrm *MiniBlocksResolverMock) RequestDataFromHashArray(hashes [][]byte) err
 	return hrm.RequestDataFromHashArrayCalled(hashes)
 }
 
-func (hrm *MiniBlocksResolverMock) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (hrm *MiniBlocksResolverMock) ProcessReceivedMessage(message p2p.MessageP2P, _ func(buffToSend []byte)) error {
 	return hrm.ProcessReceivedMessageCalled(message)
 }
 

--- a/process/mock/resolverStub.go
+++ b/process/mock/resolverStub.go
@@ -6,13 +6,13 @@ import (
 
 type ResolverStub struct {
 	RequestDataFromHashCalled    func(hash []byte) error
-	ProcessReceivedMessageCalled func(message p2p.MessageP2P) error
+	ProcessReceivedMessageCalled func(message p2p.MessageP2P, broadcastHandler func(buffToSend []byte)) error
 }
 
 func (rs *ResolverStub) RequestDataFromHash(hash []byte) error {
 	return rs.RequestDataFromHashCalled(hash)
 }
 
-func (rs *ResolverStub) ProcessReceivedMessage(message p2p.MessageP2P) error {
-	return rs.ProcessReceivedMessageCalled(message)
+func (rs *ResolverStub) ProcessReceivedMessage(message p2p.MessageP2P, broadcastHandler func(buffToSend []byte)) error {
+	return rs.ProcessReceivedMessageCalled(message, broadcastHandler)
 }

--- a/process/transaction/interceptor.go
+++ b/process/transaction/interceptor.go
@@ -16,15 +16,14 @@ import (
 
 // TxInterceptor is used for intercepting transaction and storing them into a datapool
 type TxInterceptor struct {
-	marshalizer              marshal.Marshalizer
-	txPool                   dataRetriever.ShardedDataCacherNotifier
-	txValidator              process.TxValidator
-	addrConverter            state.AddressConverter
-	hasher                   hashing.Hasher
-	singleSigner             crypto.SingleSigner
-	keyGen                   crypto.KeyGenerator
-	shardCoordinator         sharding.Coordinator
-	broadcastCallbackHandler func(buffToSend []byte)
+	marshalizer      marshal.Marshalizer
+	txPool           dataRetriever.ShardedDataCacherNotifier
+	txValidator      process.TxValidator
+	addrConverter    state.AddressConverter
+	hasher           hashing.Hasher
+	singleSigner     crypto.SingleSigner
+	keyGen           crypto.KeyGenerator
+	shardCoordinator sharding.Coordinator
 }
 
 // NewTxInterceptor hooks a new interceptor for transactions
@@ -80,7 +79,7 @@ func NewTxInterceptor(
 
 // ProcessReceivedMessage will be the callback func from the p2p.Messenger and will be called each time a new message was received
 // (for the topic this validator was registered to)
-func (txi *TxInterceptor) ProcessReceivedMessage(message p2p.MessageP2P) error {
+func (txi *TxInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, broadcastHandler func(buffToSend []byte)) error {
 	if message == nil {
 		return process.ErrNilMessage
 	}
@@ -135,16 +134,11 @@ func (txi *TxInterceptor) ProcessReceivedMessage(message p2p.MessageP2P) error {
 		}
 	}
 
-	if txi.broadcastCallbackHandler != nil {
-		txi.broadcastCallbackHandler(buffToSend)
+	if broadcastHandler != nil {
+		broadcastHandler(buffToSend)
 	}
 
 	return lastErrEncountered
-}
-
-// SetBroadcastCallback sets the callback method to send filtered out message
-func (txi *TxInterceptor) SetBroadcastCallback(callback func(buffToSend []byte)) {
-	txi.broadcastCallbackHandler = callback
 }
 
 func (txi *TxInterceptor) processTransaction(tx *InterceptedTransaction) {

--- a/process/transaction/interceptor_test.go
+++ b/process/transaction/interceptor_test.go
@@ -253,7 +253,7 @@ func TestTransactionInterceptor_ProcessReceivedMessageNilMesssageShouldErr(t *te
 		keyGen,
 		oneSharder)
 
-	err := txi.ProcessReceivedMessage(nil)
+	err := txi.ProcessReceivedMessage(nil, nil)
 
 	assert.Equal(t, process.ErrNilMessage, err)
 }
@@ -280,7 +280,7 @@ func TestTransactionInterceptor_ProcessReceivedMessageMilMessageDataShouldErr(t 
 
 	msg := &mock.P2PMessageMock{}
 
-	err := txi.ProcessReceivedMessage(msg)
+	err := txi.ProcessReceivedMessage(msg, nil)
 
 	assert.Equal(t, process.ErrNilDataToProcess, err)
 }
@@ -315,7 +315,7 @@ func TestTransactionInterceptor_ProcessReceivedMessageMarshalizerFailsAtUnmarsha
 		DataField: make([]byte, 0),
 	}
 
-	err := txi.ProcessReceivedMessage(msg)
+	err := txi.ProcessReceivedMessage(msg, nil)
 
 	assert.Equal(t, errMarshalizer, err)
 }
@@ -351,7 +351,7 @@ func TestTransactionInterceptor_ProcessReceivedMessageNoTransactionInMessageShou
 		DataField: make([]byte, 0),
 	}
 
-	err := txi.ProcessReceivedMessage(msg)
+	err := txi.ProcessReceivedMessage(msg, nil)
 
 	assert.Equal(t, process.ErrNoTransactionInMessage, err)
 }
@@ -395,7 +395,7 @@ func TestTransactionInterceptor_ProcessReceivedMessageIntegrityFailedShouldErr(t
 		DataField: buff,
 	}
 
-	err := txi.ProcessReceivedMessage(msg)
+	err := txi.ProcessReceivedMessage(msg, nil)
 
 	assert.Equal(t, process.ErrNilSignature, err)
 }
@@ -465,10 +465,10 @@ func TestTransactionInterceptor_ProcessReceivedMessageIntegrityFailedWithTwoTxsS
 		DataField: buff,
 	}
 
-	txi.SetBroadcastCallback(func(buffToSend []byte) {
+	broadcastCallback := func(buffToSend []byte) {
 		buff = buffToSend
-	})
-	err := txi.ProcessReceivedMessage(msg)
+	}
+	err := txi.ProcessReceivedMessage(msg, broadcastCallback)
 
 	assert.Equal(t, process.ErrNilSignature, err)
 	//unmarshal data and check there is only tx2 inside
@@ -530,7 +530,7 @@ func TestTransactionInterceptor_ProcessReceivedMessageVerifySigFailsShouldErr(t 
 		DataField: buff,
 	}
 
-	err := txi.ProcessReceivedMessage(msg)
+	err := txi.ProcessReceivedMessage(msg, nil)
 
 	assert.Equal(t, errExpected, err)
 }
@@ -595,7 +595,7 @@ func TestTransactionInterceptor_ProcessReceivedMessageOkValsSameShardShouldWork(
 		}
 	}
 
-	err := txi.ProcessReceivedMessage(msg)
+	err := txi.ProcessReceivedMessage(msg, nil)
 
 	assert.Nil(t, err)
 	select {
@@ -663,7 +663,7 @@ func TestTransactionInterceptor_ProcessReceivedMessageOkValsOtherShardsShouldWor
 		}
 	}
 
-	err := txi.ProcessReceivedMessage(msg)
+	err := txi.ProcessReceivedMessage(msg, nil)
 
 	assert.Nil(t, err)
 	select {
@@ -740,7 +740,7 @@ func TestTransactionInterceptor_ProcessReceivedMessageTxNotValidShouldNotAdd(t *
 		}
 	}
 
-	err := txi.ProcessReceivedMessage(msg)
+	err := txi.ProcessReceivedMessage(msg, nil)
 
 	assert.Nil(t, err)
 	select {

--- a/process/unsigned/interceptor_test.go
+++ b/process/unsigned/interceptor_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var durTimeout = time.Duration(time.Second)
+var durTimeout = time.Second
 
 //------- NewUnsignedTxInterceptor
 
@@ -173,7 +173,7 @@ func TestTransactionInterceptor_ProcessReceivedMessageNilMesssageShouldErr(t *te
 		mock.HasherMock{},
 		oneSharder)
 
-	err := scri.ProcessReceivedMessage(nil)
+	err := scri.ProcessReceivedMessage(nil, nil)
 
 	assert.Equal(t, process.ErrNilMessage, err)
 }
@@ -196,7 +196,7 @@ func TestTransactionInterceptor_ProcessReceivedMessageMilMessageDataShouldErr(t 
 
 	msg := &mock.P2PMessageMock{}
 
-	err := scri.ProcessReceivedMessage(msg)
+	err := scri.ProcessReceivedMessage(msg, nil)
 
 	assert.Equal(t, process.ErrNilDataToProcess, err)
 }
@@ -227,7 +227,7 @@ func TestTransactionInterceptor_ProcessReceivedMessageMarshalizerFailsAtUnmarsha
 		DataField: make([]byte, 0),
 	}
 
-	err := scri.ProcessReceivedMessage(msg)
+	err := scri.ProcessReceivedMessage(msg, nil)
 
 	assert.Equal(t, errMarshalizer, err)
 }
@@ -259,7 +259,7 @@ func TestTransactionInterceptor_ProcessReceivedMessageNoTransactionInMessageShou
 		DataField: make([]byte, 0),
 	}
 
-	err := scri.ProcessReceivedMessage(msg)
+	err := scri.ProcessReceivedMessage(msg, nil)
 
 	assert.Equal(t, process.ErrNoUnsignedTransactionInMessage, err)
 }
@@ -307,7 +307,7 @@ func TestTransactionInterceptor_ProcessReceivedMessageOkValsSameShardShouldWork(
 		}
 	}
 
-	err := scri.ProcessReceivedMessage(msg)
+	err := scri.ProcessReceivedMessage(msg, nil)
 
 	assert.Nil(t, err)
 	select {
@@ -361,7 +361,7 @@ func TestTransactionInterceptor_ProcessReceivedMessageOkValsOtherShardsShouldWor
 		}
 	}
 
-	err := scri.ProcessReceivedMessage(msg)
+	err := scri.ProcessReceivedMessage(msg, nil)
 
 	assert.Nil(t, err)
 	select {
@@ -423,7 +423,7 @@ func TestTransactionInterceptor_ProcessReceivedMessagePresentInStorerShouldNotAd
 		}
 	}
 
-	err := scri.ProcessReceivedMessage(msg)
+	err := scri.ProcessReceivedMessage(msg, nil)
 
 	assert.Nil(t, err)
 	select {


### PR DESCRIPTION
changed MessageProcessor's signature
removed bug when a direct message received could cause broatcast on the entire network
added test taht shows this bug has been removed