### PR TITLE
En 3833 observers get out of mem

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -1176,7 +1176,7 @@ func newShardInterceptorAndResolverContainerFactory(
 		return nil, nil, err
 	}
 
-	dataPacker, err := partitioning.NewSizeDataPacker(core.Marshalizer)
+	dataPacker, err := partitioning.NewSimpleDataPacker(core.Marshalizer)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/consensus/broadcast/shardChainMessenger.go
+++ b/consensus/broadcast/shardChainMessenger.go
@@ -151,7 +151,7 @@ func (scm *shardChainMessenger) BroadcastMiniBlocks(miniBlocks map[uint32][]byte
 
 // BroadcastTransactions will send on transaction topic the transactions
 func (scm *shardChainMessenger) BroadcastTransactions(transactions map[string][][]byte) error {
-	dataPacker, err := partitioning.NewSizeDataPacker(scm.marshalizer)
+	dataPacker, err := partitioning.NewSimpleDataPacker(scm.marshalizer)
 	if err != nil {
 		return err
 	}

--- a/core/partitioning/simpleDataPacker.go
+++ b/core/partitioning/simpleDataPacker.go
@@ -1,0 +1,71 @@
+package partitioning
+
+import (
+	"github.com/ElrondNetwork/elrond-go/core"
+	"github.com/ElrondNetwork/elrond-go/marshal"
+)
+
+// SimpleDataPacker can split a large slice of byte slices in chunks <= maxPacketSize
+// If one element still exceeds maxPacketSize, it will be returned alone
+// It does the marshaling of the resulted (smaller) slice of byte slices
+type SimpleDataPacker struct {
+	marshalizer marshal.Marshalizer
+}
+
+// NewSimpleDataPacker creates a new SizeDataPacker instance
+func NewSimpleDataPacker(marshalizer marshal.Marshalizer) (*SimpleDataPacker, error) {
+	if marshalizer == nil || marshalizer.IsInterfaceNil() {
+		return nil, core.ErrNilMarshalizer
+	}
+
+	return &SimpleDataPacker{
+		marshalizer: marshalizer,
+	}, nil
+}
+
+// PackDataInChunks packs the provided data into smaller chunks
+// limit is expressed in bytes
+func (sdp *SimpleDataPacker) PackDataInChunks(data [][]byte, limit int) ([][]byte, error) {
+	if limit < minimumMaxPacketSizeInBytes {
+		return nil, core.ErrInvalidValue
+	}
+	if data == nil {
+		return nil, core.ErrNilInputData
+	}
+
+	returningBuff := make([][]byte, 0)
+
+	elements := make([][]byte, 0)
+	lenElements := 0
+	for _, element := range data {
+		isBuffToLarge := lenElements+len(element) >= limit
+		elementsNotEmpty := len(elements) > 0
+		if isBuffToLarge && elementsNotEmpty {
+			marshaledElements, _ := sdp.marshalizer.Marshal(elements)
+			returningBuff = append(returningBuff, marshaledElements)
+			elements = make([][]byte, 0)
+			lenElements = 0
+		}
+
+		elements = append(elements, element)
+		lenElements += len(element)
+	}
+
+	if len(elements) > 0 {
+		marshaledElements, err := sdp.marshalizer.Marshal(elements)
+		if err != nil {
+			return nil, err
+		}
+		returningBuff = append(returningBuff, marshaledElements)
+	}
+
+	return returningBuff, nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (sdp *SimpleDataPacker) IsInterfaceNil() bool {
+	if sdp == nil {
+		return true
+	}
+	return false
+}

--- a/core/partitioning/simpleDataPacker_test.go
+++ b/core/partitioning/simpleDataPacker_test.go
@@ -1,0 +1,119 @@
+package partitioning_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/core"
+	"github.com/ElrondNetwork/elrond-go/core/mock"
+	"github.com/ElrondNetwork/elrond-go/core/partitioning"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSimpleDataPacker_NilMarshalizerShouldErr(t *testing.T) {
+	t.Parallel()
+
+	sdp, err := partitioning.NewSimpleDataPacker(nil)
+
+	assert.Nil(t, sdp)
+	assert.Equal(t, core.ErrNilMarshalizer, err)
+}
+
+func TestNewSimpleDataPacker_ValuesOkShouldWork(t *testing.T) {
+	t.Parallel()
+
+	sdp, err := partitioning.NewSimpleDataPacker(&mock.MarshalizerMock{})
+
+	assert.NotNil(t, sdp)
+	assert.Nil(t, err)
+}
+
+//------- PackDataInChunks
+
+func TestSimpleDataPacker_PackDataInChunksInvalidLimitShouldErr(t *testing.T) {
+	t.Parallel()
+
+	sdp, _ := partitioning.NewSimpleDataPacker(&mock.MarshalizerMock{})
+
+	buff, err := sdp.PackDataInChunks(make([][]byte, 0), 0)
+
+	assert.Equal(t, core.ErrInvalidValue, err)
+	assert.Nil(t, buff)
+}
+
+func TestSimpleDataPacker_PackDataInChunksNilInputDataShouldErr(t *testing.T) {
+	t.Parallel()
+
+	sdp, _ := partitioning.NewSimpleDataPacker(&mock.MarshalizerMock{})
+	buff, err := sdp.PackDataInChunks(nil, 1)
+
+	assert.Equal(t, core.ErrNilInputData, err)
+	assert.Nil(t, buff)
+}
+
+func TestSimpleDataPacker_PackDataInChunksEmptyDataShouldReturnEmpty(t *testing.T) {
+	t.Parallel()
+
+	sdp, _ := partitioning.NewSimpleDataPacker(&mock.MarshalizerMock{})
+	buff, err := sdp.PackDataInChunks(make([][]byte, 0), 1)
+
+	assert.Nil(t, err)
+	assert.Empty(t, buff)
+}
+
+func TestSimpleDataPacker_PackDataInChunksSmallElementsShouldPackTogether(t *testing.T) {
+	t.Parallel()
+
+	maxPacketSize := 1000
+	marshalizer := &mock.MarshalizerMock{}
+	sdp, _ := partitioning.NewSimpleDataPacker(marshalizer)
+
+	elem1 := []byte("element1")
+	elem2 := []byte("element2")
+	elem3 := []byte("element3")
+
+	buffSent, err := sdp.PackDataInChunks([][]byte{elem1, elem2, elem3}, maxPacketSize)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(buffSent))
+	assert.Nil(t, checkExpectedElements(buffSent[0], marshalizer, [][]byte{elem1, elem2, elem3}))
+}
+
+func TestSimpleSplitter_SendDataInChunksWithALargeElementShouldSplit(t *testing.T) {
+	t.Parallel()
+
+	maxPacketSize := 1000
+	marshalizer := &mock.MarshalizerMock{}
+	sdp, _ := partitioning.NewSimpleDataPacker(marshalizer)
+
+	elem1 := []byte("element1")
+	elem2 := []byte("element2")
+	elemLarge := make([]byte, maxPacketSize)
+	_, _ = rand.Read(elemLarge)
+	elem3 := []byte("element3")
+
+	buffSent, err := sdp.PackDataInChunks([][]byte{elem1, elem2, elemLarge, elem3}, maxPacketSize)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(buffSent))
+	assert.Nil(t, checkExpectedElements(buffSent[0], marshalizer, [][]byte{elem1, elem2}))
+	assert.Nil(t, checkExpectedElements(buffSent[1], marshalizer, [][]byte{elemLarge}))
+	assert.Nil(t, checkExpectedElements(buffSent[2], marshalizer, [][]byte{elem3}))
+}
+
+func TestSimpleSplitter_SendDataInChunksWithOnlyOneLargeElementShouldWork(t *testing.T) {
+	t.Parallel()
+
+	maxPacketSize := 1000
+	marshalizer := &mock.MarshalizerMock{}
+	sdp, _ := partitioning.NewSimpleDataPacker(marshalizer)
+
+	elemLarge := make([]byte, maxPacketSize)
+	_, _ = rand.Read(elemLarge)
+
+	buffSent, err := sdp.PackDataInChunks([][]byte{elemLarge}, maxPacketSize)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(buffSent))
+	assert.Nil(t, checkExpectedElements(buffSent[0], marshalizer, [][]byte{elemLarge}))
+}

