### PR TITLE
Fixed wrong type assertion for received transactions

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -738,7 +738,6 @@ func ProcessComponentsFactory(args *processComponentsFactoryArgs) (*Process, err
 	}
 
 	_, err = poolsCleaner.NewMiniBlocksPoolsCleaner(
-		blockTracker,
 		args.data.Datapool.MiniBlocks(),
 		rounder,
 		args.shardCoordinator,
@@ -749,7 +748,6 @@ func ProcessComponentsFactory(args *processComponentsFactoryArgs) (*Process, err
 
 	_, err = poolsCleaner.NewCrossTxsPoolsCleaner(
 		args.state.AddressConverter,
-		blockTracker,
 		args.data.Datapool,
 		rounder,
 		args.shardCoordinator,

--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -748,6 +748,7 @@ func ProcessComponentsFactory(args *processComponentsFactoryArgs) (*Process, err
 	}
 
 	_, err = poolsCleaner.NewCrossTxsPoolsCleaner(
+		args.state.AddressConverter,
 		blockTracker,
 		args.data.Datapool,
 		rounder,

--- a/consensus/spos/bls/blsWorker.go
+++ b/consensus/spos/bls/blsWorker.go
@@ -60,6 +60,17 @@ func (wrk *worker) IsMessageWithSignature(msgType consensus.MessageType) bool {
 	return msgType == MtSignature
 }
 
+//IsMessageTypeValid returns if the current messageType is valid
+func (wrk *worker) IsMessageTypeValid(msgType consensus.MessageType) bool {
+	isMessageTypeValid := msgType == MtBlockBodyAndHeader ||
+		msgType == MtBlockBody ||
+		msgType == MtBlockHeader ||
+		msgType == MtSignature ||
+		msgType == MtBlockHeaderFinalInfo
+
+	return isMessageTypeValid
+}
+
 //IsSubroundSignature returns if the current subround is about signature
 func (wrk *worker) IsSubroundSignature(subroundId int) bool {
 	return subroundId == SrSignature

--- a/consensus/spos/bls/blsWorker_test.go
+++ b/consensus/spos/bls/blsWorker_test.go
@@ -334,3 +334,15 @@ func TestWorker_IsSubroundStartRound(t *testing.T) {
 	ret = service.IsSubroundStartRound(bls.SrStartRound)
 	assert.True(t, ret)
 }
+
+func TestWorker_IsMessageTypeValid(t *testing.T) {
+	t.Parallel()
+
+	service, _ := bls.NewConsensusService()
+
+	ret := service.IsMessageTypeValid(bls.MtBlockBody)
+	assert.True(t, ret)
+
+	ret = service.IsMessageTypeValid(666)
+	assert.False(t, ret)
+}

--- a/consensus/spos/errors.go
+++ b/consensus/spos/errors.go
@@ -159,3 +159,6 @@ var ErrNilNetworkShardingCollector = errors.New("nil network sharding collector"
 
 // ErrInvalidMessageType signals that an invalid message type has been received from consensus topic
 var ErrInvalidMessageType = errors.New("invalid message type")
+
+// ErrInvalidHeaderHashSize signals that an invalid header hash size has been received from consensus topic
+var ErrInvalidHeaderHashSize = errors.New("invalid header hash size")

--- a/consensus/spos/errors.go
+++ b/consensus/spos/errors.go
@@ -109,6 +109,9 @@ var ErrSenderNotOk = errors.New("sender is invalid")
 // ErrMessageForPastRound is raised when message is for past round
 var ErrMessageForPastRound = errors.New("message is for past round")
 
+// ErrMessageForFutureRound is raised when message is for future round
+var ErrMessageForFutureRound = errors.New("message is for future round")
+
 // ErrInvalidSignature is raised when signature is invalid
 var ErrInvalidSignature = errors.New("signature is invalid")
 
@@ -153,3 +156,6 @@ var ErrInvalidChainID = errors.New("invalid chain ID in consensus")
 
 // ErrNilNetworkShardingCollector defines the error for setting a nil network sharding collector
 var ErrNilNetworkShardingCollector = errors.New("nil network sharding collector")
+
+// ErrInvalidMessageType signals that an invalid message type has been received from consensus topic
+var ErrInvalidMessageType = errors.New("invalid message type")

--- a/consensus/spos/interface.go
+++ b/consensus/spos/interface.go
@@ -71,6 +71,8 @@ type ConsensusService interface {
 	IsMessageWithBlockHeader(consensus.MessageType) bool
 	//IsMessageWithSignature returns if the current messageType is about signature
 	IsMessageWithSignature(consensus.MessageType) bool
+	//IsMessageTypeValid returns if the current messageType is valid
+	IsMessageTypeValid(consensus.MessageType) bool
 	//IsSubroundSignature returns if the current subround is about signature
 	IsSubroundSignature(int) bool
 	//IsSubroundStartRound returns if the current subround is about start round

--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -332,6 +332,12 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 			msgType)
 	}
 
+	if len(cnsDta.BlockHeaderHash) != core.HashSizeInBytes {
+		return fmt.Errorf("%w : received header hash from consensus topic has an invalid size: %d",
+			ErrInvalidHeaderHashSize,
+			msgType)
+	}
+
 	log.Trace("received message from consensus topic",
 		"msg type", wrk.consensusService.GetStringValue(msgType),
 		"from", core.GetTrimmedPk(hex.EncodeToString(cnsDta.PubKey)),

--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -335,7 +335,7 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 	if len(cnsDta.BlockHeaderHash) != core.HashSizeInBytes {
 		return fmt.Errorf("%w : received header hash from consensus topic has an invalid size: %d",
 			ErrInvalidHeaderHashSize,
-			msgType)
+			len(cnsDta.BlockHeaderHash))
 	}
 
 	log.Trace("received message from consensus topic",

--- a/consensus/spos/worker_test.go
+++ b/consensus/spos/worker_test.go
@@ -995,35 +995,6 @@ func TestWorker_ProcessReceivedMessageTxBlockBodyShouldRetNil(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestWorker_ProcessReceivedMessageHeaderShouldRetNil(t *testing.T) {
-	t.Parallel()
-	wrk := *initWorker()
-	hdr := &block.Header{}
-	hdr.Nonce = 1
-	hdr.TimeStamp = uint64(wrk.Rounder().TimeStamp().Unix())
-	hdrStr, _ := mock.MarshalizerMock{}.Marshal(hdr)
-	hdrHash := mock.HasherMock{}.Compute(string(hdrStr))
-	cnsMsg := consensus.NewConsensusMessage(
-		hdrHash,
-		nil,
-		nil,
-		hdrStr,
-		[]byte(wrk.ConsensusState().ConsensusGroup()[0]),
-		[]byte("sig"),
-		int(bls.MtUnknown),
-		0,
-		chainID,
-		nil,
-		nil,
-		nil,
-	)
-	buff, _ := wrk.Marshalizer().Marshal(cnsMsg)
-	time.Sleep(time.Second)
-	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff}, fromConnectedPeerId)
-
-	assert.Nil(t, err)
-}
-
 func TestWorker_ProcessReceivedMessageNilMessageShouldErr(t *testing.T) {
 	t.Parallel()
 	wrk := *initWorker()
@@ -1156,7 +1127,61 @@ func TestWorker_ProcessReceivedMessageInconsistentChainIDInConsensusMessageShoul
 	assert.True(t, errors.Is(err, spos.ErrInvalidChainID))
 }
 
-func TestWorker_ProcessReceivedMessageMessageIsForPastRoundShouldErr(t *testing.T) {
+func TestWorker_ProcessReceivedMessageTypeInvalidShouldErr(t *testing.T) {
+	t.Parallel()
+	wrk := *initWorker()
+	blk := &block.Body{}
+	blkStr, _ := mock.MarshalizerMock{}.Marshal(blk)
+	cnsMsg := consensus.NewConsensusMessage(
+		nil,
+		nil,
+		blkStr,
+		nil,
+		[]byte(wrk.ConsensusState().ConsensusGroup()[0]),
+		[]byte("sig"),
+		int(666),
+		0,
+		chainID,
+		nil,
+		nil,
+		nil,
+	)
+	buff, _ := wrk.Marshalizer().Marshal(cnsMsg)
+	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff}, fromConnectedPeerId)
+	time.Sleep(time.Second)
+
+	assert.Equal(t, 0, len(wrk.ReceivedMessages()[666]))
+	assert.True(t, errors.Is(err, spos.ErrInvalidMessageType), err)
+}
+
+func TestWorker_ProcessReceivedMessageForFutureRoundShouldErr(t *testing.T) {
+	t.Parallel()
+	wrk := *initWorker()
+	blk := &block.Body{}
+	blkStr, _ := mock.MarshalizerMock{}.Marshal(blk)
+	cnsMsg := consensus.NewConsensusMessage(
+		nil,
+		nil,
+		blkStr,
+		nil,
+		[]byte(wrk.ConsensusState().ConsensusGroup()[0]),
+		[]byte("sig"),
+		int(bls.MtBlockBody),
+		2,
+		chainID,
+		nil,
+		nil,
+		nil,
+	)
+	buff, _ := wrk.Marshalizer().Marshal(cnsMsg)
+	err := wrk.ProcessReceivedMessage(&mock.P2PMessageMock{DataField: buff}, fromConnectedPeerId)
+	time.Sleep(time.Second)
+
+	assert.Equal(t, 0, len(wrk.ReceivedMessages()[bls.MtBlockBody]))
+	assert.Equal(t, spos.ErrMessageForFutureRound, err)
+}
+
+func TestWorker_ProcessReceivedMessageForPastRoundShouldErr(t *testing.T) {
 	t.Parallel()
 	wrk := *initWorker()
 	blk := &block.Body{}

--- a/core/constants.go
+++ b/core/constants.go
@@ -306,3 +306,6 @@ const MetricP2PUnknownPeers = "erd_p2p_unknown_shard_peers"
 
 // MetricP2PNumConnectedPeersClassification is the metric for monitoring the number of connected peers split on the connection type
 const MetricP2PNumConnectedPeersClassification = "erd_p2p_num_connected_peers_classification"
+
+// HashSizeInBytes represents the size in bytes of a hash
+const HashSizeInBytes = 32

--- a/integrationTests/consensus/testInitializer.go
+++ b/integrationTests/consensus/testInitializer.go
@@ -262,7 +262,7 @@ func createCryptoParams(nodesPerShard int, nbMetaNodes int, nbShards int) *crypt
 
 func createHasher(consensusType string) hashing.Hasher {
 	if consensusType == blsConsensusType {
-		return &blake2b.Blake2b{HashSize: 16}
+		return &blake2b.Blake2b{HashSize: 32}
 	}
 	return &blake2b.Blake2b{}
 }

--- a/process/block/poolsCleaner/crossTxsPoolsCleaner.go
+++ b/process/block/poolsCleaner/crossTxsPoolsCleaner.go
@@ -138,6 +138,7 @@ func (ctpc *crossTxsPoolsCleaner) receivedRewardTx(key []byte, value interface{}
 	senderShardID, receiverShardID, err := ctpc.computeSenderAndReceiverShards(tx)
 	if err != nil {
 		log.Debug("crossTxsPoolsCleaner.receivedRewardTx", "error", err.Error())
+		return
 	}
 
 	ctpc.processReceivedTx(key, senderShardID, receiverShardID, rewardTx)
@@ -159,6 +160,7 @@ func (ctpc *crossTxsPoolsCleaner) receivedUnsignedTx(key []byte, value interface
 	senderShardID, receiverShardID, err := ctpc.computeSenderAndReceiverShards(tx)
 	if err != nil {
 		log.Debug("crossTxsPoolsCleaner.receivedUnsignedTx", "error", err.Error())
+		return
 	}
 
 	ctpc.processReceivedTx(key, senderShardID, receiverShardID, unsignedTx)

--- a/process/block/poolsCleaner/crossTxsPoolsCleaner.go
+++ b/process/block/poolsCleaner/crossTxsPoolsCleaner.go
@@ -1,10 +1,13 @@
 package poolsCleaner
 
 import (
+	"bytes"
 	"sync"
 	"time"
 
 	"github.com/ElrondNetwork/elrond-go/core/check"
+	"github.com/ElrondNetwork/elrond-go/data"
+	"github.com/ElrondNetwork/elrond-go/data/state"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/sharding"
@@ -31,6 +34,7 @@ type txInfo struct {
 
 // crossTxsPoolsCleaner represents a pools cleaner that checks and cleans cross txs which should not be in pool anymore
 type crossTxsPoolsCleaner struct {
+	addressConverter         state.AddressConverter
 	blockTracker             BlockTracker
 	blockTransactionsPool    dataRetriever.ShardedDataCacherNotifier
 	rewardTransactionsPool   dataRetriever.ShardedDataCacherNotifier
@@ -40,16 +44,21 @@ type crossTxsPoolsCleaner struct {
 
 	mutMapCrossTxsRounds sync.RWMutex
 	mapCrossTxsRounds    map[string]*txInfo
+	emptyAddress         []byte
 }
 
 // NewCrossTxsPoolsCleaner will return a new cross txs pools cleaner
 func NewCrossTxsPoolsCleaner(
+	addressConverter state.AddressConverter,
 	blockTracker BlockTracker,
 	dataPool dataRetriever.PoolsHolder,
 	rounder process.Rounder,
 	shardCoordinator sharding.Coordinator,
 ) (*crossTxsPoolsCleaner, error) {
 
+	if check.IfNil(addressConverter) {
+		return nil, process.ErrNilAddressConverter
+	}
 	if check.IfNil(blockTracker) {
 		return nil, process.ErrNilBlockTracker
 	}
@@ -73,6 +82,7 @@ func NewCrossTxsPoolsCleaner(
 	}
 
 	ctpc := crossTxsPoolsCleaner{
+		addressConverter:         addressConverter,
 		blockTracker:             blockTracker,
 		blockTransactionsPool:    dataPool.Transactions(),
 		rewardTransactionsPool:   dataPool.RewardTransactions(),
@@ -86,6 +96,8 @@ func NewCrossTxsPoolsCleaner(
 	ctpc.blockTransactionsPool.RegisterHandler(ctpc.receivedBlockTx)
 	ctpc.rewardTransactionsPool.RegisterHandler(ctpc.receivedRewardTx)
 	ctpc.unsignedTransactionsPool.RegisterHandler(ctpc.receivedUnsignedTx)
+
+	ctpc.emptyAddress = make([]byte, ctpc.addressConverter.AddressLen())
 
 	go ctpc.cleanCrossTxsPools()
 
@@ -106,7 +118,14 @@ func (ctpc *crossTxsPoolsCleaner) receivedBlockTx(key []byte, value interface{})
 	}
 
 	log.Trace("crossTxsPoolsCleaner.receivedBlockTx", "hash", key)
-	ctpc.processReceivedTx(key, value, blockTx)
+
+	wrappedTx, ok := value.(*txcache.WrappedTransaction)
+	if !ok {
+		log.Warn("crossTxsPoolsCleaner.receivedBlockTx", "error", process.ErrWrongTypeAssertion)
+		return
+	}
+
+	ctpc.processReceivedTx(key, wrappedTx.SenderShardID, wrappedTx.ReceiverShardID, blockTx)
 }
 
 func (ctpc *crossTxsPoolsCleaner) receivedRewardTx(key []byte, value interface{}) {
@@ -115,7 +134,19 @@ func (ctpc *crossTxsPoolsCleaner) receivedRewardTx(key []byte, value interface{}
 	}
 
 	log.Trace("crossTxsPoolsCleaner.receivedRewardTx", "hash", key)
-	ctpc.processReceivedTx(key, value, rewardTx)
+
+	tx, ok := value.(data.TransactionHandler)
+	if !ok {
+		log.Warn("crossTxsPoolsCleaner.receivedRewardTx", "error", process.ErrWrongTypeAssertion)
+		return
+	}
+
+	senderShardID, receiverShardID, err := ctpc.computeSenderAndReceiverShards(tx)
+	if err != nil {
+		log.Debug("crossTxsPoolsCleaner.receivedRewardTx", "error", err.Error())
+	}
+
+	ctpc.processReceivedTx(key, senderShardID, receiverShardID, rewardTx)
 }
 
 func (ctpc *crossTxsPoolsCleaner) receivedUnsignedTx(key []byte, value interface{}) {
@@ -124,17 +155,28 @@ func (ctpc *crossTxsPoolsCleaner) receivedUnsignedTx(key []byte, value interface
 	}
 
 	log.Trace("crossTxsPoolsCleaner.receivedUnsignedTx", "hash", key)
-	ctpc.processReceivedTx(key, value, unsignedTx)
-}
 
-func (ctpc *crossTxsPoolsCleaner) processReceivedTx(key []byte, value interface{}, txType int8) {
-	wrappedTx, ok := value.(*txcache.WrappedTransaction)
+	tx, ok := value.(data.TransactionHandler)
 	if !ok {
-		log.Warn("crossTxsPoolsCleaner.processReceivedTx", "error", process.ErrWrongTypeAssertion)
+		log.Warn("crossTxsPoolsCleaner.receivedUnsignedTx", "error", process.ErrWrongTypeAssertion)
 		return
 	}
 
-	if wrappedTx.SenderShardID == ctpc.shardCoordinator.SelfId() {
+	senderShardID, receiverShardID, err := ctpc.computeSenderAndReceiverShards(tx)
+	if err != nil {
+		log.Debug("crossTxsPoolsCleaner.receivedUnsignedTx", "error", err.Error())
+	}
+
+	ctpc.processReceivedTx(key, senderShardID, receiverShardID, unsignedTx)
+}
+
+func (ctpc *crossTxsPoolsCleaner) processReceivedTx(
+	key []byte,
+	senderShardID uint32,
+	receiverShardID uint32,
+	txType int8,
+) {
+	if senderShardID == ctpc.shardCoordinator.SelfId() {
 		return
 	}
 
@@ -147,7 +189,7 @@ func (ctpc *crossTxsPoolsCleaner) processReceivedTx(key []byte, value interface{
 			return
 		}
 
-		strCache := process.ShardCacherIdentifier(wrappedTx.SenderShardID, wrappedTx.ReceiverShardID)
+		strCache := process.ShardCacherIdentifier(senderShardID, receiverShardID)
 		txStore := transactionPool.ShardDataStore(strCache)
 		if txStore == nil {
 			return
@@ -155,8 +197,8 @@ func (ctpc *crossTxsPoolsCleaner) processReceivedTx(key []byte, value interface{
 
 		crossTxInfo := &txInfo{
 			round:           ctpc.rounder.Index(),
-			senderShardID:   wrappedTx.SenderShardID,
-			receiverShardID: wrappedTx.ReceiverShardID,
+			senderShardID:   senderShardID,
+			receiverShardID: receiverShardID,
 			txType:          txType,
 			txStore:         txStore,
 		}
@@ -251,4 +293,32 @@ func getTxTypeName(txType int8) string {
 	}
 
 	return "unknownTx"
+}
+
+func (ctpc *crossTxsPoolsCleaner) computeSenderAndReceiverShards(tx data.TransactionHandler) (uint32, uint32, error) {
+	senderShardID, err := ctpc.getShardFromAddress(tx.GetSndAddr())
+	if err != nil {
+		return 0, 0, err
+	}
+
+	receiverShardID, err := ctpc.getShardFromAddress(tx.GetRcvAddr())
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return senderShardID, receiverShardID, nil
+}
+
+func (ctpc *crossTxsPoolsCleaner) getShardFromAddress(address []byte) (uint32, error) {
+	isEmptyAddress := bytes.Equal(address, ctpc.emptyAddress)
+	if isEmptyAddress {
+		return ctpc.shardCoordinator.SelfId(), nil
+	}
+
+	addressContainer, err := ctpc.addressConverter.CreateAddressFromPublicKeyBytes(address)
+	if err != nil {
+		return 0, err
+	}
+
+	return ctpc.shardCoordinator.ComputeId(addressContainer), nil
 }

--- a/process/block/preprocess/basePreProcess.go
+++ b/process/block/preprocess/basePreProcess.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 	"github.com/ElrondNetwork/elrond-go/storage"
-	"github.com/ElrondNetwork/elrond-go/storage/txcache"
 )
 
 const initialTxHashesSliceLen = 10
@@ -149,22 +148,15 @@ func (bpp *basePreProcess) saveTxsToStorage(
 
 func (bpp *basePreProcess) baseReceivedTransaction(
 	txHash []byte,
-	value interface{},
+	tx data.TransactionHandler,
 	forBlock *txsForBlock,
 ) bool {
-
-	wrappedTx, ok := value.(*txcache.WrappedTransaction)
-	if !ok {
-		log.Warn("basePreProcess.baseReceivedTransaction", "error", process.ErrWrongTypeAssertion)
-		return false
-	}
-
 	forBlock.mutTxsForBlock.Lock()
 	if forBlock.missingTxs > 0 {
 		txInfoForHash := forBlock.txHashAndInfo[string(txHash)]
 		if txInfoForHash != nil && txInfoForHash.txShardInfo != nil &&
 			(txInfoForHash.tx == nil || txInfoForHash.tx.IsInterfaceNil()) {
-			forBlock.txHashAndInfo[string(txHash)].tx = wrappedTx.Tx
+			forBlock.txHashAndInfo[string(txHash)].tx = tx
 			forBlock.missingTxs--
 		}
 

--- a/process/block/preprocess/rewardTxPreProcessor.go
+++ b/process/block/preprocess/rewardTxPreProcessor.go
@@ -251,7 +251,13 @@ func (rtp *rewardTxPreprocessor) SaveTxBlockToStorage(body *block.Body) error {
 // receivedRewardTransaction is a callback function called when a new reward transaction
 // is added in the reward transactions pool
 func (rtp *rewardTxPreprocessor) receivedRewardTransaction(key []byte, value interface{}) {
-	receivedAllMissing := rtp.baseReceivedTransaction(key, value, &rtp.rewardTxsForBlock)
+	tx, ok := value.(data.TransactionHandler)
+	if !ok {
+		log.Warn("rewardTxPreprocessor.receivedRewardTransaction", "error", process.ErrWrongTypeAssertion)
+		return
+	}
+
+	receivedAllMissing := rtp.baseReceivedTransaction(key, tx, &rtp.rewardTxsForBlock)
 
 	if receivedAllMissing {
 		rtp.chReceivedAllRewardTxs <- true

--- a/process/block/preprocess/smartContractResults.go
+++ b/process/block/preprocess/smartContractResults.go
@@ -276,7 +276,13 @@ func (scr *smartContractResults) SaveTxBlockToStorage(body *block.Body) error {
 // receivedSmartContractResult is a call back function which is called when a new smartContractResult
 // is added in the smartContractResult pool
 func (scr *smartContractResults) receivedSmartContractResult(key []byte, value interface{}) {
-	receivedAllMissing := scr.baseReceivedTransaction(key, value, &scr.scrForBlock)
+	tx, ok := value.(data.TransactionHandler)
+	if !ok {
+		log.Warn("smartContractResults.receivedSmartContractResult", "error", process.ErrWrongTypeAssertion)
+		return
+	}
+
+	receivedAllMissing := scr.baseReceivedTransaction(key, tx, &scr.scrForBlock)
 
 	if receivedAllMissing {
 		scr.chRcvAllScrs <- true

--- a/process/block/preprocess/smartContractResults_test.go
+++ b/process/block/preprocess/smartContractResults_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/mock"
 	"github.com/ElrondNetwork/elrond-go/storage"
-	"github.com/ElrondNetwork/elrond-go/storage/txcache"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -457,7 +456,7 @@ func TestScrsPreprocessor_ReceivedTransactionShouldEraseRequested(t *testing.T) 
 	txs.SetMissingScr(3)
 
 	//received txHash2
-	txs.receivedSmartContractResult(txHash2, &txcache.WrappedTransaction{Tx: &smartContractResult.SmartContractResult{}})
+	txs.receivedSmartContractResult(txHash2, &smartContractResult.SmartContractResult{})
 
 	assert.True(t, txs.IsScrHashRequested(txHash1))
 	assert.False(t, txs.IsScrHashRequested(txHash2))

--- a/process/block/preprocess/transactions.go
+++ b/process/block/preprocess/transactions.go
@@ -511,7 +511,13 @@ func (txs *transactions) SaveTxBlockToStorage(body *block.Body) error {
 // receivedTransaction is a call back function which is called when a new transaction
 // is added in the transaction pool
 func (txs *transactions) receivedTransaction(key []byte, value interface{}) {
-	receivedAllMissing := txs.baseReceivedTransaction(key, value, &txs.txsForCurrBlock)
+	wrappedTx, ok := value.(*txcache.WrappedTransaction)
+	if !ok {
+		log.Warn("transactions.receivedTransaction", "error", process.ErrWrongTypeAssertion)
+		return
+	}
+
+	receivedAllMissing := txs.baseReceivedTransaction(key, wrappedTx.Tx, &txs.txsForCurrBlock)
 
 	if receivedAllMissing {
 		txs.chRcvAllTxs <- true


### PR DESCRIPTION
* Fixed wrong type assertion for received transactions
* Added guard checks for message type and message round in consensus topic interceptor
* Fixed memory leak in miniblocks/cross txs pools cleaner when pending miniblocks would not reached to 0 for a long time
* Added guard check for received header hash size from consensus message in consensus topic interceptor