### PR TITLE
En 5276 added genesis time check in fork detector

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -545,7 +545,7 @@ func ProcessComponentsFactory(args *processComponentsFactoryArgs) (*Process, err
 		return nil, err
 	}
 
-	forkDetector, err := newForkDetector(rounder, args.shardCoordinator, blackListHandler)
+	forkDetector, err := newForkDetector(rounder, args.shardCoordinator, blackListHandler, args.nodesConfig.StartTime)
 	if err != nil {
 		return nil, err
 	}
@@ -1721,12 +1721,13 @@ func newForkDetector(
 	rounder consensus.Rounder,
 	shardCoordinator sharding.Coordinator,
 	headerBlackList process.BlackListHandler,
+	genesisTime int64,
 ) (process.ForkDetector, error) {
 	if shardCoordinator.SelfId() < shardCoordinator.NumberOfShards() {
-		return processSync.NewShardForkDetector(rounder, headerBlackList)
+		return processSync.NewShardForkDetector(rounder, headerBlackList, genesisTime)
 	}
 	if shardCoordinator.SelfId() == sharding.MetachainShardId {
-		return processSync.NewMetaForkDetector(rounder, headerBlackList)
+		return processSync.NewMetaForkDetector(rounder, headerBlackList, genesisTime)
 	}
 
 	return nil, ErrCreateForkDetector

--- a/integrationTests/consensus/testInitializer.go
+++ b/integrationTests/consensus/testInitializer.go
@@ -369,7 +369,7 @@ func createConsensusOnlyNode(
 		time.Millisecond*time.Duration(uint64(roundTime)),
 		syncer)
 
-	forkDetector, _ := syncFork.NewShardForkDetector(rounder, timecache.NewTimeCache(time.Second))
+	forkDetector, _ := syncFork.NewShardForkDetector(rounder, timecache.NewTimeCache(time.Second), 0)
 
 	hdrResolver := &mock.HeaderResolverMock{}
 	mbResolver := &mock.MiniBlocksResolverMock{}

--- a/integrationTests/testSyncNode.go
+++ b/integrationTests/testSyncNode.go
@@ -134,7 +134,7 @@ func (tpn *TestProcessorNode) initBlockProcessorWithSync() {
 	}
 
 	if tpn.ShardCoordinator.SelfId() == sharding.MetachainShardId {
-		tpn.ForkDetector, _ = sync.NewMetaForkDetector(tpn.Rounder, tpn.BlackListHandler)
+		tpn.ForkDetector, _ = sync.NewMetaForkDetector(tpn.Rounder, tpn.BlackListHandler, 0)
 		argumentsBase.Core = &mock.ServiceContainerMock{}
 		argumentsBase.ForkDetector = tpn.ForkDetector
 		argumentsBase.TxCoordinator = &mock.TransactionCoordinatorMock{}
@@ -149,7 +149,7 @@ func (tpn *TestProcessorNode) initBlockProcessorWithSync() {
 		tpn.BlockProcessor, err = block.NewMetaProcessor(arguments)
 
 	} else {
-		tpn.ForkDetector, _ = sync.NewShardForkDetector(tpn.Rounder, tpn.BlackListHandler)
+		tpn.ForkDetector, _ = sync.NewShardForkDetector(tpn.Rounder, tpn.BlackListHandler, 0)
 		argumentsBase.ForkDetector = tpn.ForkDetector
 		argumentsBase.BlockChainHook = tpn.BlockchainHook
 		argumentsBase.TxCoordinator = tpn.TxCoordinator

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -1133,7 +1133,12 @@ func (mp *metaProcessor) checkShardHeadersFinality(highestNonceHdrs map[uint32]d
 		}
 
 		if nextBlocksVerified < mp.shardBlockFinality {
-			go mp.onRequestHeaderHandlerByNonce(lastVerifiedHdr.GetShardID(), lastVerifiedHdr.GetNonce()+1)
+			for nonce := lastVerifiedHdr.GetNonce(); nonce <= lastVerifiedHdr.GetNonce()+1; nonce++ {
+				go func(requestedNonce uint64) {
+					mp.onRequestHeaderHandlerByNonce(lastVerifiedHdr.GetShardID(), requestedNonce)
+				}(nonce)
+			}
+
 			errFinal = process.ErrHeaderNotFinal
 		}
 	}
@@ -1206,6 +1211,8 @@ func (mp *metaProcessor) receivedShardHeader(shardHeaderHash []byte) {
 	}
 
 	log.Debug("received shard block from network",
+		"shard", shardHeader.ShardId,
+		"round", shardHeader.Round,
 		"nonce", shardHeader.Nonce,
 		"hash", shardHeaderHash,
 	)

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -1133,12 +1133,8 @@ func (mp *metaProcessor) checkShardHeadersFinality(highestNonceHdrs map[uint32]d
 		}
 
 		if nextBlocksVerified < mp.shardBlockFinality {
-			for nonce := lastVerifiedHdr.GetNonce(); nonce <= lastVerifiedHdr.GetNonce()+1; nonce++ {
-				go func(requestedNonce uint64) {
-					mp.onRequestHeaderHandlerByNonce(lastVerifiedHdr.GetShardID(), requestedNonce)
-				}(nonce)
-			}
-
+			go mp.onRequestHeaderHandlerByNonce(lastVerifiedHdr.GetShardID(), lastVerifiedHdr.GetNonce())
+			go mp.onRequestHeaderHandlerByNonce(lastVerifiedHdr.GetShardID(), lastVerifiedHdr.GetNonce()+1)
 			errFinal = process.ErrHeaderNotFinal
 		}
 	}

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -377,12 +377,8 @@ func (sp *shardProcessor) checkMetaHdrFinality(header data.HeaderHandler) error 
 	}
 
 	if nextBlocksVerified < sp.metaBlockFinality {
-		for nonce := lastVerifiedHdr.GetNonce(); nonce <= lastVerifiedHdr.GetNonce()+1; nonce++ {
-			go func(requestedNonce uint64) {
-				sp.onRequestHeaderHandlerByNonce(lastVerifiedHdr.GetShardID(), requestedNonce)
-			}(nonce)
-		}
-
+		go sp.onRequestHeaderHandlerByNonce(lastVerifiedHdr.GetShardID(), lastVerifiedHdr.GetNonce())
+		go sp.onRequestHeaderHandlerByNonce(lastVerifiedHdr.GetShardID(), lastVerifiedHdr.GetNonce()+1)
 		return process.ErrHeaderNotFinal
 	}
 

