### PR TITLE
fix pruning on rollback

### DIFF
--- a/data/trie/patriciaMerkleTrie.go
+++ b/data/trie/patriciaMerkleTrie.go
@@ -74,7 +74,7 @@ func (tr *patriciaMerkleTrie) Get(key []byte) ([]byte, error) {
 
 	val, err := tr.root.tryGet(hexKey, tr.trieStorage.Database())
 	if err != nil {
-		log.Debug("trie get", "error", key)
+		log.Trace("trie get", "error", key)
 	}
 
 	return val, err

--- a/data/trie/patriciaMerkleTrie.go
+++ b/data/trie/patriciaMerkleTrie.go
@@ -72,7 +72,12 @@ func (tr *patriciaMerkleTrie) Get(key []byte) ([]byte, error) {
 	}
 	hexKey := keyBytesToHex(key)
 
-	return tr.root.tryGet(hexKey, tr.trieStorage.Database())
+	val, err := tr.root.tryGet(hexKey, tr.trieStorage.Database())
+	if err != nil {
+		log.Debug("trie get", "error", key)
+	}
+
+	return val, err
 }
 
 // Update updates the value at the given key.
@@ -319,7 +324,12 @@ func (tr *patriciaMerkleTrie) Recreate(root []byte) (data.Trie, error) {
 		)
 	}
 
-	return tr.recreateFromDb(root)
+	newTr, err := tr.recreateFromDb(root)
+	if err != nil {
+		log.Debug("trie recreate", "error", root)
+	}
+
+	return newTr, err
 }
 
 // DeepClone returns a new trie with all nodes deeply copied
@@ -380,6 +390,7 @@ func (tr *patriciaMerkleTrie) Prune(rootHash []byte, identifier data.TriePruning
 	defer tr.mutOperation.Unlock()
 
 	rootHash = append(rootHash, byte(identifier))
+	log.Trace("trie prune", "root", rootHash)
 	return tr.trieStorage.Prune(rootHash)
 }
 
@@ -387,6 +398,7 @@ func (tr *patriciaMerkleTrie) Prune(rootHash []byte, identifier data.TriePruning
 func (tr *patriciaMerkleTrie) CancelPrune(rootHash []byte, identifier data.TriePruningIdentifier) {
 	tr.mutOperation.Lock()
 	rootHash = append(rootHash, byte(identifier))
+	log.Trace("trie cancel prune", "root", rootHash)
 	tr.trieStorage.CancelPrune(rootHash)
 	tr.mutOperation.Unlock()
 }

--- a/data/trie/trieStorageManager.go
+++ b/data/trie/trieStorageManager.go
@@ -150,6 +150,7 @@ func (tsm *trieStorageManager) Prune(rootHash []byte) error {
 
 	err := tsm.removeFromDb(rootHash)
 	if err != nil {
+		log.Debug("trie storage manager prune", "error", rootHash)
 		return err
 	}
 
@@ -184,6 +185,7 @@ func (tsm *trieStorageManager) removeFromDb(hash []byte) error {
 func (tsm *trieStorageManager) MarkForEviction(root []byte, hashes [][]byte) error {
 	tsm.storageOperationMutex.Lock()
 	defer tsm.storageOperationMutex.Unlock()
+	log.Trace("trie storage manager: mark for eviction", "root", root)
 
 	return tsm.dbEvictionWaitingList.Put(root, hashes)
 }

--- a/data/trie/trieStorageManager_test.go
+++ b/data/trie/trieStorageManager_test.go
@@ -9,11 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ElrondNetwork/elrond-go/storage/memorydb"
-
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/mock"
+	"github.com/ElrondNetwork/elrond-go/storage/memorydb"
 	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
 	"github.com/stretchr/testify/assert"
 )

--- a/integrationTests/state/stateTrie_test.go
+++ b/integrationTests/state/stateTrie_test.go
@@ -1325,7 +1325,7 @@ func TestRollbackBlockWithSameRootHashAsPreviousAndCheckThatPruningIsNotDone(t *
 	assert.Equal(t, uint64(1), nodes[0].BlockChain.GetCurrentBlockHeader().GetNonce())
 	assert.Equal(t, uint64(1), nodes[1].BlockChain.GetCurrentBlockHeader().GetNonce())
 
-	round, _ = integrationTests.ProposeAndSyncOneBlock(t, nodes, idxProposers, round, nonce)
+	_, _ = integrationTests.ProposeAndSyncOneBlock(t, nodes, idxProposers, round, nonce)
 	time.Sleep(time.Second * 5)
 
 	assert.Equal(t, uint64(2), nodes[0].BlockChain.GetCurrentBlockHeader().GetNonce())

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -706,9 +706,11 @@ func (boot *baseBootstrap) rollBackOneBlock(
 
 		boot.accounts.CancelPrune(prevHeader.GetRootHash())
 
-		errNotCritical := boot.accounts.PruneTrie(currHeader.GetRootHash())
-		if errNotCritical != nil {
-			log.Debug(errNotCritical.Error())
+		if !bytes.Equal(currHeader.GetRootHash(), prevHeader.GetRootHash()) {
+			errNotCritical := boot.accounts.PruneTrie(currHeader.GetRootHash())
+			if errNotCritical != nil {
+				log.Debug(errNotCritical.Error())
+			}
 		}
 	} else {
 		err = boot.setCurrentBlockInfo(nil, nil, nil)

--- a/scripts/testnet/include/nodes.sh
+++ b/scripts/testnet/include/nodes.sh
@@ -121,7 +121,7 @@ assembleCommand_startObserverNode() {
   local nodeCommand="nice -n $NODE_NICENESS ./node \
         -port $PORT -rest-api-interface localhost:$RESTAPIPORT \
         -tx-sign-sk-index $KEY_INDEX -sk-index $KEY_INDEX \
-        -num-of-nodes $TOTAL_NODECOUNT -storage-cleanup -destination-shard-as-observer $SHARD \
+        -num-of-nodes $TOTAL_NODECOUNT -destination-shard-as-observer $SHARD \
         -working-directory $WORKING_DIR"
 
   if [ $NODETERMUI -eq 0 ]
@@ -145,7 +145,7 @@ assembleCommand_startValidatorNode() {
   local nodeCommand="nice -n $NODE_NICENESS ./node \
         -port $PORT -rest-api-interface localhost:$RESTAPIPORT \
         -tx-sign-sk-index $KEY_INDEX -sk-index $KEY_INDEX \
-        -num-of-nodes $TOTAL_NODECOUNT -storage-cleanup \
+        -num-of-nodes $TOTAL_NODECOUNT \
         -working-directory $WORKING_DIR"
 
   if [ $NODETERMUI -eq 0 ]


### PR DESCRIPTION
Bug 1: if root hash stays the same in some consecutive blocks, and then one block does a rollback, rootHash+newRootIdentifier will be pruned from db, thus removing values that are needed. 

Bug 2: When bootstrapping from storage, if there were some trie snapshots, they were not taken in consideration. 