### PR TITLE
return metablock if at least num of peers send it

### DIFF
--- a/epochStart/bootstrap/epochStartMetaBlockProcessor.go
+++ b/epochStart/bootstrap/epochStartMetaBlockProcessor.go
@@ -201,6 +201,7 @@ func (e *epochStartMetaBlockProcessor) getMostReceivedMetaBlock() (*block.MetaBl
 	maxLength := minNumOfPeersToConsiderBlockValid - 1
 	for hash, entry := range e.mapMetaBlocksFromPeers {
 		if len(entry) > maxLength {
+			maxLength = len(entry)
 			mostReceivedHash = hash
 		}
 	}

--- a/epochStart/bootstrap/export_test.go
+++ b/epochStart/bootstrap/export_test.go
@@ -12,3 +12,5 @@ func (e *epochStartMetaBlockProcessor) GetMapMetaBlock() map[string]*block.MetaB
 const DurationBetweenChecksForEpochStartMetaBlock = durationBetweenChecks
 
 const DurationBetweenReRequest = durationBetweenReRequests
+
+const MinNumOfPeersToConsiderBlockValid = minNumOfPeersToConsiderBlockValid


### PR DESCRIPTION
when the context expires for getting the epoch start metablock, first check if at least a minimum number of peers sent a metablock and return it instead of returning a time out error.
+ unit test