### PR TITLE
dev-fix-edge-case-in-bootstrap-from-storage-and-sync-state

### DIFF
--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -438,7 +438,7 @@ func (wrk *Worker) Extend(subroundId int) {
 		time.Sleep(time.Millisecond)
 	}
 
-	log.Trace("account state is reverted to snapshot")
+	log.Debug("account state is reverted to snapshot")
 
 	wrk.blockProcessor.RevertAccountState()
 

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -254,7 +254,7 @@ func (bp *baseProcessor) checkBlockValidity(
 func (bp *baseProcessor) verifyStateRoot(rootHash []byte) bool {
 	trieRootHash, err := bp.accounts.RootHash()
 	if err != nil {
-		log.Trace("verify account.RootHash", "error", err.Error())
+		log.Debug("verify account.RootHash", "error", err.Error())
 	}
 
 	return bytes.Equal(trieRootHash, rootHash)

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -259,6 +259,12 @@ func (sp *shardProcessor) ProcessBlock(
 		return err
 	}
 
+	//TODO: This part of code should be removed, it has been used only for debugging
+	trieRootHashBefore, err := sp.accounts.RootHash()
+	if err != nil {
+		return err
+	}
+
 	startTime := time.Now()
 	err = sp.txCoordinator.ProcessBlockTransaction(body, haveTime)
 	elapsedTime := time.Since(startTime)
@@ -268,6 +274,19 @@ func (sp *shardProcessor) ProcessBlock(
 	if err != nil {
 		return err
 	}
+
+	//TODO: This part of code should be removed, it has been used only for debugging
+	trieRootHashAfter, err := sp.accounts.RootHash()
+	if err != nil {
+		return err
+	}
+
+	//TODO: This part of code should be removed, it has been used only for debugging
+	log.Debug("root hash info",
+		"header root hash ", header.RootHash,
+		"trie root hash before", trieRootHashBefore,
+		"trie root hash after", trieRootHashAfter,
+	)
 
 	err = sp.txCoordinator.VerifyCreatedBlockTransactions(body)
 	if err != nil {
@@ -764,10 +783,6 @@ func (sp *shardProcessor) CommitBlock(
 		Nonce:   header.GetNonce(),
 		Hash:    headerHash,
 	}
-
-	log.Debug("validator info on block ",
-		"nonce", header.Nonce,
-		"validator root hash", core.ToB64(header.ValidatorStatsRootHash))
 
 	sp.mutProcessedMiniBlocks.RLock()
 	//TODO remove this

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -277,10 +277,6 @@ func (boot *baseBootstrap) waitForHeaderHash() error {
 // Note that when the node is not connected to the network, ShouldSync returns true but the SyncBlock
 // is not automatically called
 func (boot *baseBootstrap) ShouldSync() bool {
-	if !boot.networkWatcher.IsConnectedToTheNetwork() {
-		return true
-	}
-
 	boot.mutNodeSynched.Lock()
 	defer boot.mutNodeSynched.Unlock()
 
@@ -297,7 +293,9 @@ func (boot *baseBootstrap) ShouldSync() bool {
 		boot.hasLastBlock = boot.forkDetector.ProbableHighestNonce() <= boot.blkc.GetCurrentBlockHeader().GetNonce()
 	}
 
-	isNodeSynchronized := !boot.forkInfo.IsDetected && boot.hasLastBlock
+	isNodeConnectedToTheNetwork := boot.networkWatcher.IsConnectedToTheNetwork()
+
+	isNodeSynchronized := !boot.forkInfo.IsDetected && boot.hasLastBlock && isNodeConnectedToTheNetwork
 	if isNodeSynchronized != boot.isNodeSynchronized {
 		log.Debug("node has changed its synchronized state",
 			"state", isNodeSynchronized,

--- a/process/sync/storageBootstrap/baseStorageBootstrapper.go
+++ b/process/sync/storageBootstrap/baseStorageBootstrapper.go
@@ -89,6 +89,7 @@ func (st *storageBootstrapper) loadBlocks() error {
 	}
 
 	if err != nil {
+		st.restoreBlockChainToGenesis()
 		_ = st.bootStorer.SaveLastRound(0)
 		return process.ErrNotEnoughValidBlocksInStorage
 	}
@@ -303,4 +304,24 @@ func (st *storageBootstrapper) addHeaderToForkDetector(headerHash []byte, finalH
 	}
 
 	return nil
+}
+
+func (st *storageBootstrapper) restoreBlockChainToGenesis() {
+	genesisHeader := st.blkc.GetGenesisHeader()
+	err := st.blkExecutor.RevertStateToBlock(genesisHeader)
+	if err != nil {
+		log.Debug("cannot recreate trie for header with nonce", "nonce", genesisHeader.GetNonce())
+	}
+
+	err = st.blkc.SetCurrentBlockHeader(nil)
+	if err != nil {
+		log.Debug("cannot set current block header", "error", err.Error())
+	}
+
+	err = st.blkc.SetCurrentBlockBody(nil)
+	if err != nil {
+		log.Debug("cannot set current block body", "error", err.Error())
+	}
+
+	st.blkc.SetCurrentBlockHeaderHash(nil)
 }


### PR DESCRIPTION
* Fixed an edge case in bootstrap from storage when no block could be applied
* Fixed an edge case in ShoudSync method when connected peers could fall below minimum accepted threshold, while node participate in consensus (the node has been sync at the beginning of the round)