--- a/process/sync/baseForkDetector.go
+++ b/process/sync/baseForkDetector.go
@@ -43,6 +43,7 @@ type baseForkDetector struct {
 	mutFork    sync.RWMutex
 
 	blackListHandler process.BlackListHandler
+	genesisTime      int64
 }
 
 func (bfd *baseForkDetector) removePastOrInvalidRecords() {
@@ -61,20 +62,16 @@ func (bfd *baseForkDetector) checkBlockBasicValidity(
 	nonceDif := int64(header.GetNonce()) - int64(bfd.finalCheckpoint().nonce)
 	//TODO: Analyze if the acceptance of some headers which came for the next round could generate some attack vectors
 	nextRound := bfd.rounder.Index() + 1
+	genesisTimeFromHeader := bfd.computeGenesisTimeFromHeader(header)
 
 	bfd.blackListHandler.Sweep()
 	if bfd.blackListHandler.Has(string(header.GetPrevHash())) {
-		//TODO: Should be done some tests to reconsider adding here to the black list also this received header,
-		// which is bound to a previous black listed header.
-		err := bfd.blackListHandler.Add(string(headerHash))
-		if err != nil {
-			log.Trace("add requested item with error",
-				"error", err.Error(),
-				"key", headerHash)
-
-		}
-
+		process.AddHeaderToBlackList(bfd.blackListHandler, headerHash)
 		return process.ErrHeaderIsBlackListed
+	}
+	if genesisTimeFromHeader != bfd.genesisTime {
+		process.AddHeaderToBlackList(bfd.blackListHandler, headerHash)
+		return ErrGenesisTimeMissmatch
 	}
 	if roundDif < 0 {
 		return ErrLowerRoundInBlock
@@ -607,4 +604,9 @@ func (bfd *baseForkDetector) cleanupReceivedHeadersHigherThanNonce(nonce uint64)
 		bfd.headers[hdrNonce] = preservedHdrInfos
 	}
 	bfd.mutHeaders.Unlock()
+}
+
+func (bfd *baseForkDetector) computeGenesisTimeFromHeader(headerHandler data.HeaderHandler) int64 {
+	genesisTime := int64(headerHandler.GetTimeStamp() - headerHandler.GetRound()*uint64(bfd.rounder.TimeDuration()))
+	return genesisTime
 }

--- a/process/sync/baseForkDetector.go
+++ b/process/sync/baseForkDetector.go
@@ -69,6 +69,7 @@ func (bfd *baseForkDetector) checkBlockBasicValidity(
 		process.AddHeaderToBlackList(bfd.blackListHandler, headerHash)
 		return process.ErrHeaderIsBlackListed
 	}
+	//TODO: This check could be removed when this protection mechanism would be implemented on interceptors side
 	if genesisTimeFromHeader != bfd.genesisTime {
 		process.AddHeaderToBlackList(bfd.blackListHandler, headerHash)
 		return ErrGenesisTimeMissmatch

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -137,6 +137,8 @@ func (boot *baseBootstrap) requestedHeaderHash() []byte {
 
 func (boot *baseBootstrap) processReceivedHeader(headerHandler data.HeaderHandler, headerHash []byte) {
 	log.Trace("received header from network",
+		"shard", headerHandler.GetShardID(),
+		"round", headerHandler.GetRound(),
 		"nonce", headerHandler.GetNonce(),
 		"hash", headerHash,
 	)
@@ -155,6 +157,8 @@ func (boot *baseBootstrap) processReceivedHeader(headerHandler data.HeaderHandle
 
 	if bytes.Equal(hash, headerHash) {
 		log.Debug("received requested header from network",
+			"shard", headerHandler.GetShardID(),
+			"round", headerHandler.GetRound(),
 			"nonce", headerHandler.GetNonce(),
 			"hash", hash,
 		)
@@ -174,6 +178,7 @@ func (boot *baseBootstrap) receivedHeaderNonce(nonce uint64, shardId uint32, has
 	}
 
 	log.Trace("received header from network",
+		"shard", shardId,
 		"nonce", nonce,
 		"hash", hash,
 	)
@@ -196,6 +201,7 @@ func (boot *baseBootstrap) receivedHeaderNonce(nonce uint64, shardId uint32, has
 
 	if *n == nonce {
 		log.Debug("received requested header from network",
+			"shard", shardId,
 			"nonce", nonce,
 			"hash", hash,
 		)

--- a/process/sync/errors.go
+++ b/process/sync/errors.go
@@ -47,3 +47,6 @@ var ErrInvalidShardId = errors.New("invalid shard id")
 
 // ErrNilNotarizedHeader signals that an nil notarized header has been provided
 var ErrNilNotarizedHeader = errors.New("nil notarized header")
+
+// ErrGenesisTimeMissmatch signals that a received header has a genesis time missmatch
+var ErrGenesisTimeMissmatch = errors.New("genesis time missmatch")

--- a/process/sync/metaForkDetector.go
+++ b/process/sync/metaForkDetector.go
@@ -16,6 +16,7 @@ type metaForkDetector struct {
 func NewMetaForkDetector(
 	rounder consensus.Rounder,
 	blackListHandler process.BlackListHandler,
+	genesisTime int64,
 ) (*metaForkDetector, error) {
 
 	if check.IfNil(rounder) {
@@ -28,6 +29,7 @@ func NewMetaForkDetector(
 	bfd := &baseForkDetector{
 		rounder:          rounder,
 		blackListHandler: blackListHandler,
+		genesisTime:      genesisTime,
 	}
 
 	bfd.headers = make(map[uint64][]*headerInfo)

--- a/process/sync/metaForkDetector_test.go
+++ b/process/sync/metaForkDetector_test.go
@@ -13,7 +13,7 @@ import (
 func TestNewMetaForkDetector_NilRounderShouldErr(t *testing.T) {
 	t.Parallel()
 
-	sfd, err := sync.NewMetaForkDetector(nil, &mock.BlackListHandlerStub{})
+	sfd, err := sync.NewMetaForkDetector(nil, &mock.BlackListHandlerStub{}, 0)
 	assert.Nil(t, sfd)
 	assert.Equal(t, process.ErrNilRounder, err)
 }
@@ -21,7 +21,7 @@ func TestNewMetaForkDetector_NilRounderShouldErr(t *testing.T) {
 func TestNewMetaForkDetector_NilBlackListShouldErr(t *testing.T) {
 	t.Parallel()
 
-	sfd, err := sync.NewMetaForkDetector(&mock.RounderMock{}, nil)
+	sfd, err := sync.NewMetaForkDetector(&mock.RounderMock{}, nil, 0)
 	assert.Nil(t, sfd)
 	assert.Equal(t, process.ErrNilBlackListHandler, err)
 }
@@ -29,7 +29,7 @@ func TestNewMetaForkDetector_NilBlackListShouldErr(t *testing.T) {
 func TestNewMetaForkDetector_OkParamsShouldWork(t *testing.T) {
 	t.Parallel()
 
-	sfd, err := sync.NewMetaForkDetector(&mock.RounderMock{}, &mock.BlackListHandlerStub{})
+	sfd, err := sync.NewMetaForkDetector(&mock.RounderMock{}, &mock.BlackListHandlerStub{}, 0)
 	assert.Nil(t, err)
 	assert.NotNil(t, sfd)
 
@@ -43,7 +43,7 @@ func TestMetaForkDetector_AddHeaderNilHeaderShouldErr(t *testing.T) {
 	t.Parallel()
 
 	rounderMock := &mock.RounderMock{RoundIndex: 100}
-	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 	err := bfd.AddHeader(nil, make([]byte, 0), process.BHProcessed, nil, nil, false)
 	assert.Equal(t, sync.ErrNilHeader, err)
 }
@@ -52,7 +52,7 @@ func TestMetaForkDetector_AddHeaderNilHashShouldErr(t *testing.T) {
 	t.Parallel()
 
 	rounderMock := &mock.RounderMock{RoundIndex: 100}
-	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 	err := bfd.AddHeader(&block.Header{}, nil, process.BHProcessed, nil, nil, false)
 	assert.Equal(t, sync.ErrNilHash, err)
 }
@@ -61,7 +61,7 @@ func TestMetaForkDetector_AddHeaderUnsignedBlockShouldErr(t *testing.T) {
 	t.Parallel()
 
 	rounderMock := &mock.RounderMock{RoundIndex: 1}
-	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 	err := bfd.AddHeader(
 		&block.Header{Nonce: 1, Round: 1},
 		make([]byte, 0),
@@ -78,7 +78,7 @@ func TestMetaForkDetector_AddHeaderNotPresentShouldWork(t *testing.T) {
 	hdr := &block.Header{Nonce: 1, Round: 1, PubKeysBitmap: []byte("X")}
 	hash := make([]byte, 0)
 	rounderMock := &mock.RounderMock{RoundIndex: 1}
-	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 
 	err := bfd.AddHeader(hdr, hash, process.BHProcessed, nil, nil, false)
 	assert.Nil(t, err)
@@ -96,7 +96,7 @@ func TestMetaForkDetector_AddHeaderPresentShouldAppend(t *testing.T) {
 	hdr2 := &block.Header{Nonce: 1, Round: 1, PubKeysBitmap: []byte("X")}
 	hash2 := []byte("hash2")
 	rounderMock := &mock.RounderMock{RoundIndex: 1}
-	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 
 	_ = bfd.AddHeader(hdr1, hash1, process.BHProcessed, nil, nil, false)
 	err := bfd.AddHeader(hdr2, hash2, process.BHProcessed, nil, nil, false)
@@ -114,7 +114,7 @@ func TestMetaForkDetector_AddHeaderWithProcessedBlockShouldSetCheckpoint(t *test
 	hdr1 := &block.Header{Nonce: 69, Round: 72, PubKeysBitmap: []byte("X")}
 	hash1 := []byte("hash1")
 	rounderMock := &mock.RounderMock{RoundIndex: 73}
-	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 	_ = bfd.AddHeader(hdr1, hash1, process.BHProcessed, nil, nil, false)
 	assert.Equal(t, hdr1.Nonce, bfd.LastCheckpointNonce())
 }
@@ -126,7 +126,7 @@ func TestMetaForkDetector_AddHeaderPresentShouldNotRewriteState(t *testing.T) {
 	hash := []byte("hash1")
 	hdr2 := &block.Header{Nonce: 1, Round: 1, PubKeysBitmap: []byte("X")}
 	rounderMock := &mock.RounderMock{RoundIndex: 1}
-	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 
 	_ = bfd.AddHeader(hdr1, hash, process.BHReceived, nil, nil, false)
 	err := bfd.AddHeader(hdr2, hash, process.BHProcessed, nil, nil, false)
@@ -143,7 +143,7 @@ func TestMetaForkDetector_AddHeaderHigherNonceThanRoundShouldErr(t *testing.T) {
 	t.Parallel()
 
 	rounderMock := &mock.RounderMock{RoundIndex: 100}
-	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewMetaForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 	err := bfd.AddHeader(
 		&block.Header{Nonce: 1, Round: 0, PubKeysBitmap: []byte("X")},
 		[]byte("hash1"),

--- a/process/sync/metablock_test.go
+++ b/process/sync/metablock_test.go
@@ -1466,7 +1466,7 @@ func TestMetaBootstrap_ShouldSyncShouldReturnFalseWhenForkIsDetectedAndItReceive
 	marshalizer := &mock.MarshalizerMock{}
 	rounder := &mock.RounderMock{}
 	rounder.RoundIndex = 2
-	forkDetector, _ := sync.NewMetaForkDetector(rounder, &mock.BlackListHandlerStub{})
+	forkDetector, _ := sync.NewMetaForkDetector(rounder, &mock.BlackListHandlerStub{}, 0)
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
 	account := &mock.AccountsStub{}
 
@@ -1535,7 +1535,7 @@ func TestMetaBootstrap_ShouldSyncShouldReturnFalseWhenForkIsDetectedAndItReceive
 	marshalizer := &mock.MarshalizerMock{}
 	rounder := &mock.RounderMock{}
 	rounder.RoundIndex = 2
-	forkDetector, _ := sync.NewMetaForkDetector(rounder, &mock.BlackListHandlerStub{})
+	forkDetector, _ := sync.NewMetaForkDetector(rounder, &mock.BlackListHandlerStub{}, 0)
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
 	account := &mock.AccountsStub{}
 

--- a/process/sync/shardForkDetector.go
+++ b/process/sync/shardForkDetector.go
@@ -16,6 +16,7 @@ type shardForkDetector struct {
 func NewShardForkDetector(
 	rounder consensus.Rounder,
 	blackListHandler process.BlackListHandler,
+	genesisTime int64,
 ) (*shardForkDetector, error) {
 
 	if check.IfNil(rounder) {
@@ -28,6 +29,7 @@ func NewShardForkDetector(
 	bfd := &baseForkDetector{
 		rounder:          rounder,
 		blackListHandler: blackListHandler,
+		genesisTime:      genesisTime,
 	}
 
 	bfd.headers = make(map[uint64][]*headerInfo)

--- a/process/sync/shardForkDetector_test.go
+++ b/process/sync/shardForkDetector_test.go
@@ -13,7 +13,7 @@ import (
 func TestNewShardForkDetector_NilRounderShouldErr(t *testing.T) {
 	t.Parallel()
 
-	sfd, err := sync.NewShardForkDetector(nil, &mock.BlackListHandlerStub{})
+	sfd, err := sync.NewShardForkDetector(nil, &mock.BlackListHandlerStub{}, 0)
 	assert.Nil(t, sfd)
 	assert.Equal(t, process.ErrNilRounder, err)
 }
@@ -21,7 +21,7 @@ func TestNewShardForkDetector_NilRounderShouldErr(t *testing.T) {
 func TestNewShardForkDetector_NilBlackListShouldErr(t *testing.T) {
 	t.Parallel()
 
-	sfd, err := sync.NewShardForkDetector(&mock.RounderMock{}, nil)
+	sfd, err := sync.NewShardForkDetector(&mock.RounderMock{}, nil, 0)
 	assert.Nil(t, sfd)
 	assert.Equal(t, process.ErrNilBlackListHandler, err)
 }
@@ -29,7 +29,7 @@ func TestNewShardForkDetector_NilBlackListShouldErr(t *testing.T) {
 func TestNewShardForkDetector_OkParamsShouldWork(t *testing.T) {
 	t.Parallel()
 
-	sfd, err := sync.NewShardForkDetector(&mock.RounderMock{}, &mock.BlackListHandlerStub{})
+	sfd, err := sync.NewShardForkDetector(&mock.RounderMock{}, &mock.BlackListHandlerStub{}, 0)
 	assert.Nil(t, err)
 	assert.NotNil(t, sfd)
 
@@ -43,7 +43,7 @@ func TestShardForkDetector_AddHeaderNilHeaderShouldErr(t *testing.T) {
 	t.Parallel()
 
 	rounderMock := &mock.RounderMock{RoundIndex: 100}
-	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 	err := bfd.AddHeader(nil, make([]byte, 0), process.BHProcessed, nil, nil, false)
 	assert.Equal(t, sync.ErrNilHeader, err)
 }
@@ -52,7 +52,7 @@ func TestShardForkDetector_AddHeaderNilHashShouldErr(t *testing.T) {
 	t.Parallel()
 
 	rounderMock := &mock.RounderMock{RoundIndex: 100}
-	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 	err := bfd.AddHeader(&block.Header{}, nil, process.BHProcessed, nil, nil, false)
 	assert.Equal(t, sync.ErrNilHash, err)
 }
@@ -61,7 +61,7 @@ func TestShardForkDetector_AddHeaderUnsignedBlockShouldErr(t *testing.T) {
 	t.Parallel()
 
 	rounderMock := &mock.RounderMock{RoundIndex: 1}
-	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 	err := bfd.AddHeader(
 		&block.Header{Nonce: 1, Round: 1},
 		make([]byte, 0),
@@ -78,7 +78,7 @@ func TestShardForkDetector_AddHeaderNotPresentShouldWork(t *testing.T) {
 	hdr := &block.Header{Nonce: 1, Round: 1, PubKeysBitmap: []byte("X")}
 	hash := make([]byte, 0)
 	rounderMock := &mock.RounderMock{RoundIndex: 1}
-	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 
 	err := bfd.AddHeader(hdr, hash, process.BHProcessed, nil, nil, false)
 	assert.Nil(t, err)
@@ -96,7 +96,7 @@ func TestShardForkDetector_AddHeaderPresentShouldAppend(t *testing.T) {
 	hdr2 := &block.Header{Nonce: 1, Round: 1, PubKeysBitmap: []byte("X")}
 	hash2 := []byte("hash2")
 	rounderMock := &mock.RounderMock{RoundIndex: 1}
-	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 
 	_ = bfd.AddHeader(hdr1, hash1, process.BHProcessed, nil, nil, false)
 	err := bfd.AddHeader(hdr2, hash2, process.BHProcessed, nil, nil, false)
@@ -114,7 +114,7 @@ func TestShardForkDetector_AddHeaderWithProcessedBlockShouldSetCheckpoint(t *tes
 	hdr1 := &block.Header{Nonce: 69, Round: 72, PubKeysBitmap: []byte("X")}
 	hash1 := []byte("hash1")
 	rounderMock := &mock.RounderMock{RoundIndex: 73}
-	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 	_ = bfd.AddHeader(hdr1, hash1, process.BHProcessed, nil, nil, false)
 	assert.Equal(t, hdr1.Nonce, bfd.LastCheckpointNonce())
 }
@@ -126,7 +126,7 @@ func TestShardForkDetector_AddHeaderPresentShouldNotRewriteState(t *testing.T) {
 	hash := []byte("hash1")
 	hdr2 := &block.Header{Nonce: 1, Round: 1, PubKeysBitmap: []byte("X")}
 	rounderMock := &mock.RounderMock{RoundIndex: 1}
-	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 
 	_ = bfd.AddHeader(hdr1, hash, process.BHReceived, nil, nil, false)
 	err := bfd.AddHeader(hdr2, hash, process.BHProcessed, nil, nil, false)
@@ -143,7 +143,7 @@ func TestShardForkDetector_AddHeaderHigherNonceThanRoundShouldErr(t *testing.T) 
 	t.Parallel()
 
 	rounderMock := &mock.RounderMock{RoundIndex: 100}
-	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{})
+	bfd, _ := sync.NewShardForkDetector(rounderMock, &mock.BlackListHandlerStub{}, 0)
 	err := bfd.AddHeader(
 		&block.Header{Nonce: 1, Round: 0, PubKeysBitmap: []byte("X")},
 		[]byte("hash1"),

--- a/process/sync/shardblock_test.go
+++ b/process/sync/shardblock_test.go
@@ -1919,7 +1919,7 @@ func TestBootstrap_ShouldSyncShouldReturnTrueWhenForkIsDetectedAndItReceivesTheS
 	marshalizer := &mock.MarshalizerMock{}
 	rounder := &mock.RounderMock{}
 	rounder.RoundIndex = 2
-	forkDetector, _ := sync.NewShardForkDetector(rounder, &mock.BlackListHandlerStub{})
+	forkDetector, _ := sync.NewShardForkDetector(rounder, &mock.BlackListHandlerStub{}, 0)
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
 	account := &mock.AccountsStub{}
 
@@ -1995,7 +1995,7 @@ func TestBootstrap_ShouldSyncShouldReturnFalseWhenForkIsDetectedAndItReceivesThe
 	marshalizer := &mock.MarshalizerMock{}
 	rounder := &mock.RounderMock{}
 	rounder.RoundIndex = 2
-	forkDetector, _ := sync.NewShardForkDetector(rounder, &mock.BlackListHandlerStub{})
+	forkDetector, _ := sync.NewShardForkDetector(rounder, &mock.BlackListHandlerStub{}, 0)
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
 	account := &mock.AccountsStub{}
 


### PR DESCRIPTION
* Added prints info
* Added request for missing overwritten header when a finality check is done
* Added check for genesis time missmatch in fork detector
