### PR TITLE
Chain ID directory for databases

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -516,6 +516,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 	uniqueDBFolder := filepath.Join(
 		workingDir,
 		defaultDBPath,
+		nodesConfig.ChainID,
 		fmt.Sprintf("%s_%d", defaultEpochString, 0),
 		fmt.Sprintf("%s_%s", defaultShardString, shardId))
 


### PR DESCRIPTION
Added chain ID as the parent folder in the db.
Now the structure will be:
working-dir/db/CHAIN_ID/Epoch_X/Shard_X
to avoid situations when running with a common database in multiple chains