### PR TITLE
Trailing comma in cross block height string

### DIFF
--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -598,6 +598,9 @@ func (mp *metaProcessor) saveMetricCrossCheckBlockHeight() {
 
 		crossCheckBlockHeight += fmt.Sprintf("%d: %d", i, valueStored)
 	}
+	if len(crossCheckBlockHeight) > 0 { // append a trailing comma for better fetching of data
+		crossCheckBlockHeight += fmt.Sprintf(",")
+	}
 
 	mp.appStatusHandler.SetStringValue(core.MetricCrossCheckBlockHeight, crossCheckBlockHeight)
 }

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -592,14 +592,7 @@ func (mp *metaProcessor) saveMetricCrossCheckBlockHeight() {
 			continue
 		}
 
-		if i > 0 {
-			crossCheckBlockHeight += ", "
-		}
-
-		crossCheckBlockHeight += fmt.Sprintf("%d: %d", i, valueStored)
-	}
-	if len(crossCheckBlockHeight) > 0 { // append a trailing comma for better fetching of data
-		crossCheckBlockHeight += fmt.Sprintf(",")
+		crossCheckBlockHeight += fmt.Sprintf("%d: %d, ", i, valueStored)
 	}
 
 	mp.appStatusHandler.SetStringValue(core.MetricCrossCheckBlockHeight, crossCheckBlockHeight)


### PR DESCRIPTION
- added a trailing comma in the string representing the blocks heights notarized by metachain for all shards. This will help fetching the data further 