### PR TITLE
En 3996 implement db eviction cache

### DIFF
--- a/data/interface.go
+++ b/data/interface.go
@@ -105,3 +105,11 @@ type DBWriteCacher interface {
 	Get(key []byte) ([]byte, error)
 	IsInterfaceNil() bool
 }
+
+// DBRemoveCacher is used to cache keys that will be deleted from the database
+type DBRemoveCacher interface {
+	Add([]byte, [][]byte) error
+	Evict([]byte) ([][]byte, error)
+	Rollback([]byte) error
+	IsInterfaceNil() bool
+}

--- a/data/interface.go
+++ b/data/interface.go
@@ -110,6 +110,5 @@ type DBWriteCacher interface {
 type DBRemoveCacher interface {
 	Add([]byte, [][]byte) error
 	Evict([]byte) ([][]byte, error)
-	Rollback([]byte) error
 	IsInterfaceNil() bool
 }

--- a/data/interface.go
+++ b/data/interface.go
@@ -108,7 +108,7 @@ type DBWriteCacher interface {
 
 // DBRemoveCacher is used to cache keys that will be deleted from the database
 type DBRemoveCacher interface {
-	Add([]byte, [][]byte) error
+	Put([]byte, [][]byte) error
 	Evict([]byte) ([][]byte, error)
 	IsInterfaceNil() bool
 }

--- a/data/trie/errors.go
+++ b/data/trie/errors.go
@@ -33,3 +33,6 @@ var ErrEmptyNode = errors.New("the node is empty")
 
 // ErrNilNode is raised when we reach a nil node
 var ErrNilNode = errors.New("the node is nil")
+
+// ErrInvalidCacheSize is raised when the given size for the cache is invalid
+var ErrInvalidCacheSize = errors.New("cache size is invalid")

--- a/data/trie/evictionWaitingList/evictionWaitingList.go
+++ b/data/trie/evictionWaitingList/evictionWaitingList.go
@@ -8,7 +8,7 @@ import (
 
 // evictionWaitingList is a structure that caches keys that need to be removed from a certain database.
 // If the cache is full, the keys will be stored in the underlying database. Writing at the same key in
-// cacher and db will overwrite the previous values
+// cacher and db will overwrite the previous values. This structure is not concurrent safe.
 type evictionWaitingList struct {
 	cache       map[string][][]byte
 	cacheSize   int
@@ -37,18 +37,18 @@ func NewEvictionWaitingList(size int, db storage.Persister, marshalizer marshal.
 }
 
 // Put stores the given hashes in the eviction waiting list, in the position given by the root hash
-func (ec *evictionWaitingList) Put(rootHash []byte, hashes [][]byte) error {
-	if len(ec.cache) < ec.cacheSize {
-		ec.cache[string(rootHash)] = hashes
+func (ewl *evictionWaitingList) Put(rootHash []byte, hashes [][]byte) error {
+	if len(ewl.cache) < ewl.cacheSize {
+		ewl.cache[string(rootHash)] = hashes
 		return nil
 	}
 
-	marshalizedHashes, err := ec.marshalizer.Marshal(hashes)
+	marshalizedHashes, err := ewl.marshalizer.Marshal(hashes)
 	if err != nil {
 		return err
 	}
 
-	err = ec.db.Put(rootHash, marshalizedHashes)
+	err = ewl.db.Put(rootHash, marshalizedHashes)
 	if err != nil {
 		return err
 	}
@@ -57,24 +57,24 @@ func (ec *evictionWaitingList) Put(rootHash []byte, hashes [][]byte) error {
 }
 
 // Evict returns and removes from the waiting list all the hashes from the position given by the root hash
-func (ec *evictionWaitingList) Evict(rootHash []byte) ([][]byte, error) {
-	hashes := ec.cache[string(rootHash)]
-	if hashes != nil {
-		delete(ec.cache, string(rootHash))
+func (ewl *evictionWaitingList) Evict(rootHash []byte) ([][]byte, error) {
+	hashes, ok := ewl.cache[string(rootHash)]
+	if ok {
+		delete(ewl.cache, string(rootHash))
 		return hashes, nil
 	}
 
-	marshalizedHashes, err := ec.db.Get(rootHash)
+	marshalizedHashes, err := ewl.db.Get(rootHash)
 	if err != nil {
 		return nil, err
 	}
 
-	err = ec.marshalizer.Unmarshal(&hashes, marshalizedHashes)
+	err = ewl.marshalizer.Unmarshal(&hashes, marshalizedHashes)
 	if err != nil {
 		return nil, err
 	}
 
-	err = ec.db.Remove(rootHash)
+	err = ewl.db.Remove(rootHash)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (ec *evictionWaitingList) Evict(rootHash []byte) ([][]byte, error) {
 }
 
 // IsInterfaceNil returns true if there is no value under the interface
-func (ec *evictionWaitingList) IsInterfaceNil() bool {
-	if ec == nil {
+func (ewl *evictionWaitingList) IsInterfaceNil() bool {
+	if ewl == nil {
 		return true
 	}
 	return false

--- a/data/trie/evictionWaitingList/evictionWaitingList.go
+++ b/data/trie/evictionWaitingList/evictionWaitingList.go
@@ -36,8 +36,8 @@ func NewEvictionWaitingList(size int, db storage.Persister, marshalizer marshal.
 	}, nil
 }
 
-// Add adds the given hashes to the eviction waiting list, in the position given by the root hash
-func (ec *evictionWaitingList) Add(rootHash []byte, hashes [][]byte) error {
+// Put stores the given hashes in the eviction waiting list, in the position given by the root hash
+func (ec *evictionWaitingList) Put(rootHash []byte, hashes [][]byte) error {
 	if len(ec.cache) < ec.cacheSize {
 		ec.cache[string(rootHash)] = hashes
 		return nil
@@ -56,7 +56,7 @@ func (ec *evictionWaitingList) Add(rootHash []byte, hashes [][]byte) error {
 	return nil
 }
 
-// Evict returns all the hashes from the position given by the root hash
+// Evict returns and removes from the waiting list all the hashes from the position given by the root hash
 func (ec *evictionWaitingList) Evict(rootHash []byte) ([][]byte, error) {
 	hashes := ec.cache[string(rootHash)]
 	if hashes != nil {
@@ -80,22 +80,6 @@ func (ec *evictionWaitingList) Evict(rootHash []byte) ([][]byte, error) {
 	}
 
 	return hashes, nil
-}
-
-// Rollback clears the hashes from the position given by the root hash
-func (ec *evictionWaitingList) Rollback(rootHash []byte) error {
-	hashes := ec.cache[string(rootHash)]
-	if hashes != nil {
-		delete(ec.cache, string(rootHash))
-		return nil
-	}
-
-	err := ec.db.Remove(rootHash)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/data/trie/evictionWaitingList/evictionWaitingList.go
+++ b/data/trie/evictionWaitingList/evictionWaitingList.go
@@ -1,0 +1,107 @@
+package evictionWaitingList
+
+import (
+	"github.com/ElrondNetwork/elrond-go/data/trie"
+	"github.com/ElrondNetwork/elrond-go/marshal"
+	"github.com/ElrondNetwork/elrond-go/storage"
+)
+
+// evictionWaitingList is a structure that caches keys that need to be removed from a certain database.
+// If the cache is full, the keys will be stored in the underlying database. Writing at the same key in
+// cacher and db will overwrite the previous values
+type evictionWaitingList struct {
+	cache       map[string][][]byte
+	cacheSize   int
+	db          storage.Persister
+	marshalizer marshal.Marshalizer
+}
+
+// NewEvictionWaitingList creates a new instance of evictionWaitingList
+func NewEvictionWaitingList(size int, db storage.Persister, marshalizer marshal.Marshalizer) (*evictionWaitingList, error) {
+	if size < 1 {
+		return nil, trie.ErrInvalidCacheSize
+	}
+	if db == nil || db.IsInterfaceNil() {
+		return nil, trie.ErrNilDatabase
+	}
+	if marshalizer == nil || marshalizer.IsInterfaceNil() {
+		return nil, trie.ErrNilMarshalizer
+	}
+
+	return &evictionWaitingList{
+		cache:       make(map[string][][]byte),
+		cacheSize:   size,
+		db:          db,
+		marshalizer: marshalizer,
+	}, nil
+}
+
+// Add adds the given hashes to the eviction waiting list, in the position given by the root hash
+func (ec *evictionWaitingList) Add(rootHash []byte, hashes [][]byte) error {
+	if len(ec.cache) < ec.cacheSize {
+		ec.cache[string(rootHash)] = hashes
+		return nil
+	}
+
+	marshalizedHashes, err := ec.marshalizer.Marshal(hashes)
+	if err != nil {
+		return err
+	}
+
+	err = ec.db.Put(rootHash, marshalizedHashes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Evict returns all the hashes from the position given by the root hash
+func (ec *evictionWaitingList) Evict(rootHash []byte) ([][]byte, error) {
+	hashes := ec.cache[string(rootHash)]
+	if hashes != nil {
+		delete(ec.cache, string(rootHash))
+		return hashes, nil
+	}
+
+	marshalizedHashes, err := ec.db.Get(rootHash)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ec.marshalizer.Unmarshal(&hashes, marshalizedHashes)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ec.db.Remove(rootHash)
+	if err != nil {
+		return nil, err
+	}
+
+	return hashes, nil
+}
+
+// Rollback clears the hashes from the position given by the root hash
+func (ec *evictionWaitingList) Rollback(rootHash []byte) error {
+	hashes := ec.cache[string(rootHash)]
+	if hashes != nil {
+		delete(ec.cache, string(rootHash))
+		return nil
+	}
+
+	err := ec.db.Remove(rootHash)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (ec *evictionWaitingList) IsInterfaceNil() bool {
+	if ec == nil {
+		return true
+	}
+	return false
+}

--- a/data/trie/evictionWaitingList/evictionWaitingList_test.go
+++ b/data/trie/evictionWaitingList/evictionWaitingList_test.go
@@ -42,7 +42,7 @@ func TestNewEvictionWaitingList_NilDMarshalizer(t *testing.T) {
 	assert.Equal(t, trie.ErrNilMarshalizer, err)
 }
 
-func TestEvictionCache_Add(t *testing.T) {
+func TestEvictionWaitingList_Add(t *testing.T) {
 	ec, _ := NewEvictionWaitingList(getDefaultParameters())
 
 	hashes := [][]byte{
@@ -58,7 +58,7 @@ func TestEvictionCache_Add(t *testing.T) {
 	assert.Equal(t, hashes, ec.cache[string(root)])
 }
 
-func TestEvictionCache_AddMultiple(t *testing.T) {
+func TestEvictionWaitingList_AddMultiple(t *testing.T) {
 	cacheSize := 2
 	_, db, marsh := getDefaultParameters()
 	ec, _ := NewEvictionWaitingList(cacheSize, db, marsh)
@@ -94,7 +94,7 @@ func TestEvictionCache_AddMultiple(t *testing.T) {
 
 }
 
-func TestEvictionCache_Evict(t *testing.T) {
+func TestEvictionWaitingList_Evict(t *testing.T) {
 	ec, _ := NewEvictionWaitingList(getDefaultParameters())
 
 	expectedHashes := [][]byte{
@@ -111,7 +111,7 @@ func TestEvictionCache_Evict(t *testing.T) {
 	assert.Equal(t, expectedHashes, hashes)
 }
 
-func TestEvictionCache_EvictFromDB(t *testing.T) {
+func TestEvictionWaitingList_EvictFromDB(t *testing.T) {
 	cacheSize := 2
 	_, db, marsh := getDefaultParameters()
 	ec, _ := NewEvictionWaitingList(cacheSize, db, marsh)
@@ -141,7 +141,7 @@ func TestEvictionCache_EvictFromDB(t *testing.T) {
 	assert.Nil(t, val)
 }
 
-func TestEvictionCache_Rollback(t *testing.T) {
+func TestEvictionWaitingList_Rollback(t *testing.T) {
 	ec, _ := NewEvictionWaitingList(getDefaultParameters())
 
 	h1 := [][]byte{
@@ -164,7 +164,7 @@ func TestEvictionCache_Rollback(t *testing.T) {
 	assert.Equal(t, h2, ec.cache[string(root2)])
 }
 
-func TestEvictionCache_RollbackFromDB(t *testing.T) {
+func TestEvictionWaitingList_RollbackFromDB(t *testing.T) {
 	cacheSize := 2
 	_, db, marsh := getDefaultParameters()
 	ec, _ := NewEvictionWaitingList(cacheSize, db, marsh)

--- a/data/trie/evictionWaitingList/evictionWaitingList_test.go
+++ b/data/trie/evictionWaitingList/evictionWaitingList_test.go
@@ -17,6 +17,7 @@ func getDefaultParameters() (int, storage.Persister, marshal.Marshalizer) {
 
 func TestNewEvictionWaitingList(t *testing.T) {
 	t.Parallel()
+
 	ec, err := NewEvictionWaitingList(getDefaultParameters())
 	assert.Nil(t, err)
 	assert.NotNil(t, ec)
@@ -24,6 +25,7 @@ func TestNewEvictionWaitingList(t *testing.T) {
 
 func TestNewEvictionWaitingList_InvalidCacheSize(t *testing.T) {
 	t.Parallel()
+
 	_, db, marsh := getDefaultParameters()
 	ec, err := NewEvictionWaitingList(0, db, marsh)
 	assert.Nil(t, ec)
@@ -32,6 +34,7 @@ func TestNewEvictionWaitingList_InvalidCacheSize(t *testing.T) {
 
 func TestNewEvictionWaitingList_NilDatabase(t *testing.T) {
 	t.Parallel()
+
 	size, _, marsh := getDefaultParameters()
 	ec, err := NewEvictionWaitingList(size, nil, marsh)
 	assert.Nil(t, ec)
@@ -40,14 +43,16 @@ func TestNewEvictionWaitingList_NilDatabase(t *testing.T) {
 
 func TestNewEvictionWaitingList_NilDMarshalizer(t *testing.T) {
 	t.Parallel()
+
 	size, db, _ := getDefaultParameters()
 	ec, err := NewEvictionWaitingList(size, db, nil)
 	assert.Nil(t, ec)
 	assert.Equal(t, trie.ErrNilMarshalizer, err)
 }
 
-func TestEvictionWaitingList_Add(t *testing.T) {
+func TestEvictionWaitingList_Put(t *testing.T) {
 	t.Parallel()
+
 	ec, _ := NewEvictionWaitingList(getDefaultParameters())
 
 	hashes := [][]byte{
@@ -63,7 +68,7 @@ func TestEvictionWaitingList_Add(t *testing.T) {
 	assert.Equal(t, hashes, ec.cache[string(root)])
 }
 
-func TestEvictionWaitingList_AddMultiple(t *testing.T) {
+func TestEvictionWaitingList_PutMultiple(t *testing.T) {
 	t.Parallel()
 
 	cacheSize := 2
@@ -103,6 +108,7 @@ func TestEvictionWaitingList_AddMultiple(t *testing.T) {
 
 func TestEvictionWaitingList_Evict(t *testing.T) {
 	t.Parallel()
+
 	ec, _ := NewEvictionWaitingList(getDefaultParameters())
 
 	expectedHashes := [][]byte{

--- a/data/trie/evictionWaitingList/evictionWaitingList_test.go
+++ b/data/trie/evictionWaitingList/evictionWaitingList_test.go
@@ -1,0 +1,194 @@
+package evictionWaitingList
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/data/mock"
+	"github.com/ElrondNetwork/elrond-go/data/trie"
+	"github.com/ElrondNetwork/elrond-go/marshal"
+	"github.com/ElrondNetwork/elrond-go/storage"
+	"github.com/ElrondNetwork/elrond-go/storage/memorydb"
+	"github.com/stretchr/testify/assert"
+)
+
+func getDefaultParameters() (int, storage.Persister, marshal.Marshalizer) {
+	return 10, memorydb.New(), &mock.MarshalizerMock{}
+}
+
+func TestNewEvictionWaitingList(t *testing.T) {
+	ec, err := NewEvictionWaitingList(getDefaultParameters())
+	assert.Nil(t, err)
+	assert.NotNil(t, ec)
+}
+
+func TestNewEvictionWaitingList_InvalidCacheSize(t *testing.T) {
+	_, db, marsh := getDefaultParameters()
+	ec, err := NewEvictionWaitingList(0, db, marsh)
+	assert.Nil(t, ec)
+	assert.Equal(t, trie.ErrInvalidCacheSize, err)
+}
+
+func TestNewEvictionWaitingList_NilDatabase(t *testing.T) {
+	size, _, marsh := getDefaultParameters()
+	ec, err := NewEvictionWaitingList(size, nil, marsh)
+	assert.Nil(t, ec)
+	assert.Equal(t, trie.ErrNilDatabase, err)
+}
+
+func TestNewEvictionWaitingList_NilDMarshalizer(t *testing.T) {
+	size, db, _ := getDefaultParameters()
+	ec, err := NewEvictionWaitingList(size, db, nil)
+	assert.Nil(t, ec)
+	assert.Equal(t, trie.ErrNilMarshalizer, err)
+}
+
+func TestEvictionCache_Add(t *testing.T) {
+	ec, _ := NewEvictionWaitingList(getDefaultParameters())
+
+	hashes := [][]byte{
+		[]byte("hash1"),
+		[]byte("hash2"),
+	}
+	root := []byte("root")
+
+	err := ec.Add(root, hashes)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(ec.cache))
+	assert.Equal(t, hashes, ec.cache[string(root)])
+}
+
+func TestEvictionCache_AddMultiple(t *testing.T) {
+	cacheSize := 2
+	_, db, marsh := getDefaultParameters()
+	ec, _ := NewEvictionWaitingList(cacheSize, db, marsh)
+
+	hashes := [][]byte{
+		[]byte("hash0"),
+		[]byte("hash1"),
+	}
+	roots := [][]byte{
+		[]byte("root0"),
+		[]byte("root1"),
+		[]byte("root2"),
+		[]byte("root3"),
+	}
+
+	for i := range roots {
+		err := ec.Add(roots[i], hashes)
+		assert.Nil(t, err)
+	}
+
+	assert.Equal(t, 2, len(ec.cache))
+	for i := 0; i < cacheSize; i++ {
+		assert.Equal(t, hashes, ec.cache[string(roots[i])])
+	}
+	for i := cacheSize; i < len(roots); i++ {
+		val := make([][]byte, 0)
+		encVal, err := ec.db.Get(roots[i])
+		err = ec.marshalizer.Unmarshal(&val, encVal)
+
+		assert.Nil(t, err)
+		assert.Equal(t, hashes, val)
+	}
+
+}
+
+func TestEvictionCache_Evict(t *testing.T) {
+	ec, _ := NewEvictionWaitingList(getDefaultParameters())
+
+	expectedHashes := [][]byte{
+		[]byte("hash1"),
+		[]byte("hash2"),
+	}
+	root1 := []byte("root1")
+
+	_ = ec.Add(root1, expectedHashes)
+
+	hashes, err := ec.Evict([]byte("root1"))
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(ec.cache))
+	assert.Equal(t, expectedHashes, hashes)
+}
+
+func TestEvictionCache_EvictFromDB(t *testing.T) {
+	cacheSize := 2
+	_, db, marsh := getDefaultParameters()
+	ec, _ := NewEvictionWaitingList(cacheSize, db, marsh)
+
+	hashes := [][]byte{
+		[]byte("hash0"),
+		[]byte("hash1"),
+	}
+	roots := [][]byte{
+		[]byte("root0"),
+		[]byte("root1"),
+		[]byte("root2"),
+	}
+
+	for i := range roots {
+		_ = ec.Add(roots[i], hashes)
+	}
+
+	val, _ := ec.db.Get(roots[2])
+	assert.NotNil(t, val)
+
+	vals, err := ec.Evict(roots[2])
+	assert.Nil(t, err)
+	assert.Equal(t, hashes, vals)
+
+	val, _ = ec.db.Get(roots[2])
+	assert.Nil(t, val)
+}
+
+func TestEvictionCache_Rollback(t *testing.T) {
+	ec, _ := NewEvictionWaitingList(getDefaultParameters())
+
+	h1 := [][]byte{
+		[]byte("hash1"),
+		[]byte("hash2"),
+	}
+	h2 := [][]byte{
+		[]byte("hash3"),
+		[]byte("hash4"),
+	}
+	root1 := []byte("root1")
+	root2 := []byte("root2")
+
+	_ = ec.Add(root1, h1)
+	_ = ec.Add(root2, h2)
+
+	err := ec.Rollback(root1)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(ec.cache))
+	assert.Equal(t, h2, ec.cache[string(root2)])
+}
+
+func TestEvictionCache_RollbackFromDB(t *testing.T) {
+	cacheSize := 2
+	_, db, marsh := getDefaultParameters()
+	ec, _ := NewEvictionWaitingList(cacheSize, db, marsh)
+
+	hashes := [][]byte{
+		[]byte("hash0"),
+		[]byte("hash1"),
+	}
+	roots := [][]byte{
+		[]byte("root0"),
+		[]byte("root1"),
+		[]byte("root2"),
+	}
+
+	for i := range roots {
+		_ = ec.Add(roots[i], hashes)
+	}
+
+	val, _ := ec.db.Get(roots[2])
+	assert.NotNil(t, val)
+
+	err := ec.Rollback(roots[2])
+	assert.Nil(t, err)
+
+	val, _ = ec.db.Get(roots[2])
+	assert.Nil(t, val)
+}

--- a/marshal/jsonMarshalizer.go
+++ b/marshal/jsonMarshalizer.go
@@ -12,7 +12,7 @@ type JsonMarshalizer struct {
 // Marshal tries to serialize obj parameter
 func (j JsonMarshalizer) Marshal(obj interface{}) ([]byte, error) {
 	if obj == nil {
-		return nil, errors.New("NIL object to serilize from!")
+		return nil, errors.New("nil object to serialize from")
 	}
 
 	return json.Marshal(obj)
@@ -21,7 +21,7 @@ func (j JsonMarshalizer) Marshal(obj interface{}) ([]byte, error) {
 // Unmarshal tries to deserialize input buffer values into input object
 func (j JsonMarshalizer) Unmarshal(obj interface{}, buff []byte) error {
 	if obj == nil {
-		return errors.New("nil object to serilize to")
+		return errors.New("nil object to serialize to")
 	}
 	if buff == nil {
 		return errors.New("nil byte buffer to deserialize from")


### PR DESCRIPTION
Implement evictionWaitingList, which caches keys that need to be removed from a certain database. If the cache is full, the keys will be stored in the underlying database.