### PR TITLE
En 4102 improve fork detector

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -5,7 +5,7 @@
    DestinationShardAsObserver = "0"
 
    # NetworkID will be used for network versions
-   NetworkID = "undifined"
+   NetworkID = "undefined"
 
    # StatusPollingIntervalSec represents the no of seconds between multiple polling for the status for AppStatusHandler
    StatusPollingIntervalSec = 2

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -5,7 +5,7 @@
    DestinationShardAsObserver = "0"
 
    # NetworkID will be used for network versions
-   NetworkID = "undefined"
+   NetworkID = "ElrondPublicTestNET-1017"
 
    # StatusPollingIntervalSec represents the no of seconds between multiple polling for the status for AppStatusHandler
    StatusPollingIntervalSec = 2
@@ -19,7 +19,7 @@
 
 [MiniBlocksStorage]
     [MiniBlocksStorage.Cache]
-        Size = 100
+        Size = 300
         Type = "LRU"
     [MiniBlocksStorage.DB]
         FilePath = "MiniBlocks"

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -5,7 +5,7 @@
    DestinationShardAsObserver = "0"
 
    # NetworkID will be used for network versions
-   NetworkID = "ElrondPublicTestNET-1017"
+   NetworkID = "undifined"
 
    # StatusPollingIntervalSec represents the no of seconds between multiple polling for the status for AppStatusHandler
    StatusPollingIntervalSec = 2
@@ -19,7 +19,7 @@
 
 [MiniBlocksStorage]
     [MiniBlocksStorage.Cache]
-        Size = 300
+        Size = 100
         Type = "LRU"
     [MiniBlocksStorage.DB]
         FilePath = "MiniBlocks"

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -112,28 +112,28 @@ func (bp *baseProcessor) checkBlockValidity(
 				return nil
 			}
 
