### PR TITLE
fix the order of processing epoch start metablock in case of conflicts.

### DIFF
--- a/dataRetriever/factory/resolverscontainer/baseResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/baseResolversContainerFactory.go
@@ -267,13 +267,18 @@ func (brcf *baseResolversContainerFactory) createOneResolverSenderWithSpecifiedN
 	return resolverSender, nil
 }
 
-func (brcf *baseResolversContainerFactory) createTrieNodesResolver(topic string, trieId string) (dataRetriever.Resolver, error) {
+func (brcf *baseResolversContainerFactory) createTrieNodesResolver(
+	topic string,
+	trieId string,
+	numCrossShard int,
+	numIntraShard int,
+) (dataRetriever.Resolver, error) {
 	resolverSender, err := brcf.createOneResolverSenderWithSpecifiedNumRequests(
 		topic,
 		EmptyExcludePeersOnTopic,
 		defaultTargetShardID,
-		0,
-		numIntraShardPeers+numCrossShardPeers,
+		numCrossShard,
+		numIntraShard,
 	)
 	if err != nil {
 		return nil, err

--- a/dataRetriever/factory/resolverscontainer/baseResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/baseResolversContainerFactory.go
@@ -230,6 +230,16 @@ func (brcf *baseResolversContainerFactory) createOneResolverSender(
 	excludedTopic string,
 	targetShardId uint32,
 ) (dataRetriever.TopicResolverSender, error) {
+	return brcf.createOneResolverSenderWithSpecifiedNumRequests(topic, excludedTopic, targetShardId, numCrossShardPeers, numIntraShardPeers)
+}
+
+func (brcf *baseResolversContainerFactory) createOneResolverSenderWithSpecifiedNumRequests(
+	topic string,
+	excludedTopic string,
+	targetShardId uint32,
+	numCrossShard int,
+	numIntraShard int,
+) (dataRetriever.TopicResolverSender, error) {
 
 	peerListCreator, err := topicResolverSender.NewDiffPeerListCreator(brcf.messenger, topic, brcf.intraShardTopic, excludedTopic)
 	if err != nil {
@@ -244,8 +254,8 @@ func (brcf *baseResolversContainerFactory) createOneResolverSender(
 		Randomizer:         brcf.intRandomizer,
 		TargetShardId:      targetShardId,
 		OutputAntiflooder:  brcf.outputAntifloodHandler,
-		NumCrossShardPeers: numCrossShardPeers,
-		NumIntraShardPeers: numIntraShardPeers,
+		NumCrossShardPeers: numCrossShard,
+		NumIntraShardPeers: numIntraShard,
 	}
 	//TODO instantiate topic sender resolver with the shard IDs for which this resolver is supposed to serve the data
 	// this will improve the serving of transactions as the searching will be done only on 2 sharded data units
@@ -258,20 +268,26 @@ func (brcf *baseResolversContainerFactory) createOneResolverSender(
 }
 
 func (brcf *baseResolversContainerFactory) createTrieNodesResolver(topic string, trieId string) (dataRetriever.Resolver, error) {
-	resolverSender, err := brcf.createOneResolverSender(topic, EmptyExcludePeersOnTopic, defaultTargetShardID)
+	resolverSender, err := brcf.createOneResolverSenderWithSpecifiedNumRequests(
+		topic,
+		EmptyExcludePeersOnTopic,
+		defaultTargetShardID,
+		0,
+		numIntraShardPeers+numCrossShardPeers,
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	trie := brcf.triesContainer.Get([]byte(trieId))
-	arg := resolvers.ArgTrieNodeResolver{
+	argTrie := resolvers.ArgTrieNodeResolver{
 		SenderResolver:   resolverSender,
 		TrieDataGetter:   trie,
 		Marshalizer:      brcf.marshalizer,
 		AntifloodHandler: brcf.inputAntifloodHandler,
 		Throttler:        brcf.throttler,
 	}
-	resolver, err := resolvers.NewTrieNodeResolver(arg)
+	resolver, err := resolvers.NewTrieNodeResolver(argTrie)
 	if err != nil {
 		return nil, err
 	}

--- a/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory.go
@@ -233,7 +233,7 @@ func (mrcf *metaResolversContainerFactory) generateTrieNodesResolvers() error {
 
 	for i := uint32(0); i < shardC.NumberOfShards(); i++ {
 		identifierTrieNodes := factory.AccountTrieNodesTopic + shardC.CommunicationIdentifier(i)
-		resolver, err := mrcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.UserAccountTrie)
+		resolver, err := mrcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.UserAccountTrie, numCrossShardPeers, numIntraShardPeers)
 		if err != nil {
 			return err
 		}
@@ -243,7 +243,7 @@ func (mrcf *metaResolversContainerFactory) generateTrieNodesResolvers() error {
 	}
 
 	identifierTrieNodes := factory.AccountTrieNodesTopic + core.CommunicationIdentifierBetweenShards(core.MetachainShardId, core.MetachainShardId)
-	resolver, err := mrcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.UserAccountTrie)
+	resolver, err := mrcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.UserAccountTrie, 0, numIntraShardPeers+numCrossShardPeers)
 	if err != nil {
 		return err
 	}
@@ -252,7 +252,7 @@ func (mrcf *metaResolversContainerFactory) generateTrieNodesResolvers() error {
 	keys = append(keys, identifierTrieNodes)
 
 	identifierTrieNodes = factory.ValidatorTrieNodesTopic + core.CommunicationIdentifierBetweenShards(core.MetachainShardId, core.MetachainShardId)
-	resolver, err = mrcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.PeerAccountTrie)
+	resolver, err = mrcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.PeerAccountTrie, 0, numIntraShardPeers+numCrossShardPeers)
 	if err != nil {
 		return err
 	}

--- a/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory.go
@@ -198,7 +198,7 @@ func (srcf *shardResolversContainerFactory) generateTrieNodesResolvers() error {
 	resolversSlice := make([]dataRetriever.Resolver, 0)
 
 	identifierTrieNodes := factory.AccountTrieNodesTopic + shardC.CommunicationIdentifier(core.MetachainShardId)
-	resolver, err := srcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.UserAccountTrie)
+	resolver, err := srcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.UserAccountTrie, 0, numIntraShardPeers+numCrossShardPeers)
 	if err != nil {
 		return err
 	}
@@ -207,7 +207,7 @@ func (srcf *shardResolversContainerFactory) generateTrieNodesResolvers() error {
 	keys = append(keys, identifierTrieNodes)
 
 	identifierTrieNodes = factory.ValidatorTrieNodesTopic + core.CommunicationIdentifierBetweenShards(core.MetachainShardId, core.MetachainShardId)
-	resolver, err = srcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.PeerAccountTrie)
+	resolver, err = srcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.PeerAccountTrie, numCrossShardPeers, numIntraShardPeers)
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func (srcf *shardResolversContainerFactory) generateTrieNodesResolvers() error {
 	keys = append(keys, identifierTrieNodes)
 
 	identifierTrieNodes = factory.AccountTrieNodesTopic + core.CommunicationIdentifierBetweenShards(core.MetachainShardId, core.MetachainShardId)
-	resolver, err = srcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.UserAccountTrie)
+	resolver, err = srcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.UserAccountTrie, numCrossShardPeers, numIntraShardPeers)
 	if err != nil {
 		return err
 	}

--- a/epochStart/bootstrap/epochStartMetaBlockProcessor.go
+++ b/epochStart/bootstrap/epochStartMetaBlockProcessor.go
@@ -196,8 +196,7 @@ func (e *epochStartMetaBlockProcessor) getMostReceivedMetaBlock() (*block.MetaBl
 	e.mutReceivedMetaBlocks.RLock()
 	defer e.mutReceivedMetaBlocks.RUnlock()
 
-	const hashNotAvailable = "N/A"
-	mostReceivedHash := hashNotAvailable
+	var mostReceivedHash string
 	maxLength := minNumOfPeersToConsiderBlockValid - 1
 	for hash, entry := range e.mapMetaBlocksFromPeers {
 		if len(entry) > maxLength {
@@ -206,7 +205,7 @@ func (e *epochStartMetaBlockProcessor) getMostReceivedMetaBlock() (*block.MetaBl
 		}
 	}
 
-	if mostReceivedHash == hashNotAvailable {
+	if len(mostReceivedHash) == 0 {
 		return nil, epochStart.ErrTimeoutWaitingForMetaBlock
 	}
 

--- a/epochStart/bootstrap/epochStartMetaBlockProcessor.go
+++ b/epochStart/bootstrap/epochStartMetaBlockProcessor.go
@@ -21,6 +21,7 @@ const durationBetweenChecks = 200 * time.Millisecond
 const durationBetweenReRequests = 1 * time.Second
 const durationBetweenCheckingNumConnectedPeers = 500 * time.Millisecond
 const minNumConnectedPeers = 6
+const minNumOfPeersToConsiderBlockValid = 3
 
 var _ process.InterceptorProcessor = (*epochStartMetaBlockProcessor)(nil)
 
@@ -177,7 +178,7 @@ func (e *epochStartMetaBlockProcessor) GetEpochStartMetaBlock(ctx context.Contex
 		case <-e.chanConsensusReached:
 			return e.metaBlock, nil
 		case <-ctx.Done():
-			return nil, epochStart.ErrTimeoutWaitingForMetaBlock
+			return e.getMostReceivedMetaBlock()
 		case <-chanRequests:
 			err = e.requestMetaBlock()
 			if err != nil {
@@ -189,6 +190,27 @@ func (e *epochStartMetaBlockProcessor) GetEpochStartMetaBlock(ctx context.Contex
 			chanCheckMaps = time.After(durationBetweenChecks)
 		}
 	}
+}
+
+func (e *epochStartMetaBlockProcessor) getMostReceivedMetaBlock() (*block.MetaBlock, error) {
+	e.mutReceivedMetaBlocks.RLock()
+	defer e.mutReceivedMetaBlocks.RUnlock()
+
+	const hashNotAvailable = "N/A"
+	mostReceivedHash := hashNotAvailable
+	maxLength := minNumOfPeersToConsiderBlockValid - 1
+	for hash, entry := range e.mapMetaBlocksFromPeers {
+		if len(entry) > maxLength {
+			maxLength = len(entry)
+			mostReceivedHash = hash
+		}
+	}
+
+	if mostReceivedHash == hashNotAvailable {
+		return nil, epochStart.ErrTimeoutWaitingForMetaBlock
+	}
+
+	return e.mapReceivedMetaBlocks[mostReceivedHash], nil
 }
 
 func (e *epochStartMetaBlockProcessor) requestMetaBlock() error {
@@ -207,6 +229,7 @@ func (e *epochStartMetaBlockProcessor) requestMetaBlock() error {
 func (e *epochStartMetaBlockProcessor) checkMaps() {
 	e.mutReceivedMetaBlocks.RLock()
 	defer e.mutReceivedMetaBlocks.RUnlock()
+
 	for hash, peersList := range e.mapMetaBlocksFromPeers {
 		log.Debug("metablock from peers", "num peers", len(peersList), "target", e.peerCountTarget, "hash", []byte(hash))
 		found := e.processEntry(peersList, hash)

--- a/epochStart/bootstrap/export_test.go
+++ b/epochStart/bootstrap/export_test.go
@@ -12,3 +12,5 @@ func (e *epochStartMetaBlockProcessor) GetMapMetaBlock() map[string]*block.MetaB
 const DurationBetweenChecksForEpochStartMetaBlock = durationBetweenChecks
 
 const DurationBetweenReRequest = durationBetweenReRequests
+
+const MinNumOfPeersToConsiderBlockValid = minNumOfPeersToConsiderBlockValid

--- a/epochStart/bootstrap/fromLocalStorage.go
+++ b/epochStart/bootstrap/fromLocalStorage.go
@@ -182,7 +182,7 @@ func (e *epochStartBootstrap) getLastBootstrapData(storer storage.Storer) (*boot
 	}
 
 	ncInternalkey := append([]byte(core.NodesCoordinatorRegistryKeyPrefix), bootstrapData.NodesCoordinatorConfigKey...)
-	data, err := storer.Get(ncInternalkey)
+	data, err := storer.SearchFirst(ncInternalkey)
 	if err != nil {
 		log.Debug("getLastBootstrapData", "key", ncInternalkey, "error", err)
 		return nil, nil, err
@@ -199,7 +199,7 @@ func (e *epochStartBootstrap) getLastBootstrapData(storer storage.Storer) (*boot
 
 func (e *epochStartBootstrap) getEpochStartMetaFromStorage(storer storage.Storer) (*block.MetaBlock, error) {
 	epochIdentifier := core.EpochStartIdentifier(e.baseData.lastEpoch)
-	data, err := storer.Get([]byte(epochIdentifier))
+	data, err := storer.SearchFirst([]byte(epochIdentifier))
 	if err != nil {
 		log.Debug("getEpochStartMetaFromStorage", "key", epochIdentifier, "error", err)
 		return nil, err

--- a/epochStart/bootstrap/fromLocalStorage.go
+++ b/epochStart/bootstrap/fromLocalStorage.go
@@ -122,6 +122,11 @@ func (e *epochStartBootstrap) prepareEpochFromStorage() (Parameters, error) {
 		}
 	}
 
+	err = e.messenger.CreateTopic(core.ConsensusTopic+e.shardCoordinator.CommunicationIdentifier(e.shardCoordinator.SelfId()), true)
+	if err != nil {
+		return Parameters{}, err
+	}
+
 	if e.shardCoordinator.SelfId() == core.MetachainShardId {
 		err = e.requestAndProcessForMeta()
 		if err != nil {

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -231,7 +231,7 @@ func (e *epochStartBootstrap) Bootstrap() (Parameters, error) {
 	defer func() {
 		log.Debug("unregistering all message processor")
 		errMessenger := e.messenger.UnregisterAllMessageProcessors()
-		log.LogIfError(errMessenger, "error on unregistering message processor")
+		log.LogIfError(errMessenger)
 	}()
 
 	var err error

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -229,6 +229,7 @@ func (e *epochStartBootstrap) Bootstrap() (Parameters, error) {
 	}
 
 	defer func() {
+		log.Debug("unregistering all message processor")
 		errMessenger := e.messenger.UnregisterAllMessageProcessors()
 		log.LogIfError(errMessenger, "error on unregistering message processor")
 	}()
@@ -268,7 +269,12 @@ func (e *epochStartBootstrap) Bootstrap() (Parameters, error) {
 		return Parameters{}, err
 	}
 
-	return e.requestAndProcessing()
+	params, err := e.requestAndProcessing()
+	if err != nil {
+		return Parameters{}, err
+	}
+
+	return params, nil
 }
 
 func (e *epochStartBootstrap) computeIfCurrentEpochIsSaved() bool {

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -466,6 +466,11 @@ func (e *epochStartBootstrap) requestAndProcessing() (Parameters, error) {
 		}
 	}
 
+	err = e.messenger.CreateTopic(core.ConsensusTopic+e.shardCoordinator.CommunicationIdentifier(e.shardCoordinator.SelfId()), true)
+	if err != nil {
+		return Parameters{}, err
+	}
+
 	if e.shardCoordinator.SelfId() == core.MetachainShardId {
 		err = e.requestAndProcessForMeta()
 		if err != nil {

--- a/epochStart/shardchain/trigger.go
+++ b/epochStart/shardchain/trigger.go
@@ -99,19 +99,19 @@ type metaInfo struct {
 	hash string
 }
 
-type metaInfloSlice []*metaInfo
+type metaInfoSlice []*metaInfo
 
-// Len will return the length of the metaInfoList
-func (m metaInfloSlice) Len() int { return len(m) }
+// Len will return the length of the metaInfoSlice
+func (m metaInfoSlice) Len() int { return len(m) }
 
 // Swap will interchange the objects on input indexes
-func (m metaInfloSlice) Swap(i, j int) { m[i], m[j] = m[j], m[i] }
+func (m metaInfoSlice) Swap(i, j int) { m[i], m[j] = m[j], m[i] }
 
 // Less will return true if object on index i should appear before object in index j
 // Sorting of headers should be by epoch, by nonce and by hash in ascending order
 // this will ensure that in case of equality for epoch, the metaHdr with higher nonce will
 // be processed last - that is  the correct one - as it finalizes the previous nonce
-func (m metaInfloSlice) Less(i, j int) bool {
+func (m metaInfoSlice) Less(i, j int) bool {
 	if m[i].hdr.Epoch == m[j].hdr.Epoch {
 		if m[i].hdr.Nonce == m[j].hdr.Nonce {
 			return m[i].hash < m[j].hash
@@ -412,7 +412,7 @@ func (t *trigger) receivedMetaBlock(headerHandler data.HeaderHandler, metaBlockH
 
 // call only if mutex is locked before
 func (t *trigger) updateTriggerFromMeta() {
-	sortedMetaInfo := make(metaInfloSlice, 0, len(t.mapEpochStartHdrs))
+	sortedMetaInfo := make(metaInfoSlice, 0, len(t.mapEpochStartHdrs))
 	for hash, hdr := range t.mapEpochStartHdrs {
 		currMetaInfo := &metaInfo{
 			hdr:  hdr,

--- a/epochStart/shardchain/trigger.go
+++ b/epochStart/shardchain/trigger.go
@@ -454,6 +454,9 @@ func (t *trigger) updateTriggerFromMeta() {
 		// save all final-valid epoch start blocks
 		if canActivateEpochStart {
 			t.mapFinalizedEpochs[currMetaInfo.hdr.Epoch] = struct{}{}
+			epochStartIdentifier := core.EpochStartIdentifier(currMetaInfo.hdr.Epoch)
+
+			log.Debug("saving epoch start meta with", "key", epochStartIdentifier)
 
 			metaBuff, err := t.marshalizer.Marshal(currMetaInfo.hdr)
 			if err != nil {
@@ -461,7 +464,6 @@ func (t *trigger) updateTriggerFromMeta() {
 				continue
 			}
 
-			epochStartIdentifier := core.EpochStartIdentifier(currMetaInfo.hdr.Epoch)
 			err = t.metaHdrStorage.Put([]byte(epochStartIdentifier), metaBuff)
 			if err != nil {
 				log.Debug("updateTriggerMeta put into metaHdrStorage", "error", err.Error())

--- a/epochStart/shardchain/trigger.go
+++ b/epochStart/shardchain/trigger.go
@@ -194,7 +194,7 @@ func NewEpochStartTrigger(args *ArgsShardEpochStartTrigger) (*trigger, error) {
 		mapHashHdr:                  make(map[string]*block.MetaBlock),
 		mapNonceHashes:              make(map[uint64][]string),
 		mapEpochStartHdrs:           make(map[string]*block.MetaBlock),
-		mapFinalizedEpochs:          make(map[uint32]struct{}, 0),
+		mapFinalizedEpochs:          make(map[uint32]struct{}),
 		headersPool:                 args.DataPool.Headers(),
 		miniBlocksPool:              args.DataPool.MiniBlocks(),
 		metaHdrStorage:              metaHdrStorage,
@@ -754,7 +754,7 @@ func (t *trigger) SetProcessed(header data.HeaderHandler, _ data.BodyHandler) {
 	t.mapHashHdr = make(map[string]*block.MetaBlock)
 	t.mapNonceHashes = make(map[uint64][]string)
 	t.mapEpochStartHdrs = make(map[string]*block.MetaBlock)
-	t.mapFinalizedEpochs = make(map[uint32]struct{}, 0)
+	t.mapFinalizedEpochs = make(map[uint32]struct{})
 
 	t.saveCurrentState(header.GetRound())
 

--- a/epochStart/shardchain/triggerRegistry_test.go
+++ b/epochStart/shardchain/triggerRegistry_test.go
@@ -42,6 +42,7 @@ func cloneTrigger(t *trigger) *trigger {
 	rt.appStatusHandler = t.appStatusHandler
 	rt.miniBlocksPool = t.miniBlocksPool
 	rt.mapMissingMiniblocks = t.mapMissingMiniblocks
+	rt.mapFinalizedEpochs = t.mapFinalizedEpochs
 	return rt
 }
 

--- a/integrationTests/multiShard/transaction/interceptedResolvedBulkTx/interceptedResolvedBulkTx_test.go
+++ b/integrationTests/multiShard/transaction/interceptedResolvedBulkTx/interceptedResolvedBulkTx_test.go
@@ -286,7 +286,7 @@ func TestNode_InterceptorBulkTxsSentFromOtherShardShouldBeRoutedInSenderShardAnd
 	}
 }
 
-func TestNode_InMultiShardEnvRequestTxsShouldRequireOnlyFromTheOtherShard(t *testing.T) {
+func TestNode_InMultiShardEnvRequestTxsShouldRequireFromTheOtherShardAndSameShard(t *testing.T) {
 	if testing.Short() {
 		t.Skip("this is not a short test")
 	}
@@ -310,7 +310,7 @@ func TestNode_InMultiShardEnvRequestTxsShouldRequireOnlyFromTheOtherShard(t *tes
 	recvTxs := make(map[int]map[string]struct{})
 	mutRecvTxs := sync.Mutex{}
 	for i := 0; i < nodesPerShard; i++ {
-		dPool := integrationTests.CreateRequesterDataPool(t, recvTxs, &mutRecvTxs, i, 0)
+		dPool := integrationTests.CreateRequesterDataPool(recvTxs, &mutRecvTxs, i, 0)
 
 		tn := integrationTests.NewTestProcessorNodeWithCustomDataPool(
 			uint32(maxShards),

--- a/integrationTests/state/stateTrieSync/stateTrieSync_test.go
+++ b/integrationTests/state/stateTrieSync/stateTrieSync_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data/trie"
 	factory2 "github.com/ElrondNetwork/elrond-go/data/trie/factory"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/requestHandlers"
@@ -68,7 +67,7 @@ func TestNode_RequestInterceptTrieNodesWithMessenger(t *testing.T) {
 	)
 
 	waitTime := 10 * time.Second
-	trieSyncer, _ := trie.NewTrieSyncer(requestHandler, nRequester.DataPool.TrieNodes(), requesterTrie, core.MetachainShardId, factory.AccountTrieNodesTopic)
+	trieSyncer, _ := trie.NewTrieSyncer(requestHandler, nRequester.DataPool.TrieNodes(), requesterTrie, shardID, factory.AccountTrieNodesTopic)
 	ctx, cancel := context.WithTimeout(context.Background(), waitTime)
 	defer cancel()
 

--- a/integrationTests/state/stateTrieSync/stateTrieSync_test.go
+++ b/integrationTests/state/stateTrieSync/stateTrieSync_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data/trie"
 	factory2 "github.com/ElrondNetwork/elrond-go/data/trie/factory"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/requestHandlers"
@@ -29,9 +30,12 @@ func TestNode_RequestInterceptTrieNodesWithMessenger(t *testing.T) {
 
 	fmt.Println("Requester:	")
 	nRequester := integrationTests.NewTestProcessorNode(nrOfShards, shardID, txSignPrivKeyShardId, requesterNodeAddr)
+	_ = nRequester.Messenger.CreateTopic(core.ConsensusTopic+nRequester.ShardCoordinator.CommunicationIdentifier(nRequester.ShardCoordinator.SelfId()), true)
 
 	fmt.Println("Resolver:")
 	nResolver := integrationTests.NewTestProcessorNode(nrOfShards, shardID, txSignPrivKeyShardId, resolverNodeAddr)
+	_ = nResolver.Messenger.CreateTopic(core.ConsensusTopic+nResolver.ShardCoordinator.CommunicationIdentifier(nResolver.ShardCoordinator.SelfId()), true)
+
 	nRequester.Node.Start()
 	nResolver.Node.Start()
 	defer func() {

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -1465,16 +1465,13 @@ func requestMissingTransactions(n *TestProcessorNode, shardResolver uint32, need
 }
 
 // CreateRequesterDataPool creates a datapool with a mock txPool
-func CreateRequesterDataPool(t *testing.T, recvTxs map[int]map[string]struct{}, mutRecvTxs *sync.Mutex, nodeIndex int, selfShardID uint32) dataRetriever.PoolsHolder {
-
+func CreateRequesterDataPool(recvTxs map[int]map[string]struct{}, mutRecvTxs *sync.Mutex, nodeIndex int, selfShardID uint32) dataRetriever.PoolsHolder {
 	//not allowed to request data from the same shard
 	return CreateTestDataPool(&mock.ShardedDataStub{
 		SearchFirstDataCalled: func(key []byte) (value interface{}, ok bool) {
-			assert.Fail(t, "same-shard requesters should not be queried")
 			return nil, false
 		},
 		ShardDataStoreCalled: func(cacheId string) (c storage.Cacher) {
-			assert.Fail(t, "same-shard requesters should not be queried")
 			return nil
 		},
 		AddDataCalled: func(key []byte, data interface{}, cacheId string) {

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -724,6 +724,8 @@ func (tpn *TestProcessorNode) initInterceptors() {
 func (tpn *TestProcessorNode) initResolvers() {
 	dataPacker, _ := partitioning.NewSimpleDataPacker(TestMarshalizer)
 
+	_ = tpn.Messenger.CreateTopic(core.ConsensusTopic+tpn.ShardCoordinator.CommunicationIdentifier(tpn.ShardCoordinator.SelfId()), true)
+
 	resolverContainerFactory := resolverscontainer.FactoryArgs{
 		ShardCoordinator:           tpn.ShardCoordinator,
 		Messenger:                  tpn.Messenger,

--- a/node/mock/messengerStub.go
+++ b/node/mock/messengerStub.go
@@ -31,7 +31,10 @@ func (ms *MessengerStub) ID() p2p.PeerID {
 
 // RegisterMessageProcessor -
 func (ms *MessengerStub) RegisterMessageProcessor(topic string, handler p2p.MessageProcessor) error {
-	return ms.RegisterMessageProcessorCalled(topic, handler)
+	if ms.RegisterMessageProcessorCalled != nil {
+		return ms.RegisterMessageProcessorCalled(topic, handler)
+	}
+	return nil
 }
 
 // Broadcast -

--- a/node/node.go
+++ b/node/node.go
@@ -616,15 +616,15 @@ func (n *Node) createConsensusTopic(messageProcessor p2p.MessageProcessor) error
 	}
 
 	n.consensusTopic = core.ConsensusTopic + n.shardCoordinator.CommunicationIdentifier(n.shardCoordinator.SelfId())
-	if n.messenger.HasTopicValidator(n.consensusTopic) {
-		return n.messenger.RegisterMessageProcessor(n.consensusTopic, messageProcessor)
-	}
-
 	if !n.messenger.HasTopic(n.consensusTopic) {
 		err := n.messenger.CreateTopic(n.consensusTopic, true)
 		if err != nil {
 			return err
 		}
+	}
+
+	if n.messenger.HasTopicValidator(n.consensusTopic) {
+		return ErrValidatorAlreadySet
 	}
 
 	return n.messenger.RegisterMessageProcessor(n.consensusTopic, messageProcessor)

--- a/node/node.go
+++ b/node/node.go
@@ -617,7 +617,7 @@ func (n *Node) createConsensusTopic(messageProcessor p2p.MessageProcessor) error
 
 	n.consensusTopic = core.ConsensusTopic + n.shardCoordinator.CommunicationIdentifier(n.shardCoordinator.SelfId())
 	if n.messenger.HasTopicValidator(n.consensusTopic) {
-		return ErrValidatorAlreadySet
+		return n.messenger.RegisterMessageProcessor(n.consensusTopic, messageProcessor)
 	}
 
 	if !n.messenger.HasTopic(n.consensusTopic) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -987,7 +987,7 @@ func TestNode_ConsensusTopicValidatorAlreadySet(t *testing.T) {
 	)
 
 	err := n.CreateConsensusTopic(messageProc)
-	require.Equal(t, node.ErrValidatorAlreadySet, err)
+	require.Nil(t, err)
 }
 
 func TestNode_ConsensusTopicCreateTopicError(t *testing.T) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -983,11 +983,14 @@ func TestNode_ConsensusTopicValidatorAlreadySet(t *testing.T) {
 			HasTopicValidatorCalled: func(name string) bool {
 				return true
 			},
+			HasTopicCalled: func(name string) bool {
+				return true
+			},
 		}),
 	)
 
 	err := n.CreateConsensusTopic(messageProc)
-	require.Nil(t, err)
+	require.Equal(t, node.ErrValidatorAlreadySet, err)
 }
 
 func TestNode_ConsensusTopicCreateTopicError(t *testing.T) {

--- a/p2p/libp2p/netMessenger.go
+++ b/p2p/libp2p/netMessenger.go
@@ -611,8 +611,8 @@ func (netMes *networkMessenger) UnregisterAllMessageProcessors() error {
 	defer netMes.mutTopics.Unlock()
 
 	for topic, validator := range netMes.topics {
-		if validator == nil {
-			return p2p.ErrTopicValidatorOperationNotSupported
+		if check.IfNil(validator) {
+			continue
 		}
 
 		err := netMes.pb.UnregisterTopicValidator(topic)
@@ -622,7 +622,6 @@ func (netMes *networkMessenger) UnregisterAllMessageProcessors() error {
 
 		netMes.topics[topic] = nil
 	}
-
 	return nil
 }
 

--- a/p2p/libp2p/netMessenger_test.go
+++ b/p2p/libp2p/netMessenger_test.go
@@ -459,6 +459,24 @@ func TestLibp2pMessenger_UnregisterTopicValidatorShouldWork(t *testing.T) {
 	_ = mes.Close()
 }
 
+func TestLibp2pMessenger_UnregisterAllTopicValidatorShouldWork(t *testing.T) {
+	mes := createMockMessenger()
+	_ = mes.CreateTopic("test", false)
+	//registration
+	_ = mes.CreateTopic("test1", false)
+	_ = mes.RegisterMessageProcessor("test1", &mock.MessageProcessorStub{})
+	_ = mes.CreateTopic("test2", false)
+	_ = mes.RegisterMessageProcessor("test2", &mock.MessageProcessorStub{})
+	//unregistration
+	err := mes.UnregisterAllMessageProcessors()
+	assert.Nil(t, err)
+	err = mes.RegisterMessageProcessor("test1", &mock.MessageProcessorStub{})
+	assert.Nil(t, err)
+	err = mes.RegisterMessageProcessor("test2", &mock.MessageProcessorStub{})
+	assert.Nil(t, err)
+	_ = mes.Close()
+}
+
 func TestLibp2pMessenger_BroadcastDataLargeMessageShouldNotCallSend(t *testing.T) {
 	//TODO remove skip when external library is concurrent safe
 	if testing.Short() {

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -216,6 +216,13 @@ func (sp *shardProcessor) ProcessBlock(
 		go sp.checkAndRequestIfMetaHeadersMissing(header.Round)
 	}()
 
+	if header.IsStartOfEpochBlock() {
+		err = sp.checkEpochCorrectnessCrossChain()
+		if err != nil {
+			return err
+		}
+	}
+
 	err = sp.checkEpochCorrectness(header)
 	if err != nil {
 		return err
@@ -229,13 +236,6 @@ func (sp *shardProcessor) ProcessBlock(
 	err = sp.verifyCrossShardMiniBlockDstMe(header)
 	if err != nil {
 		return err
-	}
-
-	if header.IsStartOfEpochBlock() {
-		err = sp.checkEpochCorrectnessCrossChain()
-		if err != nil {
-			return err
-		}
 	}
 
 	defer func() {

--- a/update/factory/fullSyncResolversContainerFactory.go
+++ b/update/factory/fullSyncResolversContainerFactory.go
@@ -167,8 +167,8 @@ func (rcf *resolversContainerFactory) createTrieNodesResolver(baseTopic string, 
 		Randomizer:         rcf.intRandomizer,
 		TargetShardId:      defaultTargetShardID,
 		OutputAntiflooder:  rcf.outputAntifloodHandler,
-		NumCrossShardPeers: 0,
-		NumIntraShardPeers: numIntraShardPeers + numCrossShardPeers,
+		NumCrossShardPeers: numCrossShardPeers,
+		NumIntraShardPeers: numIntraShardPeers,
 	}
 	resolverSender, err := topicResolverSender.NewTopicResolverSender(arg)
 	if err != nil {

--- a/update/factory/fullSyncResolversContainerFactory.go
+++ b/update/factory/fullSyncResolversContainerFactory.go
@@ -167,11 +167,9 @@ func (rcf *resolversContainerFactory) createTrieNodesResolver(baseTopic string, 
 		Randomizer:         rcf.intRandomizer,
 		TargetShardId:      defaultTargetShardID,
 		OutputAntiflooder:  rcf.outputAntifloodHandler,
-		NumCrossShardPeers: numCrossShardPeers,
-		NumIntraShardPeers: numIntraShardPeers,
+		NumCrossShardPeers: 0,
+		NumIntraShardPeers: numIntraShardPeers + numCrossShardPeers,
 	}
-	//TODO instantiate topic sender resolver with the shard IDs for which this resolver is supposed to serve the data
-	// this will improve the serving of transactions as the searching will be done only on 2 sharded data units
 	resolverSender, err := topicResolverSender.NewTopicResolverSender(arg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- We observed an edge case in processing and validating epoch start block and the consequent blocks for the new epoch coming from epoch. There is an edge case where the epoch start block is created by a malicious leader, he gathers the signatures, but will release that only later. 
- The specific scenario was having a set of metablocks with (R:543,N:543), (R:544, N:544), (R:545, N:545, NewEpoch) and the other chain of the same (R:543, N:543) and (R:545:N:544, NewEpoch). In this case the previous hash of the epoch start metablock is different for the 2 different cases, thus resulting a different nodesConfig after shuffling. 
- The fix is keeping a defined order of processing, shuffling nodes according to the received metablocks, in this case as the longer chain is the first one, the processing order should be according to nonce - thus resulting the processing of the start of epoch block with the higher nonce last.
- Put check epoch correctness cross chain earlier in order to take a better decision to reconstruct the chain - in case of shards when they missed the new epoch. 
- Fixed trie node resolver to request only intra shard.
- Process epoch start metablock only until it is not finalized for each epoch
