### PR TITLE
En 4077 refactor shard processor constructor

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -1503,7 +1503,7 @@ func newShardBlockProcessorAndTracker(
 		return nil, nil, err
 	}
 
-	argumentsBaseProcessor := block.ArgsBaseProcessor{
+	argumentsBaseProcessor := block.ArgBaseProcessor{
 		Accounts:         state.AccountsAdapter,
 		ForkDetector:     forkDetector,
 		Hasher:           core.Hasher,
@@ -1515,12 +1515,13 @@ func newShardBlockProcessorAndTracker(
 		RequestHandler:   requestHandler,
 		Core:             coreServiceContainer,
 	}
-	arguments := block.ArgsShardProcessor{
-		ArgsBaseProcessor: &argumentsBaseProcessor,
-		DataPool:          data.Datapool,
-		BlocksTracker:     blockTracker,
-		TxCoordinator:     txCoordinator,
+	arguments := block.ArgShardProcessor{
+		ArgBaseProcessor: &argumentsBaseProcessor,
+		DataPool:         data.Datapool,
+		BlocksTracker:    blockTracker,
+		TxCoordinator:    txCoordinator,
 	}
+
 	blockProcessor, err := block.NewShardProcessor(arguments)
 	if err != nil {
 		return nil, nil, errors.New("could not create block processor: " + err.Error())

--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -1503,21 +1503,25 @@ func newShardBlockProcessorAndTracker(
 		return nil, nil, err
 	}
 
-	blockProcessor, err := block.NewShardProcessor(
-		coreServiceContainer,
-		data.Datapool,
-		data.Store,
-		core.Hasher,
-		core.Marshalizer,
-		state.AccountsAdapter,
-		shardCoordinator,
-		forkDetector,
-		blockTracker,
-		shardsGenesisBlocks,
-		requestHandler,
-		txCoordinator,
-		core.Uint64ByteSliceConverter,
-	)
+	argumentsBaseProcessor := block.ArgsBaseProcessor{
+		Accounts:         state.AccountsAdapter,
+		ForkDetector:     forkDetector,
+		Hasher:           core.Hasher,
+		Marshalizer:      core.Marshalizer,
+		Store:            data.Store,
+		ShardCoordinator: shardCoordinator,
+		Uint64Converter:  core.Uint64ByteSliceConverter,
+		StartHeaders:     shardsGenesisBlocks,
+		RequestHandler:   requestHandler,
+		Core:             coreServiceContainer,
+	}
+	arguments := block.ArgsShardProcessor{
+		ArgsBaseProcessor: &argumentsBaseProcessor,
+		DataPool:          data.Datapool,
+		BlocksTracker:     blockTracker,
+		TxCoordinator:     txCoordinator,
+	}
+	blockProcessor, err := block.NewShardProcessor(arguments)
 	if err != nil {
 		return nil, nil, errors.New("could not create block processor: " + err.Error())
 	}

--- a/integrationTests/multiShard/smartContract/testInitilalizer.go
+++ b/integrationTests/multiShard/smartContract/testInitilalizer.go
@@ -322,26 +322,32 @@ func createNetNode(
 	)
 
 	genesisBlocks := createGenesisBlocks(shardCoordinator)
-	blockProcessor, _ := block.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		dPool,
-		store,
-		testHasher,
-		testMarshalizer,
-		accntAdapter,
-		shardCoordinator,
-		&mock.ForkDetectorMock{
-			AddHeaderCalled: func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState, finalHeader data.HeaderHandler, finalHeaderHash []byte) error {
-				return nil
+
+	arguments := block.ArgsShardProcessor{
+		ArgsBaseProcessor: &block.ArgsBaseProcessor{
+			Accounts: accntAdapter,
+			ForkDetector: &mock.ForkDetectorMock{
+				AddHeaderCalled: func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState, finalHeader data.HeaderHandler, finalHeaderHash []byte) error {
+					return nil
+				},
+				GetHighestFinalBlockNonceCalled: func() uint64 {
+					return 0
+				},
+				ProbableHighestNonceCalled: func() uint64 {
+					return 0
+				},
 			},
-			GetHighestFinalBlockNonceCalled: func() uint64 {
-				return 0
-			},
-			ProbableHighestNonceCalled: func() uint64 {
-				return 0
-			},
+			Hasher:           testHasher,
+			Marshalizer:      testMarshalizer,
+			Store:            store,
+			ShardCoordinator: shardCoordinator,
+			Uint64Converter:  uint64Converter,
+			StartHeaders:     genesisBlocks,
+			RequestHandler:   requestHandler,
+			Core:             &mock.ServiceContainerMock{},
 		},
-		&mock.BlocksTrackerMock{
+		DataPool: dPool,
+		BlocksTracker: &mock.BlocksTrackerMock{
 			AddBlockCalled: func(headerHandler data.HeaderHandler) {
 			},
 			RemoveNotarisedBlocksCalled: func(headerHandler data.HeaderHandler) error {
@@ -351,11 +357,10 @@ func createNetNode(
 				return make([]data.HeaderHandler, 0)
 			},
 		},
-		genesisBlocks,
-		requestHandler,
-		tc,
-		uint64Converter,
-	)
+		TxCoordinator: tc,
+	}
+
+	blockProcessor, _ := block.NewShardProcessor(arguments)
 
 	_ = blkc.SetGenesisHeader(genesisBlocks[shardCoordinator.SelfId()])
 

--- a/integrationTests/multiShard/smartContract/testInitilalizer.go
+++ b/integrationTests/multiShard/smartContract/testInitilalizer.go
@@ -323,8 +323,8 @@ func createNetNode(
 
 	genesisBlocks := createGenesisBlocks(shardCoordinator)
 
-	arguments := block.ArgsShardProcessor{
-		ArgsBaseProcessor: &block.ArgsBaseProcessor{
+	arguments := block.ArgShardProcessor{
+		ArgBaseProcessor: &block.ArgBaseProcessor{
 			Accounts: accntAdapter,
 			ForkDetector: &mock.ForkDetectorMock{
 				AddHeaderCalled: func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState, finalHeaders []data.HeaderHandler, finalHeadersHashes [][]byte) error {

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -389,21 +389,25 @@ func (tpn *TestProcessorNode) initBlockProcessor() {
 			TestUint64Converter,
 		)
 	} else {
-		tpn.BlockProcessor, err = block.NewShardProcessor(
-			nil,
-			tpn.ShardDataPool,
-			tpn.Storage,
-			TestHasher,
-			TestMarshalizer,
-			tpn.AccntState,
-			tpn.ShardCoordinator,
-			tpn.ForkDetector,
-			tpn.BlockTracker,
-			tpn.GenesisBlocks,
-			tpn.RequestHandler,
-			tpn.TxCoordinator,
-			TestUint64Converter,
-		)
+		arguments := block.ArgsShardProcessor{
+			ArgsBaseProcessor: &block.ArgsBaseProcessor{
+				Accounts:         tpn.AccntState,
+				ForkDetector:     tpn.ForkDetector,
+				Hasher:           TestHasher,
+				Marshalizer:      TestMarshalizer,
+				Store:            tpn.Storage,
+				ShardCoordinator: tpn.ShardCoordinator,
+				Uint64Converter:  TestUint64Converter,
+				StartHeaders:     tpn.GenesisBlocks,
+				RequestHandler:   tpn.RequestHandler,
+				Core:             nil,
+			},
+			DataPool:      tpn.ShardDataPool,
+			BlocksTracker: tpn.BlockTracker,
+			TxCoordinator: tpn.TxCoordinator,
+		}
+
+		tpn.BlockProcessor, err = block.NewShardProcessor(arguments)
 	}
 
 	if err != nil {

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -389,8 +389,8 @@ func (tpn *TestProcessorNode) initBlockProcessor() {
 			TestUint64Converter,
 		)
 	} else {
-		arguments := block.ArgsShardProcessor{
-			ArgsBaseProcessor: &block.ArgsBaseProcessor{
+		arguments := block.ArgShardProcessor{
+			ArgBaseProcessor: &block.ArgBaseProcessor{
 				Accounts:         tpn.AccntState,
 				ForkDetector:     tpn.ForkDetector,
 				Hasher:           TestHasher,

--- a/integrationTests/testSyncNode.go
+++ b/integrationTests/testSyncNode.go
@@ -93,21 +93,25 @@ func (tpn *TestProcessorNode) initBlockProcessorWithSync() {
 			TestUint64Converter,
 		)
 	} else {
-		tpn.BlockProcessor, err = block.NewShardProcessor(
-			nil,
-			tpn.ShardDataPool,
-			tpn.Storage,
-			TestHasher,
-			TestMarshalizer,
-			tpn.AccntState,
-			tpn.ShardCoordinator,
-			tpn.ForkDetector,
-			tpn.BlockTracker,
-			tpn.GenesisBlocks,
-			tpn.RequestHandler,
-			tpn.TxCoordinator,
-			TestUint64Converter,
-		)
+		arguments := block.ArgsShardProcessor{
+			ArgsBaseProcessor: &block.ArgsBaseProcessor{
+				Accounts:         tpn.AccntState,
+				ForkDetector:     tpn.ForkDetector,
+				Hasher:           TestHasher,
+				Marshalizer:      TestMarshalizer,
+				Store:            tpn.Storage,
+				ShardCoordinator: tpn.ShardCoordinator,
+				Uint64Converter:  TestUint64Converter,
+				StartHeaders:     tpn.GenesisBlocks,
+				RequestHandler:   tpn.RequestHandler,
+				Core:             nil,
+			},
+			DataPool:      tpn.ShardDataPool,
+			BlocksTracker: tpn.BlockTracker,
+			TxCoordinator: tpn.TxCoordinator,
+		}
+
+		tpn.BlockProcessor, err = block.NewShardProcessor(arguments)
 	}
 
 	if err != nil {

--- a/integrationTests/testSyncNode.go
+++ b/integrationTests/testSyncNode.go
@@ -93,8 +93,8 @@ func (tpn *TestProcessorNode) initBlockProcessorWithSync() {
 			TestUint64Converter,
 		)
 	} else {
-		arguments := block.ArgsShardProcessor{
-			ArgsBaseProcessor: &block.ArgsBaseProcessor{
+		arguments := block.ArgShardProcessor{
+			ArgBaseProcessor: &block.ArgBaseProcessor{
 				Accounts:         tpn.AccntState,
 				ForkDetector:     tpn.ForkDetector,
 				Hasher:           TestHasher,

--- a/process/block/argProcessor.go
+++ b/process/block/argProcessor.go
@@ -12,9 +12,9 @@ import (
 	"github.com/ElrondNetwork/elrond-go/sharding"
 )
 
-// ArgsBaseProcessor holds all dependencies required by the process data factory in order to create
+// ArgBaseProcessor holds all dependencies required by the process data factory in order to create
 // new instances
-type ArgsBaseProcessor struct {
+type ArgBaseProcessor struct {
 	Accounts         state.AccountsAdapter
 	ForkDetector     process.ForkDetector
 	Hasher           hashing.Hasher
@@ -27,10 +27,10 @@ type ArgsBaseProcessor struct {
 	Core             serviceContainer.Core
 }
 
-// ArgsShardProcessor holds all dependencies required by the process data factory in order to create
+// ArgShardProcessor holds all dependencies required by the process data factory in order to create
 // new instances of shard processor
-type ArgsShardProcessor struct {
-	*ArgsBaseProcessor
+type ArgShardProcessor struct {
+	*ArgBaseProcessor
 	DataPool      dataRetriever.PoolsHolder
 	BlocksTracker process.BlocksTracker
 	TxCoordinator process.TransactionCoordinator

--- a/process/block/argsProcessor.go
+++ b/process/block/argsProcessor.go
@@ -1,0 +1,37 @@
+package block
+
+import (
+	"github.com/ElrondNetwork/elrond-go/core/serviceContainer"
+	"github.com/ElrondNetwork/elrond-go/data"
+	"github.com/ElrondNetwork/elrond-go/data/state"
+	"github.com/ElrondNetwork/elrond-go/data/typeConverters"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
+	"github.com/ElrondNetwork/elrond-go/hashing"
+	"github.com/ElrondNetwork/elrond-go/marshal"
+	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/sharding"
+)
+
+// ArgsBaseProcessor holds all dependencies required by the process data factory in order to create
+// new instances
+type ArgsBaseProcessor struct {
+	Accounts         state.AccountsAdapter
+	ForkDetector     process.ForkDetector
+	Hasher           hashing.Hasher
+	Marshalizer      marshal.Marshalizer
+	Store            dataRetriever.StorageService
+	ShardCoordinator sharding.Coordinator
+	Uint64Converter  typeConverters.Uint64ByteSliceConverter
+	StartHeaders     map[uint32]data.HeaderHandler
+	RequestHandler   process.RequestHandler
+	Core             serviceContainer.Core
+}
+
+// ArgsShardProcessor holds all dependencies required by the process data factory in order to create
+// new instances of shard processor
+type ArgsShardProcessor struct {
+	*ArgsBaseProcessor
+	DataPool      dataRetriever.PoolsHolder
+	BlocksTracker process.BlocksTracker
+	TxCoordinator process.TransactionCoordinator
+}

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -314,24 +314,38 @@ func (wr *wrongBody) IsInterfaceNil() bool {
 	return false
 }
 
+func CreateMockArguments() blproc.ArgsShardProcessor {
+	arguments := blproc.ArgsShardProcessor{
+		ArgsBaseProcessor: &blproc.ArgsBaseProcessor{
+			Accounts:         &mock.AccountsStub{},
+			ForkDetector:     &mock.ForkDetectorMock{},
+			Hasher:           &mock.HasherStub{},
+			Marshalizer:      &mock.MarshalizerMock{},
+			Store:            &mock.ChainStorerMock{},
+			ShardCoordinator: mock.NewMultiShardsCoordinatorMock(3),
+			Uint64Converter:  &mock.Uint64ByteSliceConverterMock{},
+			StartHeaders:     createGenesisBlocks(mock.NewOneShardCoordinatorMock()),
+			RequestHandler:   &mock.RequestHandlerMock{},
+			Core:             &mock.ServiceContainerMock{},
+		},
+		DataPool:      initDataPool([]byte("")),
+		BlocksTracker: &mock.BlocksTrackerMock{},
+		TxCoordinator: &mock.TransactionCoordinatorMock{},
+	}
+
+	return arguments
+}
+
 func TestBlockProcessor_CheckBlockValidity(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte(""))
-	bp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		initStore(),
-		&mock.HasherMock{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{},
-		mock.NewOneShardCoordinatorMock(),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewOneShardCoordinatorMock()),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArguments()
+	arguments.DataPool = initDataPool([]byte(""))
+	arguments.Store = initStore()
+	arguments.ShardCoordinator = mock.NewOneShardCoordinatorMock()
+	arguments.StartHeaders = createGenesisBlocks(arguments.ShardCoordinator)
+	arguments.Hasher = &mock.HasherMock{}
+	bp, _ := blproc.NewShardProcessor(arguments)
 	blkc := createTestBlockchain()
 	body := &block.Body{}
 	hdr := &block.Header{}
@@ -390,7 +404,6 @@ func TestBlockProcessor_CheckBlockValidity(t *testing.T) {
 
 func TestVerifyStateRoot_ShouldWork(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte(""))
 	rootHash := []byte("root hash to be tested")
 	accounts := &mock.AccountsStub{
 		RootHashCalled: func() ([]byte, error) {
@@ -399,21 +412,13 @@ func TestVerifyStateRoot_ShouldWork(t *testing.T) {
 	}
 	store := initStore()
 
-	bp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		store,
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		accounts,
-		mock.NewOneShardCoordinatorMock(),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewOneShardCoordinatorMock()),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArguments()
+	arguments.Accounts = accounts
+	arguments.Store = store
+	arguments.ShardCoordinator = mock.NewOneShardCoordinatorMock()
+	arguments.StartHeaders = createGenesisBlocks(arguments.ShardCoordinator)
+	bp, _ := blproc.NewShardProcessor(arguments)
+
 	assert.True(t, bp.VerifyStateRoot(rootHash))
 }
 
@@ -421,23 +426,14 @@ func TestVerifyStateRoot_ShouldWork(t *testing.T) {
 
 func TestBlockProcessor_computeHeaderHashMarshalizerFail1ShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte(""))
 	marshalizer := &mock.MarshalizerStub{}
-	bp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		initStore(),
-		&mock.HasherStub{},
-		marshalizer,
-		&mock.AccountsStub{},
-		mock.NewOneShardCoordinatorMock(),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewOneShardCoordinatorMock()),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArguments()
+	arguments.ShardCoordinator = mock.NewOneShardCoordinatorMock()
+	arguments.StartHeaders = createGenesisBlocks(arguments.ShardCoordinator)
+	arguments.Marshalizer = marshalizer
+	arguments.Store = initStore()
+	bp, _ := blproc.NewShardProcessor(arguments)
 	hdr, txBlock := createTestHdrTxBlockBody()
 	expectedError := errors.New("marshalizer fail")
 	marshalizer.MarshalCalled = func(obj interface{}) (bytes []byte, e error) {
@@ -456,24 +452,17 @@ func TestBlockProcessor_computeHeaderHashMarshalizerFail1ShouldErr(t *testing.T)
 
 func TestBlockPorcessor_ComputeNewNoncePrevHashShouldWork(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte(""))
 	marshalizer := &mock.MarshalizerStub{}
 	hasher := &mock.HasherStub{}
-	bp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		initStore(),
-		hasher,
-		marshalizer,
-		&mock.AccountsStub{},
-		mock.NewOneShardCoordinatorMock(),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewOneShardCoordinatorMock()),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArguments()
+	arguments.DataPool = initDataPool([]byte(""))
+	arguments.Marshalizer = marshalizer
+	arguments.Hasher = hasher
+	arguments.Store = initStore()
+	arguments.ShardCoordinator = mock.NewOneShardCoordinatorMock()
+	arguments.StartHeaders = createGenesisBlocks(arguments.ShardCoordinator)
+	bp, _ := blproc.NewShardProcessor(arguments)
 	hdr, txBlock := createTestHdrTxBlockBody()
 	marshalizer.MarshalCalled = func(obj interface{}) (bytes []byte, e error) {
 		if hdr == obj {

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -53,21 +53,25 @@ func (sp *shardProcessor) RemoveProcessedMetablocksFromPool(processedMetaHdrs []
 }
 
 func NewShardProcessorEmptyWith3shards(tdp dataRetriever.PoolsHolder, genesisBlocks map[uint32]data.HeaderHandler) (*shardProcessor, error) {
-	shardProcessor, err := NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherMock{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		genesisBlocks,
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := ArgsShardProcessor{
+		ArgsBaseProcessor: &ArgsBaseProcessor{
+			Accounts:         &mock.AccountsStub{},
+			ForkDetector:     &mock.ForkDetectorMock{},
+			Hasher:           &mock.HasherMock{},
+			Marshalizer:      &mock.MarshalizerMock{},
+			Store:            &mock.ChainStorerMock{},
+			ShardCoordinator: mock.NewMultiShardsCoordinatorMock(3),
+			Uint64Converter:  &mock.Uint64ByteSliceConverterMock{},
+			StartHeaders:     genesisBlocks,
+			RequestHandler:   &mock.RequestHandlerMock{},
+			Core:             &mock.ServiceContainerMock{},
+		},
+		DataPool:      tdp,
+		BlocksTracker: &mock.BlocksTrackerMock{},
+		TxCoordinator: &mock.TransactionCoordinatorMock{},
+	}
+	shardProcessor, err := NewShardProcessor(arguments)
 	return shardProcessor, err
 }
 

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -54,8 +54,8 @@ func (sp *shardProcessor) RemoveProcessedMetablocksFromPool(processedMetaHdrs []
 
 func NewShardProcessorEmptyWith3shards(tdp dataRetriever.PoolsHolder, genesisBlocks map[uint32]data.HeaderHandler) (*shardProcessor, error) {
 
-	arguments := ArgsShardProcessor{
-		ArgsBaseProcessor: &ArgsBaseProcessor{
+	arguments := ArgShardProcessor{
+		ArgBaseProcessor: &ArgBaseProcessor{
 			Accounts:         &mock.AccountsStub{},
 			ForkDetector:     &mock.ForkDetectorMock{},
 			Hasher:           &mock.HasherMock{},

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -10,12 +10,8 @@ import (
 	"github.com/ElrondNetwork/elrond-go/core/serviceContainer"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/block"
-	"github.com/ElrondNetwork/elrond-go/data/state"
-	"github.com/ElrondNetwork/elrond-go/data/typeConverters"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/dataPool"
-	"github.com/ElrondNetwork/elrond-go/hashing"
-	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/throttle"
 	"github.com/ElrondNetwork/elrond-go/sharding"
@@ -44,44 +40,30 @@ type shardProcessor struct {
 }
 
 // NewShardProcessor creates a new shardProcessor object
-func NewShardProcessor(
-	core serviceContainer.Core,
-	dataPool dataRetriever.PoolsHolder,
-	store dataRetriever.StorageService,
-	hasher hashing.Hasher,
-	marshalizer marshal.Marshalizer,
-	accounts state.AccountsAdapter,
-	shardCoordinator sharding.Coordinator,
-	forkDetector process.ForkDetector,
-	blocksTracker process.BlocksTracker,
-	startHeaders map[uint32]data.HeaderHandler,
-	requestHandler process.RequestHandler,
-	txCoordinator process.TransactionCoordinator,
-	uint64Converter typeConverters.Uint64ByteSliceConverter,
-) (*shardProcessor, error) {
+func NewShardProcessor(arguments ArgsShardProcessor) (*shardProcessor, error) {
 
 	err := checkProcessorNilParameters(
-		accounts,
-		forkDetector,
-		hasher,
-		marshalizer,
-		store,
-		shardCoordinator,
-		uint64Converter)
+		arguments.Accounts,
+		arguments.ForkDetector,
+		arguments.Hasher,
+		arguments.Marshalizer,
+		arguments.Store,
+		arguments.ShardCoordinator,
+		arguments.Uint64Converter)
 	if err != nil {
 		return nil, err
 	}
 
-	if dataPool == nil || dataPool.IsInterfaceNil() {
+	if arguments.DataPool == nil || arguments.DataPool.IsInterfaceNil() {
 		return nil, process.ErrNilDataPoolHolder
 	}
-	if blocksTracker == nil || blocksTracker.IsInterfaceNil() {
+	if arguments.BlocksTracker == nil || arguments.BlocksTracker.IsInterfaceNil() {
 		return nil, process.ErrNilBlocksTracker
 	}
-	if requestHandler == nil || requestHandler.IsInterfaceNil() {
+	if arguments.RequestHandler == nil || arguments.RequestHandler.IsInterfaceNil() {
 		return nil, process.ErrNilRequestHandler
 	}
-	if txCoordinator == nil || txCoordinator.IsInterfaceNil() {
+	if arguments.TxCoordinator == nil || arguments.TxCoordinator.IsInterfaceNil() {
 		return nil, process.ErrNilTransactionCoordinator
 	}
 
@@ -91,28 +73,28 @@ func NewShardProcessor(
 	}
 
 	base := &baseProcessor{
-		accounts:                      accounts,
+		accounts:                      arguments.Accounts,
 		blockSizeThrottler:            blockSizeThrottler,
-		forkDetector:                  forkDetector,
-		hasher:                        hasher,
-		marshalizer:                   marshalizer,
-		store:                         store,
-		shardCoordinator:              shardCoordinator,
-		uint64Converter:               uint64Converter,
-		onRequestHeaderHandlerByNonce: requestHandler.RequestHeaderByNonce,
+		forkDetector:                  arguments.ForkDetector,
+		hasher:                        arguments.Hasher,
+		marshalizer:                   arguments.Marshalizer,
+		store:                         arguments.Store,
+		shardCoordinator:              arguments.ShardCoordinator,
+		uint64Converter:               arguments.Uint64Converter,
+		onRequestHeaderHandlerByNonce: arguments.RequestHandler.RequestHeaderByNonce,
 		appStatusHandler:              statusHandler.NewNilStatusHandler(),
 	}
-	err = base.setLastNotarizedHeadersSlice(startHeaders)
+	err = base.setLastNotarizedHeadersSlice(arguments.StartHeaders)
 	if err != nil {
 		return nil, err
 	}
 
 	sp := shardProcessor{
-		core:          core,
+		core:          arguments.Core,
 		baseProcessor: base,
-		dataPool:      dataPool,
-		blocksTracker: blocksTracker,
-		txCoordinator: txCoordinator,
+		dataPool:      arguments.DataPool,
+		blocksTracker: arguments.BlocksTracker,
+		txCoordinator: arguments.TxCoordinator,
 		txCounter:     NewTransactionCounter(),
 	}
 
@@ -131,7 +113,7 @@ func NewShardProcessor(
 		return nil, process.ErrNilMetaBlockPool
 	}
 	metaBlockPool.RegisterHandler(sp.receivedMetaBlock)
-	sp.onRequestHeaderHandler = requestHandler.RequestHeader
+	sp.onRequestHeaderHandler = arguments.RequestHandler.RequestHeader
 
 	sp.metaBlockFinality = process.MetaBlockFinality
 	sp.allNeededMetaHdrsFound = true

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -40,7 +40,7 @@ type shardProcessor struct {
 }
 
 // NewShardProcessor creates a new shardProcessor object
-func NewShardProcessor(arguments ArgsShardProcessor) (*shardProcessor, error) {
+func NewShardProcessor(arguments ArgShardProcessor) (*shardProcessor, error) {
 
 	err := checkProcessorNilParameters(
 		arguments.Accounts,

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -83,12 +83,9 @@ func initBlockHeader(prevHash []byte, rootHash []byte, mbHdrs []block.MiniBlockH
 	return hdr
 }
 
-func CreateMockArgumentsMultiShard() blproc.ArgsShardProcessor {
-	tdp := initDataPool([]byte("tx_hash1"))
-
+func CreateMockArgumentsMultiShard() blproc.ArgShardProcessor {
 	arguments := CreateMockArguments()
-	arguments.DataPool = tdp
-	arguments.Hasher = &mock.HasherStub{}
+	arguments.DataPool = initDataPool([]byte("tx_hash1"))
 	arguments.Accounts = initAccountsMock()
 	arguments.ShardCoordinator = mock.NewMultiShardsCoordinatorMock(3)
 	arguments.StartHeaders = createGenesisBlocks(arguments.ShardCoordinator)
@@ -2158,8 +2155,6 @@ func TestShardProcessor_DisplayLogInfo(t *testing.T) {
 
 	arguments := CreateMockArgumentsMultiShard()
 	arguments.DataPool = tdp
-	arguments.Store = initStore()
-	arguments.Accounts = initAccountsMock()
 
 	sp, _ := blproc.NewShardProcessor(arguments)
 	assert.NotNil(t, sp)
@@ -2170,8 +2165,6 @@ func TestShardProcessor_DisplayLogInfo(t *testing.T) {
 func TestBlockProcessor_CreateBlockHeaderShouldNotReturnNil(t *testing.T) {
 	t.Parallel()
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.Store = initStore()
-	arguments.Accounts = initAccountsMock()
 
 	bp, _ := blproc.NewShardProcessor(arguments)
 	mbHeaders, err := bp.CreateBlockHeader(nil, 0, func() bool {
@@ -2186,9 +2179,7 @@ func TestShardProcessor_CreateBlockHeaderShouldErrWhenMarshalizerErrors(t *testi
 	t.Parallel()
 
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.Store = initStore()
 	arguments.Marshalizer = &mock.MarshalizerMock{Fail: true}
-	arguments.Accounts = initAccountsMock()
 	bp, _ := blproc.NewShardProcessor(arguments)
 	body := block.Body{
 		{
@@ -2218,8 +2209,6 @@ func TestShardProcessor_CreateBlockHeaderReturnsOK(t *testing.T) {
 	t.Parallel()
 
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.Store = initStore()
-	arguments.Accounts = initAccountsMock()
 	bp, _ := blproc.NewShardProcessor(arguments)
 	body := block.Body{
 		{
@@ -2255,7 +2244,6 @@ func TestShardProcessor_CommitBlockShouldRevertAccountStateWhenErr(t *testing.T)
 	}
 
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.Store = initStore()
 	arguments.Accounts = &mock.AccountsStub{
 		RevertToSnapshotCalled: revToSnapshot,
 	}
@@ -2315,9 +2303,7 @@ func TestShardProcessor_MarshalizedDataToBroadcastShouldWork(t *testing.T) {
 
 	arguments := CreateMockArgumentsMultiShard()
 	arguments.DataPool = tdp
-	arguments.Store = initStore()
 	arguments.Marshalizer = marshalizer
-	arguments.Accounts = initAccountsMock()
 	arguments.TxCoordinator = tc
 	sp, _ := blproc.NewShardProcessor(arguments)
 	msh, mstx, err := sp.MarshalizedDataToBroadcast(&block.Header{}, body)
@@ -2344,9 +2330,7 @@ func TestShardProcessor_MarshalizedDataWrongType(t *testing.T) {
 
 	arguments := CreateMockArgumentsMultiShard()
 	arguments.DataPool = tdp
-	arguments.Store = initStore()
 	arguments.Marshalizer = marshalizer
-	arguments.Accounts = initAccountsMock()
 
 	sp, _ := blproc.NewShardProcessor(arguments)
 	wr := &wrongBody{}
@@ -2365,9 +2349,7 @@ func TestShardProcessor_MarshalizedDataNilInput(t *testing.T) {
 
 	arguments := CreateMockArgumentsMultiShard()
 	arguments.DataPool = tdp
-	arguments.Store = initStore()
 	arguments.Marshalizer = marshalizer
-	arguments.Accounts = initAccountsMock()
 
 	sp, _ := blproc.NewShardProcessor(arguments)
 	msh, mstx, err := sp.MarshalizedDataToBroadcast(nil, nil)
@@ -2421,9 +2403,7 @@ func TestShardProcessor_MarshalizedDataMarshalWithoutSuccess(t *testing.T) {
 
 	arguments := CreateMockArgumentsMultiShard()
 	arguments.DataPool = tdp
-	arguments.Store = initStore()
 	arguments.Marshalizer = marshalizer
-	arguments.Accounts = initAccountsMock()
 	arguments.TxCoordinator = tc
 
 	sp, _ := blproc.NewShardProcessor(arguments)
@@ -2495,10 +2475,8 @@ func TestShardProcessor_ReceivedMetaBlockShouldRequestMissingMiniBlocks(t *testi
 
 	arguments := CreateMockArgumentsMultiShard()
 	arguments.DataPool = dataPool
-	arguments.Store = initStore()
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
-	arguments.Accounts = initAccountsMock()
 	arguments.RequestHandler = requestHandler
 	arguments.TxCoordinator = tc
 
@@ -2558,10 +2536,8 @@ func TestShardProcessor_ReceivedMetaBlockNoMissingMiniBlocksShouldPass(t *testin
 
 	arguments := CreateMockArgumentsMultiShard()
 	arguments.DataPool = dataPool
-	arguments.Store = initStore()
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
-	arguments.Accounts = initAccountsMock()
 	arguments.RequestHandler = requestHandler
 	arguments.TxCoordinator = tc
 
@@ -2841,7 +2817,6 @@ func TestShardProcessor_CreateMiniBlocksShouldWorkWithIntraShardTxs(t *testing.T
 
 	arguments := CreateMockArgumentsMultiShard()
 	arguments.DataPool = dataPool
-	arguments.Store = initStore()
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
 	arguments.Accounts = accntAdapter
@@ -2911,7 +2886,6 @@ func TestShardProcessor_GetProcessedMetaBlockFromPoolShouldWork(t *testing.T) {
 	arguments.DataPool = dataPool
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
-	arguments.Accounts = initAccountsMock()
 	arguments.ShardCoordinator = shardCoordinator
 	arguments.ForkDetector = &mock.ForkDetectorMock{
 		GetHighestFinalBlockNonceCalled: func() uint64 {
@@ -2960,8 +2934,6 @@ func TestBlockProcessor_RestoreBlockIntoPoolsShouldErrNilBlockHeader(t *testing.
 
 	arguments := CreateMockArgumentsMultiShard()
 	arguments.DataPool = tdp
-	arguments.Store = initStore()
-	arguments.Accounts = initAccountsMock()
 	be, _ := blproc.NewShardProcessor(arguments)
 	err := be.RestoreBlockIntoPools(nil, nil)
 	assert.NotNil(t, err)
@@ -2974,8 +2946,6 @@ func TestBlockProcessor_RestoreBlockIntoPoolsShouldErrNilTxBlockBody(t *testing.
 
 	arguments := CreateMockArgumentsMultiShard()
 	arguments.DataPool = tdp
-	arguments.Store = initStore()
-	arguments.Accounts = initAccountsMock()
 	sp, _ := blproc.NewShardProcessor(arguments)
 
 	err := sp.RestoreBlockIntoPools(&block.Header{}, nil)
@@ -3040,7 +3010,6 @@ func TestShardProcessor_RestoreBlockIntoPoolsShouldWork(t *testing.T) {
 	arguments.Store = store
 	arguments.Hasher = hasherMock
 	arguments.Marshalizer = marshalizerMock
-	arguments.Accounts = initAccountsMock()
 	arguments.TxCoordinator = tc
 	sp, _ := blproc.NewShardProcessor(arguments)
 
@@ -3086,7 +3055,6 @@ func TestShardProcessor_DecodeBlockBody(t *testing.T) {
 	arguments := CreateMockArgumentsMultiShard()
 	arguments.DataPool = tdp
 	arguments.Marshalizer = marshalizerMock
-	arguments.Accounts = initAccountsMock()
 	sp, err := blproc.NewShardProcessor(arguments)
 	body := make(block.Body, 0)
 	body = append(body, &block.MiniBlock{ReceiverShardID: 69})
@@ -3109,7 +3077,6 @@ func TestShardProcessor_DecodeBlockHeader(t *testing.T) {
 	arguments := CreateMockArgumentsMultiShard()
 	arguments.DataPool = tdp
 	arguments.Marshalizer = marshalizerMock
-	arguments.Accounts = initAccountsMock()
 	sp, err := blproc.NewShardProcessor(arguments)
 	hdr := &block.Header{}
 	hdr.Nonce = 1
@@ -3141,7 +3108,6 @@ func TestShardProcessor_IsHdrConstructionValid(t *testing.T) {
 	arguments.DataPool = dataPool
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
-	arguments.Accounts = initAccountsMock()
 	arguments.ShardCoordinator = mock.NewMultiShardsCoordinatorMock(shardNr)
 	arguments.BlocksTracker = &mock.BlocksTrackerMock{
 		RemoveNotarisedBlocksCalled: func(headerHandler data.HeaderHandler) error {
@@ -3257,7 +3223,6 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	arguments.Store = store
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
-	arguments.Accounts = initAccountsMock()
 	arguments.ShardCoordinator = mock.NewMultiShardsCoordinatorMock(shardNr)
 	arguments.ForkDetector = forkDetector
 	arguments.BlocksTracker = &mock.BlocksTrackerMock{
@@ -3416,7 +3381,6 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNotAllMBFinished(t *tes
 	arguments.Store = store
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
-	arguments.Accounts = initAccountsMock()
 	arguments.ShardCoordinator = mock.NewMultiShardsCoordinatorMock(shardNr)
 	arguments.ForkDetector = forkDetector
 	arguments.BlocksTracker = &mock.BlocksTrackerMock{
@@ -3552,7 +3516,6 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrAllMBFinished(t *testin
 	arguments.Store = store
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
-	arguments.Accounts = initAccountsMock()
 	arguments.ShardCoordinator = mock.NewMultiShardsCoordinatorMock(shardNr)
 	arguments.ForkDetector = forkDetector
 	arguments.BlocksTracker = &mock.BlocksTrackerMock{

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -83,292 +83,163 @@ func initBlockHeader(prevHash []byte, rootHash []byte, mbHdrs []block.MiniBlockH
 	return hdr
 }
 
+func CreateMockArgumentsMultiShard() blproc.ArgsShardProcessor {
+	tdp := initDataPool([]byte("tx_hash1"))
+
+	arguments := CreateMockArguments()
+	arguments.DataPool = tdp
+	arguments.Hasher = &mock.HasherStub{}
+	arguments.Accounts = initAccountsMock()
+	arguments.ShardCoordinator = mock.NewMultiShardsCoordinatorMock(3)
+	arguments.StartHeaders = createGenesisBlocks(arguments.ShardCoordinator)
+
+	return arguments
+}
+
 //------- NewBlockProcessor
 
 func TestNewBlockProcessor_NilDataPoolShouldErr(t *testing.T) {
 	t.Parallel()
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		nil,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArguments()
+	arguments.DataPool = nil
+	sp, err := blproc.NewShardProcessor(arguments)
+
 	assert.Equal(t, process.ErrNilDataPoolHolder, err)
 	assert.Nil(t, sp)
 }
 
 func TestNewShardProcessor_NilStoreShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		nil,
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArguments()
+	arguments.Store = nil
+	sp, err := blproc.NewShardProcessor(arguments)
+
 	assert.Equal(t, process.ErrNilStorage, err)
 	assert.Nil(t, sp)
 }
 
 func TestNewShardProcessor_NilHasherShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		nil,
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArguments()
+	arguments.Hasher = nil
+	sp, err := blproc.NewShardProcessor(arguments)
+
 	assert.Equal(t, process.ErrNilHasher, err)
 	assert.Nil(t, sp)
 }
 
 func TestNewShardProcessor_NilMarshalizerShouldWork(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		nil,
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArguments()
+	arguments.Marshalizer = nil
+	sp, err := blproc.NewShardProcessor(arguments)
+
 	assert.Equal(t, process.ErrNilMarshalizer, err)
 	assert.Nil(t, sp)
 }
 
 func TestNewShardProcessor_NilAccountsAdapterShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		nil,
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArguments()
+	arguments.Accounts = nil
+	sp, err := blproc.NewShardProcessor(arguments)
+
 	assert.Equal(t, process.ErrNilAccountsAdapter, err)
 	assert.Nil(t, sp)
 }
 
 func TestNewShardProcessor_NilShardCoordinatorShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		nil,
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArguments()
+	arguments.ShardCoordinator = nil
+	sp, err := blproc.NewShardProcessor(arguments)
+
 	assert.Equal(t, process.ErrNilShardCoordinator, err)
 	assert.Nil(t, sp)
 }
 
 func TestNewShardProcessor_NilForkDetectorShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		nil,
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArguments()
+	arguments.ForkDetector = nil
+	sp, err := blproc.NewShardProcessor(arguments)
+
 	assert.Equal(t, process.ErrNilForkDetector, err)
 	assert.Nil(t, sp)
 }
 
 func TestNewShardProcessor_NilBlocksTrackerShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		nil,
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArguments()
+	arguments.BlocksTracker = nil
+	sp, err := blproc.NewShardProcessor(arguments)
+
 	assert.Equal(t, process.ErrNilBlocksTracker, err)
 	assert.Nil(t, sp)
 }
 
 func TestNewShardProcessor_NilRequestTransactionHandlerShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		nil,
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArguments()
+	arguments.RequestHandler = nil
+	sp, err := blproc.NewShardProcessor(arguments)
+
 	assert.Equal(t, process.ErrNilRequestHandler, err)
 	assert.Nil(t, sp)
 }
 
 func TestNewShardProcessor_NilTransactionPoolShouldErr(t *testing.T) {
 	t.Parallel()
+
 	tdp := initDataPool([]byte("tx_hash1"))
 	tdp.TransactionsCalled = func() dataRetriever.ShardedDataCacherNotifier {
 		return nil
 	}
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	sp, err := blproc.NewShardProcessor(arguments)
+
 	assert.Equal(t, process.ErrNilTransactionPool, err)
 	assert.Nil(t, sp)
 }
 
 func TestNewShardProcessor_NilTxCoordinator(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		nil,
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArguments()
+	arguments.TxCoordinator = nil
+	sp, err := blproc.NewShardProcessor(arguments)
+
 	assert.Equal(t, process.ErrNilTransactionCoordinator, err)
 	assert.Nil(t, sp)
 }
 
 func TestNewShardProcessor_NilUint64Converter(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		nil,
-	)
+
+	arguments := CreateMockArguments()
+	arguments.Uint64Converter = nil
+	sp, err := blproc.NewShardProcessor(arguments)
+
 	assert.Equal(t, process.ErrNilUint64Converter, err)
 	assert.Nil(t, sp)
 }
 
 func TestNewShardProcessor_OkValsShouldWork(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	sp, err := blproc.NewShardProcessor(arguments)
+
 	assert.Nil(t, err)
 	assert.NotNil(t, sp)
 }
@@ -377,98 +248,49 @@ func TestNewShardProcessor_OkValsShouldWork(t *testing.T) {
 
 func TestShardProcessor_ProcessBlockWithNilBlockchainShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	sp, _ := blproc.NewShardProcessor(arguments)
 	blk := make(block.Body, 0)
 	err := sp.ProcessBlock(nil, &block.Header{}, blk, haveTime)
+
 	assert.Equal(t, process.ErrNilBlockChain, err)
 }
 
 func TestShardProcessor_ProcessBlockWithNilHeaderShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	sp, _ := blproc.NewShardProcessor(arguments)
 	body := make(block.Body, 0)
 	err := sp.ProcessBlock(&blockchain.BlockChain{}, nil, body, haveTime)
+
 	assert.Equal(t, process.ErrNilBlockHeader, err)
 }
 
 func TestShardProcessor_ProcessBlockWithNilBlockBodyShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	sp, _ := blproc.NewShardProcessor(arguments)
 	err := sp.ProcessBlock(&blockchain.BlockChain{}, &block.Header{}, nil, haveTime)
+
 	assert.Equal(t, process.ErrNilBlockBody, err)
 }
 
 func TestShardProcessor_ProcessBlockWithNilHaveTimeFuncShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	sp, _ := blproc.NewShardProcessor(arguments)
 	blk := make(block.Body, 0)
 	err := sp.ProcessBlock(&blockchain.BlockChain{}, &block.Header{}, blk, nil)
+
 	assert.Equal(t, process.ErrNilHaveTimeHandler, err)
 }
 
 func TestShardProcessor_ProcessWithDirtyAccountShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
 	// set accounts dirty
 	journalLen := func() int { return 3 }
 	revToSnapshot := func(snapshot int) error { return nil }
@@ -480,34 +302,23 @@ func TestShardProcessor_ProcessWithDirtyAccountShouldErr(t *testing.T) {
 		Signature:     []byte("signature"),
 		RootHash:      []byte("roothash"),
 	}
+
 	body := make(block.Body, 0)
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{
-			JournalLenCalled:       journalLen,
-			RevertToSnapshotCalled: revToSnapshot,
-		},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
-	// should return err
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.Accounts = &mock.AccountsStub{
+		JournalLenCalled:       journalLen,
+		RevertToSnapshotCalled: revToSnapshot,
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
 	err := sp.ProcessBlock(blkc, &hdr, body, haveTime)
+
 	assert.NotNil(t, err)
 	assert.Equal(t, err, process.ErrAccountStateDirty)
 }
 
 func TestShardProcessor_ProcessBlockHeaderBodyMismatchShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
+
 	txHash := []byte("tx_hash1")
 	blkc := &blockchain.BlockChain{}
 	hdr := block.Header{
@@ -533,32 +344,22 @@ func TestShardProcessor_ProcessBlockHeaderBodyMismatchShouldErr(t *testing.T) {
 	rootHashCalled := func() ([]byte, error) {
 		return []byte("rootHash"), nil
 	}
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{
-			JournalLenCalled:       journalLen,
-			RevertToSnapshotCalled: revertToSnapshot,
-			RootHashCalled:         rootHashCalled,
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.Accounts = &mock.AccountsStub{
+		JournalLenCalled:       journalLen,
+		RevertToSnapshotCalled: revertToSnapshot,
+		RootHashCalled:         rootHashCalled,
+	}
+	arguments.ForkDetector = &mock.ForkDetectorMock{
+		ProbableHighestNonceCalled: func() uint64 {
+			return 0
 		},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{
-			ProbableHighestNonceCalled: func() uint64 {
-				return 0
-			},
-			GetHighestFinalBlockNonceCalled: func() uint64 {
-				return 0
-			},
+		GetHighestFinalBlockNonceCalled: func() uint64 {
+			return 0
 		},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	// should return err
 	err := sp.ProcessBlock(blkc, &hdr, body, haveTime)
@@ -643,25 +444,17 @@ func TestShardProcessor_ProcessBlockWithInvalidTransactionShouldErr(t *testing.T
 		&mock.InterimProcessorContainerMock{},
 	)
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		hasher,
-		marshalizer,
-		&mock.AccountsStub{
-			JournalLenCalled:       journalLen,
-			RevertToSnapshotCalled: revertToSnapshot,
-			RootHashCalled:         rootHashCalled,
-		},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		tc,
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = &mock.AccountsStub{
+		JournalLenCalled:       journalLen,
+		RevertToSnapshotCalled: revertToSnapshot,
+		RootHashCalled:         rootHashCalled,
+	}
+	arguments.TxCoordinator = tc
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	// should return err
 	err = sp.ProcessBlock(blkc, &hdr, body, haveTime)
@@ -670,22 +463,8 @@ func TestShardProcessor_ProcessBlockWithInvalidTransactionShouldErr(t *testing.T
 
 func TestShardProcessor_ProcessWithHeaderNotFirstShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	sp, _ := blproc.NewShardProcessor(arguments)
 	hdr := &block.Header{
 		Nonce:         0,
 		Round:         1,
@@ -702,22 +481,9 @@ func TestShardProcessor_ProcessWithHeaderNotFirstShouldErr(t *testing.T) {
 
 func TestShardProcessor_ProcessWithHeaderNotCorrectNonceShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	sp, _ := blproc.NewShardProcessor(arguments)
 	hdr := &block.Header{
 		Nonce:         0,
 		Round:         1,
@@ -729,34 +495,23 @@ func TestShardProcessor_ProcessWithHeaderNotCorrectNonceShouldErr(t *testing.T) 
 	body := make(block.Body, 0)
 	blkc := &blockchain.BlockChain{}
 	err := sp.ProcessBlock(blkc, hdr, body, haveTime)
+
 	assert.Equal(t, process.ErrWrongNonceInBlock, err)
 }
 
 func TestShardProcessor_ProcessWithHeaderNotCorrectPrevHashShouldErr(t *testing.T) {
 	t.Parallel()
-	tdp := initDataPool([]byte("tx_hash1"))
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{
-			ProbableHighestNonceCalled: func() uint64 {
-				return 0
-			},
-			GetHighestFinalBlockNonceCalled: func() uint64 {
-				return 0
-			},
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.ForkDetector = &mock.ForkDetectorMock{
+		ProbableHighestNonceCalled: func() uint64 {
+			return 0
 		},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+		GetHighestFinalBlockNonceCalled: func() uint64 {
+			return 0
+		},
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
 	hdr := &block.Header{
 		Nonce:         1,
 		Round:         1,
@@ -866,28 +621,22 @@ func TestShardProcessor_ProcessBlockWithErrOnProcessBlockTransactionsCallShouldR
 		&mock.InterimProcessorContainerMock{},
 	)
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		store,
-		hasher,
-		&mock.MarshalizerMock{},
-		accounts,
-		shardCoordinator,
-		&mock.ForkDetectorMock{
-			ProbableHighestNonceCalled: func() uint64 {
-				return 0
-			},
-			GetHighestFinalBlockNonceCalled: func() uint64 {
-				return 0
-			},
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Store = store
+	arguments.Hasher = hasher
+	arguments.Accounts = accounts
+	arguments.ShardCoordinator = shardCoordinator
+	arguments.ForkDetector = &mock.ForkDetectorMock{
+		ProbableHighestNonceCalled: func() uint64 {
+			return 0
 		},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		tc,
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+		GetHighestFinalBlockNonceCalled: func() uint64 {
+			return 0
+		},
+	}
+	arguments.TxCoordinator = tc
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	// should return err
 	err2 := sp.ProcessBlock(blkc, &hdr, body, haveTime)
@@ -948,33 +697,24 @@ func TestShardProcessor_ProcessBlockWithErrOnVerifyStateRootCallShouldRevertStat
 	rootHashCalled := func() ([]byte, error) {
 		return []byte("rootHashX"), nil
 	}
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{
-			JournalLenCalled:       journalLen,
-			RevertToSnapshotCalled: revertToSnapshot,
-			RootHashCalled:         rootHashCalled,
-		},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{
-			ProbableHighestNonceCalled: func() uint64 {
-				return 0
-			},
-			GetHighestFinalBlockNonceCalled: func() uint64 {
-				return 0
-			},
-		},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
 
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Accounts = &mock.AccountsStub{
+		JournalLenCalled:       journalLen,
+		RevertToSnapshotCalled: revertToSnapshot,
+		RootHashCalled:         rootHashCalled,
+	}
+	arguments.Hasher = &mock.HasherStub{}
+	arguments.ForkDetector = &mock.ForkDetectorMock{
+		ProbableHighestNonceCalled: func() uint64 {
+			return 0
+		},
+		GetHighestFinalBlockNonceCalled: func() uint64 {
+			return 0
+		},
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
 	// should return err
 	err := sp.ProcessBlock(blkc, &hdr, body, haveTime)
 	assert.Equal(t, process.ErrRootStateMissmatch, err)
@@ -1034,25 +774,15 @@ func TestShardProcessor_ProcessBlockOnlyIntraShardShouldPass(t *testing.T) {
 	rootHashCalled := func() ([]byte, error) {
 		return rootHash, nil
 	}
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{
-			JournalLenCalled:       journalLen,
-			RevertToSnapshotCalled: revertToSnapshot,
-			RootHashCalled:         rootHashCalled,
-		},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Accounts = &mock.AccountsStub{
+		JournalLenCalled:       journalLen,
+		RevertToSnapshotCalled: revertToSnapshot,
+		RootHashCalled:         rootHashCalled,
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	// should return err
 	err := sp.ProcessBlock(blkc, &hdr, body, haveTime)
@@ -1117,25 +847,14 @@ func TestShardProcessor_ProcessBlockCrossShardWithoutMetaShouldFail(t *testing.T
 	rootHashCalled := func() ([]byte, error) {
 		return rootHash, nil
 	}
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{
-			JournalLenCalled:       journalLen,
-			RevertToSnapshotCalled: revertToSnapshot,
-			RootHashCalled:         rootHashCalled,
-		},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Accounts = &mock.AccountsStub{
+		JournalLenCalled:       journalLen,
+		RevertToSnapshotCalled: revertToSnapshot,
+		RootHashCalled:         rootHashCalled,
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	// should return err
 	err := sp.ProcessBlock(blkc, &hdr, body, haveTime)
@@ -1201,25 +920,16 @@ func TestShardProcessor_ProcessBlockCrossShardWithMetaShouldPass(t *testing.T) {
 	rootHashCalled := func() ([]byte, error) {
 		return rootHash, nil
 	}
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		hasher,
-		marshalizer,
-		&mock.AccountsStub{
-			JournalLenCalled:       journalLen,
-			RevertToSnapshotCalled: revertToSnapshot,
-			RootHashCalled:         rootHashCalled,
-		},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = &mock.AccountsStub{
+		JournalLenCalled:       journalLen,
+		RevertToSnapshotCalled: revertToSnapshot,
+		RootHashCalled:         rootHashCalled,
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	// should return err
 	err := sp.ProcessBlock(blkc, &hdr, body, haveTime)
@@ -1342,25 +1052,16 @@ func TestShardProcessor_ProcessBlockWithMissingMetaHdrShouldErr(t *testing.T) {
 	rootHashCalled := func() ([]byte, error) {
 		return rootHash, nil
 	}
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		hasher,
-		marshalizer,
-		&mock.AccountsStub{
-			JournalLenCalled:       journalLen,
-			RevertToSnapshotCalled: revertToSnapshot,
-			RootHashCalled:         rootHashCalled,
-		},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = &mock.AccountsStub{
+		JournalLenCalled:       journalLen,
+		RevertToSnapshotCalled: revertToSnapshot,
+		RootHashCalled:         rootHashCalled,
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	// should return err
 	err := sp.ProcessBlock(blkc, &hdr, body, haveTime)
@@ -1409,23 +1110,12 @@ func TestShardProcessor_ProcessBlockWithWrongMiniBlockHeaderShouldErr(t *testing
 	rootHashCalled := func() ([]byte, error) {
 		return rootHash, nil
 	}
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{
-			RootHashCalled: rootHashCalled,
-		},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Accounts = &mock.AccountsStub{
+		RootHashCalled: rootHashCalled,
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	// should return err
 	err := sp.ProcessBlock(blkc, &hdr, body, haveTime)
@@ -1493,29 +1183,22 @@ func TestShardProcessor_CheckAndRequestIfMetaHeadersMissingShouldErr(t *testing.
 	rootHashCalled := func() ([]byte, error) {
 		return rootHash, nil
 	}
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		hasher,
-		marshalizer,
-		&mock.AccountsStub{
-			JournalLenCalled:       journalLen,
-			RevertToSnapshotCalled: revertToSnapshot,
-			RootHashCalled:         rootHashCalled,
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.RequestHandler = &mock.RequestHandlerMock{
+		RequestHeaderHandlerByNonceCalled: func(destShardID uint32, nonce uint64) {
+			atomic.AddInt32(&hdrNoncesRequestCalled, 1)
 		},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{
-			RequestHeaderHandlerByNonceCalled: func(destShardID uint32, nonce uint64) {
-				atomic.AddInt32(&hdrNoncesRequestCalled, 1)
-			},
-		},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	}
+	arguments.Accounts = &mock.AccountsStub{
+		JournalLenCalled:       journalLen,
+		RevertToSnapshotCalled: revertToSnapshot,
+		RootHashCalled:         rootHashCalled,
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	err := sp.ProcessBlock(blkc, &hdr, body, haveTime)
 
@@ -1626,21 +1309,9 @@ func TestShardProcessor_RequestFinalMissingHeaders(t *testing.T) {
 	t.Parallel()
 
 	tdp := mock.NewPoolsHolderFake()
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	sp.SetCurrHighestMetaHdrNonce(1)
 	res := sp.RequestFinalMissingHeaders()
@@ -1723,21 +1394,12 @@ func TestShardProcessor_CheckMetaHeadersValidityAndFinalityShouldPass(t *testing
 	metaHash = hasher.Compute(string(metaBytes))
 
 	tdp.MetaBlocks().Put(metaHash, meta)
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		hasher,
-		marshalizer,
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		genesisBlocks,
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.StartHeaders = genesisBlocks
+	sp, _ := blproc.NewShardProcessor(arguments)
 	hdr.Round = 4
 
 	err := sp.CheckMetaHeadersValidityAndFinality(&hdr)
@@ -1776,21 +1438,10 @@ func TestShardProcessor_CommitBlockNilBlockchainShouldErr(t *testing.T) {
 	accounts.RevertToSnapshotCalled = func(snapshot int) error {
 		return nil
 	}
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		accounts,
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Accounts = accounts
+	sp, _ := blproc.NewShardProcessor(arguments)
 	blk := make(block.Body, 0)
 
 	err := sp.CommitBlock(nil, &block.Header{}, blk)
@@ -1827,21 +1478,11 @@ func TestShardProcessor_CommitBlockMarshalizerFailForHeaderShouldErr(t *testing.
 			return []byte("obj"), nil
 		},
 	}
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		marshalizer,
-		accounts,
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = accounts
+	sp, _ := blproc.NewShardProcessor(arguments)
 	blkc := createTestBlockchain()
 
 	err := sp.CommitBlock(blkc, hdr, body)
@@ -1885,31 +1526,23 @@ func TestShardProcessor_CommitBlockStorageFailsForHeaderShouldErr(t *testing.T) 
 	store := initStore()
 	store.AddStorer(dataRetriever.BlockHeaderUnit, hdrUnit)
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		store,
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		accounts,
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{
-			AddHeaderCalled: func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState, finalHeader data.HeaderHandler, finalHeaderHash []byte) error {
-				return nil
-			},
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Store = store
+	arguments.Accounts = accounts
+	arguments.ForkDetector = &mock.ForkDetectorMock{
+		AddHeaderCalled: func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState, finalHeader data.HeaderHandler, finalHeaderHash []byte) error {
+			return nil
 		},
-		&mock.BlocksTrackerMock{
-			AddBlockCalled: func(headerHandler data.HeaderHandler) {
-			},
-			UnnotarisedBlocksCalled: func() []data.HeaderHandler {
-				return make([]data.HeaderHandler, 0)
-			},
+	}
+	arguments.BlocksTracker = &mock.BlocksTrackerMock{
+		AddBlockCalled: func(headerHandler data.HeaderHandler) {
 		},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+		UnnotarisedBlocksCalled: func() []data.HeaderHandler {
+			return make([]data.HeaderHandler, 0)
+		},
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	blkc, _ := blockchain.NewBlockChain(
 		generateTestCache(),
@@ -1961,32 +1594,23 @@ func TestShardProcessor_CommitBlockStorageFailsForBodyShouldWork(t *testing.T) {
 	store := initStore()
 	store.AddStorer(dataRetriever.MiniBlockUnit, miniBlockUnit)
 
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		store,
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		accounts,
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{
-			AddHeaderCalled: func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState, finalHeader data.HeaderHandler, finalHeaderHash []byte) error {
-				return nil
-			},
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Store = store
+	arguments.Accounts = accounts
+	arguments.ForkDetector = &mock.ForkDetectorMock{
+		AddHeaderCalled: func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState, finalHeader data.HeaderHandler, finalHeaderHash []byte) error {
+			return nil
 		},
-		&mock.BlocksTrackerMock{
-			AddBlockCalled: func(headerHandler data.HeaderHandler) {
-			},
-			UnnotarisedBlocksCalled: func() []data.HeaderHandler {
-				return make([]data.HeaderHandler, 0)
-			},
+	}
+	arguments.BlocksTracker = &mock.BlocksTrackerMock{
+		AddBlockCalled: func(headerHandler data.HeaderHandler) {
 		},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
-
+		UnnotarisedBlocksCalled: func() []data.HeaderHandler {
+			return make([]data.HeaderHandler, 0)
+		},
+	}
+	sp, err := blproc.NewShardProcessor(arguments)
 	assert.Nil(t, err)
 
 	blkc, _ := blockchain.NewBlockChain(
@@ -2025,21 +1649,12 @@ func TestShardProcessor_CommitBlockNilNoncesDataPoolShouldErr(t *testing.T) {
 	body := make(block.Body, 0)
 	store := initStore()
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		store,
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		accounts,
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Store = store
+	arguments.Accounts = accounts
+	sp, _ := blproc.NewShardProcessor(arguments)
+
 	tdp.HeadersNoncesCalled = func() dataRetriever.Uint64SyncMapCacher {
 		return nil
 	}
@@ -2140,21 +1755,14 @@ func TestShardProcessor_CommitBlockNoTxInPoolShouldErr(t *testing.T) {
 		&mock.InterimProcessorContainerMock{},
 	)
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		store,
-		hasher,
-		&mock.MarshalizerMock{},
-		accounts,
-		mock.NewMultiShardsCoordinatorMock(3),
-		fd,
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		tc,
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Store = store
+	arguments.Hasher = hasher
+	arguments.ForkDetector = fd
+	arguments.TxCoordinator = tc
+	arguments.Accounts = accounts
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	blkc := createTestBlockchain()
 
@@ -2225,27 +1833,20 @@ func TestShardProcessor_CommitBlockOkValsShouldWork(t *testing.T) {
 	}
 	store := initStore()
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		store,
-		hasher,
-		&mock.MarshalizerMock{},
-		accounts,
-		mock.NewMultiShardsCoordinatorMock(3),
-		fd,
-		&mock.BlocksTrackerMock{
-			AddBlockCalled: func(headerHandler data.HeaderHandler) {
-			},
-			UnnotarisedBlocksCalled: func() []data.HeaderHandler {
-				return make([]data.HeaderHandler, 0)
-			},
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Store = store
+	arguments.Hasher = hasher
+	arguments.Accounts = accounts
+	arguments.ForkDetector = fd
+	arguments.BlocksTracker = &mock.BlocksTrackerMock{
+		AddBlockCalled: func(headerHandler data.HeaderHandler) {
 		},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+		UnnotarisedBlocksCalled: func() []data.HeaderHandler {
+			return make([]data.HeaderHandler, 0)
+		},
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	blkc := createTestBlockchain()
 	blkc.GetCurrentBlockHeaderCalled = func() data.HeaderHandler {
@@ -2323,54 +1924,51 @@ func TestShardProcessor_CommitBlockCallsIndexerMethods(t *testing.T) {
 
 	var saveBlockCalled map[string]data.TransactionHandler
 	saveBlockCalledMutex := sync.Mutex{}
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{
-			IndexerCalled: func() indexer.Indexer {
-				return &mock.IndexerMock{
-					SaveBlockCalled: func(body data.BodyHandler, header data.HeaderHandler, txPool map[string]data.TransactionHandler) {
-						saveBlockCalledMutex.Lock()
-						saveBlockCalled = txPool
-						saveBlockCalledMutex.Unlock()
-					},
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.Core = &mock.ServiceContainerMock{
+		IndexerCalled: func() indexer.Indexer {
+			return &mock.IndexerMock{
+				SaveBlockCalled: func(body data.BodyHandler, header data.HeaderHandler, txPool map[string]data.TransactionHandler) {
+					saveBlockCalledMutex.Lock()
+					saveBlockCalled = txPool
+					saveBlockCalledMutex.Unlock()
+				},
+			}
+		},
+	}
+	arguments.DataPool = tdp
+	arguments.Store = store
+	arguments.Hasher = hasher
+	arguments.Accounts = accounts
+	arguments.ForkDetector = fd
+	arguments.BlocksTracker = &mock.BlocksTrackerMock{
+		AddBlockCalled: func(headerHandler data.HeaderHandler) {
+		},
+		UnnotarisedBlocksCalled: func() []data.HeaderHandler {
+			return make([]data.HeaderHandler, 0)
+		},
+	}
+	arguments.TxCoordinator = &mock.TransactionCoordinatorMock{
+		GetAllCurrentUsedTxsCalled: func(blockType block.Type) map[string]data.TransactionHandler {
+			switch blockType {
+			case block.TxBlock:
+				return map[string]data.TransactionHandler{
+					"tx_1": &transaction.Transaction{Nonce: 1},
+					"tx_2": &transaction.Transaction{Nonce: 2},
 				}
-			},
-		},
-		tdp,
-		store,
-		hasher,
-		&mock.MarshalizerMock{},
-		accounts,
-		mock.NewMultiShardsCoordinatorMock(3),
-		fd,
-		&mock.BlocksTrackerMock{
-			AddBlockCalled: func(headerHandler data.HeaderHandler) {
-			},
-			UnnotarisedBlocksCalled: func() []data.HeaderHandler {
-				return make([]data.HeaderHandler, 0)
-			},
-		},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{
-			GetAllCurrentUsedTxsCalled: func(blockType block.Type) map[string]data.TransactionHandler {
-				switch blockType {
-				case block.TxBlock:
-					return map[string]data.TransactionHandler{
-						"tx_1": &transaction.Transaction{Nonce: 1},
-						"tx_2": &transaction.Transaction{Nonce: 2},
-					}
-				case block.SmartContractResultBlock:
-					return map[string]data.TransactionHandler{
-						"utx_1": &smartContractResult.SmartContractResult{Nonce: 1},
-						"utx_2": &smartContractResult.SmartContractResult{Nonce: 2},
-					}
-				default:
-					return nil
+			case block.SmartContractResultBlock:
+				return map[string]data.TransactionHandler{
+					"utx_1": &smartContractResult.SmartContractResult{Nonce: 1},
+					"utx_2": &smartContractResult.SmartContractResult{Nonce: 2},
 				}
-			},
+			default:
+				return nil
+			}
 		},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	}
+
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	blkc := createTestBlockchain()
 	blkc.GetCurrentBlockHeaderCalled = func() data.HeaderHandler {
@@ -2399,24 +1997,16 @@ func TestShardProcessor_CreateTxBlockBodyWithDirtyAccStateShouldErr(t *testing.T
 	tdp := initDataPool([]byte("tx_hash1"))
 	journalLen := func() int { return 3 }
 	revToSnapshot := func(snapshot int) error { return nil }
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{
-			JournalLenCalled:       journalLen,
-			RevertToSnapshotCalled: revToSnapshot,
-		},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Accounts = &mock.AccountsStub{
+		JournalLenCalled:       journalLen,
+		RevertToSnapshotCalled: revToSnapshot,
+	}
+
+	sp, _ := blproc.NewShardProcessor(arguments)
+
 	bl, err := sp.CreateBlockBody(0, func() bool { return true })
 	// nil block
 	assert.Nil(t, bl)
@@ -2432,25 +2022,15 @@ func TestShardProcessor_CreateTxBlockBodyWithNoTimeShouldEmptyBlock(t *testing.T
 		return []byte("roothash"), nil
 	}
 	revToSnapshot := func(snapshot int) error { return nil }
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{
-			JournalLenCalled:       journalLen,
-			RootHashCalled:         rootHashfunc,
-			RevertToSnapshotCalled: revToSnapshot,
-		},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Accounts = &mock.AccountsStub{
+		JournalLenCalled:       journalLen,
+		RootHashCalled:         rootHashfunc,
+		RevertToSnapshotCalled: revToSnapshot,
+	}
+
+	sp, _ := blproc.NewShardProcessor(arguments)
 	haveTime := func() bool {
 		return false
 	}
@@ -2471,24 +2051,14 @@ func TestShardProcessor_CreateTxBlockBodyOK(t *testing.T) {
 	haveTime := func() bool {
 		return true
 	}
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{
-			JournalLenCalled: journalLen,
-			RootHashCalled:   rootHashfunc,
-		},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Accounts = &mock.AccountsStub{
+		JournalLenCalled: journalLen,
+		RootHashCalled:   rootHashfunc,
+	}
+
+	sp, _ := blproc.NewShardProcessor(arguments)
 	blk, err := sp.CreateBlockBody(0, haveTime)
 	assert.NotNil(t, blk)
 	assert.Nil(t, err)
@@ -2501,21 +2071,13 @@ func TestNode_ComputeNewNoncePrevHashShouldWork(t *testing.T) {
 	tdp := initDataPool([]byte("tx_hash1"))
 	marshalizer := &mock.MarshalizerStub{}
 	hasher := &mock.HasherStub{}
-	be, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		initStore(),
-		hasher,
-		marshalizer,
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.Store = initStore()
+	arguments.DataPool = tdp
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+
+	be, _ := blproc.NewShardProcessor(arguments)
 	hdr, txBlock := createTestHdrTxBlockBody()
 	marshalizer.MarshalCalled = func(obj interface{}) (bytes []byte, e error) {
 		if hdr == obj {
@@ -2593,21 +2155,13 @@ func TestShardProcessor_DisplayLogInfo(t *testing.T) {
 	hasher := mock.HasherMock{}
 	hdr, txBlock := createTestHdrTxBlockBody()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(3)
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		initStore(),
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		shardCoordinator,
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(shardCoordinator),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Store = initStore()
+	arguments.Accounts = initAccountsMock()
+
+	sp, _ := blproc.NewShardProcessor(arguments)
 	assert.NotNil(t, sp)
 	hdr.PrevHash = hasher.Compute("prev hash")
 	sp.DisplayLogInfo(hdr, txBlock, []byte("tx_hash1"), shardCoordinator.NumberOfShards(), shardCoordinator.SelfId(), tdp)
@@ -2615,21 +2169,11 @@ func TestShardProcessor_DisplayLogInfo(t *testing.T) {
 
 func TestBlockProcessor_CreateBlockHeaderShouldNotReturnNil(t *testing.T) {
 	t.Parallel()
-	bp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		initDataPool([]byte("tx_hash1")),
-		initStore(),
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.Store = initStore()
+	arguments.Accounts = initAccountsMock()
+
+	bp, _ := blproc.NewShardProcessor(arguments)
 	mbHeaders, err := bp.CreateBlockHeader(nil, 0, func() bool {
 		return true
 	})
@@ -2640,21 +2184,12 @@ func TestBlockProcessor_CreateBlockHeaderShouldNotReturnNil(t *testing.T) {
 
 func TestShardProcessor_CreateBlockHeaderShouldErrWhenMarshalizerErrors(t *testing.T) {
 	t.Parallel()
-	bp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		initDataPool([]byte("tx_hash1")),
-		initStore(),
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{Fail: true},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.Store = initStore()
+	arguments.Marshalizer = &mock.MarshalizerMock{Fail: true}
+	arguments.Accounts = initAccountsMock()
+	bp, _ := blproc.NewShardProcessor(arguments)
 	body := block.Body{
 		{
 			ReceiverShardID: 1,
@@ -2681,21 +2216,11 @@ func TestShardProcessor_CreateBlockHeaderShouldErrWhenMarshalizerErrors(t *testi
 
 func TestShardProcessor_CreateBlockHeaderReturnsOK(t *testing.T) {
 	t.Parallel()
-	bp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		initDataPool([]byte("tx_hash1")),
-		initStore(),
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.Store = initStore()
+	arguments.Accounts = initAccountsMock()
+	bp, _ := blproc.NewShardProcessor(arguments)
 	body := block.Body{
 		{
 			ReceiverShardID: 1,
@@ -2728,23 +2253,13 @@ func TestShardProcessor_CommitBlockShouldRevertAccountStateWhenErr(t *testing.T)
 		journalEntries = 0
 		return nil
 	}
-	bp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		initDataPool([]byte("tx_hash1")),
-		initStore(),
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{
-			RevertToSnapshotCalled: revToSnapshot,
-		},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.Store = initStore()
+	arguments.Accounts = &mock.AccountsStub{
+		RevertToSnapshotCalled: revToSnapshot,
+	}
+	bp, _ := blproc.NewShardProcessor(arguments)
 	err := bp.CommitBlock(nil, nil, nil)
 	assert.NotNil(t, err)
 	assert.Equal(t, 0, journalEntries)
@@ -2798,21 +2313,13 @@ func TestShardProcessor_MarshalizedDataToBroadcastShouldWork(t *testing.T) {
 		&mock.InterimProcessorContainerMock{},
 	)
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		initStore(),
-		&mock.HasherStub{},
-		marshalizer,
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		tc,
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Store = initStore()
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = initAccountsMock()
+	arguments.TxCoordinator = tc
+	sp, _ := blproc.NewShardProcessor(arguments)
 	msh, mstx, err := sp.MarshalizedDataToBroadcast(&block.Header{}, body)
 	assert.Nil(t, err)
 	assert.NotNil(t, msh)
@@ -2834,21 +2341,14 @@ func TestShardProcessor_MarshalizedDataWrongType(t *testing.T) {
 	marshalizer := &mock.MarshalizerMock{
 		Fail: false,
 	}
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		initStore(),
-		&mock.HasherStub{},
-		marshalizer,
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Store = initStore()
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = initAccountsMock()
+
+	sp, _ := blproc.NewShardProcessor(arguments)
 	wr := &wrongBody{}
 	msh, mstx, err := sp.MarshalizedDataToBroadcast(&block.Header{}, wr)
 	assert.Equal(t, process.ErrWrongTypeAssertion, err)
@@ -2862,21 +2362,14 @@ func TestShardProcessor_MarshalizedDataNilInput(t *testing.T) {
 	marshalizer := &mock.MarshalizerMock{
 		Fail: false,
 	}
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		initStore(),
-		&mock.HasherStub{},
-		marshalizer,
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Store = initStore()
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = initAccountsMock()
+
+	sp, _ := blproc.NewShardProcessor(arguments)
 	msh, mstx, err := sp.MarshalizedDataToBroadcast(nil, nil)
 	assert.Equal(t, process.ErrNilMiniBlocks, err)
 	assert.Nil(t, msh)
@@ -2926,21 +2419,14 @@ func TestShardProcessor_MarshalizedDataMarshalWithoutSuccess(t *testing.T) {
 		&mock.InterimProcessorContainerMock{},
 	)
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		initStore(),
-		&mock.HasherStub{},
-		marshalizer,
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		tc,
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Store = initStore()
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = initAccountsMock()
+	arguments.TxCoordinator = tc
+
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	msh, mstx, err := sp.MarshalizedDataToBroadcast(&block.Header{}, body)
 	assert.Nil(t, err)
@@ -3007,21 +2493,16 @@ func TestShardProcessor_ReceivedMetaBlockShouldRequestMissingMiniBlocks(t *testi
 		&mock.InterimProcessorContainerMock{},
 	)
 
-	bp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		dataPool,
-		initStore(),
-		hasher,
-		marshalizer,
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		requestHandler,
-		tc,
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = dataPool
+	arguments.Store = initStore()
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = initAccountsMock()
+	arguments.RequestHandler = requestHandler
+	arguments.TxCoordinator = tc
+
+	bp, _ := blproc.NewShardProcessor(arguments)
 	bp.ReceivedMetaBlock(metaBlockHash)
 
 	//we have to wait to be sure txHash1Requested is not incremented by a late call
@@ -3075,21 +2556,16 @@ func TestShardProcessor_ReceivedMetaBlockNoMissingMiniBlocksShouldPass(t *testin
 		&mock.InterimProcessorContainerMock{},
 	)
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		dataPool,
-		initStore(),
-		hasher,
-		marshalizer,
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		requestHandler,
-		tc,
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = dataPool
+	arguments.Store = initStore()
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = initAccountsMock()
+	arguments.RequestHandler = requestHandler
+	arguments.TxCoordinator = tc
+
+	sp, _ := blproc.NewShardProcessor(arguments)
 	sp.ReceivedMetaBlock(metaBlockHash)
 	assert.Equal(t, int32(0), atomic.LoadInt32(&noOfMissingMiniBlocks))
 }
@@ -3152,21 +2628,10 @@ func TestShardProcessor_CreateAndProcessCrossMiniBlocksDstMe(t *testing.T) {
 	haveTimeTrue := func() bool {
 		return true
 	}
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	sp, _ := blproc.NewShardProcessor(arguments)
 	miniBlockSlice, usedMetaHdrsHashes, noOfTxs, err := sp.CreateAndProcessCrossMiniBlocksDstMe(3, 2, 2, haveTimeTrue)
 	assert.Equal(t, err == nil, true)
 	assert.Equal(t, len(miniBlockSlice) == 0, true)
@@ -3185,21 +2650,11 @@ func TestShardProcessor_NewShardProcessorWrongTypeOfStartHeaderShouldErrWrongTyp
 
 	startHeaders[sharding.MetachainShardId] = &block.Header{}
 
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		startHeaders,
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.StartHeaders = startHeaders
+
+	sp, err := blproc.NewShardProcessor(arguments)
 
 	assert.Nil(t, sp)
 	assert.Equal(t, process.ErrWrongTypeAssertion, err)
@@ -3280,21 +2735,9 @@ func TestShardProcessor_CreateAndProcessCrossMiniBlocksDstMeProcessPartOfMiniBlo
 		meta,
 	)
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	miniBlocksReturned, usedMetaHdrsHashes, nrTxAdded, err := sp.CreateAndProcessCrossMiniBlocksDstMe(3, 2, 2, haveTimeTrue)
 
@@ -3396,21 +2839,14 @@ func TestShardProcessor_CreateMiniBlocksShouldWorkWithIntraShardTxs(t *testing.T
 		&mock.InterimProcessorContainerMock{},
 	)
 
-	bp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		dataPool,
-		initStore(),
-		hasher,
-		marshalizer,
-		accntAdapter,
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		tc,
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = dataPool
+	arguments.Store = initStore()
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = accntAdapter
+	arguments.TxCoordinator = tc
+	bp, _ := blproc.NewShardProcessor(arguments)
 
 	blockBody, err := bp.CreateMiniBlocks(1, 15000, 0, func() bool { return true })
 
@@ -3471,29 +2907,24 @@ func TestShardProcessor_GetProcessedMetaBlockFromPoolShouldWork(t *testing.T) {
 	shardCoordinator.CurrentShard = destShardId
 	shardCoordinator.SetNoShards(destShardId + 1)
 
-	bp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		dataPool,
-		&mock.ChainStorerMock{},
-		hasher,
-		marshalizer,
-		initAccountsMock(),
-		shardCoordinator,
-		&mock.ForkDetectorMock{
-			GetHighestFinalBlockNonceCalled: func() uint64 {
-				return 0
-			},
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = dataPool
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = initAccountsMock()
+	arguments.ShardCoordinator = shardCoordinator
+	arguments.ForkDetector = &mock.ForkDetectorMock{
+		GetHighestFinalBlockNonceCalled: func() uint64 {
+			return 0
 		},
-		&mock.BlocksTrackerMock{
-			RemoveNotarisedBlocksCalled: func(headerHandler data.HeaderHandler) error {
-				return nil
-			},
+	}
+	arguments.BlocksTracker = &mock.BlocksTrackerMock{
+		RemoveNotarisedBlocksCalled: func(headerHandler data.HeaderHandler) error {
+			return nil
 		},
-		createGenesisBlocks(shardCoordinator),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	}
+	arguments.StartHeaders = createGenesisBlocks(shardCoordinator)
+	bp, _ := blproc.NewShardProcessor(arguments)
 
 	//create mini block headers with first 3 miniblocks from miniblocks var
 	mbHeaders := []block.MiniBlockHeader{
@@ -3527,21 +2958,11 @@ func TestBlockProcessor_RestoreBlockIntoPoolsShouldErrNilBlockHeader(t *testing.
 	t.Parallel()
 	tdp := initDataPool([]byte("tx_hash1"))
 
-	be, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		initStore(),
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Store = initStore()
+	arguments.Accounts = initAccountsMock()
+	be, _ := blproc.NewShardProcessor(arguments)
 	err := be.RestoreBlockIntoPools(nil, nil)
 	assert.NotNil(t, err)
 	assert.Equal(t, process.ErrNilBlockHeader, err)
@@ -3550,21 +2971,12 @@ func TestBlockProcessor_RestoreBlockIntoPoolsShouldErrNilBlockHeader(t *testing.
 func TestBlockProcessor_RestoreBlockIntoPoolsShouldErrNilTxBlockBody(t *testing.T) {
 	t.Parallel()
 	tdp := initDataPool([]byte("tx_hash1"))
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		initStore(),
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Store = initStore()
+	arguments.Accounts = initAccountsMock()
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	err := sp.RestoreBlockIntoPools(&block.Header{}, nil)
 	assert.NotNil(t, err)
@@ -3623,21 +3035,14 @@ func TestShardProcessor_RestoreBlockIntoPoolsShouldWork(t *testing.T) {
 		&mock.InterimProcessorContainerMock{},
 	)
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		dataPool,
-		store,
-		hasherMock,
-		marshalizerMock,
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		tc,
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = dataPool
+	arguments.Store = store
+	arguments.Hasher = hasherMock
+	arguments.Marshalizer = marshalizerMock
+	arguments.Accounts = initAccountsMock()
+	arguments.TxCoordinator = tc
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	txHashes := make([][]byte, 0)
 	txHashes = append(txHashes, txHash)
@@ -3675,23 +3080,14 @@ func TestShardProcessor_RestoreBlockIntoPoolsShouldWork(t *testing.T) {
 
 func TestShardProcessor_DecodeBlockBody(t *testing.T) {
 	t.Parallel()
+
 	tdp := initDataPool([]byte("tx_hash1"))
 	marshalizerMock := &mock.MarshalizerMock{}
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		marshalizerMock,
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Marshalizer = marshalizerMock
+	arguments.Accounts = initAccountsMock()
+	sp, err := blproc.NewShardProcessor(arguments)
 	body := make(block.Body, 0)
 	body = append(body, &block.MiniBlock{ReceiverShardID: 69})
 	message, err := marshalizerMock.Marshal(body)
@@ -3709,21 +3105,12 @@ func TestShardProcessor_DecodeBlockHeader(t *testing.T) {
 	t.Parallel()
 	tdp := initDataPool([]byte("tx_hash1"))
 	marshalizerMock := &mock.MarshalizerMock{}
-	sp, err := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		tdp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		marshalizerMock,
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = tdp
+	arguments.Marshalizer = marshalizerMock
+	arguments.Accounts = initAccountsMock()
+	sp, err := blproc.NewShardProcessor(arguments)
 	hdr := &block.Header{}
 	hdr.Nonce = 1
 	hdr.TimeStamp = uint64(0)
@@ -3750,21 +3137,22 @@ func TestShardProcessor_IsHdrConstructionValid(t *testing.T) {
 	dataPool := initDataPool([]byte("tx_hash1"))
 
 	shardNr := uint32(5)
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		dataPool,
-		&mock.ChainStorerMock{},
-		hasher,
-		marshalizer,
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(shardNr),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(shardNr)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = dataPool
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = initAccountsMock()
+	arguments.ShardCoordinator = mock.NewMultiShardsCoordinatorMock(shardNr)
+	arguments.BlocksTracker = &mock.BlocksTrackerMock{
+		RemoveNotarisedBlocksCalled: func(headerHandler data.HeaderHandler) error {
+			return nil
+		},
+		UnnotarisedBlocksCalled: func() []data.HeaderHandler {
+			return make([]data.HeaderHandler, 0)
+		},
+	}
+	arguments.StartHeaders = createGenesisBlocks(arguments.ShardCoordinator)
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	prevRandSeed := []byte("prevrand")
 	currRandSeed := []byte("currrand")
@@ -3864,28 +3252,24 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	}
 
 	shardNr := uint32(5)
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		dataPool,
-		store,
-		hasher,
-		marshalizer,
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(shardNr),
-		forkDetector,
-		&mock.BlocksTrackerMock{
-			RemoveNotarisedBlocksCalled: func(headerHandler data.HeaderHandler) error {
-				return nil
-			},
-			UnnotarisedBlocksCalled: func() []data.HeaderHandler {
-				return make([]data.HeaderHandler, 0)
-			},
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = dataPool
+	arguments.Store = store
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = initAccountsMock()
+	arguments.ShardCoordinator = mock.NewMultiShardsCoordinatorMock(shardNr)
+	arguments.ForkDetector = forkDetector
+	arguments.BlocksTracker = &mock.BlocksTrackerMock{
+		RemoveNotarisedBlocksCalled: func(headerHandler data.HeaderHandler) error {
+			return nil
 		},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(shardNr)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+		UnnotarisedBlocksCalled: func() []data.HeaderHandler {
+			return make([]data.HeaderHandler, 0)
+		},
+	}
+	arguments.StartHeaders = createGenesisBlocks(arguments.ShardCoordinator)
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	prevRandSeed := []byte("prevrand")
 	currRandSeed := []byte("currrand")
@@ -4026,28 +3410,25 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNotAllMBFinished(t *tes
 	}
 
 	shardNr := uint32(5)
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		dataPool,
-		store,
-		hasher,
-		marshalizer,
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(shardNr),
-		forkDetector,
-		&mock.BlocksTrackerMock{
-			RemoveNotarisedBlocksCalled: func(headerHandler data.HeaderHandler) error {
-				return nil
-			},
-			UnnotarisedBlocksCalled: func() []data.HeaderHandler {
-				return make([]data.HeaderHandler, 0)
-			},
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = dataPool
+	arguments.Store = store
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = initAccountsMock()
+	arguments.ShardCoordinator = mock.NewMultiShardsCoordinatorMock(shardNr)
+	arguments.ForkDetector = forkDetector
+	arguments.BlocksTracker = &mock.BlocksTrackerMock{
+		RemoveNotarisedBlocksCalled: func(headerHandler data.HeaderHandler) error {
+			return nil
 		},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(shardNr)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+		UnnotarisedBlocksCalled: func() []data.HeaderHandler {
+			return make([]data.HeaderHandler, 0)
+		},
+	}
+	arguments.StartHeaders = createGenesisBlocks(arguments.ShardCoordinator)
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	prevRandSeed := []byte("prevrand")
 	currRandSeed := []byte("currrand")
@@ -4165,28 +3546,25 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrAllMBFinished(t *testin
 	}
 
 	shardNr := uint32(5)
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		dataPool,
-		store,
-		hasher,
-		marshalizer,
-		initAccountsMock(),
-		mock.NewMultiShardsCoordinatorMock(shardNr),
-		forkDetector,
-		&mock.BlocksTrackerMock{
-			RemoveNotarisedBlocksCalled: func(headerHandler data.HeaderHandler) error {
-				return nil
-			},
-			UnnotarisedBlocksCalled: func() []data.HeaderHandler {
-				return make([]data.HeaderHandler, 0)
-			},
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = dataPool
+	arguments.Store = store
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.Accounts = initAccountsMock()
+	arguments.ShardCoordinator = mock.NewMultiShardsCoordinatorMock(shardNr)
+	arguments.ForkDetector = forkDetector
+	arguments.BlocksTracker = &mock.BlocksTrackerMock{
+		RemoveNotarisedBlocksCalled: func(headerHandler data.HeaderHandler) error {
+			return nil
 		},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(shardNr)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+		UnnotarisedBlocksCalled: func() []data.HeaderHandler {
+			return make([]data.HeaderHandler, 0)
+		},
+	}
+	arguments.StartHeaders = createGenesisBlocks(arguments.ShardCoordinator)
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	prevRandSeed := []byte("prevrand")
 	currRandSeed := []byte("currrand")
@@ -4338,21 +3716,8 @@ func TestShardProcessor_CheckHeaderBodyCorrelationReceiverMissmatch(t *testing.T
 	t.Parallel()
 
 	hdr, body := createOneHeaderOneBody()
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		initDataPool([]byte("tx_hash1")),
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	hdr.MiniBlockHeaders[0].ReceiverShardID = body[0].ReceiverShardID + 1
 	err := sp.CheckHeaderBodyCorrelation(hdr, body)
@@ -4363,21 +3728,8 @@ func TestShardProcessor_CheckHeaderBodyCorrelationSenderMissmatch(t *testing.T) 
 	t.Parallel()
 
 	hdr, body := createOneHeaderOneBody()
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		initDataPool([]byte("tx_hash1")),
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	hdr.MiniBlockHeaders[0].SenderShardID = body[0].SenderShardID + 1
 	err := sp.CheckHeaderBodyCorrelation(hdr, body)
@@ -4388,21 +3740,9 @@ func TestShardProcessor_CheckHeaderBodyCorrelationTxCountMissmatch(t *testing.T)
 	t.Parallel()
 
 	hdr, body := createOneHeaderOneBody()
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		initDataPool([]byte("tx_hash1")),
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+
+	arguments := CreateMockArgumentsMultiShard()
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	hdr.MiniBlockHeaders[0].TxCount = uint32(len(body[0].TxHashes) + 1)
 	err := sp.CheckHeaderBodyCorrelation(hdr, body)
@@ -4413,21 +3753,8 @@ func TestShardProcessor_CheckHeaderBodyCorrelationHashMissmatch(t *testing.T) {
 	t.Parallel()
 
 	hdr, body := createOneHeaderOneBody()
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		initDataPool([]byte("tx_hash1")),
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	hdr.MiniBlockHeaders[0].Hash = []byte("wrongHash")
 	err := sp.CheckHeaderBodyCorrelation(hdr, body)
@@ -4438,21 +3765,8 @@ func TestShardProcessor_CheckHeaderBodyCorrelationShouldPass(t *testing.T) {
 	t.Parallel()
 
 	hdr, body := createOneHeaderOneBody()
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		initDataPool([]byte("tx_hash1")),
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	err := sp.CheckHeaderBodyCorrelation(hdr, body)
 	assert.Nil(t, err)
@@ -4470,32 +3784,21 @@ func TestShardProcessor_RestoreMetaBlockIntoPoolShouldPass(t *testing.T) {
 		ShardInfo: make([]block.ShardData, 0),
 	}
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		poolFake,
-		&mock.ChainStorerMock{
-			GetCalled: func(unitType dataRetriever.UnitType, key []byte) ([]byte, error) {
-				return marshalizer.Marshal(&metaBlock)
-			},
-			GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
-				return &mock.StorerStub{
-					RemoveCalled: func(key []byte) error {
-						return nil
-					},
-				}
-			},
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = poolFake
+	arguments.Store = &mock.ChainStorerMock{
+		GetCalled: func(unitType dataRetriever.UnitType, key []byte) ([]byte, error) {
+			return marshalizer.Marshal(&metaBlock)
 		},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
+			return &mock.StorerStub{
+				RemoveCalled: func(key []byte) error {
+					return nil
+				},
+			}
+		},
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	miniblockHashes := make(map[string]uint32, 0)
 
@@ -4588,21 +3891,9 @@ func TestShardPreprocessor_getAllMiniBlockDstMeFromMetaShouldPass(t *testing.T) 
 		}
 	}
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		idp,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = idp
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	meta := block.MetaBlock{
 		Nonce:     0,
@@ -4627,24 +3918,8 @@ func TestShardPreprocessor_getAllMiniBlockDstMeFromMetaShouldPass(t *testing.T) 
 func TestShardProcessor_GetHighestHdrForOwnShardFromMetachainNothingToProcess(t *testing.T) {
 	t.Parallel()
 
-	dataPool := initDataPool([]byte("tx_hash1"))
-
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		dataPool,
-		&mock.ChainStorerMock{},
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3)),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
-
+	arguments := CreateMockArgumentsMultiShard()
+	sp, _ := blproc.NewShardProcessor(arguments)
 	hdr, _, err := sp.GetHighestHdrForOwnShardFromMetachain(0)
 
 	assert.Nil(t, err)
@@ -4661,21 +3936,14 @@ func TestShardProcessor_GetHighestHdrForOwnShardFromMetachaiMetaHdrsWithoutOwnHd
 	marshalizer := &mock.MarshalizerMock{}
 	genesisBlocks := createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3))
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		dataPool,
-		store,
-		hasher,
-		marshalizer,
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		genesisBlocks,
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = dataPool
+	arguments.Store = store
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.StartHeaders = genesisBlocks
+
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	shardInfo := make([]block.ShardData, 0)
 	shardInfo = append(shardInfo, block.ShardData{HeaderHash: []byte("hash"), ShardId: 1})
@@ -4725,21 +3993,14 @@ func TestShardProcessor_GetHighestHdrForOwnShardFromMetachaiMetaHdrsWithOwnHdrBu
 	marshalizer := &mock.MarshalizerMock{}
 	genesisBlocks := createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3))
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		dataPool,
-		store,
-		hasher,
-		marshalizer,
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		genesisBlocks,
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = dataPool
+	arguments.Store = store
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.StartHeaders = genesisBlocks
+
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	shardInfo := make([]block.ShardData, 0)
 	shardInfo = append(shardInfo, block.ShardData{HeaderHash: []byte("hash"), ShardId: 0})
@@ -4788,21 +4049,14 @@ func TestShardProcessor_GetHighestHdrForOwnShardFromMetachaiMetaHdrsWithOwnHdrSt
 	marshalizer := &mock.MarshalizerMock{}
 	genesisBlocks := createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3))
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		dataPool,
-		store,
-		hasher,
-		marshalizer,
-		&mock.AccountsStub{},
-		mock.NewMultiShardsCoordinatorMock(3),
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		genesisBlocks,
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = dataPool
+	arguments.Store = store
+	arguments.Hasher = hasher
+	arguments.Marshalizer = marshalizer
+	arguments.StartHeaders = genesisBlocks
+
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	ownHdr := &block.Header{
 		Nonce: 1,
@@ -4882,21 +4136,12 @@ func TestShardProcessor_RestoreMetaBlockIntoPoolVerifyMiniblocks(t *testing.T) {
 	storer := &mock.ChainStorerMock{}
 	shardC := mock.NewMultiShardsCoordinatorMock(3)
 
-	sp, _ := blproc.NewShardProcessor(
-		&mock.ServiceContainerMock{},
-		poolFake,
-		storer,
-		&mock.HasherStub{},
-		&mock.MarshalizerMock{},
-		&mock.AccountsStub{},
-		shardC,
-		&mock.ForkDetectorMock{},
-		&mock.BlocksTrackerMock{},
-		createGenesisBlocks(shardC),
-		&mock.RequestHandlerMock{},
-		&mock.TransactionCoordinatorMock{},
-		&mock.Uint64ByteSliceConverterMock{},
-	)
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.DataPool = poolFake
+	arguments.Store = storer
+	arguments.ShardCoordinator = shardC
+	arguments.StartHeaders = createGenesisBlocks(shardC)
+	sp, _ := blproc.NewShardProcessor(arguments)
 
 	miniblockHashes := make(map[string]uint32, 0)
 


### PR DESCRIPTION
Refactor shard processor constructor.
All constructor parameters was moved in a new struct.
Modify failing tests.