### PR TITLE
removed concurrent issue on rewardTxProcessor.goL245

### DIFF
--- a/process/block/preprocess/rewardTxPreProcessor.go
+++ b/process/block/preprocess/rewardTxPreProcessor.go
@@ -242,10 +242,12 @@ func (rtp *rewardTxPreprocessor) AddComputedRewardMiniBlocks(computedRewardMinib
 				log.Error(process.ErrWrongTypeAssertion.Error())
 			}
 
+			rtp.rewardTxsForBlock.mutTxsForBlock.Lock()
 			rtp.rewardTxsForBlock.txHashAndInfo[string(txHash)] = &txInfo{
 				tx:          rTx,
 				txShardInfo: txShardData,
 			}
+			rtp.rewardTxsForBlock.mutTxsForBlock.Unlock()
 		}
 	}
 }


### PR DESCRIPTION
removed concurrent issue on elrond-go/process/block/preprocess/rewardTxProcessor.go line 245

function AddComputedRewardMiniBlocks now protects rtp.rewardTxsForBlock.txHashAndInfo map write access.