-			log.Info(fmt.Sprintf("hash not match: local block hash is %s and node received block with previous hash %s\n",
+			log.Info(fmt.Sprintf("hash does not match: local block hash is %s and node received block with previous hash %s\n",
 				core.ToB64(chainHandler.GetGenesisHeaderHash()),
 				core.ToB64(headerHandler.GetPrevHash())))
 
 			return process.ErrBlockHashDoesNotMatch
 		}
 
-		log.Info(fmt.Sprintf("nonce not match: local block nonce is 0 and node received block with nonce %d\n",
+		log.Info(fmt.Sprintf("nonce does not match: local block nonce is 0 and node received block with nonce %d\n",
 			headerHandler.GetNonce()))
 
 		return process.ErrWrongNonceInBlock
 	}
 
 	if headerHandler.GetRound() <= currentBlockHeader.GetRound() {
-		log.Info(fmt.Sprintf("round not match: local block round is %d and node received block with round %d\n",
+		log.Info(fmt.Sprintf("round does not match: local block round is %d and node received block with round %d\n",
 			currentBlockHeader.GetRound(), headerHandler.GetRound()))
 
 		return process.ErrLowerRoundInBlock
 	}
 
 	if headerHandler.GetNonce() != currentBlockHeader.GetNonce()+1 {
-		log.Info(fmt.Sprintf("nonce not match: local block nonce is %d and node received block with nonce %d\n",
+		log.Info(fmt.Sprintf("nonce does not match: local block nonce is %d and node received block with nonce %d\n",
 			currentBlockHeader.GetNonce(), headerHandler.GetNonce()))
 
 		return process.ErrWrongNonceInBlock
@@ -144,18 +144,18 @@ func (bp *baseProcessor) checkBlockValidity(
 		return err
 	}
 
-	if !bytes.Equal(headerHandler.GetPrevRandSeed(), currentBlockHeader.GetRandSeed()) {
-		log.Info(fmt.Sprintf("random seed not match: local block random seed is %s and node received block with previous random seed %s\n",
-			core.ToB64(currentBlockHeader.GetRandSeed()), core.ToB64(headerHandler.GetPrevRandSeed())))
-
-		return process.ErrRandSeedMismatch
-	}
-
 	if !bytes.Equal(headerHandler.GetPrevHash(), prevHeaderHash) {
-		log.Info(fmt.Sprintf("hash not match: local block hash is %s and node received block with previous hash %s\n",
+		log.Info(fmt.Sprintf("hash does not match: local block hash is %s and node received block with previous hash %s\n",
 			core.ToB64(prevHeaderHash), core.ToB64(headerHandler.GetPrevHash())))
 
 		return process.ErrBlockHashDoesNotMatch
+	}
+
+	if !bytes.Equal(headerHandler.GetPrevRandSeed(), currentBlockHeader.GetRandSeed()) {
+		log.Info(fmt.Sprintf("random seed does not match: local block random seed is %s and node received block with previous random seed %s\n",
+			core.ToB64(currentBlockHeader.GetRandSeed()), core.ToB64(headerHandler.GetPrevRandSeed())))
+
+		return process.ErrRandSeedDoesNotMatch
 	}
 
 	if bodyHandler != nil {
@@ -198,11 +198,11 @@ func (bp *baseProcessor) isHdrConstructionValid(currHdr, prevHdr data.HeaderHand
 	// special case with genesis nonce - 0
 	if currHdr.GetNonce() == 0 {
 		if prevHdr.GetNonce() != 0 {
-			return process.ErrWrongNonceInBlock
+			return process.ErrWrongNonceInOtherChainBlock
 		}
 		// block with nonce 0 was already saved
 		if prevHdr.GetRootHash() != nil {
-			return process.ErrRootStateMissmatch
+			return process.ErrRootStateDoesNotMatchInOtherChainBlock
 		}
 		return nil
 	}
@@ -210,11 +210,16 @@ func (bp *baseProcessor) isHdrConstructionValid(currHdr, prevHdr data.HeaderHand
 	//TODO: add verification if rand seed was correctly computed add other verification
 	//TODO: check here if the 2 header blocks were correctly signed and the consensus group was correctly elected
 	if prevHdr.GetRound() >= currHdr.GetRound() {
+		log.Info(fmt.Sprintf("round does not match in other chain: local block round is %d and node received block with round %d\n",
+			prevHdr.GetRound(), currHdr.GetRound()))
 		return process.ErrLowerRoundInOtherChainBlock
 	}
 
 	if currHdr.GetNonce() != prevHdr.GetNonce()+1 {
-		return process.ErrWrongNonceInBlock
+		log.Info(fmt.Sprintf("nonce does not match in other chain: local block nonce is %d and node received block with nonce %d\n",
+			prevHdr.GetNonce(),
+			currHdr.GetNonce()))
+		return process.ErrWrongNonceInOtherChainBlock
 	}
 
 	prevHeaderHash, err := core.CalculateHash(bp.marshalizer, bp.hasher, prevHdr)
@@ -222,12 +227,18 @@ func (bp *baseProcessor) isHdrConstructionValid(currHdr, prevHdr data.HeaderHand
 		return err
 	}
 
-	if !bytes.Equal(currHdr.GetPrevRandSeed(), prevHdr.GetRandSeed()) {
-		return process.ErrRandSeedMismatch
+	if !bytes.Equal(currHdr.GetPrevHash(), prevHeaderHash) {
+		log.Info(fmt.Sprintf("hash does not match in other chain: local block hash is %s and node received block with previous hash %s\n",
+			core.ToB64(prevHeaderHash),
+			core.ToB64(currHdr.GetPrevHash())))
+		return process.ErrHashDoesNotMatchInOtherChainBlock
 	}
 
-	if !bytes.Equal(currHdr.GetPrevHash(), prevHeaderHash) {
-		return process.ErrHashDoesNotMatchInOtherChainBlock
+	if !bytes.Equal(currHdr.GetPrevRandSeed(), prevHdr.GetRandSeed()) {
+		log.Info(fmt.Sprintf("random seed does not match: local block random seed is %s and node received block with previous random seed %s\n",
+			core.ToB64(prevHdr.GetRandSeed()),
+			core.ToB64(currHdr.GetPrevRandSeed())))
+		return process.ErrRandSeedDoesNotMatchInOtherChainBlock
 	}
 
 	return nil

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -375,26 +375,19 @@ func TestBlockProcessor_CheckBlockValidity(t *testing.T) {
 	assert.Equal(t, process.ErrWrongNonceInBlock, err)
 
 	hdr.Nonce = 2
-	hdr.PrevRandSeed = []byte("X")
-	err = bp.CheckBlockValidity(blkc, hdr, body)
-	assert.Equal(t, process.ErrRandSeedMismatch, err)
-
-	hdr.PrevRandSeed = []byte("")
 	hdr.PrevHash = []byte("X")
 	err = bp.CheckBlockValidity(blkc, hdr, body)
 	assert.Equal(t, process.ErrBlockHashDoesNotMatch, err)
 
-	hdr.Nonce = 3
-	hdr.PrevHash = []byte("")
-	err = bp.CheckBlockValidity(blkc, hdr, body)
-	assert.Equal(t, process.ErrWrongNonceInBlock, err)
-
-	hdr.Nonce = 2
 	marshalizerMock := mock.MarshalizerMock{}
 	hasherMock := mock.HasherMock{}
 	prevHeader, _ := marshalizerMock.Marshal(blkc.GetCurrentBlockHeader())
 	hdr.PrevHash = hasherMock.Compute(string(prevHeader))
+	hdr.PrevRandSeed = []byte("X")
+	err = bp.CheckBlockValidity(blkc, hdr, body)
+	assert.Equal(t, process.ErrRandSeedDoesNotMatch, err)
 
+	hdr.PrevRandSeed = []byte("")
 	err = bp.CheckBlockValidity(blkc, hdr, body)
 	assert.Nil(t, err)
 }

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -785,8 +785,11 @@ func (mp *metaProcessor) getFinalityAttestingHeaders(
 			continue
 		}
 
-		if hdr.GetNonce() <= highestNonceHdrs[hdr.ShardId].GetNonce() ||
-			hdr.GetNonce() > highestNonceHdrs[hdr.ShardId].GetNonce()+finality {
+		isHdrNonceLowerOrEqualThanHighestNonce := hdr.GetNonce() <= highestNonceHdrs[hdr.ShardId].GetNonce()
+		isHdrNonceHigherThanFinalNonce := hdr.GetNonce() > highestNonceHdrs[hdr.ShardId].GetNonce()+finality
+
+		if isHdrNonceLowerOrEqualThanHighestNonce ||
+			isHdrNonceHigherThanFinalNonce {
 			continue
 		}
 

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -509,7 +509,7 @@ func (mp *metaProcessor) CommitBlock(
 		return err
 	}
 
-	log.Info(fmt.Sprintf("metaBlock with nonce %d and hash %s has been committed successfully\n",
+	log.Info(fmt.Sprintf("meta block with nonce %d and hash %s has been committed successfully\n",
 		header.Nonce,
 		core.ToB64(headerHash)))
 

--- a/process/block/metablock_test.go
+++ b/process/block/metablock_test.go
@@ -1886,7 +1886,7 @@ func TestMetaProcessor_CheckShardHeadersValidity(t *testing.T) {
 	metaHdr.ShardInfo = append(metaHdr.ShardInfo, shDataPrev)
 
 	_, err := mp.CheckShardHeadersValidity(metaHdr)
-	assert.Equal(t, process.ErrWrongNonceInOtherChainBlock, err)
+	assert.Equal(t, process.ErrWrongNonceInBlock, err)
 
 	shDataCurr = block.ShardData{ShardId: 0, HeaderHash: currHash}
 	metaHdr.ShardInfo = make([]block.ShardData, 0)
@@ -1954,7 +1954,7 @@ func TestMetaProcessor_CheckShardHeadersValidityWrongNonceFromLastNoted(t *testi
 
 	highestNonceHdrs, err := mp.CheckShardHeadersValidity(metaHdr)
 	assert.Nil(t, highestNonceHdrs)
-	assert.Equal(t, process.ErrWrongNonceInOtherChainBlock, err)
+	assert.Equal(t, process.ErrWrongNonceInBlock, err)
 }
 
 func TestMetaProcessor_CheckShardHeadersValidityRoundZeroLastNoted(t *testing.T) {
@@ -2198,12 +2198,12 @@ func TestMetaProcessor_IsHdrConstructionValid(t *testing.T) {
 
 	currHdr.Nonce = 0
 	err = mp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrWrongNonceInOtherChainBlock)
+	assert.Equal(t, err, process.ErrWrongNonceInBlock)
 
 	currHdr.Nonce = 0
 	prevHdr.Nonce = 0
 	err = mp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrRootStateDoesNotMatchInOtherChainBlock)
+	assert.Equal(t, err, process.ErrRootStateDoesNotMatch)
 
 	currHdr.Nonce = 0
 	prevHdr.Nonce = 0
@@ -2215,22 +2215,22 @@ func TestMetaProcessor_IsHdrConstructionValid(t *testing.T) {
 	prevHdr.Nonce = 45
 	prevHdr.Round = currHdr.Round + 1
 	err = mp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrLowerRoundInOtherChainBlock)
+	assert.Equal(t, err, process.ErrLowerRoundInBlock)
 
 	prevHdr.Round = currHdr.Round - 1
 	currHdr.Nonce = prevHdr.Nonce + 2
 	err = mp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrWrongNonceInOtherChainBlock)
+	assert.Equal(t, err, process.ErrWrongNonceInBlock)
 
 	currHdr.Nonce = prevHdr.Nonce + 1
 	currHdr.PrevHash = []byte("wronghash")
 	err = mp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrHashDoesNotMatchInOtherChainBlock)
+	assert.Equal(t, err, process.ErrBlockHashDoesNotMatch)
 
 	prevHdr.RandSeed = []byte("randomwrong")
 	currHdr.PrevHash, _ = mp.ComputeHeaderHash(prevHdr)
 	err = mp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrRandSeedDoesNotMatchInOtherChainBlock)
+	assert.Equal(t, err, process.ErrRandSeedDoesNotMatch)
 
 	currHdr.PrevHash = prevHash
 	prevHdr.RandSeed = currRandSeed

--- a/process/block/preprocess/basePreProcess.go
+++ b/process/block/preprocess/basePreProcess.go
@@ -71,21 +71,6 @@ func (bpp *basePreProcess) removeDataFromPools(body block.Body, miniBlockPool st
 	return nil
 }
 
-func (bpp *basePreProcess) restoreMiniBlock(
-	miniBlock *block.MiniBlock,
-	miniBlockHash []byte,
-	miniBlockPool storage.Cacher,
-) []byte {
-
-	miniBlockPool.Put(miniBlockHash, miniBlock)
-	//TODO: Analyze what is the scope of this check and return besides tests. Refactor this method
-	if miniBlock.SenderShardID != bpp.shardCoordinator.SelfId() {
-		return miniBlockHash
-	}
-
-	return nil
-}
-
 func (bpp *basePreProcess) createMarshalizedData(txHashes [][]byte, forBlock *txsForBlock) ([][]byte, error) {
 	mrsTxs := make([][]byte, 0)
 	for _, txHash := range txHashes {

--- a/process/block/preprocess/smartContractResults_test.go
+++ b/process/block/preprocess/smartContractResults_test.go
@@ -794,9 +794,8 @@ func TestScrsPreprocessor_RestoreTxBlockIntoPools(t *testing.T) {
 
 	body = append(body, &miniblock)
 	miniblockPool := mock.NewCacherMock()
-	scrRestored, miniBlockHashes, err := scr.RestoreTxBlockIntoPools(body, miniblockPool)
+	scrRestored, err := scr.RestoreTxBlockIntoPools(body, miniblockPool)
 
-	assert.Equal(t, miniBlockHashes[0], []uint8([]byte(nil)))
 	assert.Equal(t, scrRestored, 1)
 	assert.Nil(t, err)
 }
@@ -826,7 +825,7 @@ func TestScrsPreprocessor__RestoreTxBlockIntoPoolsNilMiniblockPoolShouldErr(t *t
 
 	miniblockPool := storage.Cacher(nil)
 
-	_, _, err := scr.RestoreTxBlockIntoPools(body, miniblockPool)
+	_, err := scr.RestoreTxBlockIntoPools(body, miniblockPool)
 
 	assert.NotNil(t, err)
 	assert.Equal(t, err, process.ErrNilMiniBlockPool)

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -369,8 +369,11 @@ func (sp *shardProcessor) getFinalityAttestingHeaders(
 			continue
 		}
 
-		if hdr.GetNonce() <= highestNonceHdr.GetNonce() ||
-			hdr.GetNonce() > highestNonceHdr.GetNonce()+finality {
+		isHdrNonceLowerOrEqualThanHighestNonce := hdr.GetNonce() <= highestNonceHdr.GetNonce()
+		isHdrNonceHigherThanFinalNonce := hdr.GetNonce() > highestNonceHdr.GetNonce()+finality
+
+		if isHdrNonceLowerOrEqualThanHighestNonce ||
+			isHdrNonceHigherThanFinalNonce {
 			continue
 		}
 

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -705,7 +705,7 @@ func (sp *shardProcessor) CommitBlock(
 		return err
 	}
 
-	log.Info(fmt.Sprintf("shardBlock with nonce %d and hash %s has been committed successfully\n",
+	log.Info(fmt.Sprintf("shard block with nonce %d and hash %s has been committed successfully\n",
 		header.Nonce,
 		core.ToB64(headerHash)))
 

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -3169,12 +3169,12 @@ func TestShardProcessor_IsHdrConstructionValid(t *testing.T) {
 
 	currHdr.Nonce = 0
 	err = sp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrWrongNonceInOtherChainBlock)
+	assert.Equal(t, err, process.ErrWrongNonceInBlock)
 
 	currHdr.Nonce = 0
 	prevHdr.Nonce = 0
 	err = sp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrRootStateDoesNotMatchInOtherChainBlock)
+	assert.Equal(t, err, process.ErrRootStateDoesNotMatch)
 
 	currHdr.Nonce = 0
 	prevHdr.Nonce = 0
@@ -3186,22 +3186,22 @@ func TestShardProcessor_IsHdrConstructionValid(t *testing.T) {
 	prevHdr.Nonce = 45
 	prevHdr.Round = currHdr.Round + 1
 	err = sp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrLowerRoundInOtherChainBlock)
+	assert.Equal(t, err, process.ErrLowerRoundInBlock)
 
 	prevHdr.Round = currHdr.Round - 1
 	currHdr.Nonce = prevHdr.Nonce + 2
 	err = sp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrWrongNonceInOtherChainBlock)
+	assert.Equal(t, err, process.ErrWrongNonceInBlock)
 
 	currHdr.Nonce = prevHdr.Nonce + 1
 	currHdr.PrevHash = []byte("wronghash")
 	err = sp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrHashDoesNotMatchInOtherChainBlock)
+	assert.Equal(t, err, process.ErrBlockHashDoesNotMatch)
 
 	prevHdr.RandSeed = []byte("randomwrong")
 	currHdr.PrevHash, _ = sp.ComputeHeaderHash(prevHdr)
 	err = sp.IsHdrConstructionValid(currHdr, prevHdr)
-	assert.Equal(t, err, process.ErrRandSeedDoesNotMatchInOtherChainBlock)
+	assert.Equal(t, err, process.ErrRandSeedDoesNotMatch)
 
 	currHdr.PrevHash = prevHash
 	prevHdr.RandSeed = currRandSeed

--- a/process/constants.go
+++ b/process/constants.go
@@ -33,6 +33,7 @@ const MetaBlockFinality = 1
 const MaxHeaderRequestsAllowed = 10
 const MaxItemsInBlock = 15000
 const MinItemsInBlock = 1000
+const MaxNoncesDifference = 5
 
 // TODO - calculate exactly in case of the VM, for every VM to have a similar constant, operations / seconds
 const MaxGasLimitPerMiniBlock = uint64(100000)

--- a/process/coordinator/process_test.go
+++ b/process/coordinator/process_test.go
@@ -1204,10 +1204,9 @@ func TestTransactionCoordinator_RestoreBlockDataFromStorage(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, tc)
 
-	nrTxs, mbs, err := tc.RestoreBlockDataFromStorage(nil)
+	nrTxs, err := tc.RestoreBlockDataFromStorage(nil)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, nrTxs)
-	assert.Equal(t, 0, len(mbs))
 
 	body := block.Body{}
 	miniBlock := &block.MiniBlock{SenderShardID: 1, ReceiverShardID: 0, Type: block.TxBlock, TxHashes: [][]byte{txHash}}
@@ -1216,9 +1215,8 @@ func TestTransactionCoordinator_RestoreBlockDataFromStorage(t *testing.T) {
 	tc.RequestBlockTransactions(body)
 	err = tc.SaveBlockDataToStorage(body)
 	assert.Nil(t, err)
-	nrTxs, mbs, err = tc.RestoreBlockDataFromStorage(body)
+	nrTxs, err = tc.RestoreBlockDataFromStorage(body)
 	assert.Equal(t, 1, nrTxs)
-	assert.Equal(t, 1, len(mbs))
 	assert.Nil(t, err)
 
 	txHashToAsk := []byte("tx_hashnotinPool")
@@ -1228,9 +1226,8 @@ func TestTransactionCoordinator_RestoreBlockDataFromStorage(t *testing.T) {
 	err = tc.SaveBlockDataToStorage(body)
 	assert.Equal(t, process.ErrMissingTransaction, err)
 
-	nrTxs, mbs, err = tc.RestoreBlockDataFromStorage(body)
+	nrTxs, err = tc.RestoreBlockDataFromStorage(body)
 	assert.Equal(t, 1, nrTxs)
-	assert.Equal(t, 1, len(mbs))
 	assert.NotNil(t, err)
 }
 

--- a/process/errors.go
+++ b/process/errors.go
@@ -235,6 +235,9 @@ var ErrNilMiniBlockPool = errors.New("nil mini block pool")
 // ErrNilMetaBlockPool signals that a nil meta blocks pool was used
 var ErrNilMetaBlockPool = errors.New("nil meta block pool")
 
+// ErrNilShardBlockPool signals that a nil shard blocks pool was used
+var ErrNilShardBlockPool = errors.New("nil shard block pool")
+
 // ErrNilTxProcessor signals that a nil transactions processor was used
 var ErrNilTxProcessor = errors.New("nil transactions processor")
 

--- a/process/errors.go
+++ b/process/errors.go
@@ -91,11 +91,14 @@ var ErrNilRootHash = errors.New("root hash is nil")
 // ErrWrongNonceInBlock signals the nonce in block is different than expected nonce
 var ErrWrongNonceInBlock = errors.New("wrong nonce in block")
 
-// ErrBlockHashDoesNotMatch signals the hash of the block is not matching with the previous one
+// ErrWrongNonceInOtherChainBlock signals the nonce in block is different than expected nonce
+var ErrWrongNonceInOtherChainBlock = errors.New("wrong nonce in other chain block")
+
+// ErrBlockHashDoesNotMatch signals that header hash does not match with the previous one
 var ErrBlockHashDoesNotMatch = errors.New("block hash does not match")
 
-// ErrHashDoesNotMatchInOtherChainBlock signals that header hash for one shard is not match with the previous one
-var ErrHashDoesNotMatchInOtherChainBlock = errors.New("block hash does not match with the last committed for this shard")
+// ErrHashDoesNotMatchInOtherChainBlock signals that header hash does not match with the previous one
+var ErrHashDoesNotMatchInOtherChainBlock = errors.New("block hash does not match in other chain block")
 
 // ErrMissingTransaction signals that one transaction is missing
 var ErrMissingTransaction = errors.New("missing transaction")
@@ -106,8 +109,11 @@ var ErrMarshalWithoutSuccess = errors.New("marshal without success")
 // ErrUnmarshalWithoutSuccess signals that unmarshal some data was not done with success
 var ErrUnmarshalWithoutSuccess = errors.New("unmarshal without success")
 
-// ErrRootStateMissmatch signals that persist some data was not done with success
-var ErrRootStateMissmatch = errors.New("root state does not match")
+// ErrRootStateDoesNotMatch signals that root state does not match
+var ErrRootStateDoesNotMatch = errors.New("root state does not match")
+
+// ErrRootStateDoesNotMatchInOtherChainBlock signals that root state does not match
+var ErrRootStateDoesNotMatchInOtherChainBlock = errors.New("root state does not match in other chain block")
 
 // ErrAccountStateDirty signals that the accounts were modified before starting the current modification
 var ErrAccountStateDirty = errors.New("accountState was dirty before starting to change")
@@ -292,14 +298,17 @@ var ErrNilPrevRandSeed = errors.New("provided previous rand seed is nil")
 // ErrNilRequestHeaderHandlerByNonce signals that a nil header request handler by nonce func was provided
 var ErrNilRequestHeaderHandlerByNonce = errors.New("nil request header handler by nonce")
 
-// ErrLowerRoundInOtherChainBlock signals that header round for one shard is too low for processing it
-var ErrLowerRoundInOtherChainBlock = errors.New("header round is lower than last committed for this shard")
+// ErrLowerRoundInOtherChainBlock signals that header round too low for processing it
+var ErrLowerRoundInOtherChainBlock = errors.New("header round is lower than last committed in other chain block")
 
-// ErrLowerRoundInBlock signals that a header round is too low for processing
+// ErrLowerRoundInBlock signals that a header round is too low for processing it
 var ErrLowerRoundInBlock = errors.New("header round is lower than last committed")
 
-// ErrRandSeedMismatch signals that random seeds are not equal
-var ErrRandSeedMismatch = errors.New("random seeds do not match")
+// ErrRandSeedDoesNotMatch signals that random seed does not match with the previous one
+var ErrRandSeedDoesNotMatch = errors.New("random seed do not match")
+
+// ErrRandSeedDoesNotMatchInOtherChainBlock signals that seed does not match with the previous one
+var ErrRandSeedDoesNotMatchInOtherChainBlock = errors.New("random seed does not match in other chain block")
 
 // ErrHeaderNotFinal signals that header is not final and it should be
 var ErrHeaderNotFinal = errors.New("header in metablock is not final")

--- a/process/errors.go
+++ b/process/errors.go
@@ -97,8 +97,8 @@ var ErrWrongNonceInOtherChainBlock = errors.New("wrong nonce in other chain bloc
 // ErrBlockHashDoesNotMatch signals that header hash does not match with the previous one
 var ErrBlockHashDoesNotMatch = errors.New("block hash does not match")
 
-// ErrHashDoesNotMatchInOtherChainBlock signals that header hash does not match with the previous one
-var ErrHashDoesNotMatchInOtherChainBlock = errors.New("block hash does not match in other chain block")
+// ErrBlockHashDoesNotMatchInOtherChainBlock signals that header hash does not match with the previous one
+var ErrBlockHashDoesNotMatchInOtherChainBlock = errors.New("block hash does not match in other chain block")
 
 // ErrMissingTransaction signals that one transaction is missing
 var ErrMissingTransaction = errors.New("missing transaction")

--- a/process/interface.go
+++ b/process/interface.go
@@ -55,7 +55,7 @@ type TransactionCoordinator interface {
 	IsDataPreparedForProcessing(haveTime func() time.Duration) error
 
 	SaveBlockDataToStorage(body block.Body) error
-	RestoreBlockDataFromStorage(body block.Body) (int, map[int][][]byte, error)
+	RestoreBlockDataFromStorage(body block.Body) (int, error)
 	RemoveBlockDataFromPool(body block.Body) error
 
 	ProcessBlockTransaction(body block.Body, round uint64, haveTime func() time.Duration) error
@@ -98,7 +98,7 @@ type PreProcessor interface {
 	IsDataPrepared(requestedTxs int, haveTime func() time.Duration) error
 
 	RemoveTxBlockFromPools(body block.Body, miniBlockPool storage.Cacher) error
-	RestoreTxBlockIntoPools(body block.Body, miniBlockPool storage.Cacher) (int, map[int][]byte, error)
+	RestoreTxBlockIntoPools(body block.Body, miniBlockPool storage.Cacher) (int, error)
 	SaveTxBlockToStorage(body block.Body) error
 
 	ProcessBlockTransactions(body block.Body, round uint64, haveTime func() time.Duration) error

--- a/process/mock/preprocessorMock.go
+++ b/process/mock/preprocessorMock.go
@@ -12,7 +12,7 @@ type PreProcessorMock struct {
 	CreateBlockStartedCalled              func()
 	IsDataPreparedCalled                  func(requestedTxs int, haveTime func() time.Duration) error
 	RemoveTxBlockFromPoolsCalled          func(body block.Body, miniBlockPool storage.Cacher) error
-	RestoreTxBlockIntoPoolsCalled         func(body block.Body, miniBlockPool storage.Cacher) (int, map[int][]byte, error)
+	RestoreTxBlockIntoPoolsCalled         func(body block.Body, miniBlockPool storage.Cacher) (int, error)
 	SaveTxBlockToStorageCalled            func(body block.Body) error
 	ProcessBlockTransactionsCalled        func(body block.Body, round uint64, haveTime func() time.Duration) error
 	RequestBlockTransactionsCalled        func(body block.Body) int
@@ -44,9 +44,9 @@ func (ppm *PreProcessorMock) RemoveTxBlockFromPools(body block.Body, miniBlockPo
 	return ppm.RemoveTxBlockFromPoolsCalled(body, miniBlockPool)
 }
 
-func (ppm *PreProcessorMock) RestoreTxBlockIntoPools(body block.Body, miniBlockPool storage.Cacher) (int, map[int][]byte, error) {
+func (ppm *PreProcessorMock) RestoreTxBlockIntoPools(body block.Body, miniBlockPool storage.Cacher) (int, error) {
 	if ppm.RestoreTxBlockIntoPoolsCalled == nil {
-		return 0, nil, nil
+		return 0, nil
 	}
 	return ppm.RestoreTxBlockIntoPoolsCalled(body, miniBlockPool)
 }

--- a/process/mock/transactionCoordinatorMock.go
+++ b/process/mock/transactionCoordinatorMock.go
@@ -14,7 +14,7 @@ type TransactionCoordinatorMock struct {
 	RequestBlockTransactionsCalled                       func(body block.Body)
 	IsDataPreparedForProcessingCalled                    func(haveTime func() time.Duration) error
 	SaveBlockDataToStorageCalled                         func(body block.Body) error
-	RestoreBlockDataFromStorageCalled                    func(body block.Body) (int, map[int][][]byte, error)
+	RestoreBlockDataFromStorageCalled                    func(body block.Body) (int, error)
 	RemoveBlockDataFromPoolCalled                        func(body block.Body) error
 	ProcessBlockTransactionCalled                        func(body block.Body, round uint64, haveTime func() time.Duration) error
 	CreateBlockStartedCalled                             func()
@@ -65,9 +65,9 @@ func (tcm *TransactionCoordinatorMock) SaveBlockDataToStorage(body block.Body) e
 	return tcm.SaveBlockDataToStorageCalled(body)
 }
 
-func (tcm *TransactionCoordinatorMock) RestoreBlockDataFromStorage(body block.Body) (int, map[int][][]byte, error) {
+func (tcm *TransactionCoordinatorMock) RestoreBlockDataFromStorage(body block.Body) (int, error) {
 	if tcm.RestoreBlockDataFromStorageCalled == nil {
-		return 0, nil, nil
+		return 0, nil
 	}
 
 	return tcm.RestoreBlockDataFromStorageCalled(body)

--- a/process/sync/export_test.go
+++ b/process/sync/export_test.go
@@ -273,12 +273,8 @@ func (sbm *StorageBootstrapperMock) IsInterfaceNil() bool {
 	return false
 }
 
-func (sfd *shardForkDetector) CheckShardBlockValidity(header data.HeaderHandler, state process.BlockHeaderState) error {
-	return sfd.checkShardBlockValidity(header, state)
-}
-
-func (mfd *metaForkDetector) CheckMetaBlockValidity(header data.HeaderHandler, state process.BlockHeaderState) error {
-	return mfd.checkMetaBlockValidity(header, state)
+func (bfd *baseForkDetector) ShouldAddBlockInForkDetector(header data.HeaderHandler, state process.BlockHeaderState, finality int64) error {
+	return bfd.shouldAddBlockInForkDetector(header, state, finality)
 }
 
 func (bfd *baseForkDetector) SetProbableHighestNonce(nonce uint64) {

--- a/process/sync/export_test.go
+++ b/process/sync/export_test.go
@@ -272,3 +272,15 @@ func (sbm *StorageBootstrapperMock) IsInterfaceNil() bool {
 	}
 	return false
 }
+
+func (sfd *shardForkDetector) CheckShardBlockValidity(header data.HeaderHandler, state process.BlockHeaderState) error {
+	return sfd.checkShardBlockValidity(header, state)
+}
+
+func (mfd *metaForkDetector) CheckMetaBlockValidity(header data.HeaderHandler, state process.BlockHeaderState) error {
+	return mfd.checkMetaBlockValidity(header, state)
+}
+
+func (bfd *baseForkDetector) SetProbableHighestNonce(nonce uint64) {
+	bfd.setProbableHighestNonce(nonce)
+}

--- a/process/sync/metaForkDetector.go
+++ b/process/sync/metaForkDetector.go
@@ -54,7 +54,7 @@ func (mfd *metaForkDetector) AddHeader(
 		return err
 	}
 
-	err = mfd.checkMetaBlockValidity(header, state)
+	err = mfd.shouldAddBlockInForkDetector(header, state, process.MetaBlockFinality)
 	if err != nil {
 		return err
 	}
@@ -75,21 +75,6 @@ func (mfd *metaForkDetector) AddHeader(
 	probableHighestNonce := mfd.computeProbableHighestNonce()
 	mfd.setLastBlockRound(uint64(mfd.rounder.Index()))
 	mfd.setProbableHighestNonce(probableHighestNonce)
-
-	return nil
-}
-
-func (mfd *metaForkDetector) checkMetaBlockValidity(header data.HeaderHandler, state process.BlockHeaderState) error {
-	noncesDifference := int64(mfd.ProbableHighestNonce()) - int64(header.GetNonce())
-	isSyncing := state == process.BHReceived && noncesDifference > process.MaxNoncesDifference
-	if state == process.BHProcessed || isSyncing {
-		return nil
-	}
-
-	roundTooOld := int64(header.GetRound()) < mfd.rounder.Index()-process.MetaBlockFinality
-	if roundTooOld {
-		return ErrLowerRoundInBlock
-	}
 
 	return nil
 }

--- a/process/sync/metaForkDetector.go
+++ b/process/sync/metaForkDetector.go
@@ -80,7 +80,8 @@ func (mfd *metaForkDetector) AddHeader(
 }
 
 func (mfd *metaForkDetector) checkMetaBlockValidity(header data.HeaderHandler, state process.BlockHeaderState) error {
-	isSyncing := state == process.BHReceived && mfd.ProbableHighestNonce()-header.GetNonce() > process.MaxNoncesDifference
+	noncesDifference := int64(mfd.ProbableHighestNonce()) - int64(header.GetNonce())
+	isSyncing := state == process.BHReceived && noncesDifference > process.MaxNoncesDifference
 	if state == process.BHProcessed || isSyncing {
 		return nil
 	}

--- a/process/sync/shardForkDetector.go
+++ b/process/sync/shardForkDetector.go
@@ -100,7 +100,8 @@ func (sfd *shardForkDetector) addFinalHeaders(finalHeaders []data.HeaderHandler,
 }
 
 func (sfd *shardForkDetector) checkShardBlockValidity(header data.HeaderHandler, state process.BlockHeaderState) error {
-	isSyncing := state == process.BHReceived && sfd.ProbableHighestNonce()-header.GetNonce() > process.MaxNoncesDifference
+	noncesDifference := int64(sfd.ProbableHighestNonce()) - int64(header.GetNonce())
+	isSyncing := state == process.BHReceived && noncesDifference > process.MaxNoncesDifference
 	if state == process.BHProcessed || isSyncing {
 		return nil
 	}

--- a/process/sync/shardForkDetector.go
+++ b/process/sync/shardForkDetector.go
@@ -54,7 +54,7 @@ func (sfd *shardForkDetector) AddHeader(
 		return err
 	}
 
-	err = sfd.checkShardBlockValidity(header, state)
+	err = sfd.shouldAddBlockInForkDetector(header, state, process.ShardBlockFinality)
 	if err != nil {
 		return err
 	}
@@ -97,19 +97,4 @@ func (sfd *shardForkDetector) addFinalHeaders(finalHeaders []data.HeaderHandler,
 			})
 		}
 	}
-}
-
-func (sfd *shardForkDetector) checkShardBlockValidity(header data.HeaderHandler, state process.BlockHeaderState) error {
-	noncesDifference := int64(sfd.ProbableHighestNonce()) - int64(header.GetNonce())
-	isSyncing := state == process.BHReceived && noncesDifference > process.MaxNoncesDifference
-	if state == process.BHProcessed || isSyncing {
-		return nil
-	}
-
-	roundTooOld := int64(header.GetRound()) < sfd.rounder.Index()-process.ShardBlockFinality
-	if roundTooOld {
-		return ErrLowerRoundInBlock
-	}
-
-	return nil
 }


### PR DESCRIPTION
**process/block**

* Added and refactored some print info which were confusing
* Added a new header request by hash on process block, if the new block does not pass the check block validity because of its previous hash
* Replaced the old method getOrderedHdrs with a new one getFinalityAttestingHeaders which is more efficient and solves one edge case, when requested final header has a higher round than current one at which the node reached with its bootstrap mechanism

**process/block/preprocess and process/coordinator**

* Removed some unused old code and refactored methods which were affected by it
* Changed the old mechanism which creates many miniblocks from the same sender to the same receiver (now the txs pool is sorted once per round)

**process/sync**

* Fixed an edge case in fork detector when nodes which are bootstrapping would not add blocks in theirs fork detector mechanism because of the too old round. Added unit tests for this.
* Added the same method which checks block validity in metaForkDetector, also in the shardForkDetector, to reject blocks which came from rounds older than last round (this fix would avoid intentionally attacks with valid blocks which are not broadcast by proposer fore some rounds)
