### PR TITLE
En 4551 trie node refactoring

### DIFF
--- a/data/trie/branchNode.go
+++ b/data/trie/branchNode.go
@@ -75,11 +75,11 @@ func newBranchNode(db data.DBWriteCacher, marshalizer marshal.Marshalizer, hashe
 	}
 
 	var children [nrOfChildren]node
-	EncChildren := make([][]byte, nrOfChildren)
+	encChildren := make([][]byte, nrOfChildren)
 
 	return &branchNode{
 		CollapsedBn: protobuf.CollapsedBn{
-			EncodedChildren: EncChildren,
+			EncodedChildren: encChildren,
 		},
 		children: children,
 		baseNode: &baseNode{
@@ -93,11 +93,11 @@ func newBranchNode(db data.DBWriteCacher, marshalizer marshal.Marshalizer, hashe
 
 func emptyDirtyBranchNode() *branchNode {
 	var children [nrOfChildren]node
-	EncChildren := make([][]byte, nrOfChildren)
+	encChildren := make([][]byte, nrOfChildren)
 
 	return &branchNode{
 		CollapsedBn: protobuf.CollapsedBn{
-			EncodedChildren: EncChildren,
+			EncodedChildren: encChildren,
 		},
 		children: children,
 		baseNode: &baseNode{
@@ -297,7 +297,7 @@ func (bn *branchNode) hashNode() ([]byte, error) {
 	return encodeNodeAndGetHash(bn)
 }
 
-func (bn *branchNode) commit(force bool, level byte, db data.DBWriteCacher) error {
+func (bn *branchNode) commit(force bool, level byte, targetDb data.DBWriteCacher) error {
 	level++
 	err := bn.isEmptyOrNil()
 	if err != nil {
@@ -321,13 +321,13 @@ func (bn *branchNode) commit(force bool, level byte, db data.DBWriteCacher) erro
 			continue
 		}
 
-		err = bn.children[i].commit(force, level, db)
+		err = bn.children[i].commit(force, level, targetDb)
 		if err != nil {
 			return err
 		}
 	}
 	bn.dirty = false
-	err = encodeNodeAndCommitToDB(bn, db)
+	err = encodeNodeAndCommitToDB(bn, targetDb)
 	if err != nil {
 		return err
 	}

--- a/data/trie/branchNode.go
+++ b/data/trie/branchNode.go
@@ -297,7 +297,7 @@ func (bn *branchNode) hashNode() ([]byte, error) {
 	return encodeNodeAndGetHash(bn)
 }
 
-func (bn *branchNode) commit(force bool, level byte, originDb data.DBWriteCacher, targetDb data.DBWriteCacher, marshalizer marshal.Marshalizer, hasher hashing.Hasher) error {
+func (bn *branchNode) commit(force bool, level byte, db data.DBWriteCacher) error {
 	level++
 	err := bn.isEmptyOrNil()
 	if err != nil {
@@ -311,7 +311,7 @@ func (bn *branchNode) commit(force bool, level byte, originDb data.DBWriteCacher
 
 	for i := range bn.children {
 		if force {
-			err = resolveIfCollapsed(bn, byte(i), originDb, marshalizer)
+			err = resolveIfCollapsed(bn, byte(i))
 			if err != nil {
 				return err
 			}
@@ -321,13 +321,13 @@ func (bn *branchNode) commit(force bool, level byte, originDb data.DBWriteCacher
 			continue
 		}
 
-		err = bn.children[i].commit(force, level, originDb, targetDb, marshalizer, hasher)
+		err = bn.children[i].commit(force, level, db)
 		if err != nil {
 			return err
 		}
 	}
 	bn.dirty = false
-	err = encodeNodeAndCommitToDB(bn, targetDb, marshalizer, hasher)
+	err = encodeNodeAndCommitToDB(bn, db)
 	if err != nil {
 		return err
 	}

--- a/data/trie/branchNode.go
+++ b/data/trie/branchNode.go
@@ -47,7 +47,7 @@ func branchNodeGoToCapn(seg *capn.Segment, src *branchNode) capnp.BranchNodeCapn
 
 func branchNodeCapnToGo(src capnp.BranchNodeCapn, dest *branchNode) *branchNode {
 	if dest == nil {
-		dest = newBranchNode()
+		dest = emptyDirtyBranchNode()
 	}
 	dest.dirty = false
 
@@ -63,7 +63,17 @@ func branchNodeCapnToGo(src capnp.BranchNodeCapn, dest *branchNode) *branchNode 
 	return dest
 }
 
-func newBranchNode() *branchNode {
+func newBranchNode(db data.DBWriteCacher, marshalizer marshal.Marshalizer, hasher hashing.Hasher) (*branchNode, error) {
+	if db == nil || db.IsInterfaceNil() {
+		return nil, ErrNilDatabase
+	}
+	if marshalizer == nil || marshalizer.IsInterfaceNil() {
+		return nil, ErrNilMarshalizer
+	}
+	if hasher == nil || hasher.IsInterfaceNil() {
+		return nil, ErrNilHasher
+	}
+
 	var children [nrOfChildren]node
 	EncChildren := make([][]byte, nrOfChildren)
 
@@ -73,6 +83,22 @@ func newBranchNode() *branchNode {
 		},
 		children: children,
 		hash:     nil,
+		dirty:    true,
+		db:       db,
+		marsh:    marshalizer,
+		hasher:   hasher,
+	}, nil
+}
+
+func emptyDirtyBranchNode() *branchNode {
+	var children [nrOfChildren]node
+	EncChildren := make([][]byte, nrOfChildren)
+
+	return &branchNode{
+		CollapsedBn: protobuf.CollapsedBn{
+			EncodedChildren: EncChildren,
+		},
+		children: children,
 		dirty:    true,
 	}
 }
@@ -89,7 +115,31 @@ func (bn *branchNode) isDirty() bool {
 	return bn.dirty
 }
 
-func (bn *branchNode) getCollapsed(marshalizer marshal.Marshalizer, hasher hashing.Hasher) (node, error) {
+func (bn *branchNode) getMarshalizer() marshal.Marshalizer {
+	return bn.marsh
+}
+
+func (bn *branchNode) setMarshalizer(marshalizer marshal.Marshalizer) {
+	bn.marsh = marshalizer
+}
+
+func (bn *branchNode) getHasher() hashing.Hasher {
+	return bn.hasher
+}
+
+func (bn *branchNode) setHasher(hasher hashing.Hasher) {
+	bn.hasher = hasher
+}
+
+func (bn *branchNode) getDb() data.DBWriteCacher {
+	return bn.db
+}
+
+func (bn *branchNode) setDb(db data.DBWriteCacher) {
+	bn.db = db
+}
+
+func (bn *branchNode) getCollapsed() (node, error) {
 	err := bn.isEmptyOrNil()
 	if err != nil {
 		return nil, err
@@ -105,7 +155,7 @@ func (bn *branchNode) getCollapsed(marshalizer marshal.Marshalizer, hasher hashi
 				return nil, err
 			}
 			if !ok {
-				err := bn.children[i].setHash(marshalizer, hasher)
+				err := bn.children[i].setHash()
 				if err != nil {
 					return nil, err
 				}
@@ -117,7 +167,7 @@ func (bn *branchNode) getCollapsed(marshalizer marshal.Marshalizer, hasher hashi
 	return collapsed, nil
 }
 
-func (bn *branchNode) setHash(marshalizer marshal.Marshalizer, hasher hashing.Hasher) error {
+func (bn *branchNode) setHash() error {
 	err := bn.isEmptyOrNil()
 	if err != nil {
 		return err
@@ -126,14 +176,14 @@ func (bn *branchNode) setHash(marshalizer marshal.Marshalizer, hasher hashing.Ha
 		return nil
 	}
 	if bn.isCollapsed() {
-		hash, err := encodeNodeAndGetHash(bn, marshalizer, hasher)
+		hash, err := encodeNodeAndGetHash(bn)
 		if err != nil {
 			return err
 		}
 		bn.hash = hash
 		return nil
 	}
-	hash, err := hashChildrenAndNode(bn, marshalizer, hasher)
+	hash, err := hashChildrenAndNode(bn)
 	if err != nil {
 		return err
 	}
@@ -141,7 +191,7 @@ func (bn *branchNode) setHash(marshalizer marshal.Marshalizer, hasher hashing.Ha
 	return nil
 }
 
-func (bn *branchNode) setRootHash(marshalizer marshal.Marshalizer, hasher hashing.Hasher) error {
+func (bn *branchNode) setRootHash() error {
 	err := bn.isEmptyOrNil()
 	if err != nil {
 		return err
@@ -150,7 +200,7 @@ func (bn *branchNode) setRootHash(marshalizer marshal.Marshalizer, hasher hashin
 		return nil
 	}
 	if bn.isCollapsed() {
-		hash, err := encodeNodeAndGetHash(bn, marshalizer, hasher)
+		hash, err := encodeNodeAndGetHash(bn)
 		if err != nil {
 			return err
 		}
@@ -164,7 +214,7 @@ func (bn *branchNode) setRootHash(marshalizer marshal.Marshalizer, hasher hashin
 	for i := 0; i < nrOfChildren; i++ {
 		if bn.children[i] != nil {
 			wg.Add(1)
-			go bn.children[i].setHashConcurrent(marshalizer, hasher, &wg, errc)
+			go bn.children[i].setHashConcurrent(&wg, errc)
 		}
 	}
 	wg.Wait()
@@ -174,7 +224,7 @@ func (bn *branchNode) setRootHash(marshalizer marshal.Marshalizer, hasher hashin
 		}
 	}
 
-	hashed, err := bn.hashNode(marshalizer, hasher)
+	hashed, err := bn.hashNode()
 	if err != nil {
 		return err
 	}
@@ -183,7 +233,7 @@ func (bn *branchNode) setRootHash(marshalizer marshal.Marshalizer, hasher hashin
 	return nil
 }
 
-func (bn *branchNode) setHashConcurrent(marshalizer marshal.Marshalizer, hasher hashing.Hasher, wg *sync.WaitGroup, c chan error) {
+func (bn *branchNode) setHashConcurrent(wg *sync.WaitGroup, c chan error) {
 	defer wg.Done()
 	err := bn.isEmptyOrNil()
 	if err != nil {
@@ -194,7 +244,7 @@ func (bn *branchNode) setHashConcurrent(marshalizer marshal.Marshalizer, hasher 
 		return
 	}
 	if bn.isCollapsed() {
-		hash, err := encodeNodeAndGetHash(bn, marshalizer, hasher)
+		hash, err := encodeNodeAndGetHash(bn)
 		if err != nil {
 			c <- err
 			return
@@ -202,7 +252,7 @@ func (bn *branchNode) setHashConcurrent(marshalizer marshal.Marshalizer, hasher 
 		bn.hash = hash
 		return
 	}
-	hash, err := hashChildrenAndNode(bn, marshalizer, hasher)
+	hash, err := hashChildrenAndNode(bn)
 	if err != nil {
 		c <- err
 		return
@@ -211,14 +261,14 @@ func (bn *branchNode) setHashConcurrent(marshalizer marshal.Marshalizer, hasher 
 	return
 }
 
-func (bn *branchNode) hashChildren(marshalizer marshal.Marshalizer, hasher hashing.Hasher) error {
+func (bn *branchNode) hashChildren() error {
 	err := bn.isEmptyOrNil()
 	if err != nil {
 		return err
 	}
 	for i := 0; i < nrOfChildren; i++ {
 		if bn.children[i] != nil {
-			err := bn.children[i].setHash(marshalizer, hasher)
+			err := bn.children[i].setHash()
 			if err != nil {
 				return err
 			}
@@ -227,24 +277,24 @@ func (bn *branchNode) hashChildren(marshalizer marshal.Marshalizer, hasher hashi
 	return nil
 }
 
-func (bn *branchNode) hashNode(marshalizer marshal.Marshalizer, hasher hashing.Hasher) ([]byte, error) {
+func (bn *branchNode) hashNode() ([]byte, error) {
 	err := bn.isEmptyOrNil()
 	if err != nil {
 		return nil, err
 	}
 	for i := range bn.EncodedChildren {
 		if bn.children[i] != nil {
-			encChild, err := encodeNodeAndGetHash(bn.children[i], marshalizer, hasher)
+			encChild, err := encodeNodeAndGetHash(bn.children[i])
 			if err != nil {
 				return nil, err
 			}
 			bn.EncodedChildren[i] = encChild
 		}
 	}
-	return encodeNodeAndGetHash(bn, marshalizer, hasher)
+	return encodeNodeAndGetHash(bn)
 }
 
-func (bn *branchNode) commit(force bool, level byte, db data.DBWriteCacher, marshalizer marshal.Marshalizer, hasher hashing.Hasher) error {
+func (bn *branchNode) commit(force bool, level byte) error {
 	level++
 	err := bn.isEmptyOrNil()
 	if err != nil {
@@ -258,19 +308,19 @@ func (bn *branchNode) commit(force bool, level byte, db data.DBWriteCacher, mars
 
 	for i := range bn.children {
 		if bn.children[i] != nil {
-			err := bn.children[i].commit(force, level, db, marshalizer, hasher)
+			err := bn.children[i].commit(force, level)
 			if err != nil {
 				return err
 			}
 		}
 	}
 	bn.dirty = false
-	err = encodeNodeAndCommitToDB(bn, db, marshalizer, hasher)
+	err = encodeNodeAndCommitToDB(bn)
 	if err != nil {
 		return err
 	}
 	if level == maxTrieLevelAfterCommit {
-		collapsed, err := bn.getCollapsed(marshalizer, hasher)
+		collapsed, err := bn.getCollapsed()
 		if err != nil {
 			return err
 		}
@@ -281,12 +331,12 @@ func (bn *branchNode) commit(force bool, level byte, db data.DBWriteCacher, mars
 	return nil
 }
 
-func (bn *branchNode) getEncodedNode(marshalizer marshal.Marshalizer) ([]byte, error) {
+func (bn *branchNode) getEncodedNode() ([]byte, error) {
 	err := bn.isEmptyOrNil()
 	if err != nil {
 		return nil, err
 	}
-	marshaledNode, err := marshalizer.Marshal(bn)
+	marshaledNode, err := bn.marsh.Marshal(bn)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +344,7 @@ func (bn *branchNode) getEncodedNode(marshalizer marshal.Marshalizer) ([]byte, e
 	return marshaledNode, nil
 }
 
-func (bn *branchNode) resolveCollapsed(pos byte, db data.DBWriteCacher, marshalizer marshal.Marshalizer) error {
+func (bn *branchNode) resolveCollapsed(pos byte) error {
 	err := bn.isEmptyOrNil()
 	if err != nil {
 		return err
@@ -303,7 +353,7 @@ func (bn *branchNode) resolveCollapsed(pos byte, db data.DBWriteCacher, marshali
 		return ErrChildPosOutOfRange
 	}
 	if len(bn.EncodedChildren[pos]) != 0 {
-		child, err := getNodeFromDBAndDecode(bn.EncodedChildren[pos], db, marshalizer)
+		child, err := getNodeFromDBAndDecode(bn.EncodedChildren[pos], bn.db, bn.marsh, bn.hasher)
 		if err != nil {
 			return err
 		}
@@ -326,7 +376,7 @@ func (bn *branchNode) isPosCollapsed(pos int) bool {
 	return bn.children[pos] == nil && len(bn.EncodedChildren[pos]) != 0
 }
 
-func (bn *branchNode) tryGet(key []byte, db data.DBWriteCacher, marshalizer marshal.Marshalizer) (value []byte, err error) {
+func (bn *branchNode) tryGet(key []byte) (value []byte, err error) {
 	err = bn.isEmptyOrNil()
 	if err != nil {
 		return nil, err
@@ -339,7 +389,7 @@ func (bn *branchNode) tryGet(key []byte, db data.DBWriteCacher, marshalizer mars
 		return nil, ErrChildPosOutOfRange
 	}
 	key = key[1:]
-	err = resolveIfCollapsed(bn, childPos, db, marshalizer)
+	err = resolveIfCollapsed(bn, childPos)
 	if err != nil {
 		return nil, err
 	}
@@ -347,10 +397,10 @@ func (bn *branchNode) tryGet(key []byte, db data.DBWriteCacher, marshalizer mars
 		return nil, nil
 	}
 
-	return bn.children[childPos].tryGet(key, db, marshalizer)
+	return bn.children[childPos].tryGet(key)
 }
 
-func (bn *branchNode) getNext(key []byte, db data.DBWriteCacher, marshalizer marshal.Marshalizer) (node, []byte, error) {
+func (bn *branchNode) getNext(key []byte) (node, []byte, error) {
 	err := bn.isEmptyOrNil()
 	if err != nil {
 		return nil, nil, err
@@ -363,7 +413,7 @@ func (bn *branchNode) getNext(key []byte, db data.DBWriteCacher, marshalizer mar
 		return nil, nil, ErrChildPosOutOfRange
 	}
 	key = key[1:]
-	err = resolveIfCollapsed(bn, childPos, db, marshalizer)
+	err = resolveIfCollapsed(bn, childPos)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -374,7 +424,7 @@ func (bn *branchNode) getNext(key []byte, db data.DBWriteCacher, marshalizer mar
 	return bn.children[childPos], key, nil
 }
 
-func (bn *branchNode) insert(n *leafNode, db data.DBWriteCacher, marshalizer marshal.Marshalizer) (bool, node, [][]byte, error) {
+func (bn *branchNode) insert(n *leafNode) (bool, node, [][]byte, error) {
 	emptyHashes := make([][]byte, 0)
 	err := bn.isEmptyOrNil()
 	if err != nil {
@@ -388,13 +438,13 @@ func (bn *branchNode) insert(n *leafNode, db data.DBWriteCacher, marshalizer mar
 		return false, nil, emptyHashes, ErrChildPosOutOfRange
 	}
 	n.Key = n.Key[1:]
-	err = resolveIfCollapsed(bn, childPos, db, marshalizer)
+	err = resolveIfCollapsed(bn, childPos)
 	if err != nil {
 		return false, nil, emptyHashes, err
 	}
 
 	if bn.children[childPos] != nil {
-		dirty, newNode, oldHashes, err := bn.children[childPos].insert(n, db, marshalizer)
+		dirty, newNode, oldHashes, err := bn.children[childPos].insert(n)
 		if !dirty || err != nil {
 			return false, bn, emptyHashes, err
 		}
@@ -410,7 +460,12 @@ func (bn *branchNode) insert(n *leafNode, db data.DBWriteCacher, marshalizer mar
 		}
 		return true, bn, oldHashes, nil
 	}
-	bn.children[childPos] = newLeafNode(n.Key, n.Value)
+
+	newLn, err := newLeafNode(n.Key, n.Value, bn.db, bn.marsh, bn.hasher)
+	if err != nil {
+		return false, nil, emptyHashes, err
+	}
+	bn.children[childPos] = newLn
 
 	oldHash := make([][]byte, 0)
 	if !bn.dirty {
@@ -422,7 +477,7 @@ func (bn *branchNode) insert(n *leafNode, db data.DBWriteCacher, marshalizer mar
 	return true, bn, oldHash, nil
 }
 
-func (bn *branchNode) delete(key []byte, db data.DBWriteCacher, marshalizer marshal.Marshalizer) (bool, node, [][]byte, error) {
+func (bn *branchNode) delete(key []byte) (bool, node, [][]byte, error) {
 	emptyHashes := make([][]byte, 0)
 	err := bn.isEmptyOrNil()
 	if err != nil {
@@ -436,12 +491,12 @@ func (bn *branchNode) delete(key []byte, db data.DBWriteCacher, marshalizer mars
 		return false, nil, emptyHashes, ErrChildPosOutOfRange
 	}
 	key = key[1:]
-	err = resolveIfCollapsed(bn, childPos, db, marshalizer)
+	err = resolveIfCollapsed(bn, childPos)
 	if err != nil {
 		return false, nil, emptyHashes, err
 	}
 
-	dirty, newNode, oldHashes, err := bn.children[childPos].delete(key, db, marshalizer)
+	dirty, newNode, oldHashes, err := bn.children[childPos].delete(key)
 	if !dirty || err != nil {
 		return false, nil, emptyHashes, err
 	}
@@ -459,12 +514,15 @@ func (bn *branchNode) delete(key []byte, db data.DBWriteCacher, marshalizer mars
 	nrOfChildren, pos := getChildPosition(bn)
 
 	if nrOfChildren == 1 {
-		err = resolveIfCollapsed(bn, byte(pos), db, marshalizer)
+		err = resolveIfCollapsed(bn, byte(pos))
 		if err != nil {
 			return false, nil, emptyHashes, err
 		}
 
-		newNode := bn.children[pos].reduceNode(pos)
+		newNode, err = bn.children[pos].reduceNode(pos)
+		if err != nil {
+			return false, nil, emptyHashes, err
+		}
 
 		return true, newNode, oldHashes, nil
 	}
@@ -474,8 +532,13 @@ func (bn *branchNode) delete(key []byte, db data.DBWriteCacher, marshalizer mars
 	return true, bn, oldHashes, nil
 }
 
-func (bn *branchNode) reduceNode(pos int) node {
-	return newExtensionNode([]byte{byte(pos)}, bn)
+func (bn *branchNode) reduceNode(pos int) (node, error) {
+	newEn, err := newExtensionNode([]byte{byte(pos)}, bn, bn.db, bn.marsh, bn.hasher)
+	if err != nil {
+		return nil, err
+	}
+
+	return newEn, nil
 }
 
 func getChildPosition(n *branchNode) (nrOfChildren int, childPos int) {
@@ -560,6 +623,9 @@ func (bn *branchNode) deepClone() node {
 	}
 
 	clonedNode.dirty = bn.dirty
+	clonedNode.db = bn.db
+	clonedNode.marsh = bn.marsh
+	clonedNode.hasher = bn.hasher
 
 	return clonedNode
 }

--- a/data/trie/branchNode.go
+++ b/data/trie/branchNode.go
@@ -82,11 +82,12 @@ func newBranchNode(db data.DBWriteCacher, marshalizer marshal.Marshalizer, hashe
 			EncodedChildren: EncChildren,
 		},
 		children: children,
-		hash:     nil,
-		dirty:    true,
-		db:       db,
-		marsh:    marshalizer,
-		hasher:   hasher,
+		baseNode: &baseNode{
+			dirty:  true,
+			db:     db,
+			marsh:  marshalizer,
+			hasher: hasher,
+		},
 	}, nil
 }
 
@@ -99,7 +100,9 @@ func emptyDirtyBranchNode() *branchNode {
 			EncodedChildren: EncChildren,
 		},
 		children: children,
-		dirty:    true,
+		baseNode: &baseNode{
+			dirty: true,
+		},
 	}
 }
 
@@ -595,7 +598,7 @@ func (bn *branchNode) deepClone() node {
 		return nil
 	}
 
-	clonedNode := &branchNode{}
+	clonedNode := &branchNode{baseNode: &baseNode{}}
 
 	if bn.hash != nil {
 		clonedNode.hash = make([]byte, len(bn.hash))

--- a/data/trie/branchNode_test.go
+++ b/data/trie/branchNode_test.go
@@ -280,7 +280,7 @@ func TestBranchNode_commit(t *testing.T) {
 	hash, _ := encodeNodeAndGetHash(collapsedBn)
 	_ = bn.setHash()
 
-	err := bn.commit(false, 0)
+	err := bn.commit(false, 0, bn.db)
 	assert.Nil(t, err)
 
 	encNode, _ := db.Get(hash)
@@ -295,7 +295,7 @@ func TestBranchNode_commitEmptyNode(t *testing.T) {
 
 	bn := emptyDirtyBranchNode()
 
-	err := bn.commit(false, 0)
+	err := bn.commit(false, 0, bn.db)
 	assert.Equal(t, ErrEmptyNode, err)
 }
 
@@ -304,7 +304,7 @@ func TestBranchNode_commitNilNode(t *testing.T) {
 
 	var bn *branchNode
 
-	err := bn.commit(false, 0)
+	err := bn.commit(false, 0, nil)
 	assert.Equal(t, ErrNilNode, err)
 }
 
@@ -348,7 +348,7 @@ func TestBranchNode_resolveCollapsed(t *testing.T) {
 	childPos := byte(2)
 
 	_ = bn.setHash()
-	_ = bn.commit(false, 0)
+	_ = bn.commit(false, 0, bn.db)
 	resolved, _ := newLeafNode([]byte("dog"), []byte("dog"), bn.db, bn.marsh, bn.hasher)
 	resolved.dirty = false
 	resolved.hash = bn.EncodedChildren[childPos]
@@ -448,7 +448,7 @@ func TestBranchNode_tryGetCollapsedNode(t *testing.T) {
 	bn, collapsedBn := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 
 	_ = bn.setHash()
-	_ = bn.commit(false, 0)
+	_ = bn.commit(false, 0, bn.db)
 
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
@@ -573,7 +573,7 @@ func TestBranchNode_insertCollapsedNode(t *testing.T) {
 	node, _ := newLeafNode(key, []byte("dogs"), bn.db, bn.marsh, bn.hasher)
 
 	_ = bn.setHash()
-	_ = bn.commit(false, 0)
+	_ = bn.commit(false, 0, bn.db)
 
 	dirty, newBn, _, err := collapsedBn.insert(node)
 	assert.True(t, dirty)
@@ -591,7 +591,7 @@ func TestBranchNode_insertInStoredBnOnExistingPos(t *testing.T) {
 	key := append([]byte{childPos}, []byte("dog")...)
 	node, _ := newLeafNode(key, []byte("dogs"), bn.db, bn.marsh, bn.hasher)
 
-	_ = bn.commit(false, 0)
+	_ = bn.commit(false, 0, bn.db)
 	bnHash := bn.getHash()
 	ln, _, _ := bn.getNext(key)
 	lnHash := ln.getHash()
@@ -611,7 +611,7 @@ func TestBranchNode_insertInStoredBnOnNilPos(t *testing.T) {
 	key := append([]byte{nilChildPos}, []byte("dog")...)
 	node, _ := newLeafNode(key, []byte("dogs"), bn.db, bn.marsh, bn.hasher)
 
-	_ = bn.commit(false, 0)
+	_ = bn.commit(false, 0, bn.db)
 	bnHash := bn.getHash()
 	expectedHashes := [][]byte{bnHash}
 
@@ -689,7 +689,7 @@ func TestBranchNode_deleteFromStoredBn(t *testing.T) {
 	childPos := byte(2)
 	lnKey := append([]byte{childPos}, []byte("dog")...)
 
-	_ = bn.commit(false, 0)
+	_ = bn.commit(false, 0, bn.db)
 	bnHash := bn.getHash()
 	ln, _, _ := bn.getNext(lnKey)
 	lnHash := ln.getHash()
@@ -756,7 +756,7 @@ func TestBranchNode_deleteCollapsedNode(t *testing.T) {
 
 	bn, collapsedBn := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	_ = bn.setHash()
-	_ = bn.commit(false, 0)
+	_ = bn.commit(false, 0, bn.db)
 
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)

--- a/data/trie/branchNode_test.go
+++ b/data/trie/branchNode_test.go
@@ -49,17 +49,17 @@ func newEmptyTrie(db data.DBWriteCacher, marsh marshal.Marshalizer, hsh hashing.
 func TestBranchNode_getHash(t *testing.T) {
 	t.Parallel()
 
-	bn := &branchNode{hash: []byte("test hash")}
+	bn := &branchNode{baseNode: &baseNode{hash: []byte("test hash")}}
 	assert.Equal(t, bn.hash, bn.getHash())
 }
 
 func TestBranchNode_isDirty(t *testing.T) {
 	t.Parallel()
 
-	bn := &branchNode{dirty: true}
+	bn := &branchNode{baseNode: &baseNode{dirty: true}}
 	assert.Equal(t, true, bn.isDirty())
 
-	bn = &branchNode{dirty: false}
+	bn = &branchNode{baseNode: &baseNode{dirty: false}}
 	assert.Equal(t, false, bn.isDirty())
 }
 
@@ -182,7 +182,7 @@ func TestBranchNode_setHashCollapsedNode(t *testing.T) {
 func TestBranchNode_setGivenHash(t *testing.T) {
 	t.Parallel()
 
-	bn := &branchNode{}
+	bn := &branchNode{baseNode: &baseNode{}}
 	expectedHash := []byte("node hash")
 
 	bn.setGivenHash(expectedHash)
@@ -918,16 +918,16 @@ func TestReduceBranchNodeWithLeafNodeValueShouldWork(t *testing.T) {
 func TestBranchNode_deepCloneWithNilHashShouldWork(t *testing.T) {
 	t.Parallel()
 
-	bn := &branchNode{}
+	bn := &branchNode{baseNode: &baseNode{}}
 	bn.dirty = true
 	bn.hash = nil
 	bn.EncodedChildren = make([][]byte, len(bn.children))
 	bn.EncodedChildren[4] = getRandomByteSlice()
 	bn.EncodedChildren[5] = getRandomByteSlice()
 	bn.EncodedChildren[12] = getRandomByteSlice()
-	bn.children[4] = &leafNode{}
-	bn.children[5] = &leafNode{}
-	bn.children[12] = &leafNode{}
+	bn.children[4] = &leafNode{baseNode: &baseNode{}}
+	bn.children[5] = &leafNode{baseNode: &baseNode{}}
+	bn.children[12] = &leafNode{baseNode: &baseNode{}}
 
 	cloned := bn.deepClone().(*branchNode)
 
@@ -937,16 +937,16 @@ func TestBranchNode_deepCloneWithNilHashShouldWork(t *testing.T) {
 func TestBranchNode_deepCloneShouldWork(t *testing.T) {
 	t.Parallel()
 
-	bn := &branchNode{}
+	bn := &branchNode{baseNode: &baseNode{}}
 	bn.dirty = true
 	bn.hash = getRandomByteSlice()
 	bn.EncodedChildren = make([][]byte, len(bn.children))
 	bn.EncodedChildren[4] = getRandomByteSlice()
 	bn.EncodedChildren[5] = getRandomByteSlice()
 	bn.EncodedChildren[12] = getRandomByteSlice()
-	bn.children[4] = &leafNode{}
-	bn.children[5] = &leafNode{}
-	bn.children[12] = &leafNode{}
+	bn.children[4] = &leafNode{baseNode: &baseNode{}}
+	bn.children[5] = &leafNode{baseNode: &baseNode{}}
+	bn.children[12] = &leafNode{baseNode: &baseNode{}}
 
 	cloned := bn.deepClone().(*branchNode)
 

--- a/data/trie/branchNode_test.go
+++ b/data/trie/branchNode_test.go
@@ -15,31 +15,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func getTestMarshAndHasher() (marshal.Marshalizer, hashing.Hasher) {
+func getTestDbMarshAndHasher() (data.DBWriteCacher, marshal.Marshalizer, hashing.Hasher) {
 	marsh := &mock.ProtobufMarshalizerMock{}
 	hasher := &mock.KeccakMock{}
-	return marsh, hasher
+	return mock.NewMemDbMock(), marsh, hasher
 }
 
-func getBnAndCollapsedBn() (*branchNode, *branchNode) {
-	marsh, hasher := getTestMarshAndHasher()
-
+func getBnAndCollapsedBn(db data.DBWriteCacher, marshalizer marshal.Marshalizer, hasher hashing.Hasher) (*branchNode, *branchNode) {
 	var children [nrOfChildren]node
 	EncodedChildren := make([][]byte, nrOfChildren)
 
-	children[2] = newLeafNode([]byte("dog"), []byte("dog"))
-	children[6] = newLeafNode([]byte("doe"), []byte("doe"))
-	children[13] = newLeafNode([]byte("doge"), []byte("doge"))
-	bn := newBranchNode()
+	children[2], _ = newLeafNode([]byte("dog"), []byte("dog"), db, marshalizer, hasher)
+	children[6], _ = newLeafNode([]byte("doe"), []byte("doe"), db, marshalizer, hasher)
+	children[13], _ = newLeafNode([]byte("doge"), []byte("doge"), db, marshalizer, hasher)
+	bn, _ := newBranchNode(db, marshalizer, hasher)
 	bn.children = children
 
-	EncodedChildren[2], _ = encodeNodeAndGetHash(children[2], marsh, hasher)
-	EncodedChildren[6], _ = encodeNodeAndGetHash(children[6], marsh, hasher)
-	EncodedChildren[13], _ = encodeNodeAndGetHash(children[13], marsh, hasher)
-	collapsedBn := newBranchNode()
+	EncodedChildren[2], _ = encodeNodeAndGetHash(children[2])
+	EncodedChildren[6], _ = encodeNodeAndGetHash(children[6])
+	EncodedChildren[13], _ = encodeNodeAndGetHash(children[13])
+	collapsedBn, _ := newBranchNode(db, marshalizer, hasher)
 	collapsedBn.EncodedChildren = EncodedChildren
 
 	return bn, collapsedBn
+}
+
+func newEmptyTrie(db data.DBWriteCacher, marsh marshal.Marshalizer, hsh hashing.Hasher) data.Trie {
+	cacheSize := 100
+	tr, _ := NewTrie(db, marsh, hsh, mock.NewMemDbMock(), cacheSize, config.DBConfig{})
+	return tr
 }
 
 func TestBranchNode_getHash(t *testing.T) {
@@ -62,11 +66,10 @@ func TestBranchNode_isDirty(t *testing.T) {
 func TestBranchNode_getCollapsed(t *testing.T) {
 	t.Parallel()
 
-	bn, collapsedBn := getBnAndCollapsedBn()
+	bn, collapsedBn := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	collapsedBn.dirty = true
-	marsh, hasher := getTestMarshAndHasher()
 
-	collapsed, err := bn.getCollapsed(marsh, hasher)
+	collapsed, err := bn.getCollapsed()
 	assert.Nil(t, err)
 	assert.Equal(t, collapsedBn, collapsed)
 }
@@ -74,10 +77,9 @@ func TestBranchNode_getCollapsed(t *testing.T) {
 func TestBranchNode_getCollapsedEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshAndHasher()
-	bn := newBranchNode()
+	bn := emptyDirtyBranchNode()
 
-	collapsed, err := bn.getCollapsed(marsh, hasher)
+	collapsed, err := bn.getCollapsed()
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, collapsed)
 }
@@ -85,10 +87,9 @@ func TestBranchNode_getCollapsedEmptyNode(t *testing.T) {
 func TestBranchNode_getCollapsedNilNode(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshAndHasher()
 	var bn *branchNode
 
-	collapsed, err := bn.getCollapsed(marsh, hasher)
+	collapsed, err := bn.getCollapsed()
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, collapsed)
 }
@@ -96,10 +97,9 @@ func TestBranchNode_getCollapsedNilNode(t *testing.T) {
 func TestBranchNode_getCollapsedCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	_, collapsedBn := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
+	_, collapsedBn := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 
-	collapsed, err := collapsedBn.getCollapsed(marsh, hasher)
+	collapsed, err := collapsedBn.getCollapsed()
 	assert.Nil(t, err)
 	assert.Equal(t, collapsedBn, collapsed)
 }
@@ -107,12 +107,10 @@ func TestBranchNode_getCollapsedCollapsedNode(t *testing.T) {
 func TestBranchNode_setHash(t *testing.T) {
 	t.Parallel()
 
-	bn, collapsedBn := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
+	bn, collapsedBn := getBnAndCollapsedBn(getTestDbMarshAndHasher())
+	hash, _ := encodeNodeAndGetHash(collapsedBn)
 
-	hash, _ := encodeNodeAndGetHash(collapsedBn, marsh, hasher)
-
-	err := bn.setHash(marsh, hasher)
+	err := bn.setHash()
 	assert.Nil(t, err)
 	assert.Equal(t, hash, bn.hash)
 }
@@ -121,8 +119,7 @@ func TestBranchNode_setRootHash(t *testing.T) {
 	t.Parallel()
 
 	cfg := config.DBConfig{}
-	db := mock.NewMemDbMock()
-	marsh, hsh := getTestMarshAndHasher()
+	db, marsh, hsh := getTestDbMarshAndHasher()
 	cacheSize := 100
 
 	tr1, _ := NewTrie(db, marsh, hsh, mock.NewMemDbMock(), cacheSize, cfg)
@@ -134,8 +131,8 @@ func TestBranchNode_setRootHash(t *testing.T) {
 		_ = tr2.Update(val, val)
 	}
 
-	err := tr1.root.setRootHash(marsh, hsh)
-	_ = tr2.root.setHash(marsh, hsh)
+	err := tr1.root.setRootHash()
+	_ = tr2.root.setHash()
 	assert.Nil(t, err)
 	assert.Equal(t, tr1.root.getHash(), tr2.root.getHash())
 }
@@ -143,12 +140,10 @@ func TestBranchNode_setRootHash(t *testing.T) {
 func TestBranchNode_setRootHashCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	_, collapsedBn := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
+	_, collapsedBn := getBnAndCollapsedBn(getTestDbMarshAndHasher())
+	hash, _ := encodeNodeAndGetHash(collapsedBn)
 
-	hash, _ := encodeNodeAndGetHash(collapsedBn, marsh, hasher)
-
-	err := collapsedBn.setRootHash(marsh, hasher)
+	err := collapsedBn.setRootHash()
 	assert.Nil(t, err)
 	assert.Equal(t, hash, collapsedBn.hash)
 }
@@ -156,10 +151,9 @@ func TestBranchNode_setRootHashCollapsedNode(t *testing.T) {
 func TestBranchNode_setHashEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshAndHasher()
-	bn := newBranchNode()
+	bn := emptyDirtyBranchNode()
 
-	err := bn.setHash(marsh, hasher)
+	err := bn.setHash()
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, bn.hash)
 }
@@ -167,10 +161,9 @@ func TestBranchNode_setHashEmptyNode(t *testing.T) {
 func TestBranchNode_setHashNilNode(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshAndHasher()
 	var bn *branchNode
 
-	err := bn.setHash(marsh, hasher)
+	err := bn.setHash()
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, bn)
 }
@@ -178,12 +171,10 @@ func TestBranchNode_setHashNilNode(t *testing.T) {
 func TestBranchNode_setHashCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	_, collapsedBn := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
+	_, collapsedBn := getBnAndCollapsedBn(getTestDbMarshAndHasher())
+	hash, _ := encodeNodeAndGetHash(collapsedBn)
 
-	hash, _ := encodeNodeAndGetHash(collapsedBn, marsh, hasher)
-
-	err := collapsedBn.setHash(marsh, hasher)
+	err := collapsedBn.setHash()
 	assert.Nil(t, err)
 	assert.Equal(t, hash, collapsedBn.hash)
 }
@@ -195,27 +186,25 @@ func TestBranchNode_setGivenHash(t *testing.T) {
 	expectedHash := []byte("node hash")
 
 	bn.setGivenHash(expectedHash)
-
 	assert.Equal(t, expectedHash, bn.hash)
 }
 
 func TestBranchNode_hashChildren(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 
 	for i := range bn.children {
 		if bn.children[i] != nil {
 			assert.Nil(t, bn.children[i].getHash())
 		}
 	}
-	err := bn.hashChildren(marsh, hasher)
+	err := bn.hashChildren()
 	assert.Nil(t, err)
 
 	for i := range bn.children {
 		if bn.children[i] != nil {
-			childHash, _ := encodeNodeAndGetHash(bn.children[i], marsh, hasher)
+			childHash, _ := encodeNodeAndGetHash(bn.children[i])
 			assert.Equal(t, childHash, bn.children[i].getHash())
 		}
 	}
@@ -224,10 +213,9 @@ func TestBranchNode_hashChildren(t *testing.T) {
 func TestBranchNode_hashChildrenEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	bn := newBranchNode()
-	marsh, hasher := getTestMarshAndHasher()
+	bn := emptyDirtyBranchNode()
 
-	err := bn.hashChildren(marsh, hasher)
+	err := bn.hashChildren()
 	assert.Equal(t, ErrEmptyNode, err)
 }
 
@@ -235,33 +223,30 @@ func TestBranchNode_hashChildrenNilNode(t *testing.T) {
 	t.Parallel()
 
 	var bn *branchNode
-	marsh, hasher := getTestMarshAndHasher()
 
-	err := bn.hashChildren(marsh, hasher)
+	err := bn.hashChildren()
 	assert.Equal(t, ErrNilNode, err)
 }
 
 func TestBranchNode_hashChildrenCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	_, collapsedBn := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
+	_, collapsedBn := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 
-	err := collapsedBn.hashChildren(marsh, hasher)
+	err := collapsedBn.hashChildren()
 	assert.Nil(t, err)
 
-	_, collapsedBn2 := getBnAndCollapsedBn()
+	_, collapsedBn2 := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	assert.Equal(t, collapsedBn2, collapsedBn)
 }
 
 func TestBranchNode_hashNode(t *testing.T) {
 	t.Parallel()
 
-	_, collapsedBn := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
+	_, collapsedBn := getBnAndCollapsedBn(getTestDbMarshAndHasher())
+	expectedHash, _ := encodeNodeAndGetHash(collapsedBn)
 
-	expectedHash, _ := encodeNodeAndGetHash(collapsedBn, marsh, hasher)
-	hash, err := collapsedBn.hashNode(marsh, hasher)
+	hash, err := collapsedBn.hashNode()
 	assert.Nil(t, err)
 	assert.Equal(t, expectedHash, hash)
 }
@@ -269,10 +254,9 @@ func TestBranchNode_hashNode(t *testing.T) {
 func TestBranchNode_hashNodeEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	bn := newBranchNode()
-	marsh, hasher := getTestMarshAndHasher()
+	bn := emptyDirtyBranchNode()
 
-	hash, err := bn.hashNode(marsh, hasher)
+	hash, err := bn.hashNode()
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, hash)
 }
@@ -281,9 +265,8 @@ func TestBranchNode_hashNodeNilNode(t *testing.T) {
 	t.Parallel()
 
 	var bn *branchNode
-	marsh, hasher := getTestMarshAndHasher()
 
-	hash, err := bn.hashNode(marsh, hasher)
+	hash, err := bn.hashNode()
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, hash)
 }
@@ -291,31 +274,28 @@ func TestBranchNode_hashNodeNilNode(t *testing.T) {
 func TestBranchNode_commit(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, collapsedBn := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
+	db, marsh, hasher := getTestDbMarshAndHasher()
+	bn, collapsedBn := getBnAndCollapsedBn(db, marsh, hasher)
 
-	hash, _ := encodeNodeAndGetHash(collapsedBn, marsh, hasher)
-	_ = bn.setHash(marsh, hasher)
+	hash, _ := encodeNodeAndGetHash(collapsedBn)
+	_ = bn.setHash()
 
-	err := bn.commit(false, 0, db, marsh, hasher)
+	err := bn.commit(false, 0)
 	assert.Nil(t, err)
 
 	encNode, _ := db.Get(hash)
-	node, _ := decodeNode(encNode, marsh)
-	h1, _ := encodeNodeAndGetHash(collapsedBn, marsh, hasher)
-	h2, _ := encodeNodeAndGetHash(node, marsh, hasher)
+	node, _ := decodeNode(encNode, db, marsh, hasher)
+	h1, _ := encodeNodeAndGetHash(collapsedBn)
+	h2, _ := encodeNodeAndGetHash(node)
 	assert.Equal(t, h1, h2)
 }
 
 func TestBranchNode_commitEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	bn := newBranchNode()
-	db := mock.NewMemDbMock()
-	marsh, hasher := getTestMarshAndHasher()
+	bn := emptyDirtyBranchNode()
 
-	err := bn.commit(false, 0, db, marsh, hasher)
+	err := bn.commit(false, 0)
 	assert.Equal(t, ErrEmptyNode, err)
 }
 
@@ -323,23 +303,20 @@ func TestBranchNode_commitNilNode(t *testing.T) {
 	t.Parallel()
 
 	var bn *branchNode
-	db := mock.NewMemDbMock()
-	marsh, hasher := getTestMarshAndHasher()
 
-	err := bn.commit(false, 0, db, marsh, hasher)
+	err := bn.commit(false, 0)
 	assert.Equal(t, ErrNilNode, err)
 }
 
 func TestBranchNode_getEncodedNode(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn()
-	marsh, _ := getTestMarshAndHasher()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 
-	expectedEncodedNode, _ := marsh.Marshal(bn)
+	expectedEncodedNode, _ := bn.marsh.Marshal(bn)
 	expectedEncodedNode = append(expectedEncodedNode, branch)
 
-	encNode, err := bn.getEncodedNode(marsh)
+	encNode, err := bn.getEncodedNode()
 	assert.Nil(t, err)
 	assert.Equal(t, expectedEncodedNode, encNode)
 }
@@ -347,10 +324,9 @@ func TestBranchNode_getEncodedNode(t *testing.T) {
 func TestBranchNode_getEncodedNodeEmpty(t *testing.T) {
 	t.Parallel()
 
-	bn := newBranchNode()
-	marsh, _ := getTestMarshAndHasher()
+	bn := emptyDirtyBranchNode()
 
-	encNode, err := bn.getEncodedNode(marsh)
+	encNode, err := bn.getEncodedNode()
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, encNode)
 }
@@ -359,9 +335,8 @@ func TestBranchNode_getEncodedNodeNil(t *testing.T) {
 	t.Parallel()
 
 	var bn *branchNode
-	marsh, _ := getTestMarshAndHasher()
 
-	encNode, err := bn.getEncodedNode(marsh)
+	encNode, err := bn.getEncodedNode()
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, encNode)
 }
@@ -369,18 +344,16 @@ func TestBranchNode_getEncodedNodeNil(t *testing.T) {
 func TestBranchNode_resolveCollapsed(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, collapsedBn := getBnAndCollapsedBn()
+	bn, collapsedBn := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	childPos := byte(2)
-	marsh, hasher := getTestMarshAndHasher()
 
-	_ = bn.setHash(marsh, hasher)
-	_ = bn.commit(false, 0, db, marsh, hasher)
-	resolved := newLeafNode([]byte("dog"), []byte("dog"))
+	_ = bn.setHash()
+	_ = bn.commit(false, 0)
+	resolved, _ := newLeafNode([]byte("dog"), []byte("dog"), bn.db, bn.marsh, bn.hasher)
 	resolved.dirty = false
 	resolved.hash = bn.EncodedChildren[childPos]
 
-	err := collapsedBn.resolveCollapsed(childPos, db, marsh)
+	err := collapsedBn.resolveCollapsed(childPos)
 	assert.Nil(t, err)
 	assert.Equal(t, resolved, collapsedBn.children[childPos])
 }
@@ -388,58 +361,50 @@ func TestBranchNode_resolveCollapsed(t *testing.T) {
 func TestBranchNode_resolveCollapsedEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn := newBranchNode()
-	marsh, _ := getTestMarshAndHasher()
+	bn := emptyDirtyBranchNode()
 
-	err := bn.resolveCollapsed(2, db, marsh)
+	err := bn.resolveCollapsed(2)
 	assert.Equal(t, ErrEmptyNode, err)
 }
 
 func TestBranchNode_resolveCollapsedENilNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	var bn *branchNode
-	marsh, _ := getTestMarshAndHasher()
 
-	err := bn.resolveCollapsed(2, db, marsh)
+	err := bn.resolveCollapsed(2)
 	assert.Equal(t, ErrNilNode, err)
 }
 
 func TestBranchNode_resolveCollapsedPosOutOfRange(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, _ := getTestMarshAndHasher()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 
-	err := bn.resolveCollapsed(17, db, marsh)
+	err := bn.resolveCollapsed(17)
 	assert.Equal(t, ErrChildPosOutOfRange, err)
 }
 
 func TestBranchNode_isCollapsed(t *testing.T) {
 	t.Parallel()
 
-	bn, collapsedBn := getBnAndCollapsedBn()
+	bn, collapsedBn := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 
 	assert.True(t, collapsedBn.isCollapsed())
 	assert.False(t, bn.isCollapsed())
 
-	collapsedBn.children[2] = newLeafNode([]byte("dog"), []byte("dog"))
+	collapsedBn.children[2], _ = newLeafNode([]byte("dog"), []byte("dog"), bn.db, bn.marsh, bn.hasher)
 	assert.False(t, collapsedBn.isCollapsed())
 }
 
 func TestBranchNode_tryGet(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, _ := getTestMarshAndHasher()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
-	val, err := bn.tryGet(key, db, marsh)
+	val, err := bn.tryGet(key)
 	assert.Equal(t, []byte("dog"), val)
 	assert.Nil(t, err)
 }
@@ -447,12 +412,10 @@ func TestBranchNode_tryGet(t *testing.T) {
 func TestBranchNode_tryGetEmptyKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, _ := getTestMarshAndHasher()
-
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	var key []byte
-	val, err := bn.tryGet(key, db, marsh)
+
+	val, err := bn.tryGet(key)
 	assert.Nil(t, err)
 	assert.Nil(t, val)
 }
@@ -460,12 +423,10 @@ func TestBranchNode_tryGetEmptyKey(t *testing.T) {
 func TestBranchNode_tryGetChildPosOutOfRange(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, _ := getTestMarshAndHasher()
-
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	key := []byte("dog")
-	val, err := bn.tryGet(key, db, marsh)
+
+	val, err := bn.tryGet(key)
 	assert.Equal(t, ErrChildPosOutOfRange, err)
 	assert.Nil(t, val)
 }
@@ -473,12 +434,10 @@ func TestBranchNode_tryGetChildPosOutOfRange(t *testing.T) {
 func TestBranchNode_tryGetNilChild(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, _ := getTestMarshAndHasher()
-
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	nilChildKey := []byte{3}
-	val, err := bn.tryGet(nilChildKey, db, marsh)
+
+	val, err := bn.tryGet(nilChildKey)
 	assert.Nil(t, err)
 	assert.Nil(t, val)
 }
@@ -486,16 +445,15 @@ func TestBranchNode_tryGetNilChild(t *testing.T) {
 func TestBranchNode_tryGetCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, collapsedBn := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
-	_ = bn.setHash(marsh, hasher)
-	_ = bn.commit(false, 0, db, marsh, hasher)
+	bn, collapsedBn := getBnAndCollapsedBn(getTestDbMarshAndHasher())
+
+	_ = bn.setHash()
+	_ = bn.commit(false, 0)
 
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
-	val, err := collapsedBn.tryGet(key, db, marsh)
+	val, err := collapsedBn.tryGet(key)
 	assert.Equal(t, []byte("dog"), val)
 	assert.Nil(t, err)
 }
@@ -503,14 +461,11 @@ func TestBranchNode_tryGetCollapsedNode(t *testing.T) {
 func TestBranchNode_tryGetEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn := newBranchNode()
-	marsh, _ := getTestMarshAndHasher()
-
+	bn := emptyDirtyBranchNode()
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
-	val, err := bn.tryGet(key, db, marsh)
+	val, err := bn.tryGet(key)
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, val)
 }
@@ -518,14 +473,11 @@ func TestBranchNode_tryGetEmptyNode(t *testing.T) {
 func TestBranchNode_tryGetNilNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	var bn *branchNode
-	marsh, _ := getTestMarshAndHasher()
-
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
-	val, err := bn.tryGet(key, db, marsh)
+	val, err := bn.tryGet(key)
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, val)
 }
@@ -533,19 +485,15 @@ func TestBranchNode_tryGetNilNode(t *testing.T) {
 func TestBranchNode_getNext(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
-	nextNode := newLeafNode([]byte("dog"), []byte("dog"))
-
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
+	nextNode, _ := newLeafNode([]byte("dog"), []byte("dog"), bn.db, bn.marsh, bn.hasher)
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
-	node, key, err := bn.getNext(key, db, marsh)
+	node, key, err := bn.getNext(key)
 
-	h1, _ := encodeNodeAndGetHash(nextNode, marsh, hasher)
-	h2, _ := encodeNodeAndGetHash(node, marsh, hasher)
-
+	h1, _ := encodeNodeAndGetHash(nextNode)
+	h2, _ := encodeNodeAndGetHash(node)
 	assert.Equal(t, h1, h2)
 	assert.Equal(t, []byte("dog"), key)
 	assert.Nil(t, err)
@@ -554,12 +502,10 @@ func TestBranchNode_getNext(t *testing.T) {
 func TestBranchNode_getNextWrongKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, _ := getTestMarshAndHasher()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	key := []byte("dog")
 
-	node, key, err := bn.getNext(key, db, marsh)
+	node, key, err := bn.getNext(key)
 	assert.Nil(t, node)
 	assert.Nil(t, key)
 	assert.Equal(t, ErrChildPosOutOfRange, err)
@@ -568,14 +514,11 @@ func TestBranchNode_getNextWrongKey(t *testing.T) {
 func TestBranchNode_getNextNilChild(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, _ := getTestMarshAndHasher()
-
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	nilChildPos := byte(4)
 	key := append([]byte{nilChildPos}, []byte("dog")...)
 
-	node, key, err := bn.getNext(key, db, marsh)
+	node, key, err := bn.getNext(key)
 	assert.Nil(t, node)
 	assert.Nil(t, key)
 	assert.Equal(t, ErrNodeNotFound, err)
@@ -584,15 +527,14 @@ func TestBranchNode_getNextNilChild(t *testing.T) {
 func TestBranchNode_insert(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	nodeKey := []byte{0, 2, 3}
-	node := newLeafNode(nodeKey, []byte("dogs"))
-	marsh, _ := getTestMarshAndHasher()
+	node, _ := newLeafNode(nodeKey, []byte("dogs"), bn.db, bn.marsh, bn.hasher)
 
-	dirty, newBn, _, err := bn.insert(node, db, marsh)
+	dirty, newBn, _, err := bn.insert(node)
 	nodeKeyRemainder := nodeKey[1:]
-	bn.children[0] = newLeafNode(nodeKeyRemainder, []byte("dogs"))
+
+	bn.children[0], _ = newLeafNode(nodeKeyRemainder, []byte("dogs"), bn.db, bn.marsh, bn.hasher)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, bn, newBn)
@@ -601,12 +543,10 @@ func TestBranchNode_insert(t *testing.T) {
 func TestBranchNode_insertEmptyKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	node := newLeafNode([]byte{}, []byte("dogs"))
-	marsh, _ := getTestMarshAndHasher()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
+	node, _ := newLeafNode([]byte{}, []byte("dogs"), bn.db, bn.marsh, bn.hasher)
 
-	dirty, newBn, _, err := bn.insert(node, db, marsh)
+	dirty, newBn, _, err := bn.insert(node)
 	assert.False(t, dirty)
 	assert.Equal(t, ErrValueTooShort, err)
 	assert.Nil(t, newBn)
@@ -615,12 +555,10 @@ func TestBranchNode_insertEmptyKey(t *testing.T) {
 func TestBranchNode_insertChildPosOutOfRange(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	node := newLeafNode([]byte("dog"), []byte("dogs"))
-	marsh, _ := getTestMarshAndHasher()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
+	node, _ := newLeafNode([]byte("dog"), []byte("dogs"), bn.db, bn.marsh, bn.hasher)
 
-	dirty, newBn, _, err := bn.insert(node, db, marsh)
+	dirty, newBn, _, err := bn.insert(node)
 	assert.False(t, dirty)
 	assert.Equal(t, ErrChildPosOutOfRange, err)
 	assert.Nil(t, newBn)
@@ -629,43 +567,37 @@ func TestBranchNode_insertChildPosOutOfRange(t *testing.T) {
 func TestBranchNode_insertCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, collapsedBn := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
-
+	bn, collapsedBn := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
-	node := newLeafNode(key, []byte("dogs"))
+	node, _ := newLeafNode(key, []byte("dogs"), bn.db, bn.marsh, bn.hasher)
 
-	_ = bn.setHash(marsh, hasher)
-	_ = bn.commit(false, 0, db, marsh, hasher)
+	_ = bn.setHash()
+	_ = bn.commit(false, 0)
 
-	dirty, newBn, _, err := collapsedBn.insert(node, db, marsh)
+	dirty, newBn, _, err := collapsedBn.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
-	val, _ := newBn.tryGet(key, db, marsh)
+
+	val, _ := newBn.tryGet(key)
 	assert.Equal(t, []byte("dogs"), val)
 }
 
 func TestBranchNode_insertInStoredBnOnExistingPos(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
-
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
-	node := newLeafNode(key, []byte("dogs"))
+	node, _ := newLeafNode(key, []byte("dogs"), bn.db, bn.marsh, bn.hasher)
 
-	_ = bn.commit(false, 0, db, marsh, hasher)
+	_ = bn.commit(false, 0)
 	bnHash := bn.getHash()
-	ln, _, _ := bn.getNext(key, db, marsh)
+	ln, _, _ := bn.getNext(key)
 	lnHash := ln.getHash()
 	expectedHashes := [][]byte{lnHash, bnHash}
 
-	dirty, _, oldHashes, err := bn.insert(node, db, marsh)
-
+	dirty, _, oldHashes, err := bn.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedHashes, oldHashes)
@@ -674,20 +606,16 @@ func TestBranchNode_insertInStoredBnOnExistingPos(t *testing.T) {
 func TestBranchNode_insertInStoredBnOnNilPos(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
-
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	nilChildPos := byte(11)
 	key := append([]byte{nilChildPos}, []byte("dog")...)
-	node := newLeafNode(key, []byte("dogs"))
+	node, _ := newLeafNode(key, []byte("dogs"), bn.db, bn.marsh, bn.hasher)
 
-	_ = bn.commit(false, 0, db, marsh, hasher)
+	_ = bn.commit(false, 0)
 	bnHash := bn.getHash()
 	expectedHashes := [][]byte{bnHash}
 
-	dirty, _, oldHashes, err := bn.insert(node, db, marsh)
-
+	dirty, _, oldHashes, err := bn.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedHashes, oldHashes)
@@ -696,16 +624,12 @@ func TestBranchNode_insertInStoredBnOnNilPos(t *testing.T) {
 func TestBranchNode_insertInDirtyBnOnNilPos(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, _ := getTestMarshAndHasher()
-
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	nilChildPos := byte(11)
 	key := append([]byte{nilChildPos}, []byte("dog")...)
-	node := newLeafNode(key, []byte("dogs"))
+	node, _ := newLeafNode(key, []byte("dogs"), bn.db, bn.marsh, bn.hasher)
 
-	dirty, _, oldHashes, err := bn.insert(node, db, marsh)
-
+	dirty, _, oldHashes, err := bn.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -714,16 +638,12 @@ func TestBranchNode_insertInDirtyBnOnNilPos(t *testing.T) {
 func TestBranchNode_insertInDirtyBnOnExistingPos(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, _ := getTestMarshAndHasher()
-
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
-	node := newLeafNode(key, []byte("dogs"))
+	node, _ := newLeafNode(key, []byte("dogs"), bn.db, bn.marsh, bn.hasher)
 
-	dirty, _, oldHashes, err := bn.insert(node, db, marsh)
-
+	dirty, _, oldHashes, err := bn.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -732,15 +652,9 @@ func TestBranchNode_insertInDirtyBnOnExistingPos(t *testing.T) {
 func TestBranchNode_insertInNilNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	marsh, _ := getTestMarshAndHasher()
 	var bn *branchNode
 
-	nilChildPos := byte(0)
-	key := append([]byte{nilChildPos}, []byte("dog")...)
-	node := newLeafNode(key, []byte("dogs"))
-
-	dirty, newBn, _, err := bn.insert(node, db, marsh)
+	dirty, newBn, _, err := bn.insert(&leafNode{})
 	assert.False(t, dirty)
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, newBn)
@@ -749,46 +663,39 @@ func TestBranchNode_insertInNilNode(t *testing.T) {
 func TestBranchNode_delete(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
-
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	var children [nrOfChildren]node
-	children[6] = newLeafNode([]byte("doe"), []byte("doe"))
-	children[13] = newLeafNode([]byte("doge"), []byte("doge"))
-	expectedBn := newBranchNode()
+	children[6], _ = newLeafNode([]byte("doe"), []byte("doe"), bn.db, bn.marsh, bn.hasher)
+	children[13], _ = newLeafNode([]byte("doge"), []byte("doge"), bn.db, bn.marsh, bn.hasher)
+	expectedBn, _ := newBranchNode(bn.db, bn.marsh, bn.hasher)
 	expectedBn.children = children
 
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
-	dirty, newBn, _, err := bn.delete(key, db, marsh)
+	dirty, newBn, _, err := bn.delete(key)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 
-	_ = expectedBn.setHash(marsh, hasher)
-	_ = newBn.setHash(marsh, hasher)
+	_ = expectedBn.setHash()
+	_ = newBn.setHash()
 	assert.Equal(t, expectedBn.getHash(), newBn.getHash())
 }
 
 func TestBranchNode_deleteFromStoredBn(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
-
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	childPos := byte(2)
 	lnKey := append([]byte{childPos}, []byte("dog")...)
 
-	_ = bn.commit(false, 0, db, marsh, hasher)
+	_ = bn.commit(false, 0)
 	bnHash := bn.getHash()
-	ln, _, _ := bn.getNext(lnKey, db, marsh)
+	ln, _, _ := bn.getNext(lnKey)
 	lnHash := ln.getHash()
 	expectedHashes := [][]byte{lnHash, bnHash}
 
-	dirty, _, oldHashes, err := bn.delete(lnKey, db, marsh)
-
+	dirty, _, oldHashes, err := bn.delete(lnKey)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedHashes, oldHashes)
@@ -797,14 +704,11 @@ func TestBranchNode_deleteFromStoredBn(t *testing.T) {
 func TestBranchNode_deleteFromDirtyBn(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, _ := getTestMarshAndHasher()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	childPos := byte(2)
 	lnKey := append([]byte{childPos}, []byte("dog")...)
 
-	dirty, _, oldHashes, err := bn.delete(lnKey, db, marsh)
-
+	dirty, _, oldHashes, err := bn.delete(lnKey)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -813,14 +717,11 @@ func TestBranchNode_deleteFromDirtyBn(t *testing.T) {
 func TestBranchNode_deleteEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn := newBranchNode()
-	marsh, _ := getTestMarshAndHasher()
-
+	bn := emptyDirtyBranchNode()
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
-	dirty, newBn, _, err := bn.delete(key, db, marsh)
+	dirty, newBn, _, err := bn.delete(key)
 	assert.False(t, dirty)
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, newBn)
@@ -829,14 +730,11 @@ func TestBranchNode_deleteEmptyNode(t *testing.T) {
 func TestBranchNode_deleteNilNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	var bn *branchNode
-	marsh, _ := getTestMarshAndHasher()
-
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
-	dirty, newBn, _, err := bn.delete(key, db, marsh)
+	dirty, newBn, _, err := bn.delete(key)
 	assert.False(t, dirty)
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, newBn)
@@ -845,11 +743,9 @@ func TestBranchNode_deleteNilNode(t *testing.T) {
 func TestBranchNode_deleteEmptykey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, _ := getTestMarshAndHasher()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 
-	dirty, newBn, _, err := bn.delete([]byte{}, db, marsh)
+	dirty, newBn, _, err := bn.delete([]byte{})
 	assert.False(t, dirty)
 	assert.Equal(t, ErrValueTooShort, err)
 	assert.Nil(t, newBn)
@@ -858,20 +754,18 @@ func TestBranchNode_deleteEmptykey(t *testing.T) {
 func TestBranchNode_deleteCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, collapsedBn := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
-	_ = bn.setHash(marsh, hasher)
-	_ = bn.commit(false, 0, db, marsh, hasher)
+	bn, collapsedBn := getBnAndCollapsedBn(getTestDbMarshAndHasher())
+	_ = bn.setHash()
+	_ = bn.commit(false, 0)
 
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
-	dirty, newBn, _, err := collapsedBn.delete(key, db, marsh)
+	dirty, newBn, _, err := collapsedBn.delete(key)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 
-	val, err := newBn.tryGet(key, db, marsh)
+	val, err := newBn.tryGet(key)
 	assert.Nil(t, val)
 	assert.Nil(t, err)
 }
@@ -879,22 +773,19 @@ func TestBranchNode_deleteCollapsedNode(t *testing.T) {
 func TestBranchNode_deleteAndReduceBn(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	marsh, _ := getTestMarshAndHasher()
-
+	bn, _ := newBranchNode(getTestDbMarshAndHasher())
 	var children [nrOfChildren]node
 	firstChildPos := byte(2)
 	secondChildPos := byte(6)
-	children[firstChildPos] = newLeafNode([]byte("dog"), []byte("dog"))
-	children[secondChildPos] = newLeafNode([]byte("doe"), []byte("doe"))
-	bn := newBranchNode()
+	children[firstChildPos], _ = newLeafNode([]byte("dog"), []byte("dog"), bn.db, bn.marsh, bn.hasher)
+	children[secondChildPos], _ = newLeafNode([]byte("doe"), []byte("doe"), bn.db, bn.marsh, bn.hasher)
 	bn.children = children
 
 	key := append([]byte{firstChildPos}, []byte("dog")...)
-	ln := newLeafNode(key, []byte("dog"))
+	ln, _ := newLeafNode(key, []byte("dog"), bn.db, bn.marsh, bn.hasher)
 
 	key = append([]byte{secondChildPos}, []byte("doe")...)
-	dirty, newBn, _, err := bn.delete(key, db, marsh)
+	dirty, newBn, _, err := bn.delete(key)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, ln, newBn)
@@ -903,23 +794,24 @@ func TestBranchNode_deleteAndReduceBn(t *testing.T) {
 func TestBranchNode_reduceNode(t *testing.T) {
 	t.Parallel()
 
+	bn, _ := newBranchNode(getTestDbMarshAndHasher())
 	var children [nrOfChildren]node
 	childPos := byte(2)
-	children[childPos] = newLeafNode([]byte("dog"), []byte("dog"))
-	bn := newBranchNode()
+	children[childPos], _ = newLeafNode([]byte("dog"), []byte("dog"), bn.db, bn.marsh, bn.hasher)
 	bn.children = children
 
 	key := append([]byte{childPos}, []byte("dog")...)
-	ln := newLeafNode(key, []byte("dog"))
+	ln, _ := newLeafNode(key, []byte("dog"), bn.db, bn.marsh, bn.hasher)
 
-	node := bn.children[childPos].reduceNode(int(childPos))
+	node, err := bn.children[childPos].reduceNode(int(childPos))
 	assert.Equal(t, ln, node)
+	assert.Nil(t, err)
 }
 
 func TestBranchNode_getChildPosition(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	nr, pos := getChildPosition(bn)
 	assert.Equal(t, 3, nr)
 	assert.Equal(t, 13, pos)
@@ -928,7 +820,7 @@ func TestBranchNode_getChildPosition(t *testing.T) {
 func TestBranchNode_clone(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	clone := bn.clone()
 	assert.False(t, bn == clone)
 	assert.Equal(t, bn, clone)
@@ -937,7 +829,7 @@ func TestBranchNode_clone(t *testing.T) {
 func TestBranchNode_isEmptyOrNil(t *testing.T) {
 	t.Parallel()
 
-	bn := newBranchNode()
+	bn := emptyDirtyBranchNode()
 	assert.Equal(t, ErrEmptyNode, bn.isEmptyOrNil())
 
 	bn = nil
@@ -947,8 +839,8 @@ func TestBranchNode_isEmptyOrNil(t *testing.T) {
 func TestReduceBranchNodeWithExtensionNodeChildShouldWork(t *testing.T) {
 	t.Parallel()
 
-	tr := newEmptyTrie()
-	expectedTr := newEmptyTrie()
+	tr := newEmptyTrie(getTestDbMarshAndHasher())
+	expectedTr := newEmptyTrie(getTestDbMarshAndHasher())
 
 	_ = expectedTr.Update([]byte("dog"), []byte("dog"))
 	_ = expectedTr.Update([]byte("doll"), []byte("doll"))
@@ -960,15 +852,14 @@ func TestReduceBranchNodeWithExtensionNodeChildShouldWork(t *testing.T) {
 
 	expectedHash, _ := expectedTr.Root()
 	hash, _ := tr.Root()
-
 	assert.Equal(t, expectedHash, hash)
 }
 
 func TestReduceBranchNodeWithBranchNodeChildShouldWork(t *testing.T) {
 	t.Parallel()
 
-	tr := newEmptyTrie()
-	expectedTr := newEmptyTrie()
+	tr := newEmptyTrie(getTestDbMarshAndHasher())
+	expectedTr := newEmptyTrie(getTestDbMarshAndHasher())
 
 	_ = expectedTr.Update([]byte("dog"), []byte("puppy"))
 	_ = expectedTr.Update([]byte("dogglesworth"), []byte("cat"))
@@ -980,15 +871,14 @@ func TestReduceBranchNodeWithBranchNodeChildShouldWork(t *testing.T) {
 
 	expectedHash, _ := expectedTr.Root()
 	hash, _ := tr.Root()
-
 	assert.Equal(t, expectedHash, hash)
 }
 
 func TestReduceBranchNodeWithLeafNodeChildShouldWork(t *testing.T) {
 	t.Parallel()
 
-	tr := newEmptyTrie()
-	expectedTr := newEmptyTrie()
+	tr := newEmptyTrie(getTestDbMarshAndHasher())
+	expectedTr := newEmptyTrie(getTestDbMarshAndHasher())
 
 	_ = expectedTr.Update([]byte("doe"), []byte("reindeer"))
 	_ = expectedTr.Update([]byte("dogglesworth"), []byte("cat"))
@@ -1000,15 +890,14 @@ func TestReduceBranchNodeWithLeafNodeChildShouldWork(t *testing.T) {
 
 	expectedHash, _ := expectedTr.Root()
 	hash, _ := tr.Root()
-
 	assert.Equal(t, expectedHash, hash)
 }
 
 func TestReduceBranchNodeWithLeafNodeValueShouldWork(t *testing.T) {
 	t.Parallel()
 
-	tr := newEmptyTrie()
-	expectedTr := newEmptyTrie()
+	tr := newEmptyTrie(getTestDbMarshAndHasher())
+	expectedTr := newEmptyTrie(getTestDbMarshAndHasher())
 
 	_ = expectedTr.Update([]byte("doe"), []byte("reindeer"))
 	_ = expectedTr.Update([]byte("dog"), []byte("puppy"))
@@ -1022,14 +911,6 @@ func TestReduceBranchNodeWithLeafNodeValueShouldWork(t *testing.T) {
 	hash, _ := tr.Root()
 
 	assert.Equal(t, expectedHash, hash)
-}
-
-func newEmptyTrie() data.Trie {
-	db := mock.NewMemDbMock()
-	marsh, hsh := getTestMarshAndHasher()
-	cacheSize := 100
-	tr, _ := NewTrie(db, marsh, hsh, mock.NewMemDbMock(), cacheSize, config.DBConfig{})
-	return tr
 }
 
 //------- deepClone
@@ -1114,10 +995,10 @@ func getBranchNodeContents(bn *branchNode) string {
 	}
 
 	str := fmt.Sprintf(`extension node:
-   		encoded child: %s
-   		hash: %s
-  		child: %s,	
-   		dirty: %v
+  		encoded child: %s
+  		hash: %s
+ 		child: %s,
+  		dirty: %v
 `,
 		encodedChildsString,
 		hex.EncodeToString(bn.hash),
@@ -1128,8 +1009,8 @@ func getBranchNodeContents(bn *branchNode) string {
 }
 
 func BenchmarkDecodeBranchNode(b *testing.B) {
-	tr := newEmptyTrie()
-	marsh, hsh := getTestMarshAndHasher()
+	db, marsh, hsh := getTestDbMarshAndHasher()
+	tr := newEmptyTrie(db, marsh, hsh)
 
 	nrValuesInTrie := 100000
 	values := make([][]byte, nrValuesInTrie)
@@ -1143,12 +1024,12 @@ func BenchmarkDecodeBranchNode(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = decodeNode(proof[0], marsh)
+		_, _ = decodeNode(proof[0], db, marsh, hsh)
 	}
 }
 
 func BenchmarkMarshallNodeCapnp(b *testing.B) {
-	bn, _ := getBnAndCollapsedBn()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	marsh := &marshal.CapnpMarshalizer{}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -1157,7 +1038,7 @@ func BenchmarkMarshallNodeCapnp(b *testing.B) {
 }
 
 func BenchmarkMarshallNodeJson(b *testing.B) {
-	bn, _ := getBnAndCollapsedBn()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	marsh := marshal.JsonMarshalizer{}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/data/trie/extensionNode.go
+++ b/data/trie/extensionNode.go
@@ -203,7 +203,7 @@ func (en *extensionNode) hashNode() ([]byte, error) {
 	return encodeNodeAndGetHash(en)
 }
 
-func (en *extensionNode) commit(force bool, level byte, originDb data.DBWriteCacher, targetDb data.DBWriteCacher, marshalizer marshal.Marshalizer, hasher hashing.Hasher) error {
+func (en *extensionNode) commit(force bool, level byte, db data.DBWriteCacher) error {
 	level++
 	err := en.isEmptyOrNil()
 	if err != nil {
@@ -216,21 +216,21 @@ func (en *extensionNode) commit(force bool, level byte, originDb data.DBWriteCac
 	}
 
 	if force {
-		err = resolveIfCollapsed(en, 0, originDb, marshalizer)
+		err = resolveIfCollapsed(en, 0)
 		if err != nil {
 			return err
 		}
 	}
 
 	if en.child != nil {
-		err = en.child.commit(force, level, originDb, targetDb, marshalizer, hasher)
+		err = en.child.commit(force, level, db)
 		if err != nil {
 			return err
 		}
 	}
 
 	en.dirty = false
-	err = encodeNodeAndCommitToDB(en, targetDb, marshalizer, hasher)
+	err = encodeNodeAndCommitToDB(en, db)
 	if err != nil {
 		return err
 	}

--- a/data/trie/extensionNode.go
+++ b/data/trie/extensionNode.go
@@ -69,11 +69,13 @@ func newExtensionNode(key []byte, child node, db data.DBWriteCacher, marshalizer
 			Key:          key,
 			EncodedChild: nil,
 		},
-		child:  child,
-		dirty:  true,
-		db:     db,
-		marsh:  marshalizer,
-		hasher: hasher,
+		child: child,
+		baseNode: &baseNode{
+			dirty:  true,
+			db:     db,
+			marsh:  marshalizer,
+			hasher: hasher,
+		},
 	}, nil
 }
 
@@ -491,7 +493,7 @@ func (en *extensionNode) deepClone() node {
 		return nil
 	}
 
-	clonedNode := &extensionNode{}
+	clonedNode := &extensionNode{baseNode: &baseNode{}}
 
 	if en.Key != nil {
 		clonedNode.Key = make([]byte, len(en.Key))

--- a/data/trie/extensionNode_test.go
+++ b/data/trie/extensionNode_test.go
@@ -234,7 +234,7 @@ func TestExtensionNode_commit(t *testing.T) {
 	hash, _ := encodeNodeAndGetHash(collapsedEn)
 	_ = en.setHash()
 
-	err := en.commit(false, 0)
+	err := en.commit(false, 0, en.db)
 	assert.Nil(t, err)
 
 	encNode, _ := en.db.Get(hash)
@@ -250,7 +250,7 @@ func TestExtensionNode_commitEmptyNode(t *testing.T) {
 
 	en := &extensionNode{}
 
-	err := en.commit(false, 0)
+	err := en.commit(false, 0, nil)
 	assert.Equal(t, ErrEmptyNode, err)
 }
 
@@ -259,7 +259,7 @@ func TestExtensionNode_commitNilNode(t *testing.T) {
 
 	var en *extensionNode
 
-	err := en.commit(false, 0)
+	err := en.commit(false, 0, nil)
 	assert.Equal(t, ErrNilNode, err)
 }
 
@@ -271,7 +271,7 @@ func TestExtensionNode_commitCollapsedNode(t *testing.T) {
 	_ = collapsedEn.setHash()
 
 	collapsedEn.dirty = true
-	err := collapsedEn.commit(false, 0)
+	err := collapsedEn.commit(false, 0, collapsedEn.db)
 	assert.Nil(t, err)
 
 	encNode, _ := collapsedEn.db.Get(hash)
@@ -320,7 +320,7 @@ func TestExtensionNode_resolveCollapsed(t *testing.T) {
 
 	en, collapsedEn := getEnAndCollapsedEn()
 	_ = en.setHash()
-	_ = en.commit(false, 0)
+	_ = en.commit(false, 0, en.db)
 	_, resolved := getBnAndCollapsedBn(en.db, en.marsh, en.hasher)
 
 	err := collapsedEn.resolveCollapsed(0)
@@ -405,7 +405,7 @@ func TestExtensionNode_tryGetCollapsedNode(t *testing.T) {
 
 	en, collapsedEn := getEnAndCollapsedEn()
 	_ = en.setHash()
-	_ = en.commit(false, 0)
+	_ = en.commit(false, 0, en.db)
 
 	enKey := []byte{100}
 	bnKey := []byte{2}
@@ -495,7 +495,7 @@ func TestExtensionNode_insertCollapsedNode(t *testing.T) {
 	node, _ := newLeafNode(key, []byte("dogs"), en.db, en.marsh, en.hasher)
 
 	_ = en.setHash()
-	_ = en.commit(false, 0)
+	_ = en.commit(false, 0, en.db)
 
 	dirty, newNode, _, err := collapsedEn.insert(node)
 	assert.True(t, dirty)
@@ -513,7 +513,7 @@ func TestExtensionNode_insertInStoredEnSameKey(t *testing.T) {
 	key := append(enKey, []byte{11, 12}...)
 	node, _ := newLeafNode(key, []byte("dogs"), en.db, en.marsh, en.hasher)
 
-	_ = en.commit(false, 0)
+	_ = en.commit(false, 0, en.db)
 	enHash := en.getHash()
 	bn, _, _ := en.getNext(enKey)
 	bnHash := bn.getHash()
@@ -534,7 +534,7 @@ func TestExtensionNode_insertInStoredEnDifferentKey(t *testing.T) {
 	nodeKey := []byte{11, 12}
 	node, _ := newLeafNode(nodeKey, []byte("dogs"), bn.db, bn.marsh, bn.hasher)
 
-	_ = en.commit(false, 0)
+	_ = en.commit(false, 0, en.db)
 	expectedHashes := [][]byte{en.getHash()}
 
 	dirty, _, oldHashes, err := en.insert(node)
@@ -615,7 +615,7 @@ func TestExtensionNode_deleteFromStoredEn(t *testing.T) {
 	key = append(key, lnKey...)
 	lnPathKey := key
 
-	_ = en.commit(false, 0)
+	_ = en.commit(false, 0, en.db)
 	bn, key, _ := en.getNext(key)
 	ln, _, _ := bn.getNext(key)
 	expectedHashes := [][]byte{ln.getHash(), bn.getHash(), en.getHash()}
@@ -676,7 +676,7 @@ func TestExtensionNode_deleteCollapsedNode(t *testing.T) {
 
 	en, collapsedEn := getEnAndCollapsedEn()
 	_ = en.setHash()
-	_ = en.commit(false, 0)
+	_ = en.commit(false, 0, en.db)
 
 	enKey := []byte{100}
 	bnKey := []byte{2}

--- a/data/trie/extensionNode_test.go
+++ b/data/trie/extensionNode_test.go
@@ -6,35 +6,38 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ElrondNetwork/elrond-go/data/mock"
 	protobuf "github.com/ElrondNetwork/elrond-go/data/trie/proto"
 	"github.com/stretchr/testify/assert"
 )
 
 func getEnAndCollapsedEn() (*extensionNode, *extensionNode) {
-	marsh, hasher := getTestMarshAndHasher()
-	child, collapsedChild := getBnAndCollapsedBn()
-	en := newExtensionNode([]byte("d"), child)
+	child, collapsedChild := getBnAndCollapsedBn(getTestDbMarshAndHasher())
+	en, _ := newExtensionNode([]byte("d"), child, child.db, child.marsh, child.hasher)
 
-	childHash, _ := encodeNodeAndGetHash(collapsedChild, marsh, hasher)
+	childHash, _ := encodeNodeAndGetHash(collapsedChild)
 	collapsedEn := &extensionNode{CollapsedEn: protobuf.CollapsedEn{Key: []byte("d"), EncodedChild: childHash}}
+	collapsedEn.db = child.db
+	collapsedEn.marsh = child.marsh
+	collapsedEn.hasher = child.hasher
 	return en, collapsedEn
 }
 
 func TestExtensionNode_newExtensionNode(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	expectedEn := &extensionNode{
 		CollapsedEn: protobuf.CollapsedEn{
 			Key:          []byte("dog"),
 			EncodedChild: nil,
 		},
-		child: bn,
-		hash:  nil,
-		dirty: true,
+		child:  bn,
+		dirty:  true,
+		db:     bn.db,
+		marsh:  bn.marsh,
+		hasher: bn.hasher,
 	}
-	en := newExtensionNode([]byte("dog"), bn)
+	en, _ := newExtensionNode([]byte("dog"), bn, bn.db, bn.marsh, bn.hasher)
 	assert.Equal(t, expectedEn, en)
 }
 
@@ -60,9 +63,8 @@ func TestExtensionNode_getCollapsed(t *testing.T) {
 
 	en, collapsedEn := getEnAndCollapsedEn()
 	collapsedEn.dirty = true
-	marsh, hasher := getTestMarshAndHasher()
 
-	collapsed, err := en.getCollapsed(marsh, hasher)
+	collapsed, err := en.getCollapsed()
 	assert.Nil(t, err)
 	assert.Equal(t, collapsedEn, collapsed)
 }
@@ -70,10 +72,9 @@ func TestExtensionNode_getCollapsed(t *testing.T) {
 func TestExtensionNode_getCollapsedEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshAndHasher()
 	en := &extensionNode{}
 
-	collapsed, err := en.getCollapsed(marsh, hasher)
+	collapsed, err := en.getCollapsed()
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, collapsed)
 }
@@ -81,10 +82,9 @@ func TestExtensionNode_getCollapsedEmptyNode(t *testing.T) {
 func TestExtensionNode_getCollapsedNilNode(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshAndHasher()
 	var en *extensionNode
 
-	collapsed, err := en.getCollapsed(marsh, hasher)
+	collapsed, err := en.getCollapsed()
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, collapsed)
 }
@@ -93,9 +93,8 @@ func TestExtensionNode_getCollapsedCollapsedNode(t *testing.T) {
 	t.Parallel()
 
 	_, collapsedEn := getEnAndCollapsedEn()
-	marsh, hasher := getTestMarshAndHasher()
 
-	collapsed, err := collapsedEn.getCollapsed(marsh, hasher)
+	collapsed, err := collapsedEn.getCollapsed()
 	assert.Nil(t, err)
 	assert.Equal(t, collapsedEn, collapsed)
 }
@@ -104,11 +103,9 @@ func TestExtensionNode_setHash(t *testing.T) {
 	t.Parallel()
 
 	en, collapsedEn := getEnAndCollapsedEn()
-	marsh, hasher := getTestMarshAndHasher()
+	hash, _ := encodeNodeAndGetHash(collapsedEn)
 
-	hash, _ := encodeNodeAndGetHash(collapsedEn, marsh, hasher)
-
-	err := en.setHash(marsh, hasher)
+	err := en.setHash()
 	assert.Nil(t, err)
 	assert.Equal(t, hash, en.hash)
 }
@@ -116,10 +113,9 @@ func TestExtensionNode_setHash(t *testing.T) {
 func TestExtensionNode_setHashEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshAndHasher()
 	en := &extensionNode{}
 
-	err := en.setHash(marsh, hasher)
+	err := en.setHash()
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, en.hash)
 }
@@ -127,10 +123,9 @@ func TestExtensionNode_setHashEmptyNode(t *testing.T) {
 func TestExtensionNode_setHashNilNode(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshAndHasher()
 	var en *extensionNode
 
-	err := en.setHash(marsh, hasher)
+	err := en.setHash()
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, en)
 }
@@ -139,11 +134,9 @@ func TestExtensionNode_setHashCollapsedNode(t *testing.T) {
 	t.Parallel()
 
 	_, collapsedEn := getEnAndCollapsedEn()
-	marsh, hasher := getTestMarshAndHasher()
+	hash, _ := encodeNodeAndGetHash(collapsedEn)
 
-	hash, _ := encodeNodeAndGetHash(collapsedEn, marsh, hasher)
-
-	err := collapsedEn.setHash(marsh, hasher)
+	err := collapsedEn.setHash()
 	assert.Nil(t, err)
 	assert.Equal(t, hash, collapsedEn.hash)
 }
@@ -155,7 +148,6 @@ func TestExtensionNode_setGivenHash(t *testing.T) {
 	expectedHash := []byte("node hash")
 
 	en.setGivenHash(expectedHash)
-
 	assert.Equal(t, expectedHash, en.hash)
 }
 
@@ -163,14 +155,12 @@ func TestExtensionNode_hashChildren(t *testing.T) {
 	t.Parallel()
 
 	en, _ := getEnAndCollapsedEn()
-	marsh, hasher := getTestMarshAndHasher()
-
 	assert.Nil(t, en.child.getHash())
 
-	err := en.hashChildren(marsh, hasher)
+	err := en.hashChildren()
 	assert.Nil(t, err)
 
-	childHash, _ := encodeNodeAndGetHash(en.child, marsh, hasher)
+	childHash, _ := encodeNodeAndGetHash(en.child)
 	assert.Equal(t, childHash, en.child.getHash())
 }
 
@@ -178,9 +168,8 @@ func TestExtensionNode_hashChildrenEmptyNode(t *testing.T) {
 	t.Parallel()
 
 	en := &extensionNode{}
-	marsh, hasher := getTestMarshAndHasher()
 
-	err := en.hashChildren(marsh, hasher)
+	err := en.hashChildren()
 	assert.Equal(t, ErrEmptyNode, err)
 }
 
@@ -188,9 +177,8 @@ func TestExtensionNode_hashChildrenNilNode(t *testing.T) {
 	t.Parallel()
 
 	var en *extensionNode
-	marsh, hasher := getTestMarshAndHasher()
 
-	err := en.hashChildren(marsh, hasher)
+	err := en.hashChildren()
 	assert.Equal(t, ErrNilNode, err)
 }
 
@@ -198,9 +186,8 @@ func TestExtensionNode_hashChildrenCollapsedNode(t *testing.T) {
 	t.Parallel()
 
 	_, collapsedEn := getEnAndCollapsedEn()
-	marsh, hasher := getTestMarshAndHasher()
 
-	err := collapsedEn.hashChildren(marsh, hasher)
+	err := collapsedEn.hashChildren()
 	assert.Nil(t, err)
 
 	_, collapsedEn2 := getEnAndCollapsedEn()
@@ -211,10 +198,9 @@ func TestExtensionNode_hashNode(t *testing.T) {
 	t.Parallel()
 
 	_, collapsedEn := getEnAndCollapsedEn()
-	marsh, hasher := getTestMarshAndHasher()
+	expectedHash, _ := encodeNodeAndGetHash(collapsedEn)
 
-	expectedHash, _ := encodeNodeAndGetHash(collapsedEn, marsh, hasher)
-	hash, err := collapsedEn.hashNode(marsh, hasher)
+	hash, err := collapsedEn.hashNode()
 	assert.Nil(t, err)
 	assert.Equal(t, expectedHash, hash)
 }
@@ -223,9 +209,8 @@ func TestExtensionNode_hashNodeEmptyNode(t *testing.T) {
 	t.Parallel()
 
 	en := &extensionNode{}
-	marsh, hasher := getTestMarshAndHasher()
 
-	hash, err := en.hashNode(marsh, hasher)
+	hash, err := en.hashNode()
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, hash)
 }
@@ -234,9 +219,8 @@ func TestExtensionNode_hashNodeNilNode(t *testing.T) {
 	t.Parallel()
 
 	var en *extensionNode
-	marsh, hasher := getTestMarshAndHasher()
 
-	hash, err := en.hashNode(marsh, hasher)
+	hash, err := en.hashNode()
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, hash)
 }
@@ -244,21 +228,18 @@ func TestExtensionNode_hashNodeNilNode(t *testing.T) {
 func TestExtensionNode_commit(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, collapsedEn := getEnAndCollapsedEn()
-	marsh, hasher := getTestMarshAndHasher()
+	hash, _ := encodeNodeAndGetHash(collapsedEn)
+	_ = en.setHash()
 
-	hash, _ := encodeNodeAndGetHash(collapsedEn, marsh, hasher)
-	_ = en.setHash(marsh, hasher)
-
-	err := en.commit(false, 0, db, marsh, hasher)
+	err := en.commit(false, 0)
 	assert.Nil(t, err)
 
-	encNode, _ := db.Get(hash)
-	node, _ := decodeNode(encNode, marsh)
+	encNode, _ := en.db.Get(hash)
+	node, _ := decodeNode(encNode, en.db, en.marsh, en.hasher)
 
-	h1, _ := encodeNodeAndGetHash(collapsedEn, marsh, hasher)
-	h2, _ := encodeNodeAndGetHash(node, marsh, hasher)
+	h1, _ := encodeNodeAndGetHash(collapsedEn)
+	h2, _ := encodeNodeAndGetHash(node)
 	assert.Equal(t, h1, h2)
 }
 
@@ -266,10 +247,8 @@ func TestExtensionNode_commitEmptyNode(t *testing.T) {
 	t.Parallel()
 
 	en := &extensionNode{}
-	db := mock.NewMemDbMock()
-	marsh, hasher := getTestMarshAndHasher()
 
-	err := en.commit(false, 0, db, marsh, hasher)
+	err := en.commit(false, 0)
 	assert.Equal(t, ErrEmptyNode, err)
 }
 
@@ -277,33 +256,28 @@ func TestExtensionNode_commitNilNode(t *testing.T) {
 	t.Parallel()
 
 	var en *extensionNode
-	db := mock.NewMemDbMock()
-	marsh, hasher := getTestMarshAndHasher()
 
-	err := en.commit(false, 0, db, marsh, hasher)
+	err := en.commit(false, 0)
 	assert.Equal(t, ErrNilNode, err)
 }
 
 func TestExtensionNode_commitCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	_, collapsedEn := getEnAndCollapsedEn()
-	marsh, hasher := getTestMarshAndHasher()
-
-	hash, _ := encodeNodeAndGetHash(collapsedEn, marsh, hasher)
-	_ = collapsedEn.setHash(marsh, hasher)
+	hash, _ := encodeNodeAndGetHash(collapsedEn)
+	_ = collapsedEn.setHash()
 
 	collapsedEn.dirty = true
-	err := collapsedEn.commit(false, 0, db, marsh, hasher)
+	err := collapsedEn.commit(false, 0)
 	assert.Nil(t, err)
 
-	encNode, _ := db.Get(hash)
-	node, _ := decodeNode(encNode, marsh)
+	encNode, _ := collapsedEn.db.Get(hash)
+	node, _ := decodeNode(encNode, collapsedEn.db, collapsedEn.marsh, collapsedEn.hasher)
 	collapsedEn.hash = nil
 
-	h1, _ := encodeNodeAndGetHash(collapsedEn, marsh, hasher)
-	h2, _ := encodeNodeAndGetHash(node, marsh, hasher)
+	h1, _ := encodeNodeAndGetHash(collapsedEn)
+	h2, _ := encodeNodeAndGetHash(node)
 	assert.Equal(t, h1, h2)
 }
 
@@ -311,12 +285,10 @@ func TestExtensionNode_getEncodedNode(t *testing.T) {
 	t.Parallel()
 
 	en, _ := getEnAndCollapsedEn()
-	marsh, _ := getTestMarshAndHasher()
-
-	expectedEncodedNode, _ := marsh.Marshal(en)
+	expectedEncodedNode, _ := en.marsh.Marshal(en)
 	expectedEncodedNode = append(expectedEncodedNode, extension)
 
-	encNode, err := en.getEncodedNode(marsh)
+	encNode, err := en.getEncodedNode()
 	assert.Nil(t, err)
 	assert.Equal(t, expectedEncodedNode, encNode)
 }
@@ -325,9 +297,8 @@ func TestExtensionNode_getEncodedNodeEmpty(t *testing.T) {
 	t.Parallel()
 
 	en := &extensionNode{}
-	marsh, _ := getTestMarshAndHasher()
 
-	encNode, err := en.getEncodedNode(marsh)
+	encNode, err := en.getEncodedNode()
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, encNode)
 }
@@ -336,9 +307,8 @@ func TestExtensionNode_getEncodedNodeNil(t *testing.T) {
 	t.Parallel()
 
 	var en *extensionNode
-	marsh, _ := getTestMarshAndHasher()
 
-	encNode, err := en.getEncodedNode(marsh)
+	encNode, err := en.getEncodedNode()
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, encNode)
 }
@@ -346,42 +316,35 @@ func TestExtensionNode_getEncodedNodeNil(t *testing.T) {
 func TestExtensionNode_resolveCollapsed(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, collapsedEn := getEnAndCollapsedEn()
-	marsh, hasher := getTestMarshAndHasher()
+	_ = en.setHash()
+	_ = en.commit(false, 0)
+	_, resolved := getBnAndCollapsedBn(en.db, en.marsh, en.hasher)
 
-	_ = en.setHash(marsh, hasher)
-	_ = en.commit(false, 0, db, marsh, hasher)
-	_, resolved := getBnAndCollapsedBn()
-
-	err := collapsedEn.resolveCollapsed(0, db, marsh)
+	err := collapsedEn.resolveCollapsed(0)
 	assert.Nil(t, err)
 	assert.Equal(t, en.child.getHash(), collapsedEn.child.getHash())
 
-	h1, _ := encodeNodeAndGetHash(resolved, marsh, hasher)
-	h2, _ := encodeNodeAndGetHash(collapsedEn.child, marsh, hasher)
+	h1, _ := encodeNodeAndGetHash(resolved)
+	h2, _ := encodeNodeAndGetHash(collapsedEn.child)
 	assert.Equal(t, h1, h2)
 }
 
 func TestExtensionNode_resolveCollapsedEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en := &extensionNode{}
-	marsh, _ := getTestMarshAndHasher()
 
-	err := en.resolveCollapsed(0, db, marsh)
+	err := en.resolveCollapsed(0)
 	assert.Equal(t, ErrEmptyNode, err)
 }
 
 func TestExtensionNode_resolveCollapsedNilNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	var en *extensionNode
-	marsh, _ := getTestMarshAndHasher()
 
-	err := en.resolveCollapsed(2, db, marsh)
+	err := en.resolveCollapsed(2)
 	assert.Equal(t, ErrNilNode, err)
 }
 
@@ -389,20 +352,17 @@ func TestExtensionNode_isCollapsed(t *testing.T) {
 	t.Parallel()
 
 	en, collapsedEn := getEnAndCollapsedEn()
-
 	assert.True(t, collapsedEn.isCollapsed())
 	assert.False(t, en.isCollapsed())
 
-	collapsedEn.child = newLeafNode([]byte("og"), []byte("dog"))
+	collapsedEn.child, _ = newLeafNode([]byte("og"), []byte("dog"), en.db, en.marsh, en.hasher)
 	assert.False(t, collapsedEn.isCollapsed())
 }
 
 func TestExtensionNode_tryGet(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, _ := getEnAndCollapsedEn()
-	marsh, _ := getTestMarshAndHasher()
 	dogBytes := []byte("dog")
 
 	enKey := []byte{100}
@@ -411,7 +371,7 @@ func TestExtensionNode_tryGet(t *testing.T) {
 	key := append(enKey, bnKey...)
 	key = append(key, lnKey...)
 
-	val, err := en.tryGet(key, db, marsh)
+	val, err := en.tryGet(key)
 	assert.Equal(t, dogBytes, val)
 	assert.Nil(t, err)
 }
@@ -419,12 +379,10 @@ func TestExtensionNode_tryGet(t *testing.T) {
 func TestExtensionNode_tryGetEmptyKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, _ := getEnAndCollapsedEn()
-	marsh, _ := getTestMarshAndHasher()
-
 	var key []byte
-	val, err := en.tryGet(key, db, marsh)
+
+	val, err := en.tryGet(key)
 	assert.Nil(t, err)
 	assert.Nil(t, val)
 }
@@ -432,12 +390,10 @@ func TestExtensionNode_tryGetEmptyKey(t *testing.T) {
 func TestExtensionNode_tryGetWrongKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, _ := getEnAndCollapsedEn()
-	marsh, _ := getTestMarshAndHasher()
-
 	key := []byte("gdo")
-	val, err := en.tryGet(key, db, marsh)
+
+	val, err := en.tryGet(key)
 	assert.Nil(t, err)
 	assert.Nil(t, val)
 }
@@ -445,11 +401,9 @@ func TestExtensionNode_tryGetWrongKey(t *testing.T) {
 func TestExtensionNode_tryGetCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, collapsedEn := getEnAndCollapsedEn()
-	marsh, hasher := getTestMarshAndHasher()
-	_ = en.setHash(marsh, hasher)
-	_ = en.commit(false, 0, db, marsh, hasher)
+	_ = en.setHash()
+	_ = en.commit(false, 0)
 
 	enKey := []byte{100}
 	bnKey := []byte{2}
@@ -457,7 +411,7 @@ func TestExtensionNode_tryGetCollapsedNode(t *testing.T) {
 	key := append(enKey, bnKey...)
 	key = append(key, lnKey...)
 
-	val, err := collapsedEn.tryGet(key, db, marsh)
+	val, err := collapsedEn.tryGet(key)
 	assert.Equal(t, []byte("dog"), val)
 	assert.Nil(t, err)
 }
@@ -465,12 +419,10 @@ func TestExtensionNode_tryGetCollapsedNode(t *testing.T) {
 func TestExtensionNode_tryGetEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en := &extensionNode{}
-	marsh, _ := getTestMarshAndHasher()
-
 	key := []byte("dog")
-	val, err := en.tryGet(key, db, marsh)
+
+	val, err := en.tryGet(key)
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, val)
 }
@@ -478,12 +430,10 @@ func TestExtensionNode_tryGetEmptyNode(t *testing.T) {
 func TestExtensionNode_tryGetNilNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	var en *extensionNode
-	marsh, _ := getTestMarshAndHasher()
-
 	key := []byte("dog")
-	val, err := en.tryGet(key, db, marsh)
+
+	val, err := en.tryGet(key)
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, val)
 }
@@ -491,10 +441,8 @@ func TestExtensionNode_tryGetNilNode(t *testing.T) {
 func TestExtensionNode_getNext(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, _ := getEnAndCollapsedEn()
-	marsh, _ := getTestMarshAndHasher()
-	nextNode, _ := getBnAndCollapsedBn()
+	nextNode, _ := getBnAndCollapsedBn(en.db, en.marsh, en.hasher)
 
 	enKey := []byte{100}
 	bnKey := []byte{2}
@@ -502,7 +450,7 @@ func TestExtensionNode_getNext(t *testing.T) {
 	key := append(enKey, bnKey...)
 	key = append(key, lnKey...)
 
-	node, newKey, err := en.getNext(key, db, marsh)
+	node, newKey, err := en.getNext(key)
 	assert.Equal(t, nextNode, node)
 	assert.Equal(t, key[1:], newKey)
 	assert.Nil(t, err)
@@ -511,15 +459,12 @@ func TestExtensionNode_getNext(t *testing.T) {
 func TestExtensionNode_getNextWrongKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, _ := getEnAndCollapsedEn()
-	marsh, _ := getTestMarshAndHasher()
-
 	bnKey := []byte{2}
 	lnKey := []byte("dog")
 	key := append(bnKey, lnKey...)
 
-	node, key, err := en.getNext(key, db, marsh)
+	node, key, err := en.getNext(key)
 	assert.Nil(t, node)
 	assert.Nil(t, key)
 	assert.Equal(t, ErrNodeNotFound, err)
@@ -528,58 +473,51 @@ func TestExtensionNode_getNextWrongKey(t *testing.T) {
 func TestExtensionNode_insert(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, _ := getEnAndCollapsedEn()
-
 	key := []byte{100, 15, 5, 6}
-	node := newLeafNode(key, []byte("dogs"))
-	marsh, _ := getTestMarshAndHasher()
+	node, _ := newLeafNode(key, []byte("dogs"), en.db, en.marsh, en.hasher)
 
-	dirty, newNode, _, err := en.insert(node, db, marsh)
+	dirty, newNode, _, err := en.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
-	val, _ := newNode.tryGet(key, db, marsh)
+
+	val, _ := newNode.tryGet(key)
 	assert.Equal(t, []byte("dogs"), val)
 }
 
 func TestExtensionNode_insertCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, collapsedEn := getEnAndCollapsedEn()
-
 	key := []byte{100, 15, 5, 6}
-	node := newLeafNode(key, []byte("dogs"))
-	marsh, hasher := getTestMarshAndHasher()
-	_ = en.setHash(marsh, hasher)
-	_ = en.commit(false, 0, db, marsh, hasher)
+	node, _ := newLeafNode(key, []byte("dogs"), en.db, en.marsh, en.hasher)
 
-	dirty, newNode, _, err := collapsedEn.insert(node, db, marsh)
+	_ = en.setHash()
+	_ = en.commit(false, 0)
+
+	dirty, newNode, _, err := collapsedEn.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
-	val, _ := newNode.tryGet(key, db, marsh)
+
+	val, _ := newNode.tryGet(key)
 	assert.Equal(t, []byte("dogs"), val)
 }
 
 func TestExtensionNode_insertInStoredEnSameKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, _ := getEnAndCollapsedEn()
-	marsh, hasher := getTestMarshAndHasher()
-
 	enKey := []byte{100}
 	key := append(enKey, []byte{11, 12}...)
-	node := newLeafNode(key, []byte("dogs"))
+	node, _ := newLeafNode(key, []byte("dogs"), en.db, en.marsh, en.hasher)
 
-	_ = en.commit(false, 0, db, marsh, hasher)
+	_ = en.commit(false, 0)
 	enHash := en.getHash()
-	bn, _, _ := en.getNext(enKey, db, marsh)
+	bn, _, _ := en.getNext(enKey)
 	bnHash := bn.getHash()
 	expectedHashes := [][]byte{bnHash, enHash}
 
-	dirty, _, oldHashes, err := en.insert(node, db, marsh)
-
+	dirty, _, oldHashes, err := en.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedHashes, oldHashes)
@@ -588,20 +526,16 @@ func TestExtensionNode_insertInStoredEnSameKey(t *testing.T) {
 func TestExtensionNode_insertInStoredEnDifferentKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, hasher := getTestMarshAndHasher()
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	enKey := []byte{1}
-	en := newExtensionNode(enKey, bn)
-
+	en, _ := newExtensionNode(enKey, bn, bn.db, bn.marsh, bn.hasher)
 	nodeKey := []byte{11, 12}
-	node := newLeafNode(nodeKey, []byte("dogs"))
+	node, _ := newLeafNode(nodeKey, []byte("dogs"), bn.db, bn.marsh, bn.hasher)
 
-	_ = en.commit(false, 0, db, marsh, hasher)
+	_ = en.commit(false, 0)
 	expectedHashes := [][]byte{en.getHash()}
 
-	dirty, _, oldHashes, err := en.insert(node, db, marsh)
-
+	dirty, _, oldHashes, err := en.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedHashes, oldHashes)
@@ -610,14 +544,11 @@ func TestExtensionNode_insertInStoredEnDifferentKey(t *testing.T) {
 func TestExtensionNode_insertInDirtyEnSameKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, _ := getEnAndCollapsedEn()
-	marsh, _ := getTestMarshAndHasher()
 	nodeKey := []byte{100, 11, 12}
-	node := newLeafNode(nodeKey, []byte("dogs"))
+	node, _ := newLeafNode(nodeKey, []byte("dogs"), en.db, en.marsh, en.hasher)
 
-	dirty, _, oldHashes, err := en.insert(node, db, marsh)
-
+	dirty, _, oldHashes, err := en.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -626,18 +557,13 @@ func TestExtensionNode_insertInDirtyEnSameKey(t *testing.T) {
 func TestExtensionNode_insertInDirtyEnDifferentKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn()
-	marsh, _ := getTestMarshAndHasher()
-
+	bn, _ := getBnAndCollapsedBn(getTestDbMarshAndHasher())
 	enKey := []byte{1}
-	en := newExtensionNode(enKey, bn)
-
+	en, _ := newExtensionNode(enKey, bn, bn.db, bn.marsh, bn.hasher)
 	nodeKey := []byte{11, 12}
-	node := newLeafNode(nodeKey, []byte("dogs"))
+	node, _ := newLeafNode(nodeKey, []byte("dogs"), bn.db, bn.marsh, bn.hasher)
 
-	dirty, _, oldHashes, err := en.insert(node, db, marsh)
-
+	dirty, _, oldHashes, err := en.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -646,13 +572,9 @@ func TestExtensionNode_insertInDirtyEnDifferentKey(t *testing.T) {
 func TestExtensionNode_insertInNilNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	var en *extensionNode
-	nodeKey := []byte{0, 2, 3}
-	node := newLeafNode(nodeKey, []byte("dogs"))
-	marsh, _ := getTestMarshAndHasher()
 
-	dirty, newNode, _, err := en.insert(node, db, marsh)
+	dirty, newNode, _, err := en.insert(&leafNode{})
 	assert.False(t, dirty)
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, newNode)
@@ -661,9 +583,7 @@ func TestExtensionNode_insertInNilNode(t *testing.T) {
 func TestExtensionNode_delete(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, _ := getEnAndCollapsedEn()
-	marsh, _ := getTestMarshAndHasher()
 	dogBytes := []byte("dog")
 
 	enKey := []byte{100}
@@ -672,23 +592,20 @@ func TestExtensionNode_delete(t *testing.T) {
 	key := append(enKey, bnKey...)
 	key = append(key, lnKey...)
 
-	val, _ := en.tryGet(key, db, marsh)
+	val, _ := en.tryGet(key)
 	assert.Equal(t, dogBytes, val)
 
-	dirty, _, _, err := en.delete(key, db, marsh)
+	dirty, _, _, err := en.delete(key)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
-	val, _ = en.tryGet(key, db, marsh)
+	val, _ = en.tryGet(key)
 	assert.Nil(t, val)
 }
 
 func TestExtensionNode_deleteFromStoredEn(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, _ := getEnAndCollapsedEn()
-	marsh, hasher := getTestMarshAndHasher()
-
 	enKey := []byte{100}
 	bnKey := []byte{2}
 	lnKey := []byte("dog")
@@ -696,13 +613,12 @@ func TestExtensionNode_deleteFromStoredEn(t *testing.T) {
 	key = append(key, lnKey...)
 	lnPathKey := key
 
-	_ = en.commit(false, 0, db, marsh, hasher)
-	bn, key, _ := en.getNext(key, db, marsh)
-	ln, _, _ := bn.getNext(key, db, marsh)
+	_ = en.commit(false, 0)
+	bn, key, _ := en.getNext(key)
+	ln, _, _ := bn.getNext(key)
 	expectedHashes := [][]byte{ln.getHash(), bn.getHash(), en.getHash()}
 
-	dirty, _, oldHashes, err := en.delete(lnPathKey, db, marsh)
-
+	dirty, _, oldHashes, err := en.delete(lnPathKey)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedHashes, oldHashes)
@@ -711,13 +627,10 @@ func TestExtensionNode_deleteFromStoredEn(t *testing.T) {
 func TestExtensionNode_deleteFromDirtyEn(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, _ := getEnAndCollapsedEn()
-	marsh, _ := getTestMarshAndHasher()
 	lnKey := []byte{100, 2, 100, 111, 103}
 
-	dirty, _, oldHashes, err := en.delete(lnKey, db, marsh)
-
+	dirty, _, oldHashes, err := en.delete(lnKey)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -726,11 +639,9 @@ func TestExtensionNode_deleteFromDirtyEn(t *testing.T) {
 func TestExtendedNode_deleteEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en := &extensionNode{}
-	marsh, _ := getTestMarshAndHasher()
 
-	dirty, newNode, _, err := en.delete([]byte("dog"), db, marsh)
+	dirty, newNode, _, err := en.delete([]byte("dog"))
 	assert.False(t, dirty)
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, newNode)
@@ -739,11 +650,9 @@ func TestExtendedNode_deleteEmptyNode(t *testing.T) {
 func TestExtensionNode_deleteNilNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	var en *extensionNode
-	marsh, _ := getTestMarshAndHasher()
 
-	dirty, newNode, _, err := en.delete([]byte("dog"), db, marsh)
+	dirty, newNode, _, err := en.delete([]byte("dog"))
 	assert.False(t, dirty)
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, newNode)
@@ -752,11 +661,9 @@ func TestExtensionNode_deleteNilNode(t *testing.T) {
 func TestExtensionNode_deleteEmptykey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, _ := getEnAndCollapsedEn()
-	marsh, _ := getTestMarshAndHasher()
 
-	dirty, newNode, _, err := en.delete([]byte{}, db, marsh)
+	dirty, newNode, _, err := en.delete([]byte{})
 	assert.False(t, dirty)
 	assert.Equal(t, ErrValueTooShort, err)
 	assert.Nil(t, newNode)
@@ -765,11 +672,9 @@ func TestExtensionNode_deleteEmptykey(t *testing.T) {
 func TestExtensionNode_deleteCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	en, collapsedEn := getEnAndCollapsedEn()
-	marsh, hasher := getTestMarshAndHasher()
-	_ = en.setHash(marsh, hasher)
-	_ = en.commit(false, 0, db, marsh, hasher)
+	_ = en.setHash()
+	_ = en.commit(false, 0)
 
 	enKey := []byte{100}
 	bnKey := []byte{2}
@@ -777,23 +682,30 @@ func TestExtensionNode_deleteCollapsedNode(t *testing.T) {
 	key := append(enKey, bnKey...)
 	key = append(key, lnKey...)
 
-	val, _ := en.tryGet(key, db, marsh)
+	val, _ := en.tryGet(key)
 	assert.Equal(t, []byte("dog"), val)
 
-	dirty, newNode, _, err := collapsedEn.delete(key, db, marsh)
+	dirty, newNode, _, err := collapsedEn.delete(key)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
-	val, _ = newNode.tryGet(key, db, marsh)
+	val, _ = newNode.tryGet(key)
 	assert.Nil(t, val)
 }
 
 func TestExtensionNode_reduceNode(t *testing.T) {
 	t.Parallel()
 
-	en := &extensionNode{CollapsedEn: protobuf.CollapsedEn{Key: []byte{100, 111, 103}}}
+	db, marsh, hasher := getTestDbMarshAndHasher()
+	en, _ := newExtensionNode([]byte{100, 111, 103}, nil, db, marsh, hasher)
+
 	expected := &extensionNode{CollapsedEn: protobuf.CollapsedEn{Key: []byte{2, 100, 111, 103}}, dirty: true}
-	node := en.reduceNode(2)
+	expected.db = en.db
+	expected.marsh = en.marsh
+	expected.hasher = en.hasher
+
+	node, err := en.reduceNode(2)
 	assert.Equal(t, expected, node)
+	assert.Nil(t, err)
 }
 
 func TestExtensionNode_clone(t *testing.T) {

--- a/data/trie/extensionNode_test.go
+++ b/data/trie/extensionNode_test.go
@@ -15,7 +15,7 @@ func getEnAndCollapsedEn() (*extensionNode, *extensionNode) {
 	en, _ := newExtensionNode([]byte("d"), child, child.db, child.marsh, child.hasher)
 
 	childHash, _ := encodeNodeAndGetHash(collapsedChild)
-	collapsedEn := &extensionNode{CollapsedEn: protobuf.CollapsedEn{Key: []byte("d"), EncodedChild: childHash}}
+	collapsedEn := &extensionNode{CollapsedEn: protobuf.CollapsedEn{Key: []byte("d"), EncodedChild: childHash}, baseNode: &baseNode{}}
 	collapsedEn.db = child.db
 	collapsedEn.marsh = child.marsh
 	collapsedEn.hasher = child.hasher
@@ -31,11 +31,13 @@ func TestExtensionNode_newExtensionNode(t *testing.T) {
 			Key:          []byte("dog"),
 			EncodedChild: nil,
 		},
-		child:  bn,
-		dirty:  true,
-		db:     bn.db,
-		marsh:  bn.marsh,
-		hasher: bn.hasher,
+		child: bn,
+		baseNode: &baseNode{
+			dirty:  true,
+			db:     bn.db,
+			marsh:  bn.marsh,
+			hasher: bn.hasher,
+		},
 	}
 	en, _ := newExtensionNode([]byte("dog"), bn, bn.db, bn.marsh, bn.hasher)
 	assert.Equal(t, expectedEn, en)
@@ -44,17 +46,17 @@ func TestExtensionNode_newExtensionNode(t *testing.T) {
 func TestExtensionNode_getHash(t *testing.T) {
 	t.Parallel()
 
-	en := &extensionNode{hash: []byte("test hash")}
+	en := &extensionNode{baseNode: &baseNode{hash: []byte("test hash")}}
 	assert.Equal(t, en.hash, en.getHash())
 }
 
 func TestExtensionNode_isDirty(t *testing.T) {
 	t.Parallel()
 
-	en := &extensionNode{dirty: true}
+	en := &extensionNode{baseNode: &baseNode{dirty: true}}
 	assert.Equal(t, true, en.isDirty())
 
-	en = &extensionNode{dirty: false}
+	en = &extensionNode{baseNode: &baseNode{dirty: false}}
 	assert.Equal(t, false, en.isDirty())
 }
 
@@ -113,7 +115,7 @@ func TestExtensionNode_setHash(t *testing.T) {
 func TestExtensionNode_setHashEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	en := &extensionNode{}
+	en := &extensionNode{baseNode: &baseNode{}}
 
 	err := en.setHash()
 	assert.Equal(t, ErrEmptyNode, err)
@@ -144,7 +146,7 @@ func TestExtensionNode_setHashCollapsedNode(t *testing.T) {
 func TestExtensionNode_setGivenHash(t *testing.T) {
 	t.Parallel()
 
-	en := &extensionNode{}
+	en := &extensionNode{baseNode: &baseNode{}}
 	expectedHash := []byte("node hash")
 
 	en.setGivenHash(expectedHash)
@@ -698,7 +700,7 @@ func TestExtensionNode_reduceNode(t *testing.T) {
 	db, marsh, hasher := getTestDbMarshAndHasher()
 	en, _ := newExtensionNode([]byte{100, 111, 103}, nil, db, marsh, hasher)
 
-	expected := &extensionNode{CollapsedEn: protobuf.CollapsedEn{Key: []byte{2, 100, 111, 103}}, dirty: true}
+	expected := &extensionNode{CollapsedEn: protobuf.CollapsedEn{Key: []byte{2, 100, 111, 103}}, baseNode: &baseNode{dirty: true}}
 	expected.db = en.db
 	expected.marsh = en.marsh
 	expected.hasher = en.hasher
@@ -732,12 +734,12 @@ func TestExtensionNode_isEmptyOrNil(t *testing.T) {
 func TestExtensionNode_deepCloneNilHashShouldWork(t *testing.T) {
 	t.Parallel()
 
-	en := &extensionNode{}
+	en := &extensionNode{baseNode: &baseNode{}}
 	en.dirty = true
 	en.hash = nil
 	en.EncodedChild = getRandomByteSlice()
 	en.Key = getRandomByteSlice()
-	en.child = &leafNode{}
+	en.child = &leafNode{baseNode: &baseNode{}}
 
 	cloned := en.deepClone().(*extensionNode)
 
@@ -747,12 +749,12 @@ func TestExtensionNode_deepCloneNilHashShouldWork(t *testing.T) {
 func TestExtensionNode_deepCloneNilEncodedChildShouldWork(t *testing.T) {
 	t.Parallel()
 
-	en := &extensionNode{}
+	en := &extensionNode{baseNode: &baseNode{}}
 	en.dirty = true
 	en.hash = getRandomByteSlice()
 	en.EncodedChild = nil
 	en.Key = getRandomByteSlice()
-	en.child = &leafNode{}
+	en.child = &leafNode{baseNode: &baseNode{}}
 
 	cloned := en.deepClone().(*extensionNode)
 
@@ -762,12 +764,12 @@ func TestExtensionNode_deepCloneNilEncodedChildShouldWork(t *testing.T) {
 func TestExtensionNode_deepCloneNilKeyShouldWork(t *testing.T) {
 	t.Parallel()
 
-	en := &extensionNode{}
+	en := &extensionNode{baseNode: &baseNode{}}
 	en.dirty = true
 	en.hash = getRandomByteSlice()
 	en.EncodedChild = getRandomByteSlice()
 	en.Key = nil
-	en.child = &leafNode{}
+	en.child = &leafNode{baseNode: &baseNode{}}
 
 	cloned := en.deepClone().(*extensionNode)
 
@@ -777,7 +779,7 @@ func TestExtensionNode_deepCloneNilKeyShouldWork(t *testing.T) {
 func TestExtensionNode_deepCloneNilChildShouldWork(t *testing.T) {
 	t.Parallel()
 
-	en := &extensionNode{}
+	en := &extensionNode{baseNode: &baseNode{}}
 	en.dirty = true
 	en.hash = getRandomByteSlice()
 	en.EncodedChild = getRandomByteSlice()
@@ -792,12 +794,12 @@ func TestExtensionNode_deepCloneNilChildShouldWork(t *testing.T) {
 func TestExtensionNode_deepCloneShouldWork(t *testing.T) {
 	t.Parallel()
 
-	en := &extensionNode{}
+	en := &extensionNode{baseNode: &baseNode{}}
 	en.dirty = true
 	en.hash = getRandomByteSlice()
 	en.EncodedChild = getRandomByteSlice()
 	en.Key = getRandomByteSlice()
-	en.child = &leafNode{}
+	en.child = &leafNode{baseNode: &baseNode{}}
 
 	cloned := en.deepClone().(*extensionNode)
 

--- a/data/trie/leafNode.go
+++ b/data/trie/leafNode.go
@@ -158,7 +158,7 @@ func (ln *leafNode) hashNode() ([]byte, error) {
 	return encodeNodeAndGetHash(ln)
 }
 
-func (ln *leafNode) commit(force bool, level byte, db data.DBWriteCacher) error {
+func (ln *leafNode) commit(force bool, level byte, targetDb data.DBWriteCacher) error {
 	err := ln.isEmptyOrNil()
 	if err != nil {
 		return err
@@ -170,7 +170,7 @@ func (ln *leafNode) commit(force bool, level byte, db data.DBWriteCacher) error 
 	}
 
 	ln.dirty = false
-	return encodeNodeAndCommitToDB(ln, db)
+	return encodeNodeAndCommitToDB(ln, targetDb)
 }
 
 func (ln *leafNode) getEncodedNode() ([]byte, error) {

--- a/data/trie/leafNode.go
+++ b/data/trie/leafNode.go
@@ -69,10 +69,12 @@ func newLeafNode(key, value []byte, db data.DBWriteCacher, marshalizer marshal.M
 			Key:   key,
 			Value: value,
 		},
-		dirty:  true,
-		db:     db,
-		marsh:  marshalizer,
-		hasher: hasher,
+		baseNode: &baseNode{
+			dirty:  true,
+			db:     db,
+			marsh:  marshalizer,
+			hasher: hasher,
+		},
 	}, nil
 }
 
@@ -330,7 +332,7 @@ func (ln *leafNode) deepClone() node {
 		return nil
 	}
 
-	clonedNode := &leafNode{}
+	clonedNode := &leafNode{baseNode: &baseNode{}}
 
 	if ln.Key != nil {
 		clonedNode.Key = make([]byte, len(ln.Key))

--- a/data/trie/leafNode.go
+++ b/data/trie/leafNode.go
@@ -158,7 +158,7 @@ func (ln *leafNode) hashNode() ([]byte, error) {
 	return encodeNodeAndGetHash(ln)
 }
 
-func (ln *leafNode) commit(force bool, level byte, originDb data.DBWriteCacher, targetDb data.DBWriteCacher, marshalizer marshal.Marshalizer, hasher hashing.Hasher) error {
+func (ln *leafNode) commit(force bool, level byte, db data.DBWriteCacher) error {
 	err := ln.isEmptyOrNil()
 	if err != nil {
 		return err
@@ -170,7 +170,7 @@ func (ln *leafNode) commit(force bool, level byte, originDb data.DBWriteCacher, 
 	}
 
 	ln.dirty = false
-	return encodeNodeAndCommitToDB(ln, targetDb, marshalizer, hasher)
+	return encodeNodeAndCommitToDB(ln, db)
 }
 
 func (ln *leafNode) getEncodedNode() ([]byte, error) {

--- a/data/trie/leafNode_test.go
+++ b/data/trie/leafNode_test.go
@@ -153,7 +153,7 @@ func TestLeafNode_commit(t *testing.T) {
 	hash, _ := encodeNodeAndGetHash(ln)
 	_ = ln.setHash()
 
-	err := ln.commit(false, 0)
+	err := ln.commit(false, 0, ln.db)
 	assert.Nil(t, err)
 
 	encNode, _ := ln.db.Get(hash)
@@ -168,7 +168,7 @@ func TestLeafNode_commitEmptyNode(t *testing.T) {
 
 	ln := &leafNode{}
 
-	err := ln.commit(false, 0)
+	err := ln.commit(false, 0, nil)
 	assert.Equal(t, ErrEmptyNode, err)
 }
 
@@ -177,7 +177,7 @@ func TestLeafNode_commitNilNode(t *testing.T) {
 
 	var ln *leafNode
 
-	err := ln.commit(false, 0)
+	err := ln.commit(false, 0, nil)
 	assert.Equal(t, ErrNilNode, err)
 }
 
@@ -350,7 +350,7 @@ func TestLeafNode_insertInStoredLnAtSameKey(t *testing.T) {
 
 	ln := getLn(getTestDbMarshAndHasher())
 	node, _ := newLeafNode([]byte("dog"), []byte("dogs"), ln.db, ln.marsh, ln.hasher)
-	_ = ln.commit(false, 0)
+	_ = ln.commit(false, 0, ln.db)
 	lnHash := ln.getHash()
 
 	dirty, _, oldHashes, err := ln.insert(node)
@@ -365,7 +365,7 @@ func TestLeafNode_insertInStoredLnAtDifferentKey(t *testing.T) {
 	db, marsh, hasher := getTestDbMarshAndHasher()
 	ln, _ := newLeafNode([]byte{1, 2, 3}, []byte("dog"), db, marsh, hasher)
 	node, _ := newLeafNode([]byte{4, 5, 6}, []byte("dogs"), db, marsh, hasher)
-	_ = ln.commit(false, 0)
+	_ = ln.commit(false, 0, ln.db)
 	lnHash := ln.getHash()
 
 	dirty, _, oldHashes, err := ln.insert(node)
@@ -425,7 +425,7 @@ func TestLeafNode_deleteFromStoredLnAtSameKey(t *testing.T) {
 	t.Parallel()
 
 	ln := getLn(getTestDbMarshAndHasher())
-	_ = ln.commit(false, 0)
+	_ = ln.commit(false, 0, ln.db)
 	lnHash := ln.getHash()
 
 	dirty, _, oldHashes, err := ln.delete([]byte("dog"))
@@ -438,7 +438,7 @@ func TestLeafNode_deleteFromLnAtDifferentKey(t *testing.T) {
 	t.Parallel()
 
 	ln := getLn(getTestDbMarshAndHasher())
-	_ = ln.commit(false, 0)
+	_ = ln.commit(false, 0, ln.db)
 	wrongKey := []byte{1, 2, 3}
 
 	dirty, _, oldHashes, err := ln.delete(wrongKey)

--- a/data/trie/leafNode_test.go
+++ b/data/trie/leafNode_test.go
@@ -28,11 +28,12 @@ func TestLeafNode_newLeafNode(t *testing.T) {
 			Key:   []byte("dog"),
 			Value: []byte("dog"),
 		},
-		hash:   nil,
-		dirty:  true,
-		db:     db,
-		marsh:  marsh,
-		hasher: hasher,
+		baseNode: &baseNode{
+			dirty:  true,
+			db:     db,
+			marsh:  marsh,
+			hasher: hasher,
+		},
 	}
 	ln, _ := newLeafNode([]byte("dog"), []byte("dog"), db, marsh, hasher)
 	assert.Equal(t, expectedLn, ln)
@@ -41,17 +42,17 @@ func TestLeafNode_newLeafNode(t *testing.T) {
 func TestLeafNode_getHash(t *testing.T) {
 	t.Parallel()
 
-	ln := &leafNode{hash: []byte("test hash")}
+	ln := &leafNode{baseNode: &baseNode{hash: []byte("test hash")}}
 	assert.Equal(t, ln.hash, ln.getHash())
 }
 
 func TestLeafNode_isDirty(t *testing.T) {
 	t.Parallel()
 
-	ln := &leafNode{dirty: true}
+	ln := &leafNode{baseNode: &baseNode{dirty: true}}
 	assert.Equal(t, true, ln.isDirty())
 
-	ln = &leafNode{dirty: false}
+	ln = &leafNode{baseNode: &baseNode{dirty: false}}
 	assert.Equal(t, false, ln.isDirty())
 }
 
@@ -79,7 +80,7 @@ func TestLeafNode_setHash(t *testing.T) {
 func TestLeafNode_setHashEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	ln := &leafNode{}
+	ln := &leafNode{baseNode: &baseNode{}}
 
 	err := ln.setHash()
 	assert.Equal(t, ErrEmptyNode, err)
@@ -99,7 +100,7 @@ func TestLeafNode_setHashNilNode(t *testing.T) {
 func TestLeafNode_setGivenHash(t *testing.T) {
 	t.Parallel()
 
-	ln := &leafNode{}
+	ln := &leafNode{baseNode: &baseNode{}}
 	expectedHash := []byte("node hash")
 
 	ln.setGivenHash(expectedHash)
@@ -497,7 +498,7 @@ func TestLeafNode_isEmptyOrNil(t *testing.T) {
 func TestLeafNode_deepCloneWithNilHashShouldWork(t *testing.T) {
 	t.Parallel()
 
-	ln := &leafNode{}
+	ln := &leafNode{baseNode: &baseNode{}}
 	ln.dirty = true
 	ln.hash = nil
 	ln.Value = getRandomByteSlice()
@@ -511,7 +512,7 @@ func TestLeafNode_deepCloneWithNilHashShouldWork(t *testing.T) {
 func TestLeafNode_deepCloneWithNilValueShouldWork(t *testing.T) {
 	t.Parallel()
 
-	ln := &leafNode{}
+	ln := &leafNode{baseNode: &baseNode{}}
 	ln.dirty = true
 	ln.hash = getRandomByteSlice()
 	ln.Value = nil
@@ -525,7 +526,7 @@ func TestLeafNode_deepCloneWithNilValueShouldWork(t *testing.T) {
 func TestLeafNode_deepCloneWithNilKeyShouldWork(t *testing.T) {
 	t.Parallel()
 
-	ln := &leafNode{}
+	ln := &leafNode{baseNode: &baseNode{}}
 	ln.dirty = true
 	ln.hash = getRandomByteSlice()
 	ln.Value = getRandomByteSlice()
@@ -539,7 +540,7 @@ func TestLeafNode_deepCloneWithNilKeyShouldWork(t *testing.T) {
 func TestLeafNode_deepCloneShouldWork(t *testing.T) {
 	t.Parallel()
 
-	ln := &leafNode{}
+	ln := &leafNode{baseNode: &baseNode{}}
 	ln.dirty = true
 	ln.hash = getRandomByteSlice()
 	ln.Value = getRandomByteSlice()

--- a/data/trie/leafNode_test.go
+++ b/data/trie/leafNode_test.go
@@ -7,27 +7,34 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ElrondNetwork/elrond-go/data/mock"
+	"github.com/ElrondNetwork/elrond-go/data"
 	protobuf "github.com/ElrondNetwork/elrond-go/data/trie/proto"
+	"github.com/ElrondNetwork/elrond-go/hashing"
+	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/stretchr/testify/assert"
 )
 
-func getLn() *leafNode {
-	return newLeafNode([]byte("dog"), []byte("dog"))
+func getLn(db data.DBWriteCacher, marsh marshal.Marshalizer, hasher hashing.Hasher) *leafNode {
+	newLn, _ := newLeafNode([]byte("dog"), []byte("dog"), db, marsh, hasher)
+	return newLn
 }
 
 func TestLeafNode_newLeafNode(t *testing.T) {
 	t.Parallel()
 
+	db, marsh, hasher := getTestDbMarshAndHasher()
 	expectedLn := &leafNode{
 		CollapsedLn: protobuf.CollapsedLn{
 			Key:   []byte("dog"),
 			Value: []byte("dog"),
 		},
-		hash:  nil,
-		dirty: true,
+		hash:   nil,
+		dirty:  true,
+		db:     db,
+		marsh:  marsh,
+		hasher: hasher,
 	}
-	ln := newLeafNode([]byte("dog"), []byte("dog"))
+	ln, _ := newLeafNode([]byte("dog"), []byte("dog"), db, marsh, hasher)
 	assert.Equal(t, expectedLn, ln)
 }
 
@@ -51,10 +58,9 @@ func TestLeafNode_isDirty(t *testing.T) {
 func TestLeafNode_getCollapsed(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn()
-	marsh, hasher := getTestMarshAndHasher()
+	ln := getLn(getTestDbMarshAndHasher())
 
-	collapsed, err := ln.getCollapsed(marsh, hasher)
+	collapsed, err := ln.getCollapsed()
 	assert.Nil(t, err)
 	assert.Equal(t, ln, collapsed)
 }
@@ -62,12 +68,10 @@ func TestLeafNode_getCollapsed(t *testing.T) {
 func TestLeafNode_setHash(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn()
-	marsh, hasher := getTestMarshAndHasher()
+	ln := getLn(getTestDbMarshAndHasher())
+	hash, _ := encodeNodeAndGetHash(ln)
 
-	hash, _ := encodeNodeAndGetHash(ln, marsh, hasher)
-
-	err := ln.setHash(marsh, hasher)
+	err := ln.setHash()
 	assert.Nil(t, err)
 	assert.Equal(t, hash, ln.hash)
 }
@@ -75,10 +79,9 @@ func TestLeafNode_setHash(t *testing.T) {
 func TestLeafNode_setHashEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshAndHasher()
 	ln := &leafNode{}
 
-	err := ln.setHash(marsh, hasher)
+	err := ln.setHash()
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, ln.hash)
 }
@@ -86,10 +89,9 @@ func TestLeafNode_setHashEmptyNode(t *testing.T) {
 func TestLeafNode_setHashNilNode(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshAndHasher()
 	var ln *leafNode
 
-	err := ln.setHash(marsh, hasher)
+	err := ln.setHash()
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, ln)
 }
@@ -101,26 +103,24 @@ func TestLeafNode_setGivenHash(t *testing.T) {
 	expectedHash := []byte("node hash")
 
 	ln.setGivenHash(expectedHash)
-
 	assert.Equal(t, expectedHash, ln.hash)
 }
 
 func TestLeafNode_hashChildren(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn()
-	marsh, hasher := getTestMarshAndHasher()
-	assert.Nil(t, ln.hashChildren(marsh, hasher))
+	ln := getLn(getTestDbMarshAndHasher())
+
+	assert.Nil(t, ln.hashChildren())
 }
 
 func TestLeafNode_hashNode(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn()
-	marsh, hasher := getTestMarshAndHasher()
+	ln := getLn(getTestDbMarshAndHasher())
+	expectedHash, _ := encodeNodeAndGetHash(ln)
 
-	expectedHash, _ := encodeNodeAndGetHash(ln, marsh, hasher)
-	hash, err := ln.hashNode(marsh, hasher)
+	hash, err := ln.hashNode()
 	assert.Nil(t, err)
 	assert.Equal(t, expectedHash, hash)
 }
@@ -129,9 +129,8 @@ func TestLeafNode_hashNodeEmptyNode(t *testing.T) {
 	t.Parallel()
 
 	ln := &leafNode{}
-	marsh, hasher := getTestMarshAndHasher()
 
-	hash, err := ln.hashNode(marsh, hasher)
+	hash, err := ln.hashNode()
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, hash)
 }
@@ -140,9 +139,8 @@ func TestLeafNode_hashNodeNilNode(t *testing.T) {
 	t.Parallel()
 
 	var ln *leafNode
-	marsh, hasher := getTestMarshAndHasher()
 
-	hash, err := ln.hashNode(marsh, hasher)
+	hash, err := ln.hashNode()
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, hash)
 }
@@ -150,19 +148,16 @@ func TestLeafNode_hashNodeNilNode(t *testing.T) {
 func TestLeafNode_commit(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	ln := getLn()
-	marsh, hasher := getTestMarshAndHasher()
+	ln := getLn(getTestDbMarshAndHasher())
+	hash, _ := encodeNodeAndGetHash(ln)
+	_ = ln.setHash()
 
-	hash, _ := encodeNodeAndGetHash(ln, marsh, hasher)
-	_ = ln.setHash(marsh, hasher)
-
-	err := ln.commit(false, 0, db, marsh, hasher)
+	err := ln.commit(false, 0)
 	assert.Nil(t, err)
 
-	encNode, _ := db.Get(hash)
-	node, _ := decodeNode(encNode, marsh)
-	ln = getLn()
+	encNode, _ := ln.db.Get(hash)
+	node, _ := decodeNode(encNode, ln.db, ln.marsh, ln.hasher)
+	ln = getLn(ln.db, ln.marsh, ln.hasher)
 	ln.dirty = false
 	assert.Equal(t, ln, node)
 }
@@ -171,10 +166,8 @@ func TestLeafNode_commitEmptyNode(t *testing.T) {
 	t.Parallel()
 
 	ln := &leafNode{}
-	db := mock.NewMemDbMock()
-	marsh, hasher := getTestMarshAndHasher()
 
-	err := ln.commit(false, 0, db, marsh, hasher)
+	err := ln.commit(false, 0)
 	assert.Equal(t, ErrEmptyNode, err)
 }
 
@@ -182,23 +175,19 @@ func TestLeafNode_commitNilNode(t *testing.T) {
 	t.Parallel()
 
 	var ln *leafNode
-	db := mock.NewMemDbMock()
-	marsh, hasher := getTestMarshAndHasher()
 
-	err := ln.commit(false, 0, db, marsh, hasher)
+	err := ln.commit(false, 0)
 	assert.Equal(t, ErrNilNode, err)
 }
 
 func TestLeafNode_getEncodedNode(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn()
-	marsh, _ := getTestMarshAndHasher()
-
-	expectedEncodedNode, _ := marsh.Marshal(ln)
+	ln := getLn(getTestDbMarshAndHasher())
+	expectedEncodedNode, _ := ln.marsh.Marshal(ln)
 	expectedEncodedNode = append(expectedEncodedNode, leaf)
 
-	encNode, err := ln.getEncodedNode(marsh)
+	encNode, err := ln.getEncodedNode()
 	assert.Nil(t, err)
 	assert.Equal(t, expectedEncodedNode, encNode)
 }
@@ -207,9 +196,8 @@ func TestLeafNode_getEncodedNodeEmpty(t *testing.T) {
 	t.Parallel()
 
 	ln := &leafNode{}
-	marsh, _ := getTestMarshAndHasher()
 
-	encNode, err := ln.getEncodedNode(marsh)
+	encNode, err := ln.getEncodedNode()
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, encNode)
 }
@@ -218,9 +206,8 @@ func TestLeafNode_getEncodedNodeNil(t *testing.T) {
 	t.Parallel()
 
 	var ln *leafNode
-	marsh, _ := getTestMarshAndHasher()
 
-	encNode, err := ln.getEncodedNode(marsh)
+	encNode, err := ln.getEncodedNode()
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, encNode)
 }
@@ -228,29 +215,25 @@ func TestLeafNode_getEncodedNodeNil(t *testing.T) {
 func TestLeafNode_resolveCollapsed(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	ln := getLn()
-	marsh, _ := getTestMarshAndHasher()
+	ln := getLn(getTestDbMarshAndHasher())
 
-	assert.Nil(t, ln.resolveCollapsed(0, db, marsh))
+	assert.Nil(t, ln.resolveCollapsed(0))
 }
 
 func TestLeafNode_isCollapsed(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn()
+	ln := getLn(getTestDbMarshAndHasher())
 	assert.False(t, ln.isCollapsed())
 }
 
 func TestLeafNode_tryGet(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	ln := getLn()
-	marsh, _ := getTestMarshAndHasher()
-
+	ln := getLn(getTestDbMarshAndHasher())
 	key := []byte("dog")
-	val, err := ln.tryGet(key, db, marsh)
+
+	val, err := ln.tryGet(key)
 	assert.Equal(t, []byte("dog"), val)
 	assert.Nil(t, err)
 }
@@ -258,12 +241,10 @@ func TestLeafNode_tryGet(t *testing.T) {
 func TestLeafNode_tryGetWrongKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	ln := getLn()
-	marsh, _ := getTestMarshAndHasher()
-
+	ln := getLn(getTestDbMarshAndHasher())
 	wrongKey := []byte{1, 2, 3}
-	val, err := ln.tryGet(wrongKey, db, marsh)
+
+	val, err := ln.tryGet(wrongKey)
 	assert.Nil(t, val)
 	assert.Nil(t, err)
 }
@@ -271,12 +252,10 @@ func TestLeafNode_tryGetWrongKey(t *testing.T) {
 func TestLeafNode_tryGetEmptyNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	ln := &leafNode{}
-	marsh, _ := getTestMarshAndHasher()
 
 	key := []byte("dog")
-	val, err := ln.tryGet(key, db, marsh)
+	val, err := ln.tryGet(key)
 	assert.Equal(t, ErrEmptyNode, err)
 	assert.Nil(t, val)
 }
@@ -284,12 +263,10 @@ func TestLeafNode_tryGetEmptyNode(t *testing.T) {
 func TestLeafNode_tryGetNilNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	var ln *leafNode
-	marsh, _ := getTestMarshAndHasher()
-
 	key := []byte("dog")
-	val, err := ln.tryGet(key, db, marsh)
+
+	val, err := ln.tryGet(key)
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, val)
 }
@@ -297,12 +274,10 @@ func TestLeafNode_tryGetNilNode(t *testing.T) {
 func TestLeafNode_getNext(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	ln := getLn()
-	marsh, _ := getTestMarshAndHasher()
+	ln := getLn(getTestDbMarshAndHasher())
 	key := []byte("dog")
 
-	node, key, err := ln.getNext(key, db, marsh)
+	node, key, err := ln.getNext(key)
 	assert.Nil(t, node)
 	assert.Nil(t, key)
 	assert.Nil(t, err)
@@ -311,12 +286,10 @@ func TestLeafNode_getNext(t *testing.T) {
 func TestLeafNode_getNextWrongKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	ln := getLn()
-	marsh, _ := getTestMarshAndHasher()
+	ln := getLn(getTestDbMarshAndHasher())
 	wrongKey := append([]byte{2}, []byte("dog")...)
 
-	node, key, err := ln.getNext(wrongKey, db, marsh)
+	node, key, err := ln.getNext(wrongKey)
 	assert.Nil(t, node)
 	assert.Nil(t, key)
 	assert.Equal(t, ErrNodeNotFound, err)
@@ -325,12 +298,10 @@ func TestLeafNode_getNextWrongKey(t *testing.T) {
 func TestLeafNode_getNextNilNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	var ln *leafNode
-	marsh, _ := getTestMarshAndHasher()
 	key := []byte("dog")
 
-	node, key, err := ln.getNext(key, db, marsh)
+	node, key, err := ln.getNext(key)
 	assert.Nil(t, node)
 	assert.Nil(t, key)
 	assert.Equal(t, ErrNilNode, err)
@@ -339,38 +310,36 @@ func TestLeafNode_getNextNilNode(t *testing.T) {
 func TestLeafNode_insertAtSameKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	ln := getLn()
+	ln := getLn(getTestDbMarshAndHasher())
 	key := []byte("dog")
 	expectedVal := []byte("dogs")
+	node, _ := newLeafNode(key, expectedVal, ln.db, ln.marsh, ln.hasher)
 
-	node := newLeafNode(key, expectedVal)
-	marsh, _ := getTestMarshAndHasher()
-
-	dirty, newNode, _, err := ln.insert(node, db, marsh)
+	dirty, newNode, _, err := ln.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
-	val, _ := newNode.tryGet(key, db, marsh)
+
+	val, _ := newNode.tryGet(key)
 	assert.Equal(t, expectedVal, val)
 }
 
 func TestLeafNode_insertAtDifferentKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
+	db, marsh, hasher := getTestDbMarshAndHasher()
 
 	lnKey := []byte{2, 100, 111, 103}
-	ln := newLeafNode(lnKey, []byte("dog"))
+	ln, _ := newLeafNode(lnKey, []byte("dog"), db, marsh, hasher)
 
 	nodeKey := []byte{3, 4, 5}
 	nodeVal := []byte{3, 4, 5}
-	node := newLeafNode(nodeKey, nodeVal)
-	marsh, _ := getTestMarshAndHasher()
+	node, _ := newLeafNode(nodeKey, nodeVal, db, marsh, hasher)
 
-	dirty, newNode, _, err := ln.insert(node, db, marsh)
+	dirty, newNode, _, err := ln.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
-	val, _ := newNode.tryGet(nodeKey, db, marsh)
+
+	val, _ := newNode.tryGet(nodeKey)
 	assert.Equal(t, nodeVal, val)
 	assert.IsType(t, &branchNode{}, newNode)
 }
@@ -378,15 +347,12 @@ func TestLeafNode_insertAtDifferentKey(t *testing.T) {
 func TestLeafNode_insertInStoredLnAtSameKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	ln := getLn()
-	marsh, hasher := getTestMarshAndHasher()
-	node := newLeafNode([]byte("dog"), []byte("dogs"))
-	_ = ln.commit(false, 0, db, marsh, hasher)
+	ln := getLn(getTestDbMarshAndHasher())
+	node, _ := newLeafNode([]byte("dog"), []byte("dogs"), ln.db, ln.marsh, ln.hasher)
+	_ = ln.commit(false, 0)
 	lnHash := ln.getHash()
 
-	dirty, _, oldHashes, err := ln.insert(node, db, marsh)
-
+	dirty, _, oldHashes, err := ln.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{lnHash}, oldHashes)
@@ -395,15 +361,13 @@ func TestLeafNode_insertInStoredLnAtSameKey(t *testing.T) {
 func TestLeafNode_insertInStoredLnAtDifferentKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	marsh, hasher := getTestMarshAndHasher()
-	ln := newLeafNode([]byte{1, 2, 3}, []byte("dog"))
-	node := newLeafNode([]byte{4, 5, 6}, []byte("dogs"))
-	_ = ln.commit(false, 0, db, marsh, hasher)
+	db, marsh, hasher := getTestDbMarshAndHasher()
+	ln, _ := newLeafNode([]byte{1, 2, 3}, []byte("dog"), db, marsh, hasher)
+	node, _ := newLeafNode([]byte{4, 5, 6}, []byte("dogs"), db, marsh, hasher)
+	_ = ln.commit(false, 0)
 	lnHash := ln.getHash()
 
-	dirty, _, oldHashes, err := ln.insert(node, db, marsh)
-
+	dirty, _, oldHashes, err := ln.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{lnHash}, oldHashes)
@@ -412,13 +376,10 @@ func TestLeafNode_insertInStoredLnAtDifferentKey(t *testing.T) {
 func TestLeafNode_insertInDirtyLnAtSameKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	ln := getLn()
-	marsh, _ := getTestMarshAndHasher()
-	node := newLeafNode([]byte("dog"), []byte("dogs"))
+	ln := getLn(getTestDbMarshAndHasher())
+	node, _ := newLeafNode([]byte("dog"), []byte("dogs"), ln.db, ln.marsh, ln.hasher)
 
-	dirty, _, oldHashes, err := ln.insert(node, db, marsh)
-
+	dirty, _, oldHashes, err := ln.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -427,13 +388,11 @@ func TestLeafNode_insertInDirtyLnAtSameKey(t *testing.T) {
 func TestLeafNode_insertInDirtyLnAtDifferentKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	marsh, _ := getTestMarshAndHasher()
-	ln := newLeafNode([]byte{1, 2, 3}, []byte("dog"))
-	node := newLeafNode([]byte{4, 5, 6}, []byte("dogs"))
+	db, marsh, hasher := getTestDbMarshAndHasher()
+	ln, _ := newLeafNode([]byte{1, 2, 3}, []byte("dog"), db, marsh, hasher)
+	node, _ := newLeafNode([]byte{4, 5, 6}, []byte("dogs"), db, marsh, hasher)
 
-	dirty, _, oldHashes, err := ln.insert(node, db, marsh)
-
+	dirty, _, oldHashes, err := ln.insert(node)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -442,12 +401,9 @@ func TestLeafNode_insertInDirtyLnAtDifferentKey(t *testing.T) {
 func TestLeafNode_insertInNilNode(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
 	var ln *leafNode
-	node := newLeafNode([]byte("dog"), []byte("dogs"))
-	marsh, _ := getTestMarshAndHasher()
 
-	dirty, newNode, _, err := ln.insert(node, db, marsh)
+	dirty, newNode, _, err := ln.insert(&leafNode{})
 	assert.False(t, dirty)
 	assert.Equal(t, ErrNilNode, err)
 	assert.Nil(t, newNode)
@@ -456,11 +412,9 @@ func TestLeafNode_insertInNilNode(t *testing.T) {
 func TestLeafNode_deletePresent(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	ln := getLn()
-	marsh, _ := getTestMarshAndHasher()
+	ln := getLn(getTestDbMarshAndHasher())
 
-	dirty, newNode, _, err := ln.delete([]byte("dog"), db, marsh)
+	dirty, newNode, _, err := ln.delete([]byte("dog"))
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Nil(t, newNode)
@@ -469,14 +423,11 @@ func TestLeafNode_deletePresent(t *testing.T) {
 func TestLeafNode_deleteFromStoredLnAtSameKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	ln := getLn()
-	marsh, hasher := getTestMarshAndHasher()
-	_ = ln.commit(false, 0, db, marsh, hasher)
+	ln := getLn(getTestDbMarshAndHasher())
+	_ = ln.commit(false, 0)
 	lnHash := ln.getHash()
 
-	dirty, _, oldHashes, err := ln.delete([]byte("dog"), db, marsh)
-
+	dirty, _, oldHashes, err := ln.delete([]byte("dog"))
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{lnHash}, oldHashes)
@@ -485,14 +436,11 @@ func TestLeafNode_deleteFromStoredLnAtSameKey(t *testing.T) {
 func TestLeafNode_deleteFromLnAtDifferentKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	marsh, hasher := getTestMarshAndHasher()
-	ln := getLn()
-	_ = ln.commit(false, 0, db, marsh, hasher)
-
+	ln := getLn(getTestDbMarshAndHasher())
+	_ = ln.commit(false, 0)
 	wrongKey := []byte{1, 2, 3}
-	dirty, _, oldHashes, err := ln.delete(wrongKey, db, marsh)
 
+	dirty, _, oldHashes, err := ln.delete(wrongKey)
 	assert.False(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -501,12 +449,9 @@ func TestLeafNode_deleteFromLnAtDifferentKey(t *testing.T) {
 func TestLeafNode_deleteFromDirtyLnAtSameKey(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	marsh, _ := getTestMarshAndHasher()
-	ln := getLn()
+	ln := getLn(getTestDbMarshAndHasher())
 
-	dirty, _, oldHashes, err := ln.delete([]byte("dog"), db, marsh)
-
+	dirty, _, oldHashes, err := ln.delete([]byte("dog"))
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -515,12 +460,10 @@ func TestLeafNode_deleteFromDirtyLnAtSameKey(t *testing.T) {
 func TestLeafNode_deleteNotPresent(t *testing.T) {
 	t.Parallel()
 
-	db := mock.NewMemDbMock()
-	ln := getLn()
-	marsh, _ := getTestMarshAndHasher()
-
+	ln := getLn(getTestDbMarshAndHasher())
 	wrongKey := []byte{1, 2, 3}
-	dirty, newNode, _, err := ln.delete(wrongKey, db, marsh)
+
+	dirty, newNode, _, err := ln.delete(wrongKey)
 	assert.False(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, ln, newNode)
@@ -529,10 +472,14 @@ func TestLeafNode_deleteNotPresent(t *testing.T) {
 func TestLeafNode_reduceNode(t *testing.T) {
 	t.Parallel()
 
-	ln := &leafNode{CollapsedLn: protobuf.CollapsedLn{Key: []byte{100, 111, 103}}}
-	expected := &leafNode{CollapsedLn: protobuf.CollapsedLn{Key: []byte{2, 100, 111, 103}}, dirty: true}
-	node := ln.reduceNode(2)
+	db, marsh, hasher := getTestDbMarshAndHasher()
+	ln, _ := newLeafNode([]byte{100, 111, 103}, nil, db, marsh, hasher)
+	expected, _ := newLeafNode([]byte{2, 100, 111, 103}, nil, db, marsh, hasher)
+	expected.dirty = true
+
+	node, err := ln.reduceNode(2)
 	assert.Equal(t, expected, node)
+	assert.Nil(t, err)
 }
 
 func TestLeafNode_isEmptyOrNil(t *testing.T) {
@@ -625,10 +572,10 @@ func getRandomByteSlice() []byte {
 
 func getLeafNodeContents(lf *leafNode) string {
 	str := fmt.Sprintf(`leaf node:
-   key: %s
-   value: %s
-   hash: %s
-   dirty: %v
+  key: %s
+  value: %s
+  hash: %s
+  dirty: %v
 `,
 		hex.EncodeToString(lf.Key),
 		hex.EncodeToString(lf.Value),

--- a/data/trie/node.go
+++ b/data/trie/node.go
@@ -26,7 +26,7 @@ type node interface {
 	isPosCollapsed(pos int) bool
 	isDirty() bool
 	getEncodedNode() ([]byte, error)
-	commit(force bool, level byte) error
+	commit(force bool, level byte, db data.DBWriteCacher) error
 	resolveCollapsed(pos byte) error
 	hashNode() ([]byte, error)
 	hashChildren() error
@@ -98,7 +98,7 @@ func encodeNodeAndGetHash(n node) ([]byte, error) {
 	return hash, nil
 }
 
-func encodeNodeAndCommitToDB(n node) error {
+func encodeNodeAndCommitToDB(n node, db data.DBWriteCacher) error {
 	key := n.getHash()
 	if key == nil {
 		err := n.setHash()
@@ -118,7 +118,7 @@ func encodeNodeAndCommitToDB(n node) error {
 		return err
 	}
 
-	err = n.getDb().Put(key, val)
+	err = db.Put(key, val)
 
 	return err
 }

--- a/data/trie/node.go
+++ b/data/trie/node.go
@@ -48,33 +48,29 @@ type node interface {
 	setDb(data.DBWriteCacher)
 }
 
+type baseNode struct {
+	hash   []byte
+	dirty  bool
+	db     data.DBWriteCacher
+	marsh  marshal.Marshalizer
+	hasher hashing.Hasher
+}
+
 type branchNode struct {
 	protobuf.CollapsedBn
 	children [nrOfChildren]node
-	hash     []byte
-	dirty    bool
-	db       data.DBWriteCacher
-	marsh    marshal.Marshalizer
-	hasher   hashing.Hasher
+	*baseNode
 }
 
 type extensionNode struct {
 	protobuf.CollapsedEn
-	child  node
-	hash   []byte
-	dirty  bool
-	db     data.DBWriteCacher
-	marsh  marshal.Marshalizer
-	hasher hashing.Hasher
+	child node
+	*baseNode
 }
 
 type leafNode struct {
 	protobuf.CollapsedLn
-	hash   []byte
-	dirty  bool
-	db     data.DBWriteCacher
-	marsh  marshal.Marshalizer
-	hasher hashing.Hasher
+	*baseNode
 }
 
 func hashChildrenAndNode(n node) ([]byte, error) {
@@ -208,11 +204,11 @@ func decodeNode(encNode []byte, db data.DBWriteCacher, marshalizer marshal.Marsh
 func getEmptyNodeOfType(t byte) (node, error) {
 	switch t {
 	case extension:
-		return &extensionNode{}, nil
+		return &extensionNode{baseNode: &baseNode{}}, nil
 	case leaf:
-		return &leafNode{}, nil
+		return &leafNode{baseNode: &baseNode{}}, nil
 	case branch:
-		return &branchNode{}, nil
+		return &branchNode{baseNode: &baseNode{}}, nil
 	default:
 		return nil, ErrInvalidNode
 	}

--- a/data/trie/node.go
+++ b/data/trie/node.go
@@ -17,28 +17,35 @@ const hexTerminator = 16
 
 type node interface {
 	getHash() []byte
-	setHash(marshalizer marshal.Marshalizer, hasher hashing.Hasher) error
+	setHash() error
 	setGivenHash([]byte)
-	setHashConcurrent(marshalizer marshal.Marshalizer, hasher hashing.Hasher, wg *sync.WaitGroup, c chan error)
-	setRootHash(marshalizer marshal.Marshalizer, hasher hashing.Hasher) error
-	getCollapsed(marshalizer marshal.Marshalizer, hasher hashing.Hasher) (node, error) // a collapsed node is a node that instead of the children holds the children hashes
+	setHashConcurrent(wg *sync.WaitGroup, c chan error)
+	setRootHash() error
+	getCollapsed() (node, error) // a collapsed node is a node that instead of the children holds the children hashes
 	isCollapsed() bool
 	isPosCollapsed(pos int) bool
 	isDirty() bool
-	getEncodedNode(marshal.Marshalizer) ([]byte, error)
-	commit(force bool, level byte, dbw data.DBWriteCacher, marshalizer marshal.Marshalizer, hasher hashing.Hasher) error
-	resolveCollapsed(pos byte, dbw data.DBWriteCacher, marshalizer marshal.Marshalizer) error
-	hashNode(marshalizer marshal.Marshalizer, hasher hashing.Hasher) ([]byte, error)
-	hashChildren(marshalizer marshal.Marshalizer, hasher hashing.Hasher) error
-	tryGet(key []byte, dbw data.DBWriteCacher, marshalizer marshal.Marshalizer) ([]byte, error)
-	getNext(key []byte, dbw data.DBWriteCacher, marshalizer marshal.Marshalizer) (node, []byte, error)
-	insert(n *leafNode, dbw data.DBWriteCacher, marshalizer marshal.Marshalizer) (bool, node, [][]byte, error)
-	delete(key []byte, dbw data.DBWriteCacher, marshalizer marshal.Marshalizer) (bool, node, [][]byte, error)
-	reduceNode(pos int) node
+	getEncodedNode() ([]byte, error)
+	commit(force bool, level byte) error
+	resolveCollapsed(pos byte) error
+	hashNode() ([]byte, error)
+	hashChildren() error
+	tryGet(key []byte) ([]byte, error)
+	getNext(key []byte) (node, []byte, error)
+	insert(n *leafNode) (bool, node, [][]byte, error)
+	delete(key []byte) (bool, node, [][]byte, error)
+	reduceNode(pos int) (node, error)
 	isEmptyOrNil() error
 	print(writer io.Writer, index int)
 	deepClone() node
 	getDirtyHashes() ([][]byte, error)
+
+	getMarshalizer() marshal.Marshalizer
+	setMarshalizer(marshal.Marshalizer)
+	getHasher() hashing.Hasher
+	setHasher(hashing.Hasher)
+	getDb() data.DBWriteCacher
+	setDb(data.DBWriteCacher)
 }
 
 type branchNode struct {
@@ -46,28 +53,37 @@ type branchNode struct {
 	children [nrOfChildren]node
 	hash     []byte
 	dirty    bool
+	db       data.DBWriteCacher
+	marsh    marshal.Marshalizer
+	hasher   hashing.Hasher
 }
 
 type extensionNode struct {
 	protobuf.CollapsedEn
-	child node
-	hash  []byte
-	dirty bool
+	child  node
+	hash   []byte
+	dirty  bool
+	db     data.DBWriteCacher
+	marsh  marshal.Marshalizer
+	hasher hashing.Hasher
 }
 
 type leafNode struct {
 	protobuf.CollapsedLn
-	hash  []byte
-	dirty bool
+	hash   []byte
+	dirty  bool
+	db     data.DBWriteCacher
+	marsh  marshal.Marshalizer
+	hasher hashing.Hasher
 }
 
-func hashChildrenAndNode(n node, marshalizer marshal.Marshalizer, hasher hashing.Hasher) ([]byte, error) {
-	err := n.hashChildren(marshalizer, hasher)
+func hashChildrenAndNode(n node) ([]byte, error) {
+	err := n.hashChildren()
 	if err != nil {
 		return nil, err
 	}
 
-	hashed, err := n.hashNode(marshalizer, hasher)
+	hashed, err := n.hashNode()
 	if err != nil {
 		return nil, err
 	}
@@ -75,49 +91,49 @@ func hashChildrenAndNode(n node, marshalizer marshal.Marshalizer, hasher hashing
 	return hashed, nil
 }
 
-func encodeNodeAndGetHash(n node, marshalizer marshal.Marshalizer, hasher hashing.Hasher) ([]byte, error) {
-	encNode, err := n.getEncodedNode(marshalizer)
+func encodeNodeAndGetHash(n node) ([]byte, error) {
+	encNode, err := n.getEncodedNode()
 	if err != nil {
 		return nil, err
 	}
 
-	hash := hasher.Compute(string(encNode))
+	hash := n.getHasher().Compute(string(encNode))
 
 	return hash, nil
 }
 
-func encodeNodeAndCommitToDB(n node, db data.DBWriteCacher, marshalizer marshal.Marshalizer, hasher hashing.Hasher) error {
+func encodeNodeAndCommitToDB(n node) error {
 	key := n.getHash()
 	if key == nil {
-		err := n.setHash(marshalizer, hasher)
+		err := n.setHash()
 		if err != nil {
 			return err
 		}
 		key = n.getHash()
 	}
 
-	n, err := n.getCollapsed(marshalizer, hasher)
+	n, err := n.getCollapsed()
 	if err != nil {
 		return err
 	}
 
-	val, err := n.getEncodedNode(marshalizer)
+	val, err := n.getEncodedNode()
 	if err != nil {
 		return err
 	}
 
-	err = db.Put(key, val)
+	err = n.getDb().Put(key, val)
 
 	return err
 }
 
-func getNodeFromDBAndDecode(n []byte, db data.DBWriteCacher, marshalizer marshal.Marshalizer) (node, error) {
+func getNodeFromDBAndDecode(n []byte, db data.DBWriteCacher, marshalizer marshal.Marshalizer, hasher hashing.Hasher) (node, error) {
 	encChild, err := db.Get(n)
 	if err != nil {
 		return nil, err
 	}
 
-	node, err := decodeNode(encChild, marshalizer)
+	node, err := decodeNode(encChild, db, marshalizer, hasher)
 	if err != nil {
 		return nil, err
 	}
@@ -125,14 +141,14 @@ func getNodeFromDBAndDecode(n []byte, db data.DBWriteCacher, marshalizer marshal
 	return node, nil
 }
 
-func resolveIfCollapsed(n node, pos byte, db data.DBWriteCacher, marshalizer marshal.Marshalizer) error {
+func resolveIfCollapsed(n node, pos byte) error {
 	err := n.isEmptyOrNil()
 	if err != nil {
 		return err
 	}
 
 	if n.isPosCollapsed(int(pos)) {
-		err := n.resolveCollapsed(pos, db, marshalizer)
+		err := n.resolveCollapsed(pos)
 		if err != nil {
 			return err
 		}
@@ -164,7 +180,7 @@ func hasValidHash(n node) (bool, error) {
 	return true, nil
 }
 
-func decodeNode(encNode []byte, marshalizer marshal.Marshalizer) (node, error) {
+func decodeNode(encNode []byte, db data.DBWriteCacher, marshalizer marshal.Marshalizer, hasher hashing.Hasher) (node, error) {
 	if encNode == nil || len(encNode) < 1 {
 		return nil, ErrInvalidEncoding
 	}
@@ -182,6 +198,10 @@ func decodeNode(encNode []byte, marshalizer marshal.Marshalizer) (node, error) {
 		return nil, err
 	}
 
+	node.setDb(db)
+	node.setMarshalizer(marshalizer)
+	node.setHasher(hasher)
+
 	return node, nil
 }
 
@@ -192,9 +212,7 @@ func getEmptyNodeOfType(t byte) (node, error) {
 	case leaf:
 		return &leafNode{}, nil
 	case branch:
-		decNode := newBranchNode()
-		decNode.dirty = false
-		return decNode, nil
+		return &branchNode{}, nil
 	default:
 		return nil, ErrInvalidNode
 	}

--- a/data/trie/node_test.go
+++ b/data/trie/node_test.go
@@ -76,9 +76,11 @@ func TestNode_encodeNodeAndGetHashExtensionNode(t *testing.T) {
 			Key:          []byte{2},
 			EncodedChild: []byte("doge"),
 		},
-		db:     db,
-		marsh:  marsh,
-		hasher: hasher,
+		baseNode: &baseNode{
+			db:     db,
+			marsh:  marsh,
+			hasher: hasher,
+		},
 	}
 
 	encNode, _ := marsh.Marshal(en)
@@ -477,12 +479,14 @@ func TestGetOldHashesIfNodeIsCollapsed(t *testing.T) {
 			Key:          rootKey,
 			EncodedChild: nextNode.getHash(),
 		},
-		child:  nil,
-		hash:   rootHash,
-		dirty:  false,
-		db:     db,
-		marsh:  msh,
-		hasher: hsh,
+		child: nil,
+		baseNode: &baseNode{
+			hash:   rootHash,
+			dirty:  false,
+			db:     db,
+			marsh:  msh,
+			hasher: hsh,
+		},
 	}
 	_ = tr.Update([]byte("doeee"), []byte("value of doeee"))
 

--- a/data/trie/patriciaMerkleTrie.go
+++ b/data/trie/patriciaMerkleTrie.go
@@ -509,12 +509,7 @@ func (tr *patriciaMerkleTrie) Snapshot() error {
 		tr.snapshots = tr.snapshots[1:]
 
 		removePath := path.Join(tr.snapshotDbCfg.FilePath, dbUniqueId)
-		go func() {
-			err = os.RemoveAll(removePath)
-			if err != nil {
-				log.Error(err.Error())
-			}
-		}()
+		go removeDirectory(removePath)
 	}
 
 	newTrie, err := NewTrie(
@@ -545,6 +540,13 @@ func (tr *patriciaMerkleTrie) Snapshot() error {
 	go tr.snapshot(newTrie, db)
 
 	return nil
+}
+
+func removeDirectory(path string) {
+	err := os.RemoveAll(path)
+	if err != nil {
+		log.Error(err.Error())
+	}
 }
 
 func (tr *patriciaMerkleTrie) snapshot(newTrie *patriciaMerkleTrie, db data.DBWriteCacher) {

--- a/data/trie/patriciaMerkleTrie.go
+++ b/data/trie/patriciaMerkleTrie.go
@@ -324,7 +324,7 @@ func (tr *patriciaMerkleTrie) Commit() error {
 		tr.oldHashes = make([][]byte, 0)
 	}
 
-	err = tr.root.commit(false, 0, tr.db, tr.db, tr.marshalizer, tr.hasher)
+	err = tr.root.commit(false, 0, tr.db)
 	if err != nil {
 		return err
 	}
@@ -483,7 +483,7 @@ func (tr *patriciaMerkleTrie) Snapshot() error {
 	}
 	tr.snapshotInProgress = true
 
-	err := tr.root.commit(false, 0, tr.db, tr.db, tr.marshalizer, tr.hasher)
+	err := tr.root.commit(false, 0, tr.db)
 	if err != nil {
 		return err
 	}
@@ -534,7 +534,7 @@ func (tr *patriciaMerkleTrie) Snapshot() error {
 		return err
 	}
 
-	newRoot, err := decodeNode(encRoot, tr.marshalizer)
+	newRoot, err := decodeNode(encRoot, tr.db, tr.marshalizer, tr.hasher)
 	if err != nil {
 		return err
 	}
@@ -548,7 +548,7 @@ func (tr *patriciaMerkleTrie) Snapshot() error {
 }
 
 func (tr *patriciaMerkleTrie) snapshot(newTrie *patriciaMerkleTrie, db data.DBWriteCacher) {
-	err := newTrie.root.commit(true, 0, newTrie.db, db, newTrie.marshalizer, newTrie.hasher)
+	err := newTrie.root.commit(true, 0, db)
 	if err != nil {
 		log.Error(err.Error())
 	}


### PR DESCRIPTION
Add db, marshalizer and hasher to nodes instead of passing them around as parameters to functions.