--- a/integrationTests/multiShard/smartContract/testInitilalizer.go
+++ b/integrationTests/multiShard/smartContract/testInitilalizer.go
@@ -226,7 +226,7 @@ func createNetNode(
 	blkc := createTestShardChain()
 	store := createTestShardStore(shardCoordinator.NumberOfShards())
 	uint64Converter := uint64ByteSlice.NewBigEndianConverter()
-	dataPacker, _ := partitioning.NewSizeDataPacker(testMarshalizer)
+	dataPacker, _ := partitioning.NewSimpleDataPacker(testMarshalizer)
 
 	interceptorContainerFactory, _ := shard.NewInterceptorsContainerFactory(
 		shardCoordinator,

--- a/integrationTests/singleShard/transaction/interceptedBulkUnsignedTx_test.go
+++ b/integrationTests/singleShard/transaction/interceptedBulkUnsignedTx_test.go
@@ -123,7 +123,7 @@ func generateAndSendBulkSmartContractResults(
 	messenger p2p.Messenger,
 ) error {
 
-	dataPacker, err := partitioning.NewSizeDataPacker(marshalizer)
+	dataPacker, err := partitioning.NewSimpleDataPacker(marshalizer)
 	if err != nil {
 		return err
 	}

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -228,7 +228,7 @@ func (tpn *TestProcessorNode) initInterceptors() {
 }
 
 func (tpn *TestProcessorNode) initResolvers() {
-	dataPacker, _ := partitioning.NewSizeDataPacker(TestMarshalizer)
+	dataPacker, _ := partitioning.NewSimpleDataPacker(TestMarshalizer)
 
 	if tpn.ShardCoordinator.SelfId() == sharding.MetachainShardId {
 		resolversContainerFactory, _ := metafactoryDataRetriever.NewResolversContainerFactory(

--- a/node/node.go
+++ b/node/node.go
@@ -614,7 +614,7 @@ func (n *Node) SendBulkTransactions(txs []*transaction.Transaction) (uint64, err
 }
 
 func (n *Node) sendBulkTransactionsFromShard(transactions [][]byte, senderShardId uint32) error {
-	dataPacker, err := partitioning.NewSizeDataPacker(n.marshalizer)
+	dataPacker, err := partitioning.NewSimpleDataPacker(n.marshalizer)
 	if err != nil {
 		return err
 	}

--- a/node/nodeTesting.go
+++ b/node/nodeTesting.go
@@ -88,7 +88,7 @@ func (n *Node) GenerateAndSendBulkTransactions(receiverHex string, value *big.In
 	mutErrFound := sync.Mutex{}
 	var errFound error
 
-	dataPacker, err := partitioning.NewSizeDataPacker(n.marshalizer)
+	dataPacker, err := partitioning.NewSimpleDataPacker(n.marshalizer)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Added a new implementation of DataPacker that calculates less precise but more optimum the packed size in bytes.