### PR TITLE
transaction fee calculation refactor:

### DIFF
--- a/data/rewardTx/rewardTx.go
+++ b/data/rewardTx/rewardTx.go
@@ -18,22 +18,22 @@ type RewardTx struct {
 }
 
 // Save saves the serialized data of a RewardTx into a stream through Capnp protocol
-func (scr *RewardTx) Save(w io.Writer) error {
+func (rtx *RewardTx) Save(w io.Writer) error {
 	seg := capn.NewBuffer(nil)
-	RewardTxGoToCapn(seg, scr)
+	RewardTxGoToCapn(seg, rtx)
 	_, err := seg.WriteTo(w)
 	return err
 }
 
 // Load loads the data from the stream into a RewardTx object through Capnp protocol
-func (scr *RewardTx) Load(r io.Reader) error {
+func (rtx *RewardTx) Load(r io.Reader) error {
 	capMsg, err := capn.ReadFromStream(r, nil)
 	if err != nil {
 		return err
 	}
 
 	z := capnp.ReadRootRewardTxCapn(capMsg)
-	RewardTxCapnToGo(z, scr)
+	RewardTxCapnToGo(z, rtx)
 	return nil
 }
 

--- a/data/rewardTx/rewardTx.go
+++ b/data/rewardTx/rewardTx.go
@@ -76,44 +76,44 @@ func RewardTxGoToCapn(seg *capn.Segment, src *RewardTx) capnp.RewardTxCapn {
 }
 
 // IsInterfaceNil verifies if underlying object is nil
-func (scr *RewardTx) IsInterfaceNil() bool {
-	return scr == nil
+func (rtx *RewardTx) IsInterfaceNil() bool {
+	return rtx == nil
 }
 
 // GetValue returns the value of the reward transaction
-func (scr *RewardTx) GetValue() *big.Int {
-	return scr.Value
+func (rtx *RewardTx) GetValue() *big.Int {
+	return rtx.Value
 }
 
 // GetData returns the data of the reward transaction
-func (scr *RewardTx) GetData() string {
+func (rtx *RewardTx) GetData() string {
 	return ""
 }
 
 // GetRecvAddress returns the receiver address from the reward transaction
-func (scr *RewardTx) GetRecvAddress() []byte {
-	return scr.RcvAddr
+func (rtx *RewardTx) GetRecvAddress() []byte {
+	return rtx.RcvAddr
 }
 
 // GetSndAddress returns the sender address from the reward transaction
-func (scr *RewardTx) GetSndAddress() []byte {
+func (rtx *RewardTx) GetSndAddress() []byte {
 	return nil
 }
 
 // SetValue sets the value of the reward transaction
-func (scr *RewardTx) SetValue(value *big.Int) {
-	scr.Value = value
+func (rtx *RewardTx) SetValue(value *big.Int) {
+	rtx.Value = value
 }
 
 // SetData sets the data of the reward transaction
-func (scr *RewardTx) SetData(data string) {
+func (rtx *RewardTx) SetData(data string) {
 }
 
 // SetRecvAddress sets the receiver address of the reward transaction
-func (scr *RewardTx) SetRecvAddress(addr []byte) {
-	scr.RcvAddr = addr
+func (rtx *RewardTx) SetRecvAddress(addr []byte) {
+	rtx.RcvAddr = addr
 }
 
 // SetSndAddress sets the sender address of the reward transaction
-func (scr *RewardTx) SetSndAddress(addr []byte) {
+func (rtx *RewardTx) SetSndAddress(addr []byte) {
 }

--- a/data/transaction/transaction.go
+++ b/data/transaction/transaction.go
@@ -139,3 +139,13 @@ func (tx *Transaction) SetRecvAddress(addr []byte) {
 func (tx *Transaction) SetSndAddress(addr []byte) {
 	tx.SndAddr = addr
 }
+
+// GetGasLimit returns the provided gas limit in the transaction
+func (tx *Transaction) GetGasLimit() uint64 {
+	return tx.GasLimit
+}
+
+// GetGasPrice returns the provided gas price in the transaction
+func (tx *Transaction) GetGasPrice() uint64 {
+	return tx.GasPrice
+}

--- a/integrationTests/mock/feeHandlerStub.go
+++ b/integrationTests/mock/feeHandlerStub.go
@@ -7,11 +7,11 @@ import (
 )
 
 type FeeHandlerStub struct {
-	SetMinGasPriceCalled  func(minasPrice uint64)
-	SetMinGasLimitCalled  func(minGasLimit uint64)
-	ComputeGasLimitCalled func(tx process.TransactionWithFeeHandler) uint64
-	ComputeFeeCalled      func(tx process.TransactionWithFeeHandler) *big.Int
-	CheckTxHandlerCalled  func(tx process.TransactionWithFeeHandler) error
+	SetMinGasPriceCalled        func(minasPrice uint64)
+	SetMinGasLimitCalled        func(minGasLimit uint64)
+	ComputeGasLimitCalled       func(tx process.TransactionWithFeeHandler) uint64
+	ComputeFeeCalled            func(tx process.TransactionWithFeeHandler) *big.Int
+	CheckValidityTxValuesCalled func(tx process.TransactionWithFeeHandler) error
 }
 
 func (fhs *FeeHandlerStub) SetMinGasPrice(minGasPrice uint64) {
@@ -30,8 +30,8 @@ func (fhs *FeeHandlerStub) ComputeFee(tx process.TransactionWithFeeHandler) *big
 	return fhs.ComputeFeeCalled(tx)
 }
 
-func (fhs *FeeHandlerStub) CheckTxHandler(tx process.TransactionWithFeeHandler) error {
-	return fhs.CheckTxHandlerCalled(tx)
+func (fhs *FeeHandlerStub) CheckValidityTxValues(tx process.TransactionWithFeeHandler) error {
+	return fhs.CheckValidityTxValuesCalled(tx)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/integrationTests/mock/feeHandlerStub.go
+++ b/integrationTests/mock/feeHandlerStub.go
@@ -1,21 +1,37 @@
 package mock
 
+import (
+	"math/big"
+
+	"github.com/ElrondNetwork/elrond-go/process"
+)
+
 type FeeHandlerStub struct {
-	MinGasPriceCalled func() uint64
-	MinGasLimitCalled func() uint64
-	MinTxFeeCalled    func() uint64
+	SetMinGasPriceCalled  func(minasPrice uint64)
+	SetMinGasLimitCalled  func(minGasLimit uint64)
+	ComputeGasLimitCalled func(tx process.TransactionWithFeeHandler) uint64
+	ComputeFeeCalled      func(tx process.TransactionWithFeeHandler) *big.Int
+	CheckTxHandlerCalled  func(tx process.TransactionWithFeeHandler) error
 }
 
-func (fhs *FeeHandlerStub) MinGasPrice() uint64 {
-	return fhs.MinGasPriceCalled()
+func (fhs *FeeHandlerStub) SetMinGasPrice(minGasPrice uint64) {
+	fhs.SetMinGasPriceCalled(minGasPrice)
 }
 
-func (fhs *FeeHandlerStub) MinGasLimit() uint64 {
-	return fhs.MinGasLimitCalled()
+func (fhs *FeeHandlerStub) SetMinGasLimit(minGasLimit uint64) {
+	fhs.SetMinGasLimitCalled(minGasLimit)
 }
 
-func (fhs *FeeHandlerStub) MinTxFee() uint64 {
-	return fhs.MinTxFeeCalled()
+func (fhs *FeeHandlerStub) ComputeGasLimit(tx process.TransactionWithFeeHandler) uint64 {
+	return fhs.ComputeGasLimitCalled(tx)
+}
+
+func (fhs *FeeHandlerStub) ComputeFee(tx process.TransactionWithFeeHandler) *big.Int {
+	return fhs.ComputeFeeCalled(tx)
+}
+
+func (fhs *FeeHandlerStub) CheckTxHandler(tx process.TransactionWithFeeHandler) error {
+	return fhs.CheckTxHandlerCalled(tx)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/integrationTests/multiShard/block/executingRewardMiniblocks_test.go
+++ b/integrationTests/multiShard/block/executingRewardMiniblocks_test.go
@@ -52,7 +52,14 @@ func TestExecuteBlocksWithTransactionsAndCheckRewards(t *testing.T) {
 		seedAddress,
 	)
 
+	gasPrice := uint64(10)
+	gasLimit := uint64(100)
+	valToTransfer := big.NewInt(100)
+	nbTxsPerShard := uint32(100)
+	mintValue := big.NewInt(1000000)
+
 	for _, nodes := range nodesMap {
+		integrationTests.SetEconomicsParameters(nodes, gasPrice, gasLimit)
 		integrationTests.DisplayAndStartNodes(nodes)
 	}
 
@@ -64,12 +71,6 @@ func TestExecuteBlocksWithTransactionsAndCheckRewards(t *testing.T) {
 			}
 		}
 	}()
-
-	gasPrice := uint64(10)
-	gasLimit := uint64(100)
-	valToTransfer := big.NewInt(100)
-	nbTxsPerShard := uint32(100)
-	mintValue := big.NewInt(1000000)
 
 	generateIntraShardTransactions(nodesMap, nbTxsPerShard, mintValue, valToTransfer, gasPrice, gasLimit)
 

--- a/integrationTests/multiShard/smartContract/testInitializer.go
+++ b/integrationTests/multiShard/smartContract/testInitializer.go
@@ -281,7 +281,7 @@ func createMockTxFeeHandler() process.FeeHandler {
 
 			return fee
 		},
-		CheckTxHandlerCalled: func(tx process.TransactionWithFeeHandler) error {
+		CheckValidityTxValuesCalled: func(tx process.TransactionWithFeeHandler) error {
 			return nil
 		},
 	}

--- a/integrationTests/singleShard/transaction/interceptedResolvedTx_test.go
+++ b/integrationTests/singleShard/transaction/interceptedResolvedTx_test.go
@@ -54,14 +54,14 @@ func TestNode_RequestInterceptTransactionWithMessenger(t *testing.T) {
 	//Step 1. Generate a signed transaction
 	txData := "tx notarized data"
 	//TODO change here when gas limit will no longer be linear with the tx data length
-	txNotarizedDataGasLimit := uint64(len(txData))
+	txDataCost := uint64(len(txData))
 	tx := transaction.Transaction{
 		Nonce:    0,
 		Value:    big.NewInt(0),
 		RcvAddr:  integrationTests.TestHasher.Compute("receiver"),
 		SndAddr:  buffPk1,
 		Data:     txData,
-		GasLimit: integrationTests.MinTxGasLimit + txNotarizedDataGasLimit,
+		GasLimit: integrationTests.MinTxGasLimit + txDataCost,
 		GasPrice: integrationTests.MinTxGasPrice,
 	}
 

--- a/integrationTests/singleShard/transaction/interceptedResolvedTx_test.go
+++ b/integrationTests/singleShard/transaction/interceptedResolvedTx_test.go
@@ -52,13 +52,17 @@ func TestNode_RequestInterceptTransactionWithMessenger(t *testing.T) {
 	valMinting := big.NewInt(100000)
 	integrationTests.CreateMintingForSenders([]*integrationTests.TestProcessorNode{nRequester}, 0, []crypto.PrivateKey{nRequester.OwnAccount.SkTxSign}, valMinting)
 	//Step 1. Generate a signed transaction
+	txData := "tx notarized data"
+	//TODO change here when gas limit will no longer be linear with the tx data length
+	txNotarizedDataGasLimit := uint64(len(txData))
 	tx := transaction.Transaction{
 		Nonce:    0,
 		Value:    big.NewInt(0),
 		RcvAddr:  integrationTests.TestHasher.Compute("receiver"),
 		SndAddr:  buffPk1,
-		Data:     "tx notarized data",
-		GasLimit: integrationTests.MinTxGasLimit,
+		Data:     txData,
+		GasLimit: integrationTests.MinTxGasLimit + txNotarizedDataGasLimit,
+		GasPrice: integrationTests.MinTxGasPrice,
 	}
 
 	txBuff, _ := integrationTests.TestMarshalizer.Marshal(&tx)

--- a/integrationTests/state/stateExecTransaction_test.go
+++ b/integrationTests/state/stateExecTransaction_test.go
@@ -44,7 +44,7 @@ func TestExecTransaction_SelfTransactionShouldWork(t *testing.T) {
 	hashAfterExec, _ := accnts.Commit()
 	assert.NotEqual(t, hashCreated, hashAfterExec)
 
-	balance = balance.Sub(balance, big.NewInt(0).SetUint64(tx.GasPrice*tx.GasLimit))
+	balance.Sub(balance, big.NewInt(0).SetUint64(tx.GasPrice*tx.GasLimit))
 
 	accountAfterExec, _ := accnts.GetAccountWithJournal(address)
 	assert.Equal(t, nonce+1, accountAfterExec.(*state.Account).Nonce)

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -435,7 +435,7 @@ func CreateSimpleTxProcessor(accnts state.AccountsAdapter) process.TransactionPr
 			ComputeGasLimitCalled: func(tx process.TransactionWithFeeHandler) uint64 {
 				return tx.GetGasLimit()
 			},
-			CheckTxHandlerCalled: func(tx process.TransactionWithFeeHandler) error {
+			CheckValidityTxValuesCalled: func(tx process.TransactionWithFeeHandler) error {
 				return nil
 			},
 			ComputeFeeCalled: func(tx process.TransactionWithFeeHandler) *big.Int {

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -432,14 +432,17 @@ func CreateSimpleTxProcessor(accnts state.AccountsAdapter) process.TransactionPr
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
 		&mock.FeeHandlerStub{
-			MinGasPriceCalled: func() uint64 {
-				return 0
+			ComputeGasLimitCalled: func(tx process.TransactionWithFeeHandler) uint64 {
+				return tx.GetGasLimit()
 			},
-			MinGasLimitCalled: func() uint64 {
-				return 5
+			CheckTxHandlerCalled: func(tx process.TransactionWithFeeHandler) error {
+				return nil
 			},
-			MinTxFeeCalled: func() uint64 {
-				return 0
+			ComputeFeeCalled: func(tx process.TransactionWithFeeHandler) *big.Int {
+				fee := big.NewInt(0).SetUint64(tx.GetGasLimit())
+				fee.Mul(fee, big.NewInt(0).SetUint64(tx.GetGasPrice()))
+
+				return fee
 			},
 		},
 	)
@@ -719,6 +722,14 @@ func DisplayAndStartNodes(nodes []*TestProcessorNode) {
 
 	fmt.Println("Delaying for node bootstrap and topic announcement...")
 	time.Sleep(p2pBootstrapStepDelay)
+}
+
+// SetEconomicsParameters will set minGasPrice and minGasLimits to provided nodes
+func SetEconomicsParameters(nodes []*TestProcessorNode, minGasPrice uint64, minGasLimit uint64) {
+	for _, n := range nodes {
+		n.EconomicsData.SetMinGasPrice(minGasPrice)
+		n.EconomicsData.SetMinGasLimit(minGasLimit)
+	}
 }
 
 // GenerateAndDisseminateTxs generates and sends multiple txs

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -102,7 +102,7 @@ type TestProcessorNode struct {
 	BlockChain    data.ChainHandler
 	GenesisBlocks map[uint32]data.HeaderHandler
 
-	EconomicsData *economics.EconomicsData
+	EconomicsData *economics.TestEconomicsData
 
 	InterceptorsContainer process.InterceptorsContainer
 	ResolversContainer    dataRetriever.ResolversContainer
@@ -277,7 +277,9 @@ func (tpn *TestProcessorNode) initEconomicsData() {
 		},
 	)
 
-	tpn.EconomicsData = economicsData
+	tpn.EconomicsData = &economics.TestEconomicsData{
+		EconomicsData: economicsData,
+	}
 }
 
 func (tpn *TestProcessorNode) initInterceptors() {
@@ -382,7 +384,7 @@ func (tpn *TestProcessorNode) initInnerProcessors() {
 		tpn.SpecialAddressHandler,
 		tpn.Storage,
 		tpn.ShardDataPool,
-		tpn.EconomicsData,
+		tpn.EconomicsData.EconomicsData,
 	)
 
 	tpn.InterimProcContainer, _ = interimProcFactory.Create()

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -431,17 +431,7 @@ func (tpn *TestProcessorNode) initInnerProcessors() {
 		tpn.ScProcessor,
 		rewardsHandler,
 		txTypeHandler,
-		&mock.FeeHandlerStub{
-			MinGasPriceCalled: func() uint64 {
-				return 0
-			},
-			MinGasLimitCalled: func() uint64 {
-				return 5
-			},
-			MinTxFeeCalled: func() uint64 {
-				return 0
-			},
-		},
+		tpn.EconomicsData,
 	)
 
 	fact, _ := shard.NewPreProcessorsContainerFactory(
@@ -458,17 +448,7 @@ func (tpn *TestProcessorNode) initInnerProcessors() {
 		tpn.ScProcessor.(process.SmartContractResultProcessor),
 		tpn.RewardsProcessor,
 		internalTxProducer,
-		&mock.FeeHandlerStub{
-			MinGasPriceCalled: func() uint64 {
-				return 0
-			},
-			MinGasLimitCalled: func() uint64 {
-				return 5
-			},
-			MinTxFeeCalled: func() uint64 {
-				return 0
-			},
-		},
+		tpn.EconomicsData,
 	)
 	tpn.PreProcessorsContainer, _ = fact.Create()
 

--- a/process/block/preprocess/transactions.go
+++ b/process/block/preprocess/transactions.go
@@ -519,7 +519,7 @@ func (txs *transactions) CreateAndProcessMiniBlock(
 			continue
 		}
 
-		currTxGasLimit := txs.economicsFee.MinGasLimit()
+		currTxGasLimit := txs.economicsFee.ComputeGasLimit(orderedTxs[index])
 		if isSmartContractAddress(orderedTxs[index].RcvAddr) {
 			currTxGasLimit = orderedTxs[index].GasLimit
 		}

--- a/process/block/preprocess/transactions_test.go
+++ b/process/block/preprocess/transactions_test.go
@@ -27,15 +27,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func FeeHandlerMock() *mock.FeeHandlerStub {
+func feeHandlerMock() *mock.FeeHandlerStub {
 	return &mock.FeeHandlerStub{
-		MinGasPriceCalled: func() uint64 {
-			return 0
-		},
-		MinGasLimitCalled: func() uint64 {
-			return 5
-		},
-		MinTxFeeCalled: func() uint64 {
+		ComputeGasLimitCalled: func(tx process.TransactionWithFeeHandler) uint64 {
 			return 0
 		},
 	}
@@ -201,7 +195,7 @@ func TestTxsPreprocessor_NewTransactionPreprocessorNilPool(t *testing.T) {
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Nil(t, txs)
@@ -222,7 +216,7 @@ func TestTxsPreprocessor_NewTransactionPreprocessorNilStore(t *testing.T) {
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Nil(t, txs)
@@ -243,7 +237,7 @@ func TestTxsPreprocessor_NewTransactionPreprocessorNilHasher(t *testing.T) {
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Nil(t, txs)
@@ -264,7 +258,7 @@ func TestTxsPreprocessor_NewTransactionPreprocessorNilMarsalizer(t *testing.T) {
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Nil(t, txs)
@@ -285,7 +279,7 @@ func TestTxsPreprocessor_NewTransactionPreprocessorNilTxProce(t *testing.T) {
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Nil(t, txs)
@@ -306,7 +300,7 @@ func TestTxsPreprocessor_NewTransactionPreprocessorNilShardCoord(t *testing.T) {
 		nil,
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Nil(t, txs)
@@ -327,7 +321,7 @@ func TestTxsPreprocessor_NewTransactionPreprocessorNilAccounts(t *testing.T) {
 		mock.NewMultiShardsCoordinatorMock(3),
 		nil,
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Nil(t, txs)
@@ -347,7 +341,7 @@ func TestTxsPreprocessor_NewTransactionPreprocessorNilRequestFunc(t *testing.T) 
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		nil,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Nil(t, txs)
@@ -367,7 +361,7 @@ func TestTxsPreProcessor_GetTransactionFromPool(t *testing.T) {
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 	txHash := []byte("tx1_hash")
 	tx, _ := process.GetTransactionHandlerFromPool(1, 1, txHash, tdp.Transactions())
@@ -389,7 +383,7 @@ func TestTransactionPreprocessor_RequestTransactionFromNetwork(t *testing.T) {
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 	shardId := uint32(1)
 	txHash1 := []byte("tx_hash1")
@@ -417,7 +411,7 @@ func TestTransactionPreprocessor_RequestBlockTransactionFromMiniBlockFromNetwork
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	shardId := uint32(1)
@@ -460,7 +454,7 @@ func TestTransactionPreprocessor_ReceivedTransactionShouldEraseRequested(t *test
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	//add 3 tx hashes on requested list
@@ -534,7 +528,7 @@ func TestTransactionPreprocessor_GetAllTxsFromMiniBlockShouldWork(t *testing.T) 
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	mb := &block.MiniBlock{
@@ -569,7 +563,7 @@ func TestTransactionPreprocessor_RemoveBlockTxsFromPoolNilBlockShouldErr(t *test
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 	err := txs.RemoveTxBlockFromPools(nil, tdp.MiniBlocks())
 	assert.NotNil(t, err)
@@ -589,7 +583,7 @@ func TestTransactionPreprocessor_RemoveBlockTxsFromPoolOK(t *testing.T) {
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 	body := make(block.Body, 0)
 	txHash := []byte("txHash")
@@ -624,7 +618,7 @@ func TestTransactions_CreateAndProcessMiniBlockCrossShardGasLimitAddAll(t *testi
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 	assert.NotNil(t, txs)
 
@@ -667,7 +661,7 @@ func TestTransactions_CreateAndProcessMiniBlockCrossShardGasLimitAddAllAsNoSCCal
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 	assert.NotNil(t, txs)
 
@@ -712,7 +706,7 @@ func TestTransactions_CreateAndProcessMiniBlockCrossShardGasLimitAddOnly5asSCCal
 		mock.NewMultiShardsCoordinatorMock(3),
 		&mock.AccountsStub{},
 		requestTransaction,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 	assert.NotNil(t, txs)
 

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -17,9 +17,11 @@ import (
 	"github.com/ElrondNetwork/elrond-go/data/blockchain"
 	"github.com/ElrondNetwork/elrond-go/data/smartContractResult"
 	"github.com/ElrondNetwork/elrond-go/data/transaction"
+	"github.com/ElrondNetwork/elrond-go/data/typeConverters/uint64ByteSlice"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever/dataPool"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever/shardedData"
 	"github.com/ElrondNetwork/elrond-go/hashing"
-	"github.com/ElrondNetwork/elrond-go/integrationTests"
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/process"
 	blproc "github.com/ElrondNetwork/elrond-go/process/block"
@@ -28,8 +30,44 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process/mock"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 	"github.com/ElrondNetwork/elrond-go/storage"
+	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
 	"github.com/stretchr/testify/assert"
 )
+
+func createTestShardDataPool() dataRetriever.PoolsHolder {
+	txPool, _ := shardedData.NewShardedData(storageUnit.CacheConfig{Size: 100000, Type: storageUnit.LRUCache, Shards: 1})
+
+	uTxPool, _ := shardedData.NewShardedData(storageUnit.CacheConfig{Size: 100000, Type: storageUnit.LRUCache, Shards: 1})
+	rewardsTxPool, _ := shardedData.NewShardedData(storageUnit.CacheConfig{Size: 300, Type: storageUnit.LRUCache, Shards: 1})
+	cacherCfg := storageUnit.CacheConfig{Size: 100, Type: storageUnit.LRUCache, Shards: 1}
+	hdrPool, _ := storageUnit.NewCache(cacherCfg.Type, cacherCfg.Size, cacherCfg.Shards)
+
+	cacherCfg = storageUnit.CacheConfig{Size: 100000, Type: storageUnit.LRUCache, Shards: 1}
+	hdrNoncesCacher, _ := storageUnit.NewCache(cacherCfg.Type, cacherCfg.Size, cacherCfg.Shards)
+	hdrNonces, _ := dataPool.NewNonceSyncMapCacher(hdrNoncesCacher, uint64ByteSlice.NewBigEndianConverter())
+
+	cacherCfg = storageUnit.CacheConfig{Size: 100000, Type: storageUnit.LRUCache, Shards: 1}
+	txBlockBody, _ := storageUnit.NewCache(cacherCfg.Type, cacherCfg.Size, cacherCfg.Shards)
+
+	cacherCfg = storageUnit.CacheConfig{Size: 100000, Type: storageUnit.LRUCache, Shards: 1}
+	peerChangeBlockBody, _ := storageUnit.NewCache(cacherCfg.Type, cacherCfg.Size, cacherCfg.Shards)
+
+	cacherCfg = storageUnit.CacheConfig{Size: 100000, Type: storageUnit.LRUCache, Shards: 1}
+	metaBlocks, _ := storageUnit.NewCache(cacherCfg.Type, cacherCfg.Size, cacherCfg.Shards)
+
+	dPool, _ := dataPool.NewShardedDataPool(
+		txPool,
+		uTxPool,
+		rewardsTxPool,
+		hdrPool,
+		hdrNonces,
+		txBlockBody,
+		peerChangeBlockBody,
+		metaBlocks,
+	)
+
+	return dPool
+}
 
 //------- NewShardProcessor
 
@@ -2456,7 +2494,7 @@ func TestShardProcessor_ReceivedMetaBlockShouldRequestMissingMiniBlocks(t *testi
 
 	hasher := mock.HasherMock{}
 	marshalizer := &mock.MarshalizerMock{}
-	dataPool := mock.NewPoolsHolderMock()
+	datapool := mock.NewPoolsHolderMock()
 
 	//we will have a metablock that will return 3 miniblock hashes
 	//1 miniblock hash will be in cache
@@ -2481,9 +2519,9 @@ func TestShardProcessor_ReceivedMetaBlockShouldRequestMissingMiniBlocks(t *testi
 
 	//put this metaBlock inside datapool
 	metaBlockHash := []byte("metablock hash")
-	dataPool.MetaBlocks().Put(metaBlockHash, metaBlock)
+	datapool.MetaBlocks().Put(metaBlockHash, metaBlock)
 	//put the existing miniblock inside datapool
-	dataPool.MiniBlocks().Put(miniBlockHash1, &block.MiniBlock{})
+	datapool.MiniBlocks().Put(miniBlockHash1, &block.MiniBlock{})
 
 	miniBlockHash1Requested := int32(0)
 	miniBlockHash2Requested := int32(0)
@@ -2504,14 +2542,14 @@ func TestShardProcessor_ReceivedMetaBlockShouldRequestMissingMiniBlocks(t *testi
 	tc, _ := coordinator.NewTransactionCoordinator(
 		mock.NewMultiShardsCoordinatorMock(3),
 		initAccountsMock(),
-		dataPool,
+		datapool,
 		requestHandler,
 		&mock.PreProcessorContainerMock{},
 		&mock.InterimProcessorContainerMock{},
 	)
 
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.DataPool = dataPool
+	arguments.DataPool = datapool
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
 	arguments.RequestHandler = requestHandler
@@ -2534,7 +2572,7 @@ func TestShardProcessor_ReceivedMetaBlockNoMissingMiniBlocksShouldPass(t *testin
 
 	hasher := mock.HasherMock{}
 	marshalizer := &mock.MarshalizerMock{}
-	dataPool := mock.NewPoolsHolderMock()
+	datapool := mock.NewPoolsHolderMock()
 
 	//we will have a metablock that will return 3 miniblock hashes
 	//1 miniblock hash will be in cache
@@ -2546,18 +2584,23 @@ func TestShardProcessor_ReceivedMetaBlockNoMissingMiniBlocksShouldPass(t *testin
 		Nonce: 1,
 		Round: 1,
 		ShardInfo: []block.ShardData{
-			block.ShardData{
+			{
 				ShardId: 1,
 				ShardMiniBlockHeaders: []block.ShardMiniBlockHeader{
-					block.ShardMiniBlockHeader{Hash: miniBlockHash1, SenderShardId: 1, ReceiverShardId: 0},
-				}},
+					{
+						Hash:            miniBlockHash1,
+						SenderShardId:   1,
+						ReceiverShardId: 0,
+					},
+				},
+			},
 		}}
 
 	//put this metaBlock inside datapool
 	metaBlockHash := []byte("metablock hash")
-	dataPool.MetaBlocks().Put(metaBlockHash, &metaBlock)
+	datapool.MetaBlocks().Put(metaBlockHash, &metaBlock)
 	//put the existing miniblock inside datapool
-	dataPool.MiniBlocks().Put(miniBlockHash1, &block.MiniBlock{})
+	datapool.MiniBlocks().Put(miniBlockHash1, &block.MiniBlock{})
 
 	noOfMissingMiniBlocks := int32(0)
 
@@ -2568,14 +2611,14 @@ func TestShardProcessor_ReceivedMetaBlockNoMissingMiniBlocksShouldPass(t *testin
 	tc, _ := coordinator.NewTransactionCoordinator(
 		mock.NewMultiShardsCoordinatorMock(3),
 		initAccountsMock(),
-		dataPool,
+		datapool,
 		requestHandler,
 		&mock.PreProcessorContainerMock{},
 		&mock.InterimProcessorContainerMock{},
 	)
 
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.DataPool = dataPool
+	arguments.DataPool = datapool
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
 	arguments.RequestHandler = requestHandler
@@ -2770,7 +2813,7 @@ func TestShardProcessor_CreateMiniBlocksShouldWorkWithIntraShardTxs(t *testing.T
 
 	hasher := mock.HasherMock{}
 	marshalizer := &mock.MarshalizerMock{}
-	dataPool := mock.NewPoolsHolderMock()
+	datapool := mock.NewPoolsHolderMock()
 
 	//we will have a 3 txs in pool
 
@@ -2787,15 +2830,15 @@ func TestShardProcessor_CreateMiniBlocksShouldWorkWithIntraShardTxs(t *testing.T
 
 	//put the existing tx inside datapool
 	cacheId := process.ShardCacherIdentifier(senderShardId, receiverShardId)
-	dataPool.Transactions().AddData(txHash1, &transaction.Transaction{
+	datapool.Transactions().AddData(txHash1, &transaction.Transaction{
 		Nonce: tx1Nonce,
 		Data:  string(txHash1),
 	}, cacheId)
-	dataPool.Transactions().AddData(txHash2, &transaction.Transaction{
+	datapool.Transactions().AddData(txHash2, &transaction.Transaction{
 		Nonce: tx2Nonce,
 		Data:  string(txHash2),
 	}, cacheId)
-	dataPool.Transactions().AddData(txHash3, &transaction.Transaction{
+	datapool.Transactions().AddData(txHash3, &transaction.Transaction{
 		Nonce: tx3Nonce,
 		Data:  string(txHash3),
 	}, cacheId)
@@ -2836,7 +2879,7 @@ func TestShardProcessor_CreateMiniBlocksShouldWorkWithIntraShardTxs(t *testing.T
 		initStore(),
 		marshalizer,
 		hasher,
-		dataPool,
+		datapool,
 		&mock.AddressConverterMock{},
 		accntAdapter,
 		&mock.RequestHandlerMock{},
@@ -2846,7 +2889,7 @@ func TestShardProcessor_CreateMiniBlocksShouldWorkWithIntraShardTxs(t *testing.T
 		&mock.RewardTxProcessorMock{},
 		&mock.IntermediateTransactionHandlerMock{},
 		&mock.FeeHandlerStub{
-			MinGasLimitCalled: func() uint64 {
+			ComputeGasLimitCalled: func(tx process.TransactionWithFeeHandler) uint64 {
 				return 0
 			},
 		},
@@ -2856,14 +2899,14 @@ func TestShardProcessor_CreateMiniBlocksShouldWorkWithIntraShardTxs(t *testing.T
 	tc, err := coordinator.NewTransactionCoordinator(
 		mock.NewMultiShardsCoordinatorMock(3),
 		accntAdapter,
-		dataPool,
+		datapool,
 		&mock.RequestHandlerMock{},
 		container,
 		&mock.InterimProcessorContainerMock{},
 	)
 
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.DataPool = dataPool
+	arguments.DataPool = datapool
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
 	arguments.Accounts = accntAdapter
@@ -2898,7 +2941,7 @@ func TestShardProcessor_GetProcessedMetaBlockFromPoolShouldWork(t *testing.T) {
 
 	hasher := mock.HasherMock{}
 	marshalizer := &mock.MarshalizerMock{}
-	dataPool := mock.NewPoolsHolderMock()
+	datapool := mock.NewPoolsHolderMock()
 
 	miniblockHashes := make([][]byte, 6)
 
@@ -2911,19 +2954,19 @@ func TestShardProcessor_GetProcessedMetaBlockFromPoolShouldWork(t *testing.T) {
 	//put 3 metablocks in pool
 	metaBlockHash1 := []byte("meta block 1")
 	metaBlock1 := createDummyMetaBlock(destShardId, destShards[0], miniblockHashes[0], miniblockHashes[1])
-	dataPool.MetaBlocks().Put(
+	datapool.MetaBlocks().Put(
 		metaBlockHash1,
 		metaBlock1,
 	)
 	metaBlockHash2 := []byte("meta block 2")
 	metaBlock2 := createDummyMetaBlock(destShardId, destShards[1], miniblockHashes[2], miniblockHashes[3])
-	dataPool.MetaBlocks().Put(
+	datapool.MetaBlocks().Put(
 		metaBlockHash2,
 		metaBlock2,
 	)
 	metaBlockHash3 := []byte("meta block 3")
 	metaBlock3 := createDummyMetaBlock(destShardId, destShards[2], miniblockHashes[4], miniblockHashes[5])
-	dataPool.MetaBlocks().Put(
+	datapool.MetaBlocks().Put(
 		metaBlockHash3,
 		metaBlock3,
 	)
@@ -2933,7 +2976,7 @@ func TestShardProcessor_GetProcessedMetaBlockFromPoolShouldWork(t *testing.T) {
 	shardCoordinator.SetNoShards(destShardId + 1)
 
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.DataPool = dataPool
+	arguments.DataPool = datapool
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
 	arguments.ShardCoordinator = shardCoordinator
@@ -3005,7 +3048,7 @@ func TestShardProcessor_RestoreBlockIntoPoolsShouldWork(t *testing.T) {
 
 	txHash := []byte("tx hash 1")
 
-	dataPool := mock.NewPoolsHolderMock()
+	datapool := mock.NewPoolsHolderMock()
 	marshalizerMock := &mock.MarshalizerMock{}
 	hasherMock := &mock.HasherStub{}
 
@@ -3033,7 +3076,7 @@ func TestShardProcessor_RestoreBlockIntoPoolsShouldWork(t *testing.T) {
 		store,
 		marshalizerMock,
 		hasherMock,
-		dataPool,
+		datapool,
 		&mock.AddressConverterMock{},
 		initAccountsMock(),
 		&mock.RequestHandlerMock{},
@@ -3049,14 +3092,14 @@ func TestShardProcessor_RestoreBlockIntoPoolsShouldWork(t *testing.T) {
 	tc, err := coordinator.NewTransactionCoordinator(
 		mock.NewMultiShardsCoordinatorMock(3),
 		initAccountsMock(),
-		dataPool,
+		datapool,
 		&mock.RequestHandlerMock{},
 		container,
 		&mock.InterimProcessorContainerMock{},
 	)
 
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.DataPool = dataPool
+	arguments.DataPool = datapool
 	arguments.Store = store
 	arguments.Hasher = hasherMock
 	arguments.Marshalizer = marshalizerMock
@@ -3079,7 +3122,7 @@ func TestShardProcessor_RestoreBlockIntoPoolsShouldWork(t *testing.T) {
 
 	metablockHash := []byte("meta block hash 1")
 	metablockHeader := createDummyMetaBlock(0, 1, miniblockHash)
-	dataPool.MetaBlocks().Put(
+	datapool.MetaBlocks().Put(
 		metablockHash,
 		metablockHeader,
 	)
@@ -3099,8 +3142,8 @@ func TestShardProcessor_RestoreBlockIntoPoolsShouldWork(t *testing.T) {
 
 	err = sp.RestoreBlockIntoPools(&block.Header{MetaBlockHashes: [][]byte{metablockHash}, MiniBlockHeaders: []block.MiniBlockHeader{miniBlockHeader}}, body)
 
-	miniblockFromPool, _ := dataPool.MiniBlocks().Get(miniblockHash)
-	txFromPool, _ := dataPool.Transactions().SearchFirstData(txHash)
+	miniblockFromPool, _ := datapool.MiniBlocks().Get(miniblockHash)
+	txFromPool, _ := datapool.Transactions().SearchFirstData(txHash)
 	assert.Nil(t, err)
 	assert.Equal(t, &miniblock, miniblockFromPool)
 	assert.Equal(t, &tx, txFromPool)
@@ -3161,11 +3204,11 @@ func TestShardProcessor_IsHdrConstructionValid(t *testing.T) {
 
 	hasher := mock.HasherMock{}
 	marshalizer := &mock.MarshalizerMock{}
-	dataPool := initDataPool([]byte("tx_hash1"))
+	datapool := initDataPool([]byte("tx_hash1"))
 
 	shardNr := uint32(5)
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.DataPool = dataPool
+	arguments.DataPool = datapool
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
 	arguments.ShardCoordinator = mock.NewMultiShardsCoordinatorMock(shardNr)
@@ -3255,7 +3298,7 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 
 	hasher := mock.HasherMock{}
 	marshalizer := &mock.MarshalizerMock{}
-	dataPool := mock.NewPoolsHolderMock()
+	datapool := mock.NewPoolsHolderMock()
 	forkDetector := &mock.ForkDetectorMock{}
 	highNonce := uint64(500)
 	forkDetector.GetHighestFinalBlockNonceCalled = func() uint64 {
@@ -3272,7 +3315,7 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 
 	shardNr := uint32(5)
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.DataPool = dataPool
+	arguments.DataPool = datapool
 	arguments.Store = store
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
@@ -3332,7 +3375,7 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	assert.Equal(t, 0, len(processedMetaHdrs))
 
 	// wrong header type in pool and defer called
-	dataPool.MetaBlocks().Put(currHash, shardHdr)
+	datapool.MetaBlocks().Put(currHash, shardHdr)
 	sp.SetHdrForCurrentBlock(currHash, shardHdr, true)
 
 	hashes := make([][]byte, 0)
@@ -3353,8 +3396,8 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNoDstMB(t *testing.T) {
 	assert.Equal(t, firstNonce, sp.LastNotarizedHdrForShard(sharding.MetachainShardId).GetNonce())
 
 	// put headers in pool
-	dataPool.MetaBlocks().Put(currHash, currHdr)
-	dataPool.MetaBlocks().Put(prevHash, prevHdr)
+	datapool.MetaBlocks().Put(currHash, currHdr)
+	datapool.MetaBlocks().Put(prevHash, prevHdr)
 
 	sp.CreateBlockStarted()
 	sp.SetHdrForCurrentBlock(currHash, currHdr, true)
@@ -3407,7 +3450,7 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNotAllMBFinished(t *tes
 
 	hasher := mock.HasherMock{}
 	marshalizer := &mock.MarshalizerMock{}
-	dataPool := mock.NewPoolsHolderMock()
+	datapool := mock.NewPoolsHolderMock()
 	forkDetector := &mock.ForkDetectorMock{}
 	highNonce := uint64(500)
 	forkDetector.GetHighestFinalBlockNonceCalled = func() uint64 {
@@ -3425,7 +3468,7 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNotAllMBFinished(t *tes
 	shardNr := uint32(5)
 
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.DataPool = dataPool
+	arguments.DataPool = datapool
 	arguments.Store = store
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
@@ -3509,8 +3552,8 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrNotAllMBFinished(t *tes
 	prevHash, _ = sp.ComputeHeaderHash(prevHdr)
 
 	// put headers in pool
-	dataPool.MetaBlocks().Put(currHash, currHdr)
-	dataPool.MetaBlocks().Put(prevHash, prevHdr)
+	datapool.MetaBlocks().Put(currHash, currHdr)
+	datapool.MetaBlocks().Put(prevHash, prevHdr)
 
 	sp.SetHdrForCurrentBlock(currHash, currHdr, true)
 	sp.SetHdrForCurrentBlock(prevHash, prevHdr, true)
@@ -3538,7 +3581,7 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrAllMBFinished(t *testin
 
 	hasher := mock.HasherMock{}
 	marshalizer := &mock.MarshalizerMock{}
-	dataPool := mock.NewPoolsHolderMock()
+	datapool := mock.NewPoolsHolderMock()
 	forkDetector := &mock.ForkDetectorMock{}
 	highNonce := uint64(500)
 	forkDetector.GetHighestFinalBlockNonceCalled = func() uint64 {
@@ -3555,7 +3598,7 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrAllMBFinished(t *testin
 	shardNr := uint32(5)
 
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.DataPool = dataPool
+	arguments.DataPool = datapool
 	arguments.Store = store
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
@@ -3644,9 +3687,9 @@ func TestShardProcessor_RemoveAndSaveLastNotarizedMetaHdrAllMBFinished(t *testin
 	prevHash, _ = sp.ComputeHeaderHash(prevHdr)
 
 	// put headers in pool
-	dataPool.MetaBlocks().Put(currHash, currHdr)
-	dataPool.MetaBlocks().Put(prevHash, prevHdr)
-	dataPool.MetaBlocks().Put([]byte("shouldNotRemove"), &block.MetaBlock{
+	datapool.MetaBlocks().Put(currHash, currHdr)
+	datapool.MetaBlocks().Put(prevHash, prevHdr)
+	datapool.MetaBlocks().Put([]byte("shouldNotRemove"), &block.MetaBlock{
 		Round:        12,
 		PrevRandSeed: []byte("nextrand"),
 		PrevHash:     currHash,
@@ -3903,14 +3946,14 @@ func TestShardProcessor_GetHighestHdrForOwnShardFromMetachaiMetaHdrsWithoutOwnHd
 	t.Parallel()
 
 	processedHdrs := make([]data.HeaderHandler, 0)
-	dataPool := integrationTests.CreateTestShardDataPool(nil)
+	datapool := createTestShardDataPool()
 	store := initStore()
 	hasher := &mock.HasherMock{}
 	marshalizer := &mock.MarshalizerMock{}
 	genesisBlocks := createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3))
 
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.DataPool = dataPool
+	arguments.DataPool = datapool
 	arguments.Store = store
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
@@ -3920,7 +3963,7 @@ func TestShardProcessor_GetHighestHdrForOwnShardFromMetachaiMetaHdrsWithoutOwnHd
 
 	shardInfo := make([]block.ShardData, 0)
 	shardInfo = append(shardInfo, block.ShardData{HeaderHash: []byte("hash"), ShardId: 1})
-	_ = dataPool.Headers().Put([]byte("hash"), &block.Header{ShardId: 0, Nonce: 1})
+	_ = datapool.Headers().Put([]byte("hash"), &block.Header{ShardId: 0, Nonce: 1})
 
 	prevMetaHdr := genesisBlocks[sharding.MetachainShardId]
 	prevHash, _ := core.CalculateHash(marshalizer, hasher, prevMetaHdr)
@@ -3934,7 +3977,7 @@ func TestShardProcessor_GetHighestHdrForOwnShardFromMetachaiMetaHdrsWithoutOwnHd
 		ShardInfo:    shardInfo,
 	}
 	currHash, _ := core.CalculateHash(marshalizer, hasher, currMetaHdr)
-	_ = dataPool.MetaBlocks().Put(currHash, currMetaHdr)
+	_ = datapool.MetaBlocks().Put(currHash, currMetaHdr)
 	processedHdrs = append(processedHdrs, currMetaHdr)
 
 	prevMetaHdr = currMetaHdr
@@ -3949,7 +3992,7 @@ func TestShardProcessor_GetHighestHdrForOwnShardFromMetachaiMetaHdrsWithoutOwnHd
 		ShardInfo:    shardInfo,
 	}
 	currHash, _ = core.CalculateHash(marshalizer, hasher, currMetaHdr)
-	_ = dataPool.MetaBlocks().Put(currHash, currMetaHdr)
+	_ = datapool.MetaBlocks().Put(currHash, currMetaHdr)
 	processedHdrs = append(processedHdrs, currMetaHdr)
 
 	hdrs, _, _ := sp.GetHighestHdrForOwnShardFromMetachain(processedHdrs)
@@ -3962,14 +4005,14 @@ func TestShardProcessor_GetHighestHdrForOwnShardFromMetachaiMetaHdrsWithOwnHdrBu
 	t.Parallel()
 
 	processedHdrs := make([]data.HeaderHandler, 0)
-	dataPool := integrationTests.CreateTestShardDataPool(nil)
+	datapool := createTestShardDataPool()
 	store := initStore()
 	hasher := &mock.HasherMock{}
 	marshalizer := &mock.MarshalizerMock{}
 	genesisBlocks := createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3))
 
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.DataPool = dataPool
+	arguments.DataPool = datapool
 	arguments.Store = store
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
@@ -3992,7 +4035,7 @@ func TestShardProcessor_GetHighestHdrForOwnShardFromMetachaiMetaHdrsWithOwnHdrBu
 		ShardInfo:    shardInfo,
 	}
 	currHash, _ := core.CalculateHash(marshalizer, hasher, currMetaHdr)
-	_ = dataPool.MetaBlocks().Put(currHash, currMetaHdr)
+	_ = datapool.MetaBlocks().Put(currHash, currMetaHdr)
 	processedHdrs = append(processedHdrs, currMetaHdr)
 
 	prevMetaHdr = currMetaHdr
@@ -4007,7 +4050,7 @@ func TestShardProcessor_GetHighestHdrForOwnShardFromMetachaiMetaHdrsWithOwnHdrBu
 		ShardInfo:    shardInfo,
 	}
 	currHash, _ = core.CalculateHash(marshalizer, hasher, currMetaHdr)
-	_ = dataPool.MetaBlocks().Put(currHash, currMetaHdr)
+	_ = datapool.MetaBlocks().Put(currHash, currMetaHdr)
 	processedHdrs = append(processedHdrs, currMetaHdr)
 
 	hdrs, _, _ := sp.GetHighestHdrForOwnShardFromMetachain(processedHdrs)
@@ -4019,14 +4062,14 @@ func TestShardProcessor_GetHighestHdrForOwnShardFromMetachaiMetaHdrsWithOwnHdrSt
 	t.Parallel()
 
 	processedHdrs := make([]data.HeaderHandler, 0)
-	dataPool := integrationTests.CreateTestShardDataPool(nil)
+	datapool := createTestShardDataPool()
 	store := initStore()
 	hasher := &mock.HasherMock{}
 	marshalizer := &mock.MarshalizerMock{}
 	genesisBlocks := createGenesisBlocks(mock.NewMultiShardsCoordinatorMock(3))
 
 	arguments := CreateMockArgumentsMultiShard()
-	arguments.DataPool = dataPool
+	arguments.DataPool = datapool
 	arguments.Store = store
 	arguments.Hasher = hasher
 	arguments.Marshalizer = marshalizer
@@ -4039,7 +4082,7 @@ func TestShardProcessor_GetHighestHdrForOwnShardFromMetachaiMetaHdrsWithOwnHdrSt
 		Round: 1,
 	}
 	ownHash, _ := core.CalculateHash(marshalizer, hasher, ownHdr)
-	_ = dataPool.Headers().Put(ownHash, ownHdr)
+	_ = datapool.Headers().Put(ownHash, ownHdr)
 
 	shardInfo := make([]block.ShardData, 0)
 	shardInfo = append(shardInfo, block.ShardData{HeaderHash: ownHash, ShardId: 0})
@@ -4056,7 +4099,7 @@ func TestShardProcessor_GetHighestHdrForOwnShardFromMetachaiMetaHdrsWithOwnHdrSt
 		ShardInfo:    shardInfo,
 	}
 	currHash, _ := core.CalculateHash(marshalizer, hasher, currMetaHdr)
-	_ = dataPool.MetaBlocks().Put(currHash, currMetaHdr)
+	_ = datapool.MetaBlocks().Put(currHash, currMetaHdr)
 
 	ownHdr = &block.Header{
 		Nonce: 2,
@@ -4081,7 +4124,7 @@ func TestShardProcessor_GetHighestHdrForOwnShardFromMetachaiMetaHdrsWithOwnHdrSt
 		ShardInfo:    shardInfo,
 	}
 	currHash, _ = core.CalculateHash(marshalizer, hasher, currMetaHdr)
-	_ = dataPool.MetaBlocks().Put(currHash, currMetaHdr)
+	_ = datapool.MetaBlocks().Put(currHash, currMetaHdr)
 	processedHdrs = append(processedHdrs, currMetaHdr)
 
 	prevMetaHdr = currMetaHdr
@@ -4095,7 +4138,7 @@ func TestShardProcessor_GetHighestHdrForOwnShardFromMetachaiMetaHdrsWithOwnHdrSt
 		RandSeed:     prevMetaHdr.GetRandSeed(),
 	}
 	currHash, _ = core.CalculateHash(marshalizer, hasher, currMetaHdr)
-	_ = dataPool.MetaBlocks().Put(currHash, currMetaHdr)
+	_ = datapool.MetaBlocks().Put(currHash, currMetaHdr)
 	processedHdrs = append(processedHdrs, currMetaHdr)
 
 	hdrs, _, _ := sp.GetHighestHdrForOwnShardFromMetachain(processedHdrs)

--- a/process/coordinator/process_test.go
+++ b/process/coordinator/process_test.go
@@ -33,13 +33,7 @@ import (
 
 func FeeHandlerMock() *mock.FeeHandlerStub {
 	return &mock.FeeHandlerStub{
-		MinGasPriceCalled: func() uint64 {
-			return 0
-		},
-		MinGasLimitCalled: func() uint64 {
-			return 5
-		},
-		MinTxFeeCalled: func() uint64 {
+		ComputeGasLimitCalled: func(tx process.TransactionWithFeeHandler) uint64 {
 			return 0
 		},
 	}

--- a/process/economics/economicsData.go
+++ b/process/economics/economicsData.go
@@ -123,16 +123,6 @@ func (ed *EconomicsData) BurnPercentage() float64 {
 	return ed.burnPercentage
 }
 
-// SetMinGasPrice sets the minimum gas price for a transaction to be accepted
-func (ed *EconomicsData) SetMinGasPrice(minGasPrice uint64) {
-	ed.minGasPrice = minGasPrice
-}
-
-// SetMinGasLimit sets the minimum gas limit for a transaction to be accepted
-func (ed *EconomicsData) SetMinGasLimit(minGasLimit uint64) {
-	ed.minGasLimit = minGasLimit
-}
-
 // ComputeFee computes the provided transaction's fee
 func (ed *EconomicsData) ComputeFee(tx process.TransactionWithFeeHandler) *big.Int {
 	gasPrice := big.NewInt(0).SetUint64(tx.GetGasPrice())
@@ -141,8 +131,8 @@ func (ed *EconomicsData) ComputeFee(tx process.TransactionWithFeeHandler) *big.I
 	return gasPrice.Mul(gasPrice, gasLimit)
 }
 
-// CheckTxHandler checks if the provided transaction is economically correct
-func (ed *EconomicsData) CheckTxHandler(tx process.TransactionWithFeeHandler) error {
+// CheckValidityTxValues checks if the provided transaction is economically correct
+func (ed *EconomicsData) CheckValidityTxValues(tx process.TransactionWithFeeHandler) error {
 	if ed.minGasPrice > tx.GetGasPrice() {
 		return process.ErrInsufficientGasPriceInTx
 	}

--- a/process/economics/economicsData_test.go
+++ b/process/economics/economicsData_test.go
@@ -1,6 +1,7 @@
 package economics_test
 
 import (
+	"fmt"
 	"math/big"
 	"strconv"
 	"testing"
@@ -264,15 +265,15 @@ func TestEconomicsData_TxWithLowerGasPriceShouldErr(t *testing.T) {
 	minGasPrice := uint64(500)
 	minGasLimit := uint64(12)
 	economicsConfig := createDummyEconomicsConfig()
+	economicsConfig.FeeSettings.MinGasPrice = fmt.Sprintf("%d", minGasPrice)
+	economicsConfig.FeeSettings.MinGasLimit = fmt.Sprintf("%d", minGasLimit)
 	economicsData, _ := economics.NewEconomicsData(economicsConfig)
-	economicsData.SetMinGasLimit(minGasLimit)
-	economicsData.SetMinGasPrice(minGasPrice)
 	tx := &transaction.Transaction{
 		GasPrice: minGasPrice - 1,
 		GasLimit: minGasLimit,
 	}
 
-	err := economicsData.CheckTxHandler(tx)
+	err := economicsData.CheckValidityTxValues(tx)
 
 	assert.Equal(t, process.ErrInsufficientGasPriceInTx, err)
 }
@@ -283,15 +284,15 @@ func TestEconomicsData_TxWithLowerGasLimitShouldErr(t *testing.T) {
 	minGasPrice := uint64(500)
 	minGasLimit := uint64(12)
 	economicsConfig := createDummyEconomicsConfig()
+	economicsConfig.FeeSettings.MinGasPrice = fmt.Sprintf("%d", minGasPrice)
+	economicsConfig.FeeSettings.MinGasLimit = fmt.Sprintf("%d", minGasLimit)
 	economicsData, _ := economics.NewEconomicsData(economicsConfig)
-	economicsData.SetMinGasLimit(minGasLimit)
-	economicsData.SetMinGasPrice(minGasPrice)
 	tx := &transaction.Transaction{
 		GasPrice: minGasPrice,
 		GasLimit: minGasLimit - 1,
 	}
 
-	err := economicsData.CheckTxHandler(tx)
+	err := economicsData.CheckValidityTxValues(tx)
 
 	assert.Equal(t, process.ErrInsufficientGasLimitInTx, err)
 }
@@ -302,15 +303,15 @@ func TestEconomicsData_TxWithWithEqualGasPriceLimitShouldWork(t *testing.T) {
 	minGasPrice := uint64(500)
 	minGasLimit := uint64(12)
 	economicsConfig := createDummyEconomicsConfig()
+	economicsConfig.FeeSettings.MinGasPrice = fmt.Sprintf("%d", minGasPrice)
+	economicsConfig.FeeSettings.MinGasLimit = fmt.Sprintf("%d", minGasLimit)
 	economicsData, _ := economics.NewEconomicsData(economicsConfig)
-	economicsData.SetMinGasLimit(minGasLimit)
-	economicsData.SetMinGasPrice(minGasPrice)
 	tx := &transaction.Transaction{
 		GasPrice: minGasPrice,
 		GasLimit: minGasLimit,
 	}
 
-	err := economicsData.CheckTxHandler(tx)
+	err := economicsData.CheckValidityTxValues(tx)
 
 	assert.Nil(t, err)
 }
@@ -321,15 +322,15 @@ func TestEconomicsData_TxWithWithMoreGasPriceLimitShouldWork(t *testing.T) {
 	minGasPrice := uint64(500)
 	minGasLimit := uint64(12)
 	economicsConfig := createDummyEconomicsConfig()
+	economicsConfig.FeeSettings.MinGasPrice = fmt.Sprintf("%d", minGasPrice)
+	economicsConfig.FeeSettings.MinGasLimit = fmt.Sprintf("%d", minGasLimit)
 	economicsData, _ := economics.NewEconomicsData(economicsConfig)
-	economicsData.SetMinGasLimit(minGasLimit)
-	economicsData.SetMinGasPrice(minGasPrice)
 	tx := &transaction.Transaction{
 		GasPrice: minGasPrice + 1,
 		GasLimit: minGasLimit + 1,
 	}
 
-	err := economicsData.CheckTxHandler(tx)
+	err := economicsData.CheckValidityTxValues(tx)
 
 	assert.Nil(t, err)
 }

--- a/process/economics/testEconomicsData.go
+++ b/process/economics/testEconomicsData.go
@@ -1,0 +1,18 @@
+package economics
+
+// TestEconomicsData extends EconomicsData and is used in integration tests as it exposes some functions
+// that are not supposed to be used in production code
+// Exported functions simplify the reproduction of edge cases
+type TestEconomicsData struct {
+	*EconomicsData
+}
+
+// SetMinGasPrice sets the minimum gas price for a transaction to be accepted
+func (ted *TestEconomicsData) SetMinGasPrice(minGasPrice uint64) {
+	ted.minGasPrice = minGasPrice
+}
+
+// SetMinGasLimit sets the minimum gas limit for a transaction to be accepted
+func (ted *TestEconomicsData) SetMinGasLimit(minGasLimit uint64) {
+	ted.minGasLimit = minGasLimit
+}

--- a/process/errors.go
+++ b/process/errors.go
@@ -316,9 +316,6 @@ var ErrMintAddressNotInThisShard = errors.New("mint address does not belong to c
 // ErrNotarizedHdrsSliceIsNil signals that the slice holding last notarized headers is nil
 var ErrNotarizedHdrsSliceIsNil = errors.New("notarized shard headers slice is nil")
 
-// ErrNoSortedHdrsForShard signals that there are no sorted hdrs in pool
-var ErrNoSortedHdrsForShard = errors.New("no sorted headers in pool")
-
 // ErrCrossShardMBWithoutConfirmationFromMeta signals that miniblock was not yet notarized by metachain
 var ErrCrossShardMBWithoutConfirmationFromMeta = errors.New("cross shard miniblock with destination current shard is not confirmed by metachain")
 
@@ -442,9 +439,6 @@ var ErrNilHeaderHandlerValidator = errors.New("nil header handler validator prov
 // ErrNilAppStatusHandler defines the error for setting a nil AppStatusHandler
 var ErrNilAppStatusHandler = errors.New("nil AppStatusHandler")
 
-// ErrNotEnoughFeeInTransactions signals that the transaction does not enough fee
-var ErrNotEnoughFeeInTransactions = errors.New("transaction fee is not enough")
-
 // ErrNilUnsignedTxHandler signals that the unsigned tx handler is nil
 var ErrNilUnsignedTxHandler = errors.New("nil unsigned tx handler")
 
@@ -505,5 +499,5 @@ var ErrInvalidMinimumGasLimitForTx = errors.New("invalid minimum gas limit for t
 // ErrInvalidRewardsValue signals that an invalid rewards value has been read from config file
 var ErrInvalidRewardsValue = errors.New("invalid rewards value")
 
-// ErrInvalidRewardsPercentages signal that rewards percentages are not correct
+// ErrInvalidRewardsPercentages signals that rewards percentages are not correct
 var ErrInvalidRewardsPercentages = errors.New("invalid rewards percentages")

--- a/process/interface.go
+++ b/process/interface.go
@@ -416,11 +416,21 @@ type RewardsHandler interface {
 	IsInterfaceNil() bool
 }
 
-// FeeHandler will return information about fees
+// FeeHandler is able to perform some economics calculation on a provided transaction
 type FeeHandler interface {
-	MinGasPrice() uint64
-	MinGasLimit() uint64
+	SetMinGasPrice(minGasPrice uint64)
+	SetMinGasLimit(minGasLimit uint64)
+	ComputeGasLimit(tx TransactionWithFeeHandler) uint64
+	ComputeFee(tx TransactionWithFeeHandler) *big.Int
+	CheckTxHandler(tx TransactionWithFeeHandler) error
 	IsInterfaceNil() bool
+}
+
+// TransactionWithFeeHandler represents a transaction structure that has economics variables defined
+type TransactionWithFeeHandler interface {
+	GetGasLimit() uint64
+	GetGasPrice() uint64
+	GetData() string
 }
 
 // EconomicsAddressesHandler will return information about economics addresses

--- a/process/interface.go
+++ b/process/interface.go
@@ -418,11 +418,9 @@ type RewardsHandler interface {
 
 // FeeHandler is able to perform some economics calculation on a provided transaction
 type FeeHandler interface {
-	SetMinGasPrice(minGasPrice uint64)
-	SetMinGasLimit(minGasLimit uint64)
 	ComputeGasLimit(tx TransactionWithFeeHandler) uint64
 	ComputeFee(tx TransactionWithFeeHandler) *big.Int
-	CheckTxHandler(tx TransactionWithFeeHandler) error
+	CheckValidityTxValues(tx TransactionWithFeeHandler) error
 	IsInterfaceNil() bool
 }
 

--- a/process/mock/feeHandlerStub.go
+++ b/process/mock/feeHandlerStub.go
@@ -1,21 +1,37 @@
 package mock
 
+import (
+	"math/big"
+
+	"github.com/ElrondNetwork/elrond-go/process"
+)
+
 type FeeHandlerStub struct {
-	MinGasPriceCalled func() uint64
-	MinGasLimitCalled func() uint64
-	MinTxFeeCalled    func() uint64
+	SetMinGasPriceCalled  func(minasPrice uint64)
+	SetMinGasLimitCalled  func(minGasLimit uint64)
+	ComputeGasLimitCalled func(tx process.TransactionWithFeeHandler) uint64
+	ComputeFeeCalled      func(tx process.TransactionWithFeeHandler) *big.Int
+	CheckTxHandlerCalled  func(tx process.TransactionWithFeeHandler) error
 }
 
-func (fhs *FeeHandlerStub) MinGasPrice() uint64 {
-	return fhs.MinGasPriceCalled()
+func (fhs *FeeHandlerStub) SetMinGasPrice(minGasPrice uint64) {
+	fhs.SetMinGasPriceCalled(minGasPrice)
 }
 
-func (fhs *FeeHandlerStub) MinGasLimit() uint64 {
-	return fhs.MinGasLimitCalled()
+func (fhs *FeeHandlerStub) SetMinGasLimit(minGasLimit uint64) {
+	fhs.SetMinGasLimitCalled(minGasLimit)
 }
 
-func (fhs *FeeHandlerStub) MinTxFee() uint64 {
-	return fhs.MinTxFeeCalled()
+func (fhs *FeeHandlerStub) ComputeGasLimit(tx process.TransactionWithFeeHandler) uint64 {
+	return fhs.ComputeGasLimitCalled(tx)
+}
+
+func (fhs *FeeHandlerStub) ComputeFee(tx process.TransactionWithFeeHandler) *big.Int {
+	return fhs.ComputeFeeCalled(tx)
+}
+
+func (fhs *FeeHandlerStub) CheckTxHandler(tx process.TransactionWithFeeHandler) error {
+	return fhs.CheckTxHandlerCalled(tx)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/process/mock/feeHandlerStub.go
+++ b/process/mock/feeHandlerStub.go
@@ -7,19 +7,11 @@ import (
 )
 
 type FeeHandlerStub struct {
-	SetMinGasPriceCalled  func(minasPrice uint64)
-	SetMinGasLimitCalled  func(minGasLimit uint64)
-	ComputeGasLimitCalled func(tx process.TransactionWithFeeHandler) uint64
-	ComputeFeeCalled      func(tx process.TransactionWithFeeHandler) *big.Int
-	CheckTxHandlerCalled  func(tx process.TransactionWithFeeHandler) error
-}
-
-func (fhs *FeeHandlerStub) SetMinGasPrice(minGasPrice uint64) {
-	fhs.SetMinGasPriceCalled(minGasPrice)
-}
-
-func (fhs *FeeHandlerStub) SetMinGasLimit(minGasLimit uint64) {
-	fhs.SetMinGasLimitCalled(minGasLimit)
+	SetMinGasPriceCalled        func(minasPrice uint64)
+	SetMinGasLimitCalled        func(minGasLimit uint64)
+	ComputeGasLimitCalled       func(tx process.TransactionWithFeeHandler) uint64
+	ComputeFeeCalled            func(tx process.TransactionWithFeeHandler) *big.Int
+	CheckValidityTxValuesCalled func(tx process.TransactionWithFeeHandler) error
 }
 
 func (fhs *FeeHandlerStub) ComputeGasLimit(tx process.TransactionWithFeeHandler) uint64 {
@@ -30,8 +22,8 @@ func (fhs *FeeHandlerStub) ComputeFee(tx process.TransactionWithFeeHandler) *big
 	return fhs.ComputeFeeCalled(tx)
 }
 
-func (fhs *FeeHandlerStub) CheckTxHandler(tx process.TransactionWithFeeHandler) error {
-	return fhs.CheckTxHandlerCalled(tx)
+func (fhs *FeeHandlerStub) CheckValidityTxValues(tx process.TransactionWithFeeHandler) error {
+	return fhs.CheckValidityTxValuesCalled(tx)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/process/transaction/interceptedTransaction.go
+++ b/process/transaction/interceptedTransaction.go
@@ -152,21 +152,7 @@ func (inTx *InterceptedTransaction) integrity() error {
 		return process.ErrNegativeValue
 	}
 
-	return inTx.checkFeeValues()
-}
-
-func (inTx *InterceptedTransaction) checkFeeValues() error {
-	isLowerGasLimitInTx := inTx.tx.GasLimit < inTx.feeHandler.MinGasLimit()
-	if isLowerGasLimitInTx {
-		return process.ErrInsufficientGasLimitInTx
-	}
-
-	isLowerGasPrice := inTx.tx.GasPrice < inTx.feeHandler.MinGasPrice()
-	if isLowerGasPrice {
-		return process.ErrInsufficientGasPriceInTx
-	}
-
-	return nil
+	return inTx.feeHandler.CheckTxHandler(inTx.tx)
 }
 
 // verifySig checks if the tx is correctly signed

--- a/process/transaction/interceptedTransaction.go
+++ b/process/transaction/interceptedTransaction.go
@@ -152,7 +152,7 @@ func (inTx *InterceptedTransaction) integrity() error {
 		return process.ErrNegativeValue
 	}
 
-	return inTx.feeHandler.CheckTxHandler(inTx.tx)
+	return inTx.feeHandler.CheckValidityTxValues(inTx.tx)
 }
 
 // verifySig checks if the tx is correctly signed

--- a/process/transaction/interceptedTransaction_test.go
+++ b/process/transaction/interceptedTransaction_test.go
@@ -49,7 +49,7 @@ func createKeyGenMock() crypto.KeyGenerator {
 
 func createFreeTxFeeHandler() process.FeeHandler {
 	return &mock.FeeHandlerStub{
-		CheckTxHandlerCalled: func(tx process.TransactionWithFeeHandler) error {
+		CheckValidityTxValuesCalled: func(tx process.TransactionWithFeeHandler) error {
 			return nil
 		},
 	}
@@ -442,7 +442,7 @@ func TestNewInterceptedTransaction_InsufficientFeeShouldErr(t *testing.T) {
 	}
 	errExpected := errors.New("insufficient fee")
 	feeHandler := &mock.FeeHandlerStub{
-		CheckTxHandlerCalled: func(tx process.TransactionWithFeeHandler) error {
+		CheckValidityTxValuesCalled: func(tx process.TransactionWithFeeHandler) error {
 			return errExpected
 		},
 	}

--- a/process/transaction/interceptedTransaction_test.go
+++ b/process/transaction/interceptedTransaction_test.go
@@ -47,21 +47,12 @@ func createKeyGenMock() crypto.KeyGenerator {
 	}
 }
 
-func createTxFeeHandler(gasPrice uint64, gasLimit uint64) process.FeeHandler {
-	feeHandler := &mock.FeeHandlerStub{
-		MinGasPriceCalled: func() uint64 {
-			return gasPrice
-		},
-		MinGasLimitCalled: func() uint64 {
-			return gasLimit
+func createFreeTxFeeHandler() process.FeeHandler {
+	return &mock.FeeHandlerStub{
+		CheckTxHandlerCalled: func(tx process.TransactionWithFeeHandler) error {
+			return nil
 		},
 	}
-
-	return feeHandler
-}
-
-func createFreeTxFeeHandler() process.FeeHandler {
-	return createTxFeeHandler(0, 0)
 }
 
 func createInterceptedTxFromPlainTx(tx *dataTransaction.Transaction, txFeeHandler process.FeeHandler) (*transaction.InterceptedTransaction, error) {
@@ -434,7 +425,7 @@ func TestNewInterceptedTransaction_InvalidSenderShouldErr(t *testing.T) {
 	assert.Equal(t, errSingleSignKeyGenMock, err)
 }
 
-func TestNewInterceptedTransaction_InsufficientGasPriceShouldErr(t *testing.T) {
+func TestNewInterceptedTransaction_InsufficientFeeShouldErr(t *testing.T) {
 	t.Parallel()
 
 	gasLimit := uint64(3)
@@ -449,35 +440,17 @@ func TestNewInterceptedTransaction_InsufficientGasPriceShouldErr(t *testing.T) {
 		SndAddr:   []byte(""),
 		Signature: sigOk,
 	}
-	feeHandler := createTxFeeHandler(gasPrice+1, gasLimit)
-
-	txi, err := createInterceptedTxFromPlainTx(tx, feeHandler)
-
-	assert.Nil(t, txi)
-	assert.Equal(t, process.ErrInsufficientGasPriceInTx, err)
-}
-
-func TestNewInterceptedTransaction_InsufficientGasLimitShouldErr(t *testing.T) {
-	t.Parallel()
-
-	gasLimit := uint64(3)
-	gasPrice := uint64(4)
-	tx := &dataTransaction.Transaction{
-		Nonce:     1,
-		Value:     big.NewInt(2),
-		Data:      "data",
-		GasLimit:  gasLimit,
-		GasPrice:  gasPrice,
-		RcvAddr:   recvAddress,
-		SndAddr:   []byte(""),
-		Signature: sigOk,
+	errExpected := errors.New("insufficient fee")
+	feeHandler := &mock.FeeHandlerStub{
+		CheckTxHandlerCalled: func(tx process.TransactionWithFeeHandler) error {
+			return errExpected
+		},
 	}
-	feeHandler := createTxFeeHandler(gasPrice, gasLimit+1)
 
 	txi, err := createInterceptedTxFromPlainTx(tx, feeHandler)
 
 	assert.Nil(t, txi)
-	assert.Equal(t, process.ErrInsufficientGasLimitInTx, err)
+	assert.Equal(t, errExpected, err)
 }
 
 func TestNewInterceptedTransaction_VerifyFailsShouldErr(t *testing.T) {

--- a/process/transaction/process.go
+++ b/process/transaction/process.go
@@ -125,7 +125,7 @@ func (txProc *txProcessor) processTxFee(tx *transaction.Transaction, acntSnd *st
 		return nil, nil
 	}
 
-	err := txProc.economicsFee.CheckTxHandler(tx)
+	err := txProc.economicsFee.CheckValidityTxValues(tx)
 	if err != nil {
 		return nil, err
 	}

--- a/process/transaction/process.go
+++ b/process/transaction/process.go
@@ -3,7 +3,6 @@ package transaction
 import (
 	"bytes"
 	"math/big"
-	"sync"
 
 	"github.com/ElrondNetwork/elrond-go/core/logger"
 	"github.com/ElrondNetwork/elrond-go/data/state"
@@ -27,7 +26,6 @@ type txProcessor struct {
 	shardCoordinator sharding.Coordinator
 	txTypeHandler    process.TxTypeHandler
 	economicsFee     process.FeeHandler
-	mutTxFee         sync.RWMutex
 }
 
 // NewTxProcessor creates a new txProcessor engine
@@ -81,7 +79,6 @@ func NewTxProcessor(
 		txFeeHandler:     txFeeHandler,
 		txTypeHandler:    txTypeHandler,
 		economicsFee:     economicsFee,
-		mutTxFee:         sync.RWMutex{},
 	}, nil
 }
 
@@ -128,29 +125,18 @@ func (txProc *txProcessor) processTxFee(tx *transaction.Transaction, acntSnd *st
 		return nil, nil
 	}
 
-	cost := big.NewInt(0)
-	cost = cost.Mul(big.NewInt(0).SetUint64(tx.GasPrice), big.NewInt(0).SetUint64(tx.GasLimit))
-
-	txDataLen := int64(len(tx.Data))
-	txProc.mutTxFee.RLock()
-	minTxFee := big.NewInt(0).SetUint64(txProc.economicsFee.MinGasLimit())
-	minTxFee.Mul(minTxFee, big.NewInt(0).SetUint64(txProc.economicsFee.MinGasPrice()))
-
-	minFee := big.NewInt(0)
-	minFee.Mul(big.NewInt(txDataLen), big.NewInt(0).SetUint64(txProc.economicsFee.MinGasPrice()))
-	minFee.Add(minFee, minTxFee)
-	txProc.mutTxFee.RUnlock()
-
-	if minFee.Cmp(cost) > 0 {
-		return nil, process.ErrNotEnoughFeeInTransactions
+	err := txProc.economicsFee.CheckTxHandler(tx)
+	if err != nil {
+		return nil, err
 	}
 
+	cost := txProc.economicsFee.ComputeFee(tx)
 	if acntSnd.Balance.Cmp(cost) < 0 {
 		return nil, process.ErrInsufficientFunds
 	}
 
 	operation := big.NewInt(0)
-	err := acntSnd.SetBalanceWithJournal(operation.Sub(acntSnd.Balance, cost))
+	err = acntSnd.SetBalanceWithJournal(operation.Sub(acntSnd.Balance, cost))
 	if err != nil {
 		return nil, err
 	}

--- a/process/transaction/process_test.go
+++ b/process/transaction/process_test.go
@@ -24,16 +24,13 @@ func generateRandomByteSlice(size int) []byte {
 	return buff
 }
 
-func FeeHandlerMock() *mock.FeeHandlerStub {
+func feeHandlerMock() *mock.FeeHandlerStub {
 	return &mock.FeeHandlerStub{
-		MinGasPriceCalled: func() uint64 {
-			return 0
+		CheckTxHandlerCalled: func(tx process.TransactionWithFeeHandler) error {
+			return nil
 		},
-		MinGasLimitCalled: func() uint64 {
-			return 5
-		},
-		MinTxFeeCalled: func() uint64 {
-			return 0
+		ComputeFeeCalled: func(tx process.TransactionWithFeeHandler) *big.Int {
+			return big.NewInt(0)
 		},
 	}
 }
@@ -68,7 +65,7 @@ func createTxProcessor() txproc.TxProcessor {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	return txProc
@@ -88,7 +85,7 @@ func TestNewTxProcessor_NilAccountsShouldErr(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Equal(t, process.ErrNilAccountsAdapter, err)
@@ -107,7 +104,7 @@ func TestNewTxProcessor_NilHasherShouldErr(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Equal(t, process.ErrNilHasher, err)
@@ -126,7 +123,7 @@ func TestNewTxProcessor_NilAddressConverterMockShouldErr(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Equal(t, process.ErrNilAddressConverter, err)
@@ -145,7 +142,7 @@ func TestNewTxProcessor_NilMarshalizerMockShouldErr(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Equal(t, process.ErrNilMarshalizer, err)
@@ -164,7 +161,7 @@ func TestNewTxProcessor_NilShardCoordinatorMockShouldErr(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Equal(t, process.ErrNilShardCoordinator, err)
@@ -183,7 +180,7 @@ func TestNewTxProcessor_NilSCProcessorShouldErr(t *testing.T) {
 		nil,
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Equal(t, process.ErrNilSmartContractProcessor, err)
@@ -202,7 +199,7 @@ func TestNewTxProcessor_NilTxFeeHandlerShouldErr(t *testing.T) {
 		&mock.SCProcessorMock{},
 		nil,
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Equal(t, process.ErrNilUnsignedTxHandler, err)
@@ -221,7 +218,7 @@ func TestNewTxProcessor_OkValsShouldWork(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	assert.Nil(t, err)
@@ -244,7 +241,7 @@ func TestTxProcessor_GetAddressErrAddressConvShouldErr(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	addressConv.Fail = true
@@ -286,7 +283,7 @@ func TestTxProcessor_GetAccountsShouldErrNilAddressContainer(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	adr1 := mock.NewAddressMock([]byte{65})
@@ -313,7 +310,7 @@ func TestTxProcessor_GetAccountsMalfunctionAccountsShouldErr(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	adr1 := mock.NewAddressMock([]byte{65})
@@ -357,7 +354,7 @@ func TestTxProcessor_GetAccountsOkValsSrcShouldWork(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	shardCoordinator.ComputeIdCalled = func(container state.AddressContainer) uint32 {
@@ -410,7 +407,7 @@ func TestTxProcessor_GetAccountsOkValsDsthouldWork(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	shardCoordinator.ComputeIdCalled = func(container state.AddressContainer) uint32 {
@@ -448,7 +445,7 @@ func TestTxProcessor_GetAccountsOkValsShouldWork(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	a1, a2, err := execTx.GetAccounts(adr1, adr2)
@@ -477,7 +474,7 @@ func TestTxProcessor_GetSameAccountShouldWork(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	a1, a2, err := execTx.GetAccounts(adr1, adr1)
@@ -720,7 +717,7 @@ func TestTxProcessor_ProcessTransactionErrAddressConvShouldErr(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	addressConv.Fail = true
@@ -743,7 +740,7 @@ func TestTxProcessor_ProcessTransactionMalfunctionAccountsShouldErr(t *testing.T
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	tx := transaction.Transaction{}
@@ -782,7 +779,7 @@ func TestTxProcessor_ProcessCheckNotPassShouldErr(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	err = execTx.ProcessTransaction(&tx, 4)
@@ -836,7 +833,7 @@ func TestTxProcessor_ProcessCheckShouldPassWhenAdrSrcIsNotInNodeShard(t *testing
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	err = execTx.ProcessTransaction(&tx, 4)
@@ -882,7 +879,7 @@ func TestTxProcessor_ProcessMoveBalancesShouldWork(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	err = execTx.ProcessTransaction(&tx, 4)
@@ -938,7 +935,7 @@ func TestTxProcessor_ProcessMoveBalancesShouldPassWhenAdrSrcIsNotInNodeShard(t *
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	err = execTx.ProcessTransaction(&tx, 4)
@@ -994,7 +991,7 @@ func TestTxProcessor_ProcessIncreaseNonceShouldPassWhenAdrSrcIsNotInNodeShard(t 
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	err = execTx.ProcessTransaction(&tx, 4)
@@ -1044,7 +1041,7 @@ func TestTxProcessor_ProcessOkValsShouldWork(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	err = execTx.ProcessTransaction(&tx, 4)
@@ -1088,6 +1085,16 @@ func TestTxProcessor_MoveBalanceWithFeesShouldWork(t *testing.T) {
 
 	accounts := createAccountStub(tx.SndAddr, tx.RcvAddr, acntSrc, acntDst)
 
+	txCost := big.NewInt(16)
+	feeHandler := &mock.FeeHandlerStub{
+		CheckTxHandlerCalled: func(tx process.TransactionWithFeeHandler) error {
+			return nil
+		},
+		ComputeFeeCalled: func(tx process.TransactionWithFeeHandler) *big.Int {
+			return txCost
+		},
+	}
+
 	execTx, _ := txproc.NewTxProcessor(
 		accounts,
 		mock.HasherMock{},
@@ -1097,13 +1104,13 @@ func TestTxProcessor_MoveBalanceWithFeesShouldWork(t *testing.T) {
 		&mock.SCProcessorMock{},
 		&mock.UnsignedTxHandlerMock{},
 		&mock.TxTypeHandlerMock{},
-		FeeHandlerMock(),
+		feeHandler,
 	)
 
 	err = execTx.ProcessTransaction(&tx, 4)
 	assert.Nil(t, err)
 	assert.Equal(t, uint64(5), acntSrc.Nonce)
-	assert.Equal(t, big.NewInt(25), acntSrc.Balance)
+	assert.Equal(t, big.NewInt(13), acntSrc.Balance)
 	assert.Equal(t, big.NewInt(71), acntDst.Balance)
 	assert.Equal(t, 4, journalizeCalled)
 	assert.Equal(t, 4, saveAccountCalled)
@@ -1165,7 +1172,7 @@ func TestTxProcessor_ProcessTransactionScTxShouldWork(t *testing.T) {
 				return process.SCInvoking, nil
 			},
 		},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	err = execTx.ProcessTransaction(&tx, 4)
@@ -1226,7 +1233,7 @@ func TestTxProcessor_ProcessTransactionScTxShouldReturnErrWhenExecutionFails(t *
 		&mock.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType process.TransactionType, e error) {
 			return process.SCInvoking, nil
 		}},
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	err = execTx.ProcessTransaction(&tx, 4)
@@ -1299,7 +1306,7 @@ func TestTxProcessor_ProcessTransactionScTxShouldNotBeCalledWhenAdrDstIsNotInNod
 		scProcessorMock,
 		&mock.UnsignedTxHandlerMock{},
 		computeType,
-		FeeHandlerMock(),
+		feeHandlerMock(),
 	)
 
 	err = execTx.ProcessTransaction(&tx, 4)

--- a/process/transaction/process_test.go
+++ b/process/transaction/process_test.go
@@ -26,7 +26,7 @@ func generateRandomByteSlice(size int) []byte {
 
 func feeHandlerMock() *mock.FeeHandlerStub {
 	return &mock.FeeHandlerStub{
-		CheckTxHandlerCalled: func(tx process.TransactionWithFeeHandler) error {
+		CheckValidityTxValuesCalled: func(tx process.TransactionWithFeeHandler) error {
 			return nil
 		},
 		ComputeFeeCalled: func(tx process.TransactionWithFeeHandler) *big.Int {
@@ -1087,7 +1087,7 @@ func TestTxProcessor_MoveBalanceWithFeesShouldWork(t *testing.T) {
 
 	txCost := big.NewInt(16)
 	feeHandler := &mock.FeeHandlerStub{
-		CheckTxHandlerCalled: func(tx process.TransactionWithFeeHandler) error {
+		CheckValidityTxValuesCalled: func(tx process.TransactionWithFeeHandler) error {
 			return nil
 		},
 		ComputeFeeCalled: func(tx process.TransactionWithFeeHandler) *big.Int {


### PR DESCRIPTION
transaction fee calculation refactor:
- changed the fee handler so it can compute fees, required gas limits and such: behavior is now consistent between interceptor and transaction processor
- found and fixed the bug that made the cost of a transaction minTxGasLimit * minTxGasPrice regardless the tx data notarized
- found and fixed a bug that made the miniblock max gaslimit calculation based only on minGasLimit instead of the real gas limit of the transaction