### PR TITLE
EN-4967-Fix-network-split-in-metachain

### DIFF
--- a/process/constants.go
+++ b/process/constants.go
@@ -6,6 +6,8 @@ type BlockHeaderState int
 const (
 	// BHReceived defines ID of a received block header
 	BHReceived BlockHeaderState = iota
+	// BHReceivedTooLate defines ID of a late received block header
+	BHReceivedTooLate
 	// BHProcessed defines ID of a processed block header
 	BHProcessed
 	// BHProposed defines ID of a proposed block header

--- a/process/sync/baseForkDetector.go
+++ b/process/sync/baseForkDetector.go
@@ -62,6 +62,12 @@ func (bfd *baseForkDetector) checkBlockBasicValidity(
 	//TODO: Analyze if the acceptance of some headers which came for the next round could generate some attack vectors
 	nextRound := bfd.rounder.Index() + 1
 
+	if bfd.blackListHandler.Has(string(header.GetPrevHash())) {
+		//TODO: Should be done some tests to reconsider adding here to the black list also this received header,
+		// which is bound to a previous black listed header.
+		bfd.blackListHandler.Add(string(headerHash))
+		return process.ErrHeaderIsBlackListed
+	}
 	if roundDif < 0 {
 		return ErrLowerRoundInBlock
 	}
@@ -73,12 +79,6 @@ func (bfd *baseForkDetector) checkBlockBasicValidity(
 	}
 	if roundDif < nonceDif {
 		return ErrHigherNonceInBlock
-	}
-	if bfd.blackListHandler.Has(string(header.GetPrevHash())) {
-		//TODO: Should be done some tests to reconsider adding here to the black list also this received header,
-		// which is bound to a previous black listed header.
-		bfd.blackListHandler.Add(string(headerHash))
-		return process.ErrHeaderIsBlackListed
 	}
 	if state == process.BHProposed {
 		if !isRandomSeedValid(header) {
@@ -118,7 +118,8 @@ func (bfd *baseForkDetector) removeInvalidReceivedHeaders() {
 		for i := 0; i < len(hdrInfos); i++ {
 			roundDif := int64(hdrInfos[i].round) - int64(finalCheckpointRound)
 			nonceDif := int64(hdrInfos[i].nonce) - int64(finalCheckpointNonce)
-			isReceivedHeaderInvalid := hdrInfos[i].state == process.BHReceived && roundDif < nonceDif
+			hasStateReceived := hdrInfos[i].state == process.BHReceived || hdrInfos[i].state == process.BHReceivedTooLate
+			isReceivedHeaderInvalid := hasStateReceived && roundDif < nonceDif
 			if isReceivedHeaderInvalid {
 				continue
 			}
@@ -370,10 +371,7 @@ func (bfd *baseForkDetector) isNotarizedShardStuck() bool {
 
 // IsInterfaceNil returns true if there is no value under the interface
 func (bfd *baseForkDetector) IsInterfaceNil() bool {
-	if bfd == nil {
-		return true
-	}
-	return false
+	return bfd == nil
 }
 
 // CheckFork method checks if the node could be on the fork
@@ -438,6 +436,10 @@ func (bfd *baseForkDetector) computeForkInfo(
 	lastForkRound uint64,
 ) ([]byte, uint64) {
 
+	if headerInfo.state == process.BHReceivedTooLate {
+		return lastForkHash, lastForkRound
+	}
+
 	currentForkRound := headerInfo.round
 	if headerInfo.state == process.BHNotarized {
 		currentForkRound = process.MinForkRound
@@ -469,55 +471,77 @@ func (bfd *baseForkDetector) shouldSignalFork(
 	return shouldSignalFork
 }
 
-func (bfd *baseForkDetector) shouldAddBlockInForkDetector(
+func (bfd *baseForkDetector) isHeaderReceivedTooLate(
 	header data.HeaderHandler,
 	state process.BlockHeaderState,
 	finality int64,
-) error {
+) bool {
 
 	if state == process.BHProcessed {
-		return nil
+		return false
 	}
 
 	// This condition would avoid a stuck situation, when shards would set as final, block with nonce n received from
 	// meta-chain, because they also received n+1. In the same time meta-chain would be reverted to an older block with
 	// nonce n received it with latency but before n+1. Actually this condition would reject these older blocks.
-	roundTooOld := int64(header.GetRound()) < bfd.rounder.Index()-finality
-	if roundTooOld {
-		return ErrLowerRoundInBlock
-	}
+	isHeaderReceivedTooLate := int64(header.GetRound()) < bfd.rounder.Index()-finality
 
-	return nil
+	return isHeaderReceivedTooLate
 }
 
 func (bfd *baseForkDetector) activateForcedForkIfNeeded(
 	header data.HeaderHandler,
 	state process.BlockHeaderState,
 ) {
+	bfd.activateForcedForkOnConsensusStuckIfNeeded(header, state)
+	bfd.activateForcedForkOnCrossNotarizedStuckIfNeeded(header, state)
+}
 
+func (bfd *baseForkDetector) activateForcedForkOnConsensusStuckIfNeeded(
+	header data.HeaderHandler,
+	state process.BlockHeaderState,
+) {
 	if state != process.BHProposed || bfd.isSyncing() {
 		return
 	}
 
 	lastCheckpointRound := bfd.lastCheckpoint().round
 	lastCheckpointNonce := bfd.lastCheckpoint().nonce
-	finalCheckpointNonce := bfd.finalCheckpoint().nonce
 
 	roundsDifference := int64(header.GetRound()) - int64(lastCheckpointRound)
 	noncesDifference := int64(header.GetNonce()) - int64(lastCheckpointNonce)
-	noncesWithoutCrossNotarizedDifference := int64(header.GetNonce()) - int64(finalCheckpointNonce)
 	isInProperRound := process.IsInProperRound(bfd.rounder.Index())
 
 	isConsensusStuck := roundsDifference > process.MaxRoundsWithoutCommittedBlock &&
 		noncesDifference <= 1 &&
 		isInProperRound
 
+	if isConsensusStuck {
+		bfd.setShouldForceFork(true)
+	}
+}
+
+func (bfd *baseForkDetector) activateForcedForkOnCrossNotarizedStuckIfNeeded(
+	header data.HeaderHandler,
+	state process.BlockHeaderState,
+) {
+	if state != process.BHProposed || bfd.isSyncing() {
+		return
+	}
+
+	lastCheckpointNonce := bfd.lastCheckpoint().nonce
+	finalCheckpointNonce := bfd.finalCheckpoint().nonce
+
+	noncesDifference := int64(header.GetNonce()) - int64(lastCheckpointNonce)
+	noncesWithoutCrossNotarizedDifference := int64(header.GetNonce()) - int64(finalCheckpointNonce)
+	isInProperRound := process.IsInProperRound(bfd.rounder.Index())
+
 	isCrossNotarizedStuck := noncesWithoutCrossNotarizedDifference > process.MaxNoncesWithoutCrossNotarized &&
 		noncesDifference <= 1 &&
 		isInProperRound &&
 		!bfd.isNotarizedShardStuck()
 
-	if isConsensusStuck || isCrossNotarizedStuck {
+	if isCrossNotarizedStuck {
 		bfd.setShouldForceFork(true)
 	}
 }

--- a/process/sync/export_test.go
+++ b/process/sync/export_test.go
@@ -323,8 +323,8 @@ func (sbm *StorageBootstrapperMock) IsInterfaceNil() bool {
 	return false
 }
 
-func (bfd *baseForkDetector) ShouldAddBlockInForkDetector(header data.HeaderHandler, state process.BlockHeaderState, finality int64) error {
-	return bfd.shouldAddBlockInForkDetector(header, state, finality)
+func (bfd *baseForkDetector) IsHeaderReceivedTooLate(header data.HeaderHandler, state process.BlockHeaderState, finality int64) bool {
+	return bfd.isHeaderReceivedTooLate(header, state, finality)
 }
 
 func (bfd *baseForkDetector) SetProbableHighestNonce(nonce uint64) {

--- a/process/sync/metaForkDetector.go
+++ b/process/sync/metaForkDetector.go
@@ -52,7 +52,7 @@ func (mfd *metaForkDetector) AddHeader(
 	isNotarizedShardStuck bool,
 ) error {
 
-	if header == nil || header.IsInterfaceNil() {
+	if check.IfNil(header) {
 		return ErrNilHeader
 	}
 	if headerHash == nil {
@@ -64,11 +64,11 @@ func (mfd *metaForkDetector) AddHeader(
 		return err
 	}
 
-	mfd.activateForcedForkIfNeeded(header, state)
+	mfd.activateForcedForkOnConsensusStuckIfNeeded(header, state)
 
-	err = mfd.shouldAddBlockInForkDetector(header, state, process.MetaBlockFinality)
-	if err != nil {
-		return err
+	isHeaderReceivedTooLate := mfd.isHeaderReceivedTooLate(header, state, process.MetaBlockFinality)
+	if isHeaderReceivedTooLate {
+		state = process.BHReceivedTooLate
 	}
 
 	if state == process.BHProcessed {

--- a/process/sync/shardForkDetector.go
+++ b/process/sync/shardForkDetector.go
@@ -52,7 +52,7 @@ func (sfd *shardForkDetector) AddHeader(
 	isNotarizedShardStuck bool,
 ) error {
 
-	if header == nil || header.IsInterfaceNil() {
+	if check.IfNil(header) {
 		return ErrNilHeader
 	}
 	if headerHash == nil {
@@ -66,9 +66,9 @@ func (sfd *shardForkDetector) AddHeader(
 
 	sfd.activateForcedForkIfNeeded(header, state)
 
-	err = sfd.shouldAddBlockInForkDetector(header, state, process.ShardBlockFinality)
-	if err != nil {
-		return err
+	isHeaderReceivedTooLate := sfd.isHeaderReceivedTooLate(header, state, process.ShardBlockFinality)
+	if isHeaderReceivedTooLate {
+		state = process.BHReceivedTooLate
 	}
 
 	if state == process.BHProcessed {


### PR DESCRIPTION
* Added a new state for late received headers, which are added in fork detector, instead of rejected them. These headers would trigger that a probable highest nonce exists and the longest chain should be selected by other nodes, which would be entered in sync mode requesting for that nonce.