### PR TITLE
Metachain peer processor implementation

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -138,6 +138,17 @@
         MaxBatchSize = 45000
         MaxOpenFiles = 10
 
+[PeerAccountsTrieStorage]
+    [PeerAccountsTrieStorage.Cache]
+        Size = 100000
+        Type = "LRU"
+    [PeerAccountsTrieStorage.DB]
+        FilePath = "PeerAccountsTrie"
+        Type = "LvlDBSerial"
+        BatchDelaySeconds = 15
+        MaxBatchSize = 45000
+        MaxOpenFiles = 10
+
 [BadBlocksCache]
     Size = 1000
     Type = "LRU"

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -618,6 +618,7 @@ func startNode(ctx *cli.Context, log *logger.Logger, version string) error {
 	}
 
 	processArgs := factory.NewProcessComponentsFactoryArgs(
+		coreArgs,
 		genesisConfig,
 		nodesConfig,
 		syncer,
@@ -1122,6 +1123,7 @@ func createNode(
 		node.WithSyncer(syncer),
 		node.WithBlockProcessor(process.BlockProcessor),
 		node.WithBlockTracker(process.BlockTracker),
+		node.WithPeerProcessor(process.PeerProcessor),
 		node.WithGenesisTime(time.Unix(nodesConfig.StartTime, 0)),
 		node.WithRounder(process.Rounder),
 		node.WithShardCoordinator(shardCoordinator),

--- a/config/config.go
+++ b/config/config.go
@@ -70,8 +70,9 @@ type Config struct {
 	MetaBlockStorage StorageConfig
 	PeerDataStorage  StorageConfig
 
-	AccountsTrieStorage StorageConfig
-	BadBlocksCache      CacheConfig
+	AccountsTrieStorage     StorageConfig
+	PeerAccountsTrieStorage StorageConfig
+	BadBlocksCache          CacheConfig
 
 	TxBlockBodyDataPool         CacheConfig
 	StateBlockBodyDataPool      CacheConfig

--- a/consensus/mock/consensusDataContainerMock.go
+++ b/consensus/mock/consensusDataContainerMock.go
@@ -15,6 +15,7 @@ type ConsensusCoreMock struct {
 	blockChain             data.ChainHandler
 	blockProcessor         process.BlockProcessor
 	blocksTracker          process.BlocksTracker
+	peerProcessor          process.PeerProcessor
 	bootstrapper           process.Bootstrapper
 	broadcastMessenger     consensus.BroadcastMessenger
 	chronologyHandler      consensus.ChronologyHandler
@@ -143,4 +144,8 @@ func (cdc *ConsensusCoreMock) IsInterfaceNil() bool {
 		return true
 	}
 	return false
+}
+
+func (cdc *ConsensusCoreMock) PeerProcessor() process.PeerProcessor {
+	return cdc.peerProcessor
 }

--- a/consensus/mock/mockTestInitializer.go
+++ b/consensus/mock/mockTestInitializer.go
@@ -123,11 +123,13 @@ func InitConsensusCore() *ConsensusCoreMock {
 	shardCoordinatorMock := ShardCoordinatorMock{}
 	syncTimerMock := &SyncTimerMock{}
 	validatorGroupSelector := &NodesCoordinatorMock{}
+	peerProcessor := &PeerProcessorMock{}
 
 	container := &ConsensusCoreMock{
 		blockChain,
 		blockProcessorMock,
 		blockTrackerMock,
+		peerProcessor,
 		bootstrapperMock,
 		broadcastMessengerMock,
 		chronologyHandlerMock,

--- a/consensus/mock/peerProcessorMock.go
+++ b/consensus/mock/peerProcessorMock.go
@@ -1,0 +1,33 @@
+package mock
+
+import (
+	"github.com/ElrondNetwork/elrond-go/data"
+	"github.com/ElrondNetwork/elrond-go/sharding"
+)
+
+type PeerProcessorMock struct {
+	LoadInitialStateCalled func(in []*sharding.InitialNode) error
+	UpdatePeerStateCalled func(header, previousHeader data.HeaderHandler) error
+	IsInterfaceNilCalled func() bool
+}
+
+func (pm *PeerProcessorMock) LoadInitialState(in []*sharding.InitialNode) error {
+	if pm.LoadInitialStateCalled != nil {
+		return pm.LoadInitialStateCalled(in)
+	}
+	return nil
+}
+
+func (pm *PeerProcessorMock) UpdatePeerState(header, previousHeader data.HeaderHandler) error {
+	if pm.UpdatePeerStateCalled != nil {
+		return pm.UpdatePeerStateCalled(header, previousHeader)
+	}
+	return nil
+}
+
+func (pm *PeerProcessorMock) IsInterfaceNil() bool {
+	if pm.IsInterfaceNilCalled != nil {
+		return pm.IsInterfaceNilCalled()
+	}
+	return false
+}

--- a/consensus/spos/bn/subroundEndRound.go
+++ b/consensus/spos/bn/subroundEndRound.go
@@ -82,6 +82,12 @@ func (sr *subroundEndRound) doEndRoundJob() bool {
 	sr.Header.SetSignature(sig)
 
 	timeBefore := time.Now()
+	prevHeader := sr.Blockchain().GetCurrentBlockHeader()
+	err = sr.PeerProcessor().UpdatePeerState(prevHeader, sr.Header)
+	if err != nil {
+		log.Error(err.Error())
+		return false
+	}
 	// Commit the block (commits also the account state)
 	err = sr.BlockProcessor().CommitBlock(sr.Blockchain(), sr.Header, sr.BlockBody)
 	if err != nil {

--- a/consensus/spos/consensusCore.go
+++ b/consensus/spos/consensusCore.go
@@ -17,6 +17,7 @@ type ConsensusCore struct {
 	blockChain         data.ChainHandler
 	blockProcessor     process.BlockProcessor
 	blocksTracker      process.BlocksTracker
+	peerProcessor      process.PeerProcessor
 	bootstrapper       process.Bootstrapper
 	broadcastMessenger consensus.BroadcastMessenger
 	chronologyHandler  consensus.ChronologyHandler
@@ -36,6 +37,7 @@ func NewConsensusCore(
 	blockChain data.ChainHandler,
 	blockProcessor process.BlockProcessor,
 	blocksTracker process.BlocksTracker,
+	peerProcessor process.PeerProcessor,
 	bootstrapper process.Bootstrapper,
 	broadcastMessenger consensus.BroadcastMessenger,
 	chronologyHandler consensus.ChronologyHandler,
@@ -54,6 +56,7 @@ func NewConsensusCore(
 		blockChain,
 		blockProcessor,
 		blocksTracker,
+		peerProcessor,
 		bootstrapper,
 		broadcastMessenger,
 		chronologyHandler,
@@ -157,4 +160,9 @@ func (cc *ConsensusCore) IsInterfaceNil() bool {
 		return true
 	}
 	return false
+}
+
+// PeerProcessor returns the processor used to save the peer consensus statistics
+func (cc *ConsensusCore) PeerProcessor() process.PeerProcessor {
+	return cc.peerProcessor
 }

--- a/consensus/spos/consensusCoreValidator.go
+++ b/consensus/spos/consensusCoreValidator.go
@@ -14,6 +14,9 @@ func ValidateConsensusCore(container ConsensusCoreHandler) error {
 	if container.BlocksTracker() == nil || container.BlocksTracker().IsInterfaceNil() {
 		return ErrNilBlocksTracker
 	}
+	if container.PeerProcessor() == nil || container.PeerProcessor().IsInterfaceNil() {
+		return ErrNilPeerProcessor
+	}
 	if container.BootStrapper() == nil || container.BootStrapper().IsInterfaceNil() {
 		return ErrNilBootstrapper
 	}

--- a/consensus/spos/consensusCoreValidator_test.go
+++ b/consensus/spos/consensusCoreValidator_test.go
@@ -23,11 +23,13 @@ func initConsensusDataContainer() *ConsensusCore {
 	shardCoordinatorMock := mock.ShardCoordinatorMock{}
 	syncTimerMock := &mock.SyncTimerMock{}
 	validatorGroupSelector := &mock.NodesCoordinatorMock{}
+	peerProcessor := &mock.PeerProcessorMock{}
 
 	return &ConsensusCore{
-		blockChain:             blockChain,
-		blockProcessor:         blockProcessorMock,
+		blockChain:         blockChain,
+		blockProcessor:     blockProcessorMock,
 		blocksTracker:      blocksTrackerMock,
+		peerProcessor:      peerProcessor,
 		bootstrapper:       bootstrapperMock,
 		broadcastMessenger: broadcastMessengerMock,
 		chronologyHandler:  chronologyHandlerMock,
@@ -51,7 +53,7 @@ func TestConsensusContainerValidator_ValidateNilBlockchainShouldFail(t *testing.
 
 	err := ValidateConsensusCore(container)
 
-	assert.Equal(t, err, ErrNilBlockChain)
+	assert.Equal(t, ErrNilBlockChain, err)
 }
 
 func TestConsensusContainerValidator_ValidateNilProcessorShouldFail(t *testing.T) {
@@ -62,7 +64,7 @@ func TestConsensusContainerValidator_ValidateNilProcessorShouldFail(t *testing.T
 
 	err := ValidateConsensusCore(container)
 
-	assert.Equal(t, err, ErrNilBlockProcessor)
+	assert.Equal(t, ErrNilBlockProcessor, err)
 }
 
 func TestConsensusContainerValidator_ValidateNilBootstrapperShouldFail(t *testing.T) {
@@ -73,7 +75,7 @@ func TestConsensusContainerValidator_ValidateNilBootstrapperShouldFail(t *testin
 
 	err := ValidateConsensusCore(container)
 
-	assert.Equal(t, err, ErrNilBootstrapper)
+	assert.Equal(t, ErrNilBootstrapper, err)
 }
 
 func TestConsensusContainerValidator_ValidateNilChronologyShouldFail(t *testing.T) {
@@ -84,7 +86,7 @@ func TestConsensusContainerValidator_ValidateNilChronologyShouldFail(t *testing.
 
 	err := ValidateConsensusCore(container)
 
-	assert.Equal(t, err, ErrNilChronologyHandler)
+	assert.Equal(t, ErrNilChronologyHandler, err)
 }
 
 func TestConsensusContainerValidator_ValidateNilHasherShouldFail(t *testing.T) {
@@ -95,7 +97,7 @@ func TestConsensusContainerValidator_ValidateNilHasherShouldFail(t *testing.T) {
 
 	err := ValidateConsensusCore(container)
 
-	assert.Equal(t, err, ErrNilHasher)
+	assert.Equal(t, ErrNilHasher, err)
 }
 
 func TestConsensusContainerValidator_ValidateNilMarshalizerShouldFail(t *testing.T) {
@@ -106,7 +108,7 @@ func TestConsensusContainerValidator_ValidateNilMarshalizerShouldFail(t *testing
 
 	err := ValidateConsensusCore(container)
 
-	assert.Equal(t, err, ErrNilMarshalizer)
+	assert.Equal(t, ErrNilMarshalizer, err)
 }
 
 func TestConsensusContainerValidator_ValidateNilMultiSignerShouldFail(t *testing.T) {
@@ -117,7 +119,7 @@ func TestConsensusContainerValidator_ValidateNilMultiSignerShouldFail(t *testing
 
 	err := ValidateConsensusCore(container)
 
-	assert.Equal(t, err, ErrNilMultiSigner)
+	assert.Equal(t, ErrNilMultiSigner, err)
 }
 
 func TestConsensusContainerValidator_ValidateNilRounderShouldFail(t *testing.T) {
@@ -128,7 +130,7 @@ func TestConsensusContainerValidator_ValidateNilRounderShouldFail(t *testing.T) 
 
 	err := ValidateConsensusCore(container)
 
-	assert.Equal(t, err, ErrNilRounder)
+	assert.Equal(t, ErrNilRounder, err)
 }
 
 func TestConsensusContainerValidator_ValidateNilShardCoordinatorShouldFail(t *testing.T) {
@@ -139,7 +141,7 @@ func TestConsensusContainerValidator_ValidateNilShardCoordinatorShouldFail(t *te
 
 	err := ValidateConsensusCore(container)
 
-	assert.Equal(t, err, ErrNilShardCoordinator)
+	assert.Equal(t, ErrNilShardCoordinator, err)
 }
 
 func TestConsensusContainerValidator_ValidateNilSyncTimerShouldFail(t *testing.T) {
@@ -150,7 +152,7 @@ func TestConsensusContainerValidator_ValidateNilSyncTimerShouldFail(t *testing.T
 
 	err := ValidateConsensusCore(container)
 
-	assert.Equal(t, err, ErrNilSyncTimer)
+	assert.Equal(t, ErrNilSyncTimer, err)
 }
 
 func TestConsensusContainerValidator_ValidateNilValidatorGroupSelectorShouldFail(t *testing.T) {
@@ -161,5 +163,5 @@ func TestConsensusContainerValidator_ValidateNilValidatorGroupSelectorShouldFail
 
 	err := ValidateConsensusCore(container)
 
-	assert.Equal(t, err, ErrNilValidatorGroupSelector)
+	assert.Equal(t, ErrNilValidatorGroupSelector, err)
 }

--- a/consensus/spos/consensusCore_test.go
+++ b/consensus/spos/consensusCore_test.go
@@ -17,6 +17,7 @@ func TestConsensusCore_WithNilBlockchainShouldFail(t *testing.T) {
 		nil,
 		consensusCoreMock.BlockProcessor(),
 		consensusCoreMock.BlocksTracker(),
+		consensusCoreMock.PeerProcessor(),
 		consensusCoreMock.BootStrapper(),
 		consensusCoreMock.BroadcastMessenger(),
 		consensusCoreMock.Chronology(),
@@ -44,6 +45,7 @@ func TestConsensusCore_WithNilBlockProcessorShouldFail(t *testing.T) {
 		consensusCoreMock.Blockchain(),
 		nil,
 		consensusCoreMock.BlocksTracker(),
+		consensusCoreMock.PeerProcessor(),
 		consensusCoreMock.BootStrapper(),
 		consensusCoreMock.BroadcastMessenger(),
 		consensusCoreMock.Chronology(),
@@ -71,6 +73,7 @@ func TestConsensusCore_WithNilBlocksTrackerShouldFail(t *testing.T) {
 		consensusCoreMock.Blockchain(),
 		consensusCoreMock.BlockProcessor(),
 		nil,
+		consensusCoreMock.PeerProcessor(),
 		consensusCoreMock.BootStrapper(),
 		consensusCoreMock.BroadcastMessenger(),
 		consensusCoreMock.Chronology(),
@@ -98,6 +101,7 @@ func TestConsensusCore_WithNilBootstrapperShouldFail(t *testing.T) {
 		consensusCoreMock.Blockchain(),
 		consensusCoreMock.BlockProcessor(),
 		consensusCoreMock.BlocksTracker(),
+		consensusCoreMock.PeerProcessor(),
 		nil,
 		consensusCoreMock.BroadcastMessenger(),
 		consensusCoreMock.Chronology(),
@@ -116,6 +120,34 @@ func TestConsensusCore_WithNilBootstrapperShouldFail(t *testing.T) {
 	assert.Equal(t, spos.ErrNilBootstrapper, err)
 }
 
+func TestConsensusCore_WithNilPeerProcessorShouldFail(t *testing.T) {
+	t.Parallel()
+
+	consensusCoreMock := mock.InitConsensusCore()
+
+	consensusCore, err := spos.NewConsensusCore(
+		consensusCoreMock.Blockchain(),
+		consensusCoreMock.BlockProcessor(),
+		consensusCoreMock.BlocksTracker(),
+		nil,
+		consensusCoreMock.BootStrapper(),
+		consensusCoreMock.BroadcastMessenger(),
+		consensusCoreMock.Chronology(),
+		consensusCoreMock.Hasher(),
+		consensusCoreMock.Marshalizer(),
+		consensusCoreMock.RandomnessPrivateKey(),
+		consensusCoreMock.RandomnessSingleSigner(),
+		consensusCoreMock.MultiSigner(),
+		consensusCoreMock.Rounder(),
+		consensusCoreMock.ShardCoordinator(),
+		consensusCoreMock.NodesCoordinator(),
+		consensusCoreMock.SyncTimer(),
+	)
+
+	assert.Nil(t, consensusCore)
+	assert.Equal(t, spos.ErrNilPeerProcessor, err)
+}
+
 func TestConsensusCore_WithNilBroadcastMessengerShouldFail(t *testing.T) {
 	t.Parallel()
 
@@ -125,6 +157,7 @@ func TestConsensusCore_WithNilBroadcastMessengerShouldFail(t *testing.T) {
 		consensusCoreMock.Blockchain(),
 		consensusCoreMock.BlockProcessor(),
 		consensusCoreMock.BlocksTracker(),
+		consensusCoreMock.PeerProcessor(),
 		consensusCoreMock.BootStrapper(),
 		nil,
 		consensusCoreMock.Chronology(),
@@ -152,6 +185,7 @@ func TestConsensusCore_WithNilChronologyShouldFail(t *testing.T) {
 		consensusCoreMock.Blockchain(),
 		consensusCoreMock.BlockProcessor(),
 		consensusCoreMock.BlocksTracker(),
+		consensusCoreMock.PeerProcessor(),
 		consensusCoreMock.BootStrapper(),
 		consensusCoreMock.BroadcastMessenger(),
 		nil,
@@ -179,6 +213,7 @@ func TestConsensusCore_WithNilHasherShouldFail(t *testing.T) {
 		consensusCoreMock.Blockchain(),
 		consensusCoreMock.BlockProcessor(),
 		consensusCoreMock.BlocksTracker(),
+		consensusCoreMock.PeerProcessor(),
 		consensusCoreMock.BootStrapper(),
 		consensusCoreMock.BroadcastMessenger(),
 		consensusCoreMock.Chronology(),
@@ -206,6 +241,7 @@ func TestConsensusCore_WithNilMarshalizerShouldFail(t *testing.T) {
 		consensusCoreMock.Blockchain(),
 		consensusCoreMock.BlockProcessor(),
 		consensusCoreMock.BlocksTracker(),
+		consensusCoreMock.PeerProcessor(),
 		consensusCoreMock.BootStrapper(),
 		consensusCoreMock.BroadcastMessenger(),
 		consensusCoreMock.Chronology(),
@@ -233,6 +269,7 @@ func TestConsensusCore_WithNilBlsPrivateKeyShouldFail(t *testing.T) {
 		consensusCoreMock.Blockchain(),
 		consensusCoreMock.BlockProcessor(),
 		consensusCoreMock.BlocksTracker(),
+		consensusCoreMock.PeerProcessor(),
 		consensusCoreMock.BootStrapper(),
 		consensusCoreMock.BroadcastMessenger(),
 		consensusCoreMock.Chronology(),
@@ -260,6 +297,7 @@ func TestConsensusCore_WithNilBlsSingleSignerShouldFail(t *testing.T) {
 		consensusCoreMock.Blockchain(),
 		consensusCoreMock.BlockProcessor(),
 		consensusCoreMock.BlocksTracker(),
+		consensusCoreMock.PeerProcessor(),
 		consensusCoreMock.BootStrapper(),
 		consensusCoreMock.BroadcastMessenger(),
 		consensusCoreMock.Chronology(),
@@ -287,6 +325,7 @@ func TestConsensusCore_WithNilMultiSignerShouldFail(t *testing.T) {
 		consensusCoreMock.Blockchain(),
 		consensusCoreMock.BlockProcessor(),
 		consensusCoreMock.BlocksTracker(),
+		consensusCoreMock.PeerProcessor(),
 		consensusCoreMock.BootStrapper(),
 		consensusCoreMock.BroadcastMessenger(),
 		consensusCoreMock.Chronology(),
@@ -314,6 +353,7 @@ func TestConsensusCore_WithNilRounderShouldFail(t *testing.T) {
 		consensusCoreMock.Blockchain(),
 		consensusCoreMock.BlockProcessor(),
 		consensusCoreMock.BlocksTracker(),
+		consensusCoreMock.PeerProcessor(),
 		consensusCoreMock.BootStrapper(),
 		consensusCoreMock.BroadcastMessenger(),
 		consensusCoreMock.Chronology(),
@@ -341,6 +381,7 @@ func TestConsensusCore_WithNilShardCoordinatorShouldFail(t *testing.T) {
 		consensusCoreMock.Blockchain(),
 		consensusCoreMock.BlockProcessor(),
 		consensusCoreMock.BlocksTracker(),
+		consensusCoreMock.PeerProcessor(),
 		consensusCoreMock.BootStrapper(),
 		consensusCoreMock.BroadcastMessenger(),
 		consensusCoreMock.Chronology(),
@@ -368,6 +409,7 @@ func TestConsensusCore_WithNilValidatorGroupSelectorShouldFail(t *testing.T) {
 		consensusCoreMock.Blockchain(),
 		consensusCoreMock.BlockProcessor(),
 		consensusCoreMock.BlocksTracker(),
+		consensusCoreMock.PeerProcessor(),
 		consensusCoreMock.BootStrapper(),
 		consensusCoreMock.BroadcastMessenger(),
 		consensusCoreMock.Chronology(),
@@ -395,6 +437,7 @@ func TestConsensusCore_WithNilSyncTimerShouldFail(t *testing.T) {
 		consensusCoreMock.Blockchain(),
 		consensusCoreMock.BlockProcessor(),
 		consensusCoreMock.BlocksTracker(),
+		consensusCoreMock.PeerProcessor(),
 		consensusCoreMock.BootStrapper(),
 		consensusCoreMock.BroadcastMessenger(),
 		consensusCoreMock.Chronology(),
@@ -422,6 +465,7 @@ func TestConsensusCore_CreateConsensusCoreShouldWork(t *testing.T) {
 		consensusCoreMock.Blockchain(),
 		consensusCoreMock.BlockProcessor(),
 		consensusCoreMock.BlocksTracker(),
+		consensusCoreMock.PeerProcessor(),
 		consensusCoreMock.BootStrapper(),
 		consensusCoreMock.BroadcastMessenger(),
 		consensusCoreMock.Chronology(),

--- a/consensus/spos/errors.go
+++ b/consensus/spos/errors.go
@@ -67,6 +67,9 @@ var ErrNilBlockProcessor = errors.New("block processor is nil")
 // ErrNilBlocksTracker is raised when a valid block tracker is expected but nil used
 var ErrNilBlocksTracker = errors.New("blocks tracker is nil")
 
+// ErrNilPeerProcessor is raised when a valid peer processor is expected but nil used
+var ErrNilPeerProcessor = errors.New("peer processor is nil")
+
 // ErrNilBootstrapper is raised when a valid block processor is expected but nil used
 var ErrNilBootstrapper = errors.New("bootstrapper is nil")
 

--- a/consensus/spos/interface.go
+++ b/consensus/spos/interface.go
@@ -20,6 +20,8 @@ type ConsensusCoreHandler interface {
 	BlockProcessor() process.BlockProcessor
 	// BlocksTracker gets the BlockTracker stored in the ConsensusCore
 	BlocksTracker() process.BlocksTracker
+	// PeerProcessor gets the PeerProcessor stored in the ConsensusCore
+	PeerProcessor() process.PeerProcessor
 	// BootStrapper gets the Bootstrapper stored in the ConsensusCore
 	BootStrapper() process.Bootstrapper
 	// BroadcastMessenger gets the BroadcastMessenger stored in ConsensusCore

--- a/data/state/peerAccountsDB.go
+++ b/data/state/peerAccountsDB.go
@@ -1,6 +1,46 @@
 package state
 
-// peerAccountsDB will save and synchronize data from peer processor, plus will synchronize with nodesCoordinator
-type peerAccountsDB struct {
+import (
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go/data"
+	"github.com/ElrondNetwork/elrond-go/hashing"
+	"github.com/ElrondNetwork/elrond-go/marshal"
+)
+
+// PeerAccountsDB will save and synchronize data from peer processor, plus will synchronize with nodesCoordinator
+type PeerAccountsDB struct {
 	*AccountsDB
+}
+
+// NewPeerAccountsDB creates a new account manager
+func NewPeerAccountsDB(
+	trie data.Trie,
+	hasher hashing.Hasher,
+	marshalizer marshal.Marshalizer,
+	accountFactory AccountFactory,
+) (*PeerAccountsDB, error) {
+	if trie == nil {
+		return nil, ErrNilTrie
+	}
+	if hasher == nil {
+		return nil, ErrNilHasher
+	}
+	if marshalizer == nil {
+		return nil, ErrNilMarshalizer
+	}
+	if accountFactory == nil {
+		return nil, ErrNilAccountFactory
+	}
+
+	return &PeerAccountsDB{
+		&AccountsDB{
+			mainTrie:       trie,
+			hasher:         hasher,
+			marshalizer:    marshalizer,
+			accountFactory: accountFactory,
+			entries:        make([]JournalEntry, 0),
+			mutEntries:     sync.RWMutex{},
+		},
+	}, nil
 }

--- a/integrationTests/consensus/testInitializer.go
+++ b/integrationTests/consensus/testInitializer.go
@@ -421,6 +421,7 @@ func createConsensusOnlyNode(
 		node.WithResolversFinder(resolverFinder),
 		node.WithConsensusType(consensusType),
 		node.WithBlockTracker(blockTracker),
+		node.WithPeerProcessor(&mock.PeerProcessorMock{}),
 	)
 
 	if err != nil {

--- a/integrationTests/mock/peerProcessorMock.go
+++ b/integrationTests/mock/peerProcessorMock.go
@@ -1,0 +1,33 @@
+package mock
+
+import (
+	"github.com/ElrondNetwork/elrond-go/data"
+	"github.com/ElrondNetwork/elrond-go/sharding"
+)
+
+type PeerProcessorMock struct {
+	LoadInitialStateCalled func(in []*sharding.InitialNode) error
+	UpdatePeerStateCalled func(header, perviousHeader data.HeaderHandler) error
+	IsInterfaceNilCalled func() bool
+}
+
+func (pm *PeerProcessorMock) LoadInitialState(in []*sharding.InitialNode) error {
+	if pm.LoadInitialStateCalled != nil {
+		return pm.LoadInitialStateCalled(in)
+	}
+	return nil
+}
+
+func (pm *PeerProcessorMock) UpdatePeerState(header, previousHeader data.HeaderHandler) error {
+	if pm.UpdatePeerStateCalled != nil {
+		return pm.UpdatePeerStateCalled(header, previousHeader)
+	}
+	return nil
+}
+
+func (pm *PeerProcessorMock) IsInterfaceNil() bool {
+	if pm.IsInterfaceNilCalled != nil {
+		return pm.IsInterfaceNilCalled()
+	}
+	return false
+}

--- a/node/defineOptions.go
+++ b/node/defineOptions.go
@@ -225,6 +225,17 @@ func WithBlockTracker(blockTracker process.BlocksTracker) Option {
 	}
 }
 
+// WithPeerProcessor sets up the peer processor option for the Node
+func WithPeerProcessor(peerProcessor process.PeerProcessor) Option {
+	return func(n *Node) error {
+		if peerProcessor == nil {
+			return ErrNilPeerProcessor
+		}
+		n.peerProcessor = peerProcessor
+		return nil
+	}
+}
+
 // WithGenesisTime sets up the genesis time option for the Node
 func WithGenesisTime(genesisTime time.Time) Option {
 	return func(n *Node) error {

--- a/node/defineOptions_test.go
+++ b/node/defineOptions_test.go
@@ -452,6 +452,32 @@ func TestWithBlockProcessor_ShouldWork(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestWithPeerProcessor_NilProcessorShouldErr(t *testing.T) {
+	t.Parallel()
+
+	node, _ := NewNode()
+
+	opt := WithPeerProcessor(nil)
+	err := opt(node)
+
+	assert.Nil(t, node.syncTimer)
+	assert.Equal(t, ErrNilPeerProcessor, err)
+}
+
+func TestWithPeerProcessor_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	node, _ := NewNode()
+
+	pp := &mock.PeerProcessorMock{}
+
+	opt := WithPeerProcessor(pp)
+	err := opt(node)
+
+	assert.True(t, node.peerProcessor == pp)
+	assert.Nil(t, err)
+}
+
 func TestWithGenesisTime(t *testing.T) {
 	t.Parallel()
 

--- a/node/errors.go
+++ b/node/errors.go
@@ -49,6 +49,9 @@ var ErrNilRounder = errors.New("trying to set nil rounder")
 // ErrNilBlockProcessor signals that a nil block processor has been provided
 var ErrNilBlockProcessor = errors.New("trying to set nil block processor")
 
+// ErrNilPeerProcessor signals that a nil peer processor has been provided
+var ErrNilPeerProcessor = errors.New("trying to set nil peer processor")
+
 // ErrNilBlockTracker signals that a nil block tracker has been provided
 var ErrNilBlockTracker = errors.New("trying to set nil block tracker")
 

--- a/node/mock/peerProcessorMock.go
+++ b/node/mock/peerProcessorMock.go
@@ -1,0 +1,33 @@
+package mock
+
+import (
+	"github.com/ElrondNetwork/elrond-go/data"
+	"github.com/ElrondNetwork/elrond-go/sharding"
+)
+
+type PeerProcessorMock struct {
+	LoadInitialStateCalled func(in []*sharding.InitialNode) error
+	UpdatePeerStateCalled func(header, previousHeader data.HeaderHandler) error
+	IsInterfaceNilCalled func() bool
+}
+
+func (pm *PeerProcessorMock) LoadInitialState(in []*sharding.InitialNode) error {
+	if pm.LoadInitialStateCalled != nil {
+		return pm.LoadInitialStateCalled(in)
+	}
+	return nil
+}
+
+func (pm *PeerProcessorMock) UpdatePeerState(header, previousHeader data.HeaderHandler) error {
+	if pm.UpdatePeerStateCalled != nil {
+		return pm.UpdatePeerStateCalled(header, previousHeader)
+	}
+	return nil
+}
+
+func (pm *PeerProcessorMock) IsInterfaceNil() bool {
+	if pm.IsInterfaceNilCalled != nil {
+		return pm.IsInterfaceNilCalled()
+	}
+	return false
+}

--- a/node/node.go
+++ b/node/node.go
@@ -64,6 +64,7 @@ type Node struct {
 	rounder                  consensus.Rounder
 	blockProcessor           process.BlockProcessor
 	blockTracker             process.BlocksTracker
+	peerProcessor            process.PeerProcessor
 	genesisTime              time.Time
 	accounts                 state.AccountsAdapter
 	addrConverter            state.AddressConverter
@@ -289,6 +290,7 @@ func (n *Node) StartConsensus() error {
 		n.blkc,
 		n.blockProcessor,
 		n.blockTracker,
+		n.peerProcessor,
 		bootstrapper,
 		broadcastMessenger,
 		chronologyHandler,

--- a/process/errors.go
+++ b/process/errors.go
@@ -444,3 +444,18 @@ var ErrNilTxTypeHandler = errors.New("nil tx type handler")
 
 // ErrNilSpecialAddressHandler signals that special address handler is nil
 var ErrNilSpecialAddressHandler = errors.New("nil special address handler")
+
+// ErrNilPeerAccountsAdapter signals that a nil peer accounts database was provided
+var ErrNilPeerAccountsAdapter = errors.New("nil peer accounts database")
+
+// ErrInvalidInitialNodesState signals that the initial nodes state is invalid
+var ErrInvalidInitialNodesState = errors.New("provided initial state is invalid")
+
+// ErrInvalidPeerAccount signals that a peer account is invalid
+var ErrInvalidPeerAccount = errors.New("invalid peer account")
+
+// ErrInvalidMetaHeader signals that a wrong implementation of HeaderHandler was provided
+var ErrInvalidMetaHeader = errors.New("invalid header provided, expected MetaBlock")
+
+// ErrNilShardHeaderStorage signals that nil storage was provided for shard headers
+var ErrNilShardHeaderStorage = errors.New("nil shard header storage")

--- a/process/interface.go
+++ b/process/interface.go
@@ -151,6 +151,13 @@ type BlockProcessor interface {
 	IsInterfaceNil() bool
 }
 
+// PeerProcessor is the main interface for validators' consensus participation statistics
+type PeerProcessor interface {
+	LoadInitialState(in []*sharding.InitialNode) error
+	UpdatePeerState(header, previousHeader data.HeaderHandler) error
+	IsInterfaceNil() bool
+}
+
 // Checker provides functionality to checks the integrity and validity of a data structure
 type Checker interface {
 	// IntegrityAndValidity does both validity and integrity checks on the data structure

--- a/process/mock/headerHandlerStub.go
+++ b/process/mock/headerHandlerStub.go
@@ -1,6 +1,7 @@
 package mock
 
 type HeaderHandlerStub struct {
+	GetRandSeedCalled func() []byte
 	GetMiniBlockHeadersWithDstCalled func(destId uint32) map[string]uint32
 }
 
@@ -37,7 +38,10 @@ func (hhs *HeaderHandlerStub) GetPrevRandSeed() []byte {
 }
 
 func (hhs *HeaderHandlerStub) GetRandSeed() []byte {
-	panic("implement me")
+	if hhs.GetRandSeedCalled != nil {
+		return hhs.GetRandSeedCalled()
+	}
+	return nil
 }
 
 func (hhs *HeaderHandlerStub) GetPubKeysBitmap() []byte {

--- a/process/peer/process.go
+++ b/process/peer/process.go
@@ -1,0 +1,288 @@
+package peer
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go/data"
+	"github.com/ElrondNetwork/elrond-go/data/block"
+	"github.com/ElrondNetwork/elrond-go/data/state"
+	"github.com/ElrondNetwork/elrond-go/marshal"
+	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/sharding"
+	"github.com/ElrondNetwork/elrond-go/storage"
+)
+
+// ShardedPeerAdapters represents a list of peer account adapters organized by the shard id
+//  each validator account is alocated to
+type ShardedPeerAdapters map[uint32]state.AccountsAdapter
+
+type peerProcess struct {
+	marshalizer marshal.Marshalizer
+	shardHeaderStorage storage.Storer
+	nodesCoordinator sharding.NodesCoordinator
+	shardCoordinator sharding.Coordinator
+	adrConv state.AddressConverter
+	peerAdapters ShardedPeerAdapters
+	mutPeerAdapters *sync.RWMutex
+}
+
+// NewPeerProcessor instantiates a new peerProcess structure responsible of keeping account of
+//  each validator actions in the consensus process
+func NewPeerProcessor(
+	peerAdapters ShardedPeerAdapters,
+	adrConv state.AddressConverter,
+	nodesCoordinator sharding.NodesCoordinator,
+	shardCoordinator sharding.Coordinator,
+	shardHeaderStorage storage.Storer,
+) (*peerProcess, error) {
+	if peerAdapters == nil {
+		return nil, process.ErrNilPeerAccountsAdapter
+	}
+	if adrConv == nil {
+		return nil, process.ErrNilAddressConverter
+	}
+	if nodesCoordinator == nil {
+		return nil, process.ErrNilNodesCoordinator
+	}
+	if shardCoordinator == nil {
+		return nil, process.ErrNilShardCoordinator
+	}
+	if shardHeaderStorage == nil {
+		return nil, process.ErrNilShardHeaderStorage
+	}
+
+	return &peerProcess{
+		mutPeerAdapters: &sync.RWMutex{},
+		peerAdapters: peerAdapters,
+		adrConv: adrConv,
+		nodesCoordinator: nodesCoordinator,
+		shardCoordinator: shardCoordinator,
+		shardHeaderStorage: shardHeaderStorage,
+	}, nil
+}
+
+// LoadInitialState takes an initial peer list, validates it and sets up the initial state for each of the peers
+func (p *peerProcess) LoadInitialState(in []*sharding.InitialNode) error {
+	for _, node := range in {
+		err := p.processNode(node)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, peerAdapter := range p.peerAdapters {
+		_, err := peerAdapter.Commit()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// IsNodeValid calculates if a node that's present in the initial validator list
+//  contains all the required information in order to be able to participate in consensus
+func (p *peerProcess) IsNodeValid(node *sharding.InitialNode) bool {
+	if len(node.PubKey) == 0 {
+		return false
+	}
+	if len(node.Address) == 0 {
+		return false
+	}
+
+	return true
+}
+
+// UpdatePeerState takes the current and previous headers and updates the peer state
+//  for all of the consensus members
+func (p *peerProcess) UpdatePeerState(header, previousHeader data.HeaderHandler) error {
+	consensusGroup, err := p.nodesCoordinator.ComputeValidatorsGroup(previousHeader.GetRandSeed(), previousHeader.GetRound(), previousHeader.GetShardID())
+	if err != nil {
+		return err
+	}
+
+	err  = p.updateValidatorInfo(consensusGroup, previousHeader.GetPubKeysBitmap(), previousHeader.GetShardID())
+	if err != nil {
+		return err
+	}
+
+	if header.GetShardID() == sharding.MetachainShardId {
+		err = p.updateShardDataPeerState(header)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *peerProcess) updateShardDataPeerState(header data.HeaderHandler) error {
+	metaHeader, ok := header.(*block.MetaBlock)
+	if !ok {
+		return process.ErrInvalidMetaHeader
+	}
+
+	for _, h := range metaHeader.ShardInfo {
+		shardHeaderBytes, err := p.shardHeaderStorage.Get(h.HeaderHash)
+		if err != nil {
+			return err
+		}
+
+		shardHeader := &block.Header{}
+		err = p.marshalizer.Unmarshal(shardHeader, shardHeaderBytes)
+		if err != nil {
+			return err
+		}
+
+		shardConsensus, err := p.nodesCoordinator.ComputeValidatorsGroup(shardHeader.GetRandSeed(), shardHeader.GetRound(), shardHeader.GetShardID())
+		if err != nil {
+			return err
+		}
+
+		err = p.updateValidatorInfo(shardConsensus, shardHeader.GetPubKeysBitmap(), shardHeader.GetShardID())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *peerProcess) processNode(node *sharding.InitialNode) error {
+	if !p.IsNodeValid(node) {
+		return process.ErrInvalidInitialNodesState
+	}
+
+	peerAccount, err := p.generatePeerAccount(node)
+	if err != nil {
+		return err
+	}
+
+	err = p.savePeerAccountData(peerAccount, node)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *peerProcess) generatePeerAccount(node *sharding.InitialNode) (*state.PeerAccount, error) {
+	address, err := p.adrConv.CreateAddressFromHex(node.Address)
+	if err != nil {
+		return nil, err
+	}
+
+	peerAdapter, err := p.getPeerAdapter(node.AssignedShard())
+	if err != nil {
+		return nil, err
+	}
+
+	acc, err := peerAdapter.GetAccountWithJournal(address)
+	if err != nil {
+		return nil, err
+	}
+
+	peerAccount, ok := acc.(*state.PeerAccount)
+	if !ok {
+		return nil, process.ErrInvalidPeerAccount
+	}
+
+	return peerAccount, nil
+}
+
+func (p *peerProcess) savePeerAccountData(peerAccount *state.PeerAccount, data *sharding.InitialNode) error {
+	err := peerAccount.SetAddressWithJournal([]byte(data.Address))
+	if err != nil {
+		return err
+	}
+
+	err = peerAccount.SetSchnorrPublicKeyWithJournal([]byte(data.Address))
+	if err != nil {
+		return err
+	}
+
+	err = peerAccount.SetBLSPublicKeyWithJournal([]byte(data.PubKey))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *peerProcess) updateValidatorInfo(validatorList []sharding.Validator, signingBitmap []byte, shardId uint32) error {
+	lenValidators := len(validatorList)
+	for i := 0; i < lenValidators; i++ {
+		peerAcc, err := p.getPeerAccount(validatorList[i].Address(), shardId)
+		if err != nil {
+			return err
+		}
+
+		isLeader := i == 0
+		validatorSigned := (signingBitmap[i/8] & (1 << (uint16(i) % 8))) != 0
+		if isLeader && validatorSigned {
+			err = peerAcc.IncreaseLeaderSuccessRateWithJournal()
+		}
+		if isLeader && !validatorSigned {
+			err = peerAcc.DecreaseLeaderSuccessRateWithJournal()
+		}
+
+		if !isLeader && validatorSigned {
+			err = peerAcc.IncreaseValidatorSuccessRateWithJournal()
+		}
+		if !isLeader && !validatorSigned {
+			err = peerAcc.DecreaseValidatorSuccessRateWithJournal()
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *peerProcess) getPeerAccount(address []byte, shardId uint32) (*state.PeerAccount, error) {
+	peerAdapter, err := p.getPeerAdapter(shardId)
+	if err != nil {
+		return nil, err
+	}
+
+	addressContainer, err := p.adrConv.CreateAddressFromPublicKeyBytes(address)
+	if err != nil {
+		return nil, err
+	}
+
+	account, err := peerAdapter.GetExistingAccount(addressContainer)
+	if err != nil {
+		return nil, err
+	}
+
+	peerAccount, ok := account.(*state.PeerAccount)
+	if !ok {
+		return nil, process.ErrInvalidPeerAccount
+	}
+
+	return peerAccount, nil
+}
+
+func (p *peerProcess) getPeerAdapter(shardId uint32) (state.AccountsAdapter, error) {
+	p.mutPeerAdapters.RLock()
+	defer p.mutPeerAdapters.RUnlock()
+
+	adapter, exists := p.peerAdapters[shardId]
+	if !exists {
+		return nil, errors.New(fmt.Sprintf("peer account adapter for shard id %d is not initialized", shardId))
+	}
+
+	return adapter, nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (p *peerProcess) IsInterfaceNil() bool {
+	if p == nil {
+		return true
+	}
+	return false
+}

--- a/process/peer/process_test.go
+++ b/process/peer/process_test.go
@@ -1,0 +1,417 @@
+package peer_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/data/state"
+	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/process/mock"
+	"github.com/ElrondNetwork/elrond-go/process/peer"
+	"github.com/ElrondNetwork/elrond-go/sharding"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPeerProcessor_NilPeerAdaptersShouldErr(t *testing.T) {
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+	peerProcessor, err := peer.NewPeerProcessor(
+		nil,
+		&mock.AddressConverterMock{},
+		&mock.NodesCoordinatorMock{},
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	assert.Nil(t, peerProcessor)
+	assert.Equal(t, process.ErrNilPeerAccountsAdapter, err)
+}
+
+func TestNewPeerProcessor_NilAddressConverterShouldErr(t *testing.T) {
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+	peerProcessor, err := peer.NewPeerProcessor(
+		peerAdapters,
+		nil,
+		&mock.NodesCoordinatorMock{},
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	assert.Nil(t, peerProcessor)
+	assert.Equal(t, process.ErrNilAddressConverter, err)
+}
+
+func TestNewPeerProcessor_NilNodesCoordinatorShouldErr(t *testing.T) {
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+	peerProcessor, err := peer.NewPeerProcessor(
+		peerAdapters,
+		&mock.AddressConverterMock{},
+		nil,
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	assert.Nil(t, peerProcessor)
+	assert.Equal(t, process.ErrNilNodesCoordinator, err)
+}
+
+func TestNewPeerProcessor_ShardCoordinatorShouldErr(t *testing.T) {
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	peerProcessor, err := peer.NewPeerProcessor(
+		peerAdapters,
+		&mock.AddressConverterMock{},
+		&mock.NodesCoordinatorMock{},
+		nil,
+		&mock.StorerStub{},
+	)
+
+	assert.Nil(t, peerProcessor)
+	assert.Equal(t, process.ErrNilShardCoordinator, err)
+}
+
+func TestNewPeerProcessor_ShardHeaderStorageShouldErr(t *testing.T) {
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+	peerProcessor, err := peer.NewPeerProcessor(
+		peerAdapters,
+		&mock.AddressConverterMock{},
+		&mock.NodesCoordinatorMock{},
+		shardCoordinatorMock,
+		nil,
+	)
+
+	assert.Nil(t, peerProcessor)
+	assert.Equal(t, process.ErrNilShardHeaderStorage, err)
+}
+
+func TestNewPeerProcessor(t *testing.T) {
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+	peerProcessor, err := peer.NewPeerProcessor(
+		peerAdapters,
+		&mock.AddressConverterMock{},
+		&mock.NodesCoordinatorMock{},
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	assert.NotNil(t, peerProcessor)
+	assert.Nil(t, err)
+}
+
+func TestPeerProcessor_LoadInitialStateErrOnInvalidNode(t *testing.T) {
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+	peerProcessor, _ := peer.NewPeerProcessor(
+		peerAdapters,
+		&mock.AddressConverterMock{},
+		&mock.NodesCoordinatorMock{},
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	initialNodes := []*sharding.InitialNode{{PubKey:"", Address: ""}}
+	err := peerProcessor.LoadInitialState(initialNodes)
+
+	assert.Equal(t, process.ErrInvalidInitialNodesState, err)
+}
+
+func TestPeerProcessor_LoadInitialStateErrOnWrongAddressConverter(t *testing.T) {
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+
+	addressErr := errors.New("hex address error")
+	addressConverter := &mock.AddressConverterStub{
+		CreateAddressFromHexCalled: func(hexAddress string) (container state.AddressContainer, e error) {
+			return nil, addressErr
+		},
+	}
+	peerProcessor, _ := peer.NewPeerProcessor(
+		peerAdapters,
+		addressConverter,
+		&mock.NodesCoordinatorMock{},
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	initialNodes := []*sharding.InitialNode{{PubKey:"aaaa", Address: "aaaa"}}
+	err := peerProcessor.LoadInitialState(initialNodes)
+
+	assert.Equal(t, addressErr, err)
+}
+
+func TestPeerProcessor_LoadInitialStateErrOnInvalidAssignedShard(t *testing.T) {
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+
+	addressConverter := &mock.AddressConverterStub{
+		CreateAddressFromHexCalled: func(hexAddress string) (container state.AddressContainer, e error) {
+			return &mock.AddressMock{}, nil
+		},
+	}
+	peerProcessor, _ := peer.NewPeerProcessor(
+		peerAdapters,
+		addressConverter,
+		&mock.NodesCoordinatorMock{},
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	initialNodes := []*sharding.InitialNode{{PubKey:"aaaa", Address: "aaaa",}}
+	err := peerProcessor.LoadInitialState(initialNodes)
+
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "peer account adapter for shard id")
+}
+
+func TestPeerProcessor_LoadInitialStateErrOnGetAccountFail(t *testing.T) {
+	adapterError := errors.New("account error")
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	peerAdapters[0] = &mock.AccountsStub{
+		GetAccountWithJournalCalled: func(addressContainer state.AddressContainer) (handler state.AccountHandler, e error) {
+			return nil, adapterError
+		},
+	}
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+
+	addressConverter := &mock.AddressConverterStub{
+		CreateAddressFromHexCalled: func(hexAddress string) (container state.AddressContainer, e error) {
+			return &mock.AddressMock{}, nil
+		},
+	}
+	peerProcessor, _ := peer.NewPeerProcessor(
+		peerAdapters,
+		addressConverter,
+		&mock.NodesCoordinatorMock{},
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	initialNodes := []*sharding.InitialNode{{PubKey:"aaaa", Address: "aaaa"}}
+	err := peerProcessor.LoadInitialState(initialNodes)
+
+	assert.Equal(t, adapterError, err)
+}
+
+func TestPeerProcessor_LoadInitialStateGetAccountReturnsInvalid(t *testing.T) {
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	peerAdapters[0] = &mock.AccountsStub{
+		GetAccountWithJournalCalled: func(addressContainer state.AddressContainer) (handler state.AccountHandler, e error) {
+			return &mock.AccountWrapMock{}, nil
+		},
+	}
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+
+	addressConverter := &mock.AddressConverterStub{
+		CreateAddressFromHexCalled: func(hexAddress string) (container state.AddressContainer, e error) {
+			return &mock.AddressMock{}, nil
+		},
+	}
+	peerProcessor, _ := peer.NewPeerProcessor(
+		peerAdapters,
+		addressConverter,
+		&mock.NodesCoordinatorMock{},
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	initialNodes := []*sharding.InitialNode{{PubKey:"aaaa", Address: "aaaa"}}
+	err := peerProcessor.LoadInitialState(initialNodes)
+
+	assert.Equal(t, process.ErrInvalidPeerAccount, err)
+}
+
+func TestPeerProcessor_LoadInitialStateSetAddressErrors(t *testing.T) {
+	saveAccountError := errors.New("save account error")
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	peerAccount, _ := state.NewPeerAccount(&mock.AddressMock{}, &mock.AccountTrackerStub{
+		JournalizeCalled: func(entry state.JournalEntry) {
+
+		},
+		SaveAccountCalled: func(accountHandler state.AccountHandler) error {
+			return saveAccountError
+		},
+	})
+	peerAdapters[0] = &mock.AccountsStub{
+		GetAccountWithJournalCalled: func(addressContainer state.AddressContainer) (handler state.AccountHandler, e error) {
+			return peerAccount, nil
+		},
+	}
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+
+	addressConverter := &mock.AddressConverterStub{
+		CreateAddressFromHexCalled: func(hexAddress string) (container state.AddressContainer, e error) {
+			return &mock.AddressMock{}, nil
+		},
+	}
+	peerProcessor, _ := peer.NewPeerProcessor(
+		peerAdapters,
+		addressConverter,
+		&mock.NodesCoordinatorMock{},
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	initialNodes := []*sharding.InitialNode{{PubKey:"aaaa", Address: "aaaa"}}
+	err := peerProcessor.LoadInitialState(initialNodes)
+
+	assert.Equal(t, saveAccountError, err)
+}
+
+func TestPeerProcessor_LoadInitialStateCommitErrors(t *testing.T) {
+	commitError := errors.New("commit error")
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	peerAccount, _ := state.NewPeerAccount(&mock.AddressMock{}, &mock.AccountTrackerStub{
+		JournalizeCalled: func(entry state.JournalEntry) {
+
+		},
+		SaveAccountCalled: func(accountHandler state.AccountHandler) error {
+			return nil
+		},
+	})
+	peerAdapters[0] = &mock.AccountsStub{
+		GetAccountWithJournalCalled: func(addressContainer state.AddressContainer) (handler state.AccountHandler, e error) {
+			return peerAccount, nil
+		},
+		CommitCalled: func() (bytes []byte, e error) {
+			return nil, commitError
+		},
+	}
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+
+	addressConverter := &mock.AddressConverterStub{
+		CreateAddressFromHexCalled: func(hexAddress string) (container state.AddressContainer, e error) {
+			return &mock.AddressMock{}, nil
+		},
+	}
+	peerProcessor, _ := peer.NewPeerProcessor(
+		peerAdapters,
+		addressConverter,
+		&mock.NodesCoordinatorMock{},
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	initialNodes := []*sharding.InitialNode{{PubKey:"aaaa", Address: "aaaa"}}
+	err := peerProcessor.LoadInitialState(initialNodes)
+
+	assert.Equal(t, commitError, err)
+}
+
+func TestPeerProcessor_LoadInitialStateCommit(t *testing.T) {
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	peerAccount, _ := state.NewPeerAccount(&mock.AddressMock{}, &mock.AccountTrackerStub{
+		JournalizeCalled: func(entry state.JournalEntry) {
+
+		},
+		SaveAccountCalled: func(accountHandler state.AccountHandler) error {
+			return nil
+		},
+	})
+	peerAdapters[0] = &mock.AccountsStub{
+		GetAccountWithJournalCalled: func(addressContainer state.AddressContainer) (handler state.AccountHandler, e error) {
+			return peerAccount, nil
+		},
+		CommitCalled: func() (bytes []byte, e error) {
+			return nil, nil
+		},
+	}
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+
+	addressConverter := &mock.AddressConverterStub{
+		CreateAddressFromHexCalled: func(hexAddress string) (container state.AddressContainer, e error) {
+			return &mock.AddressMock{}, nil
+		},
+	}
+	peerProcessor, _ := peer.NewPeerProcessor(
+		peerAdapters,
+		addressConverter,
+		&mock.NodesCoordinatorMock{},
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	initialNodes := []*sharding.InitialNode{{PubKey:"aaaa", Address: "aaaa"}}
+	err := peerProcessor.LoadInitialState(initialNodes)
+
+	assert.Nil(t, err)
+}
+
+func TestPeerProcess_IsNodeValidEmptyAddressShoudErr(t *testing.T) {
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+	peerProcessor, _ := peer.NewPeerProcessor(
+		peerAdapters,
+		&mock.AddressConverterMock{},
+		&mock.NodesCoordinatorMock{},
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	isValid := peerProcessor.IsNodeValid(&sharding.InitialNode{Address: "", PubKey: "aaaaa"})
+	assert.False(t, isValid)
+}
+
+func TestPeerProcess_IsNodeValidEmptyPubKeyShoudErr(t *testing.T) {
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+	peerProcessor, _ := peer.NewPeerProcessor(
+		peerAdapters,
+		&mock.AddressConverterMock{},
+		&mock.NodesCoordinatorMock{},
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	isValid := peerProcessor.IsNodeValid(&sharding.InitialNode{Address: "aaaaa", PubKey: ""})
+	assert.False(t, isValid)
+}
+
+func TestPeerProcess_IsNodeValid(t *testing.T) {
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+	peerProcessor, _ := peer.NewPeerProcessor(
+		peerAdapters,
+		&mock.AddressConverterMock{},
+		&mock.NodesCoordinatorMock{},
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	isValid := peerProcessor.IsNodeValid(&sharding.InitialNode{Address: "aaaaa", PubKey: "aaaaaa"})
+	assert.True(t, isValid)
+}
+
+func TestPeerProcess_UpdatePeerStateComputeValidatorErrShouldError(t *testing.T) {
+	computeValidatorsErr := errors.New("compute validators error")
+	peerAdapters := make(peer.ShardedPeerAdapters, 0)
+	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
+	peerProcessor, _ := peer.NewPeerProcessor(
+		peerAdapters,
+		&mock.AddressConverterMock{},
+		&mock.NodesCoordinatorMock{
+			ComputeValidatorsGroupCalled: func(randomness []byte, round uint64, shardId uint32) (validatorsGroup []sharding.Validator, err error) {
+				return nil, computeValidatorsErr
+			},
+		},
+		shardCoordinatorMock,
+		&mock.StorerStub{},
+	)
+
+	header := getHeaderHandler([]byte("header"))
+	prevHEader := getHeaderHandler([]byte("prevheader"))
+	err := peerProcessor.UpdatePeerState(header, prevHEader)
+
+	assert.Equal(t, computeValidatorsErr, err)
+}
+
+
+
+func getHeaderHandler(randSeed []byte) *mock.HeaderHandlerStub {
+	return &mock.HeaderHandlerStub{
+		GetRandSeedCalled: func() []byte {
+			return randSeed
+		},
+	}
+}


### PR DESCRIPTION
First part of the peer processor implementation.
Contains basic peer processor code and initialisation. 

Next PR will contain some more unit tests and a bit more differentiation between what is executed by a metachain node and a shard node