### PR TITLE
trie checkpoint

### DIFF
--- a/data/mock/evictionWaitingListMock.go
+++ b/data/mock/evictionWaitingListMock.go
@@ -84,10 +84,7 @@ func (ewl *EvictionWaitingList) Evict(rootHash []byte) ([][]byte, error) {
 
 // IsInterfaceNil returns true if there is no value under the interface
 func (ewl *EvictionWaitingList) IsInterfaceNil() bool {
-	if ewl == nil {
-		return true
-	}
-	return false
+	return ewl == nil
 }
 
 // GetSize returns the size of the cache

--- a/data/trie/branchNode_test.go
+++ b/data/trie/branchNode_test.go
@@ -51,6 +51,8 @@ func newEmptyTrie(marsh marshal.Marshalizer, hsh hashing.Hasher) *patriciaMerkle
 	evictionWaitListSize := 100
 	evictionWaitList, _ := mock.NewEvictionWaitingList(evictionWaitListSize, mock.NewMemDbMock(), marsh)
 
+	// TODO change this initialization of the persister  (and everywhere in this package)
+	// by using a persister factory
 	tempDir, _ := ioutil.TempDir("", "leveldb_temp")
 	cfg := config.DBConfig{
 		FilePath:          tempDir,

--- a/data/trie/branchNode_test.go
+++ b/data/trie/branchNode_test.go
@@ -9,14 +9,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ElrondNetwork/elrond-go/storage"
-
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/mock"
-	protobuf "github.com/ElrondNetwork/elrond-go/data/trie/proto"
+	"github.com/ElrondNetwork/elrond-go/data/trie/proto"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
+	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/ElrondNetwork/elrond-go/storage/lrucache"
 	"github.com/ElrondNetwork/elrond-go/storage/memorydb"
 	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"

--- a/data/trie/branchNode_test.go
+++ b/data/trie/branchNode_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ElrondNetwork/elrond-go/storage"
+
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/mock"
@@ -64,7 +66,7 @@ func newEmptyTrie(marsh marshal.Marshalizer, hsh hashing.Hasher) *patriciaMerkle
 
 	return &patriciaMerkleTrie{
 		db:                    db,
-		snapshots:             make([]data.DBWriteCacher, 0),
+		snapshots:             make([]storage.Persister, 0),
 		snapshotDbCfg:         cfg,
 		dbEvictionWaitingList: evictionWaitList,
 		marshalizer:           marsh,

--- a/data/trie/branchNode_test.go
+++ b/data/trie/branchNode_test.go
@@ -9,9 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ElrondNetwork/elrond-go/storage/memorydb"
-	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
-
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/mock"
@@ -19,6 +16,8 @@ import (
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/storage/lrucache"
+	"github.com/ElrondNetwork/elrond-go/storage/memorydb"
+	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/data/trie/errors.go
+++ b/data/trie/errors.go
@@ -51,3 +51,9 @@ var ErrInvalidHash = errors.New("the received hash is invalid")
 
 // ErrTimeIsOut signals that time is out
 var ErrTimeIsOut = errors.New("time is out")
+
+// ErrTrieNotCommited signals that the trie is dirty
+var ErrTrieNotCommited = errors.New("trie is not commited")
+
+// ErrHashNotFound signals that the given hash was not found in db or snapshots
+var ErrHashNotFound = errors.New("hash not found")

--- a/data/trie/errors.go
+++ b/data/trie/errors.go
@@ -52,8 +52,8 @@ var ErrInvalidHash = errors.New("the received hash is invalid")
 // ErrTimeIsOut signals that time is out
 var ErrTimeIsOut = errors.New("time is out")
 
-// ErrTrieNotCommited signals that the trie is dirty
-var ErrTrieNotCommited = errors.New("trie is not commited")
+// ErrTrieNotCommitted signals that the trie is dirty
+var ErrTrieNotCommitted = errors.New("trie is not committed")
 
 // ErrHashNotFound signals that the given hash was not found in db or snapshots
 var ErrHashNotFound = errors.New("hash not found")

--- a/data/trie/evictionWaitingList/evictionWaitingList_test.go
+++ b/data/trie/evictionWaitingList/evictionWaitingList_test.go
@@ -98,6 +98,8 @@ func TestEvictionWaitingList_PutMultiple(t *testing.T) {
 	for i := cacheSize; i < len(roots); i++ {
 		val := make([][]byte, 0)
 		encVal, err := ec.db.Get(roots[i])
+		assert.Nil(t, err)
+
 		err = ec.marshalizer.Unmarshal(&val, encVal)
 
 		assert.Nil(t, err)

--- a/data/trie/node_test.go
+++ b/data/trie/node_test.go
@@ -853,7 +853,6 @@ func TestPruningAndPruningCancellingOnTrieRollback(t *testing.T) {
 	}
 
 	rootHashes := make([][]byte, 0)
-	rootHashes = append(rootHashes)
 	for _, testVal := range testVals {
 		_ = tr.Update(testVal.key, testVal.value)
 		_ = tr.Commit()

--- a/data/trie/node_test.go
+++ b/data/trie/node_test.go
@@ -8,13 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ElrondNetwork/elrond-go/storage"
-
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/mock"
 	"github.com/ElrondNetwork/elrond-go/data/trie/proto"
 	"github.com/ElrondNetwork/elrond-go/marshal"
+	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
 	"github.com/stretchr/testify/assert"
 )

--- a/data/trie/node_test.go
+++ b/data/trie/node_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ElrondNetwork/elrond-go/storage"
+
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/mock"
@@ -704,7 +706,7 @@ func TestEachSnapshotCreatesOwnDatabase(t *testing.T) {
 
 	tr := &patriciaMerkleTrie{
 		db:                    db,
-		snapshots:             make([]data.DBWriteCacher, 0),
+		snapshots:             make([]storage.Persister, 0),
 		snapshotId:            0,
 		snapshotDbCfg:         cfg,
 		dbEvictionWaitingList: evictionWaitList,
@@ -758,7 +760,7 @@ func TestDeleteOldSnapshots(t *testing.T) {
 
 	tr := &patriciaMerkleTrie{
 		db:                    db,
-		snapshots:             make([]data.DBWriteCacher, 0),
+		snapshots:             make([]storage.Persister, 0),
 		snapshotId:            0,
 		snapshotDbCfg:         cfg,
 		dbEvictionWaitingList: evictionWaitList,
@@ -914,7 +916,7 @@ func TestPruningIsBufferedWhileSnapshoting(t *testing.T) {
 
 	tr := &patriciaMerkleTrie{
 		db:                    db,
-		snapshots:             make([]data.DBWriteCacher, 0),
+		snapshots:             make([]storage.Persister, 0),
 		snapshotDbCfg:         cfg,
 		dbEvictionWaitingList: evictionWaitList,
 		marshalizer:           msh,

--- a/data/trie/node_test.go
+++ b/data/trie/node_test.go
@@ -653,61 +653,27 @@ func TestTrieAddHashesToOldHashes(t *testing.T) {
 func TestRecreateTrieFromSnapshotDb(t *testing.T) {
 	t.Parallel()
 
-	testVals := []struct {
-		key   []byte
-		value []byte
-	}{
-		{[]byte("doe"), []byte("reindeer")},
-		{[]byte("dog"), []byte("puppy")},
-		{[]byte("dogglesworth"), []byte("cat")},
-	}
+	tr := initTrie()
 
-	db := mock.NewMemDbMock()
-	msh, hsh := getTestMarshAndHasher()
-	evictionWaitListSize := 100
-	evictionWaitList, _ := mock.NewEvictionWaitingList(evictionWaitListSize, mock.NewMemDbMock(), msh)
-
-	tempDir, _ := ioutil.TempDir("", "leveldb_temp")
-	cfg := config.DBConfig{
-		FilePath:          tempDir,
-		Type:              string(storageUnit.LvlDbSerial),
-		BatchDelaySeconds: 1,
-		MaxBatchSize:      1,
-		MaxOpenFiles:      10,
-	}
-
-	tr := &patriciaMerkleTrie{
-		db:                    db,
-		snapshots:             make([]data.DBWriteCacher, 0),
-		snapshotDbCfg:         cfg,
-		dbEvictionWaitingList: evictionWaitList,
-		marshalizer:           msh,
-		hasher:                hsh,
-	}
-
-	for _, testVal := range testVals {
-		_ = tr.Update(testVal.key, testVal.value)
-	}
-
+	_ = tr.Commit()
+	rootHash, _ := tr.Root()
 	_ = tr.Snapshot()
-	collapsedRoot, _ := tr.root.getCollapsed()
-
-	snapshotTrie := &patriciaMerkleTrie{
-		root:        collapsedRoot,
-		db:          tr.snapshots[0],
-		marshalizer: msh,
-		hasher:      hsh,
-	}
 
 	for tr.isSnapshotInProgress() {
 		time.Sleep(snapshotDelay)
 	}
 
-	for _, testVal := range testVals {
-		val, err := snapshotTrie.Get(testVal.key)
-		assert.Nil(t, err)
-		assert.Equal(t, testVal.value, val)
-	}
+	_ = tr.Update([]byte("doge"), []byte("doge"))
+	_ = tr.Commit()
+	_ = tr.Prune(rootHash, data.OldRoot)
+
+	val, err := tr.db.Get(rootHash)
+	assert.Nil(t, val)
+	assert.NotNil(t, err)
+
+	newTrie, err := tr.Recreate(rootHash)
+	assert.Nil(t, err)
+	assert.NotNil(t, newTrie)
 }
 
 func TestEachSnapshotCreatesOwnDatabase(t *testing.T) {
@@ -748,6 +714,7 @@ func TestEachSnapshotCreatesOwnDatabase(t *testing.T) {
 
 	for _, testVal := range testVals {
 		_ = tr.Update(testVal.key, testVal.value)
+		_ = tr.Commit()
 		_ = tr.Snapshot()
 		for tr.isSnapshotInProgress() {
 			time.Sleep(snapshotDelay)
@@ -801,6 +768,7 @@ func TestDeleteOldSnapshots(t *testing.T) {
 
 	for _, testVal := range testVals {
 		_ = tr.Update(testVal.key, testVal.value)
+		_ = tr.Commit()
 		_ = tr.Snapshot()
 		for tr.isSnapshotInProgress() {
 			time.Sleep(snapshotDelay)
@@ -990,8 +958,8 @@ func TestPruningIsBufferedWhileSnapshoting(t *testing.T) {
 	time.Sleep(snapshotDelay)
 
 	for i := range rootHashes {
-		trie, err := tr.Recreate(rootHashes[i])
-		assert.Nil(t, trie)
+		val, err := tr.db.Get(rootHashes[i])
+		assert.Nil(t, val)
 		assert.NotNil(t, err)
 	}
 
@@ -1013,4 +981,64 @@ func (tr *patriciaMerkleTrie) pruningBufferLength() int {
 	defer tr.mutOperation.Unlock()
 
 	return len(tr.pruningBuffer)
+}
+
+func TestTrieCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	tr := initTrie()
+
+	_ = tr.Commit()
+	_ = tr.Snapshot()
+
+	for tr.isSnapshotInProgress() {
+		time.Sleep(snapshotDelay)
+	}
+
+	_ = tr.Update([]byte("doge"), []byte("reindeer"))
+	_ = tr.Commit()
+
+	val, err := tr.Get([]byte("doge"))
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("reindeer"), val)
+
+	collapsedRoot, _ := tr.root.getCollapsed()
+	snapshotTrie := &patriciaMerkleTrie{
+		root:        collapsedRoot,
+		db:          tr.snapshots[0],
+		marshalizer: tr.marshalizer,
+		hasher:      tr.hasher,
+	}
+
+	val, err = snapshotTrie.Get([]byte("doge"))
+	assert.NotNil(t, err)
+	assert.Nil(t, val)
+
+	err = tr.Checkpoint()
+	assert.Nil(t, err)
+
+	for tr.isSnapshotInProgress() {
+		time.Sleep(snapshotDelay)
+	}
+
+	val, err = snapshotTrie.Get([]byte("doge"))
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("reindeer"), val)
+}
+
+func TestTrieCheckpointWithNoSnapshotCreatesSnapshot(t *testing.T) {
+	t.Parallel()
+
+	tr := initTrie()
+
+	assert.Equal(t, 0, len(tr.snapshots))
+
+	_ = tr.Commit()
+	err := tr.Checkpoint()
+	assert.Nil(t, err)
+	for tr.isSnapshotInProgress() {
+		time.Sleep(snapshotDelay)
+	}
+
+	assert.Equal(t, 1, len(tr.snapshots))
 }

--- a/data/trie/node_test.go
+++ b/data/trie/node_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/mock"
-	protobuf "github.com/ElrondNetwork/elrond-go/data/trie/proto"
+	"github.com/ElrondNetwork/elrond-go/data/trie/proto"
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
 	"github.com/stretchr/testify/assert"

--- a/data/trie/patriciaMerkleTrie.go
+++ b/data/trie/patriciaMerkleTrie.go
@@ -711,16 +711,17 @@ func (tr *patriciaMerkleTrie) GetSerializedNodes(rootHash []byte, maxBuffToSend 
 }
 
 func (tr *patriciaMerkleTrie) getDbThatContainsHash(rootHash []byte) data.DBWriteCacher {
-	encNode, err := tr.db.Get(rootHash)
+	_, err := tr.db.Get(rootHash)
+
 	hashPresent := err == nil
 	if hashPresent {
 		return tr.db
 	}
 
 	for i := range tr.snapshots {
-		encNode, err = tr.snapshots[i].Get(rootHash)
+		_, err := tr.snapshots[i].Get(rootHash)
 
-		hashPresent = err == nil && encNode != nil
+		hashPresent = err == nil
 		if hashPresent {
 			return tr.snapshots[i]
 		}

--- a/data/trie/patriciaMerkleTrie_test.go
+++ b/data/trie/patriciaMerkleTrie_test.go
@@ -523,6 +523,7 @@ func TestPatriciaMerkleTrie_Snapshot(t *testing.T) {
 
 	tr := initTrie()
 
+	_ = tr.Commit()
 	err := tr.Snapshot()
 	assert.Nil(t, err)
 }
@@ -532,9 +533,19 @@ func TestPatriciaMerkleTrie_SnapshotWhileSnapshotShouldFail(t *testing.T) {
 
 	tr, _ := initTrieMultipleValues(1000)
 
+	_ = tr.Commit()
 	_ = tr.Snapshot()
 	err := tr.Snapshot()
 	assert.Equal(t, trie.ErrSnapshotInProgress, err)
+}
+
+func TestPatriciaMerkleTrie_SnapshotDirtyTrie(t *testing.T) {
+	t.Parallel()
+
+	tr := initTrie()
+
+	err := tr.Snapshot()
+	assert.Equal(t, trie.ErrTrieNotCommited, err)
 }
 
 func TestPatriciaMerkleTrie_GetSerializedNodes(t *testing.T) {

--- a/data/trie/patriciaMerkleTrie_test.go
+++ b/data/trie/patriciaMerkleTrie_test.go
@@ -544,7 +544,7 @@ func TestPatriciaMerkleTrie_SnapshotDirtyTrie(t *testing.T) {
 	tr := initTrie()
 
 	err := tr.Snapshot()
-	assert.Equal(t, trie.ErrTrieNotCommited, err)
+	assert.Equal(t, trie.ErrTrieNotCommitted, err)
 }
 
 func TestPatriciaMerkleTrie_GetSerializedNodes(t *testing.T) {

--- a/data/trie/patriciaMerkleTrie_test.go
+++ b/data/trie/patriciaMerkleTrie_test.go
@@ -2,7 +2,6 @@ package trie_test
 
 import (
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -490,7 +489,7 @@ func TestPatriciaMerkleTrie_PruneAfterCancelPruneShouldFail(t *testing.T) {
 
 	tr.CancelPrune(rootHash, data.OldRoot)
 
-	expectedErr := errors.New(fmt.Sprintf("key: %s not found", base64.StdEncoding.EncodeToString(append(rootHash, byte(data.OldRoot)))))
+	expectedErr := fmt.Errorf("key: %s not found", base64.StdEncoding.EncodeToString(append(rootHash, byte(data.OldRoot))))
 	err := tr.Prune(rootHash, data.OldRoot)
 	assert.Equal(t, expectedErr, err)
 }
@@ -512,7 +511,7 @@ func TestPatriciaMerkleTrie_Prune(t *testing.T) {
 
 	_ = tr.Prune(rootHash, data.OldRoot)
 
-	expectedErr := errors.New(fmt.Sprintf("key: %s not found", base64.StdEncoding.EncodeToString(rootHash)))
+	expectedErr := fmt.Errorf("key: %s not found", base64.StdEncoding.EncodeToString(rootHash))
 	val, err := db.Get(rootHash)
 	assert.Nil(t, val)
 	assert.Equal(t, expectedErr, err)

--- a/data/trie/sync.go
+++ b/data/trie/sync.go
@@ -61,8 +61,6 @@ func (ts *trieSyncer) StartSyncing(rootHash []byte) error {
 	}
 	ts.interceptedNodes.RegisterHandler(ts.trieNodeIntercepted)
 
-	nextNodes := make([]node, 0)
-
 	currentNode, err := ts.getNode(rootHash)
 	if err != nil {
 		return err
@@ -74,7 +72,7 @@ func (ts *trieSyncer) StartSyncing(rootHash []byte) error {
 		return err
 	}
 
-	nextNodes, err = ts.trie.root.getChildren(ts.trie.Database())
+	nextNodes, err := ts.trie.root.getChildren(ts.trie.Database())
 	if err != nil {
 		return err
 	}

--- a/data/trie/sync_test.go
+++ b/data/trie/sync_test.go
@@ -72,7 +72,7 @@ func TestTrieSyncer_StartSyncing(t *testing.T) {
 	}
 
 	rootHash, _ := syncTrie.Root()
-	sync, _ := trie.NewTrieSyncer(resolver, interceptedNodesCacher, tr, time.Second)
+	sync, _ := trie.NewTrieSyncer(resolver, interceptedNodesCacher, tr, 10*time.Second)
 
 	_ = sync.StartSyncing(rootHash)
 	newTrieRootHash, _ := tr.Root()

--- a/integrationTests/state/stateTrie_test.go
+++ b/integrationTests/state/stateTrie_test.go
@@ -1104,6 +1104,7 @@ func TestTrieDbPruning_GetAccountAfterPruning(t *testing.T) {
 	_ = tr.Prune(rootHash1, data.OldRoot)
 
 	err := adb.RecreateTrie(rootHash2)
+	assert.Nil(t, err)
 	ok, err := adb.HasAccount(address1)
 	assert.True(t, ok)
 	assert.Nil(t, err)
@@ -1151,6 +1152,7 @@ func TestTrieDbPruning_GetDataTrieTrackerAfterPruning(t *testing.T) {
 	_ = tr.Prune(oldRootHash, data.OldRoot)
 
 	err := adb.RecreateTrie(newRootHash)
+	assert.Nil(t, err)
 	ok, err := adb.HasAccount(address1)
 	assert.True(t, ok)
 	assert.Nil(t, err)
@@ -1228,7 +1230,7 @@ func TestRollbackBlockAndCheckThatPruningIsCancelled(t *testing.T) {
 	fmt.Println("Delaying for disseminating transactions...")
 	time.Sleep(time.Second * 5)
 
-	round, nonce = integrationTests.ProposeAndSyncOneBlock(t, nodes, idxProposers, round, nonce)
+	round, _ = integrationTests.ProposeAndSyncOneBlock(t, nodes, idxProposers, round, nonce)
 	time.Sleep(time.Second * 5)
 
 	rootHashOfRollbackedBlock, _ := shardNode.AccntState.RootHash()

--- a/process/interceptors/processor/trieNodeInterceptorProcessor.go
+++ b/process/interceptors/processor/trieNodeInterceptorProcessor.go
@@ -58,8 +58,5 @@ func (tnip *TrieNodeInterceptorProcessor) SignalEndOfProcessing(data []process.I
 
 // IsInterfaceNil returns true if there is no value under the interface
 func (tnip *TrieNodeInterceptorProcessor) IsInterfaceNil() bool {
-	if tnip == nil {
-		return true
-	}
-	return false
+	return tnip == nil
 }

--- a/process/mock/trieStub.go
+++ b/process/mock/trieStub.go
@@ -97,10 +97,7 @@ func (ts *TrieStub) DeepClone() (data.Trie, error) {
 
 // IsInterfaceNil returns true if there is no value under the interface
 func (ts *TrieStub) IsInterfaceNil() bool {
-	if ts == nil {
-		return true
-	}
-	return false
+	return ts == nil
 }
 
 // CancelPrune invalidates the hashes that correspond to the given root hash from the eviction waiting list


### PR DESCRIPTION
Implemented trie checkpoint.
Recreate trie also checks snapshots for root hash.
Fix golangcibot comments from feat/storage-trie-pruning.