### PR TITLE
En 5702 fix trie bugs

### DIFF
--- a/data/trie/extensionNode.go
+++ b/data/trie/extensionNode.go
@@ -298,7 +298,7 @@ func (en *extensionNode) insert(n *leafNode, db data.DBWriteCacher) (bool, node,
 		n.Key = n.Key[keyMatchLen:]
 		dirty, newNode, oldHashes, err = en.child.insert(n, db)
 		if !dirty || err != nil {
-			return false, nil, emptyHashes, err
+			return false, en, emptyHashes, err
 		}
 
 		if !en.dirty {

--- a/data/trie/leafNode.go
+++ b/data/trie/leafNode.go
@@ -181,6 +181,10 @@ func (ln *leafNode) insert(n *leafNode, _ data.DBWriteCacher) (bool, node, [][]b
 	}
 
 	if bytes.Equal(n.Key, ln.Key) {
+		if bytes.Equal(ln.Value, n.Value) {
+			return false, ln, [][]byte{}, nil
+		}
+
 		ln.Value = n.Value
 		ln.dirty = true
 		ln.hash = nil
@@ -224,8 +228,7 @@ func (ln *leafNode) insert(n *leafNode, _ data.DBWriteCacher) (bool, node, [][]b
 }
 
 func (ln *leafNode) delete(key []byte, _ data.DBWriteCacher) (bool, node, [][]byte, error) {
-	keyMatchLen := prefixLen(key, ln.Key)
-	if keyMatchLen == len(key) {
+	if bytes.Equal(key, ln.Key) {
 		oldHash := make([][]byte, 0)
 		if !ln.dirty {
 			oldHash = append(oldHash, ln.hash)

--- a/data/trie/leafNode_test.go
+++ b/data/trie/leafNode_test.go
@@ -645,3 +645,58 @@ func getLeafNodeContents(lf *leafNode) string {
 
 	return str
 }
+
+func TestInsertSameNodeShouldNotSetDirtyBnRoot(t *testing.T) {
+	t.Parallel()
+
+	tr := initTrie()
+	_ = tr.Commit()
+	rootHash := tr.root.getHash()
+
+	_ = tr.Update([]byte("dog"), []byte("puppy"))
+	assert.False(t, tr.root.isDirty())
+	assert.Equal(t, rootHash, tr.root.getHash())
+	assert.Equal(t, [][]byte{}, tr.oldHashes)
+}
+
+func TestInsertSameNodeShouldNotSetDirtyEnRoot(t *testing.T) {
+	t.Parallel()
+
+	tr, _, _ := newEmptyTrie()
+	_ = tr.Update([]byte("dog"), []byte("puppy"))
+	_ = tr.Update([]byte("log"), []byte("wood"))
+	_ = tr.Commit()
+	rootHash := tr.root.getHash()
+
+	_ = tr.Update([]byte("dog"), []byte("puppy"))
+	assert.False(t, tr.root.isDirty())
+	assert.Equal(t, rootHash, tr.root.getHash())
+	assert.Equal(t, [][]byte{}, tr.oldHashes)
+}
+
+func TestInsertSameNodeShouldNotSetDirtyLnRoot(t *testing.T) {
+	t.Parallel()
+
+	tr, _, _ := newEmptyTrie()
+	_ = tr.Update([]byte("dog"), []byte("puppy"))
+	_ = tr.Commit()
+	rootHash := tr.root.getHash()
+
+	_ = tr.Update([]byte("dog"), []byte("puppy"))
+	assert.False(t, tr.root.isDirty())
+	assert.Equal(t, rootHash, tr.root.getHash())
+	assert.Equal(t, [][]byte{}, tr.oldHashes)
+}
+
+func TestLeafNode_deleteDifferentKeyShouldNotModifyTrie(t *testing.T) {
+	t.Parallel()
+
+	tr := initTrie()
+	_ = tr.Commit()
+	rootHash := tr.root.getHash()
+
+	_ = tr.Update([]byte("ddoe"), []byte{})
+	assert.False(t, tr.root.isDirty())
+	assert.Equal(t, rootHash, tr.root.getHash())
+	assert.Equal(t, [][]byte{}, tr.oldHashes)
+}

--- a/data/trie/trieStorageManager.go
+++ b/data/trie/trieStorageManager.go
@@ -1,6 +1,7 @@
 package trie
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -168,6 +169,15 @@ func (tsm *trieStorageManager) CancelPrune(rootHash []byte) {
 
 	log.Trace("trie storage manager cancel prune", "root", rootHash)
 	_, _ = tsm.dbEvictionWaitingList.Evict(rootHash)
+	tsm.removeHashFromPruningBuffer(rootHash)
+}
+
+func (tsm *trieStorageManager) removeHashFromPruningBuffer(rootHash []byte) {
+	for i := range tsm.pruningBuffer {
+		if bytes.Equal(tsm.pruningBuffer[i], rootHash) {
+			tsm.pruningBuffer = append(tsm.pruningBuffer[:i], tsm.pruningBuffer[i+1:]...)
+		}
+	}
 }
 
 func (tsm *trieStorageManager) removeFromDb(hash []byte) error {

--- a/data/trie/trieStorageManager.go
+++ b/data/trie/trieStorageManager.go
@@ -176,6 +176,7 @@ func (tsm *trieStorageManager) removeHashFromPruningBuffer(rootHash []byte) {
 	for i := range tsm.pruningBuffer {
 		if bytes.Equal(tsm.pruningBuffer[i], rootHash) {
 			tsm.pruningBuffer = append(tsm.pruningBuffer[:i], tsm.pruningBuffer[i+1:]...)
+			break
 		}
 	}
 }

--- a/data/trie/trieStorageManager_test.go
+++ b/data/trie/trieStorageManager_test.go
@@ -10,14 +10,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/mock"
 	"github.com/ElrondNetwork/elrond-go/storage/memorydb"
 	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewTrieStorageManagerNilDb(t *testing.T) {


### PR DESCRIPTION
- When canceling prune, also remove the hash from pruning buffer.
- When updating the trie with an existent key-value pair, nothing should be modified.