### PR TITLE
Changed the way transactions are signed using bech32 addresses

### DIFF
--- a/data/mock/marshalizerStub.go
+++ b/data/mock/marshalizerStub.go
@@ -1,0 +1,22 @@
+package mock
+
+// MarshalizerStub -
+type MarshalizerStub struct {
+	MarshalCalled   func(obj interface{}) ([]byte, error)
+	UnmarshalCalled func(obj interface{}, buff []byte) error
+}
+
+// Marshal -
+func (ms *MarshalizerStub) Marshal(obj interface{}) ([]byte, error) {
+	return ms.MarshalCalled(obj)
+}
+
+// Unmarshal -
+func (ms *MarshalizerStub) Unmarshal(obj interface{}, buff []byte) error {
+	return ms.UnmarshalCalled(obj, buff)
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (ms *MarshalizerStub) IsInterfaceNil() bool {
+	return ms == nil
+}

--- a/data/mock/pubkeyConverterStub.go
+++ b/data/mock/pubkeyConverterStub.go
@@ -1,0 +1,62 @@
+package mock
+
+import "github.com/ElrondNetwork/elrond-go/data/state"
+
+// PubkeyConverterStub -
+type PubkeyConverterStub struct {
+	LenCalled                     func() int
+	DecodeCalled                  func(humanReadable string) ([]byte, error)
+	EncodeCalled                  func(pkBytes []byte) string
+	CreateAddressFromStringCalled func(humanReadable string) (state.AddressContainer, error)
+	CreateAddressFromBytesCalled  func(pkBytes []byte) (state.AddressContainer, error)
+}
+
+// Len -
+func (pcs *PubkeyConverterStub) Len() int {
+	if pcs.LenCalled != nil {
+		return pcs.LenCalled()
+	}
+
+	return 0
+}
+
+// Decode -
+func (pcs *PubkeyConverterStub) Decode(humanReadable string) ([]byte, error) {
+	if pcs.DecodeCalled != nil {
+		return pcs.DecodeCalled(humanReadable)
+	}
+
+	return make([]byte, 0), nil
+}
+
+// Encode -
+func (pcs *PubkeyConverterStub) Encode(pkBytes []byte) string {
+	if pcs.EncodeCalled != nil {
+		return pcs.EncodeCalled(pkBytes)
+	}
+
+	return ""
+}
+
+// CreateAddressFromString -
+func (pcs *PubkeyConverterStub) CreateAddressFromString(humanReadable string) (state.AddressContainer, error) {
+	if pcs.CreateAddressFromBytesCalled != nil {
+		return pcs.CreateAddressFromStringCalled(humanReadable)
+	}
+
+	return nil, nil
+}
+
+// CreateAddressFromBytes -
+func (pcs *PubkeyConverterStub) CreateAddressFromBytes(pkBytes []byte) (state.AddressContainer, error) {
+	if pcs.CreateAddressFromBytesCalled != nil {
+		return pcs.CreateAddressFromBytesCalled(pkBytes)
+	}
+
+	return nil, nil
+}
+
+// IsInterfaceNil -
+func (pcs *PubkeyConverterStub) IsInterfaceNil() bool {
+	return pcs == nil
+}

--- a/data/transaction/errors.go
+++ b/data/transaction/errors.go
@@ -1,0 +1,9 @@
+package transaction
+
+import "errors"
+
+// ErrNilEncoder signals that a nil encoder has been provided
+var ErrNilEncoder = errors.New("nil encoder")
+
+// ErrNilMarshalizer signals that a nil marshalizer has been provided
+var ErrNilMarshalizer = errors.New("nil marshalizer")

--- a/data/transaction/interface.go
+++ b/data/transaction/interface.go
@@ -1,0 +1,13 @@
+package transaction
+
+// Encoder represents a byte slice to string encoder
+type Encoder interface {
+	Encode(buff []byte) string
+	IsInterfaceNil() bool
+}
+
+// Marshalizer is able to encode an object to its byte slice representation
+type Marshalizer interface {
+	Marshal(obj interface{}) ([]byte, error)
+	IsInterfaceNil() bool
+}

--- a/data/transaction/transaction.go
+++ b/data/transaction/transaction.go
@@ -61,8 +61,8 @@ type frontendTransaction struct {
 	Value            string `json:"value"`
 	Receiver         string `json:"receiver"`
 	Sender           string `json:"sender"`
-	SenderUsername   []byte `json:"senderusername,omitempty"`
-	ReceiverUsername []byte `json:"receiverusername,omitempty"`
+	SenderUsername   []byte `json:"senderUsername,omitempty"`
+	ReceiverUsername []byte `json:"receiverUsername,omitempty"`
 	GasPrice         uint64 `json:"gasPrice"`
 	GasLimit         uint64 `json:"gasLimit"`
 	Data             []byte `json:"data,omitempty"`

--- a/data/transaction/transaction.go
+++ b/data/transaction/transaction.go
@@ -10,7 +10,7 @@ import (
 
 var _ = data.TransactionHandler(&Transaction{})
 
-// IsInterfaceNil vesorrifies if underlying object is nil
+// IsInterfaceNil verifies if underlying object is nil
 func (tx *Transaction) IsInterfaceNil() bool {
 	return tx == nil
 }
@@ -69,8 +69,8 @@ type frontendTransaction struct {
 	Signature        string `json:"signature,omitempty"`
 }
 
-// GetFataForSigning returns the serialized transaction having the
-func (tx *Transaction) GetFataForSigning(encoder Encoder, marshalizer Marshalizer) ([]byte, error) {
+// GetDataForSigning returns the serialized transaction having an empty signature field
+func (tx *Transaction) GetDataForSigning(encoder Encoder, marshalizer Marshalizer) ([]byte, error) {
 	if check.IfNil(encoder) {
 		return nil, ErrNilEncoder
 	}

--- a/data/transaction/transaction_test.go
+++ b/data/transaction/transaction_test.go
@@ -131,36 +131,36 @@ func TestTransaction_TrimsSliceHandler(t *testing.T) {
 	assert.Equal(t, 2, cap(input))
 }
 
-func TestTransaction_GetFataForSigningNilPubkeyConverterShouldErr(t *testing.T) {
+func TestTransaction_GetDataForSigningNilPubkeyConverterShouldErr(t *testing.T) {
 	t.Parallel()
 
 	tx := &transaction.Transaction{}
 
-	buff, err := tx.GetFataForSigning(nil, &mock.MarshalizerStub{})
+	buff, err := tx.GetDataForSigning(nil, &mock.MarshalizerStub{})
 
 	assert.Nil(t, buff)
 	assert.Equal(t, transaction.ErrNilEncoder, err)
 }
 
-func TestTransaction_GetFataForSigningNilMarshalizerShouldErr(t *testing.T) {
+func TestTransaction_GetDataForSigningNilMarshalizerShouldErr(t *testing.T) {
 	t.Parallel()
 
 	tx := &transaction.Transaction{}
 
-	buff, err := tx.GetFataForSigning(&mock.PubkeyConverterStub{}, nil)
+	buff, err := tx.GetDataForSigning(&mock.PubkeyConverterStub{}, nil)
 
 	assert.Nil(t, buff)
 	assert.Equal(t, transaction.ErrNilMarshalizer, err)
 }
 
-func TestTransaction_GetFataForSigningMarshalizerErrShouldErr(t *testing.T) {
+func TestTransaction_GetDataForSigningMarshalizerErrShouldErr(t *testing.T) {
 	t.Parallel()
 
 	tx := &transaction.Transaction{}
 
 	numEncodeCalled := 0
 	expectedErr := errors.New("expected error")
-	buff, err := tx.GetFataForSigning(
+	buff, err := tx.GetDataForSigning(
 		&mock.PubkeyConverterStub{
 			EncodeCalled: func(pkBytes []byte) string {
 				numEncodeCalled++
@@ -179,14 +179,14 @@ func TestTransaction_GetFataForSigningMarshalizerErrShouldErr(t *testing.T) {
 	assert.Equal(t, 2, numEncodeCalled)
 }
 
-func TestTransaction_GetFataForSigningShouldWork(t *testing.T) {
+func TestTransaction_GetDataForSigningShouldWork(t *testing.T) {
 	t.Parallel()
 
 	tx := &transaction.Transaction{}
 
 	numEncodeCalled := 0
 	marshalizerWasCalled := false
-	buff, err := tx.GetFataForSigning(
+	buff, err := tx.GetDataForSigning(
 		&mock.PubkeyConverterStub{
 			EncodeCalled: func(pkBytes []byte) string {
 				numEncodeCalled++

--- a/data/transaction/transaction_test.go
+++ b/data/transaction/transaction_test.go
@@ -2,11 +2,13 @@ package transaction_test
 
 import (
 	"encoding/json"
+	"errors"
 	"math/big"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/data"
+	"github.com/ElrondNetwork/elrond-go/data/mock"
 	"github.com/ElrondNetwork/elrond-go/data/transaction"
 	"github.com/stretchr/testify/assert"
 )
@@ -127,4 +129,81 @@ func TestTransaction_TrimsSliceHandler(t *testing.T) {
 
 	assert.Equal(t, 2, len(input))
 	assert.Equal(t, 2, cap(input))
+}
+
+func TestTransaction_GetFataForSigningNilPubkeyConverterShouldErr(t *testing.T) {
+	t.Parallel()
+
+	tx := &transaction.Transaction{}
+
+	buff, err := tx.GetFataForSigning(nil, &mock.MarshalizerStub{})
+
+	assert.Nil(t, buff)
+	assert.Equal(t, transaction.ErrNilEncoder, err)
+}
+
+func TestTransaction_GetFataForSigningNilMarshalizerShouldErr(t *testing.T) {
+	t.Parallel()
+
+	tx := &transaction.Transaction{}
+
+	buff, err := tx.GetFataForSigning(&mock.PubkeyConverterStub{}, nil)
+
+	assert.Nil(t, buff)
+	assert.Equal(t, transaction.ErrNilMarshalizer, err)
+}
+
+func TestTransaction_GetFataForSigningMarshalizerErrShouldErr(t *testing.T) {
+	t.Parallel()
+
+	tx := &transaction.Transaction{}
+
+	numEncodeCalled := 0
+	expectedErr := errors.New("expected error")
+	buff, err := tx.GetFataForSigning(
+		&mock.PubkeyConverterStub{
+			EncodeCalled: func(pkBytes []byte) string {
+				numEncodeCalled++
+				return ""
+			},
+		},
+		&mock.MarshalizerStub{
+			MarshalCalled: func(obj interface{}) (bytes []byte, err error) {
+				return nil, expectedErr
+			},
+		},
+	)
+
+	assert.Nil(t, buff)
+	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, 2, numEncodeCalled)
+}
+
+func TestTransaction_GetFataForSigningShouldWork(t *testing.T) {
+	t.Parallel()
+
+	tx := &transaction.Transaction{}
+
+	numEncodeCalled := 0
+	marshalizerWasCalled := false
+	buff, err := tx.GetFataForSigning(
+		&mock.PubkeyConverterStub{
+			EncodeCalled: func(pkBytes []byte) string {
+				numEncodeCalled++
+				return ""
+			},
+		},
+		&mock.MarshalizerStub{
+			MarshalCalled: func(obj interface{}) (bytes []byte, err error) {
+				marshalizerWasCalled = true
+
+				return make([]byte, 0), nil
+			},
+		},
+	)
+
+	assert.Equal(t, 0, len(buff))
+	assert.Nil(t, err)
+	assert.True(t, marshalizerWasCalled)
+	assert.Equal(t, 2, numEncodeCalled)
 }

--- a/integrationTests/frontend/wallet/txInterception_test.go
+++ b/integrationTests/frontend/wallet/txInterception_test.go
@@ -2,7 +2,6 @@ package wallet
 
 import (
 	"encoding/hex"
-	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -14,23 +13,37 @@ import (
 
 const mintingValue = "100000000"
 
-func TestInterceptedTxFromFrontendLargeValue(t *testing.T) {
+func TestInterceptedTxWhithoutDataField(t *testing.T) {
 	value := big.NewInt(0)
-	value.SetString("777", 10)
-
-	fmt.Println(value.Text(10))
-	fmt.Println(value.Text(16))
+	value.SetString("999", 10)
 
 	testInterceptedTxFromFrontendGeneratedParams(
 		t,
 		0,
 		value,
-		"53669be65aac358a6add8e8a8b1251bb994dc1e4a0cc885956f5ecd53396f0d8",
-		"2d7aa683fbb37eafc2426bfe63e1c20aa5872ee4627c51b6789f41bfb8d31fdb",
-		"a18a6c6647d10a579acd7e39258f38cee4cd36998ae12edf4e884066231b00e18d792cc14ece72d3ac6fb26281c5419b1ec9736291d1c9fbb312ee2a730c8103",
+		"erd1t2cct2ahdna5n2q3ljzj4tgn6fnqqrncs967pekunl7cuscqxymsgm388y",
+		"erd14t6l0x27w4d4354sqfm40wuv9p0r49uzl9598eka290x9kws2nvqlkc36j",
+		"7a98196903b09ef70cb182462a83b38ecbba819ec93e82b1d7bf29556a40afbcf739d1e2ddc8ca615a8ab1ebde1e6feafb809249c772d5cfa61562afb5d86f01",
 		10,
 		100000,
-		[]byte("a@b@c!!$%^<>#!"),
+		[]byte(""),
+	)
+}
+
+func TestInterceptedTxWhithDataField(t *testing.T) {
+	value := big.NewInt(0)
+	value.SetString("999", 10)
+
+	testInterceptedTxFromFrontendGeneratedParams(
+		t,
+		0,
+		value,
+		"erd1t2cct2ahdna5n2q3ljzj4tgn6fnqqrncs967pekunl7cuscqxymsgm388y",
+		"erd14t6l0x27w4d4354sqfm40wuv9p0r49uzl9598eka290x9kws2nvqlkc36j",
+		"9b5dc11f0b8da13bd0e6590ba79f9bc4635464cc7a1d5f33493d5a4a91015bac6e523c88917f17f94eb4133f5df791a3bb432d927f45ce1c8fd015fc5cc02705",
+		10,
+		100000,
+		[]byte("!!!!!"),
 	)
 }
 
@@ -40,9 +53,9 @@ func testInterceptedTxFromFrontendGeneratedParams(
 	t *testing.T,
 	frontendNonce uint64,
 	frontendValue *big.Int,
-	frontendReceiverHex string,
-	frontendSenderHex string,
-	frontendSignature string,
+	frontendReceiver string,
+	frontendSender string,
+	frontendSignatureHex string,
 	frontendGasPrice uint64,
 	frontendGasLimit uint64,
 	frontendData []byte,
@@ -84,22 +97,22 @@ func testInterceptedTxFromFrontendGeneratedParams(
 		assert.Equal(t, frontendNonce, txRecovered.Nonce)
 		assert.Equal(t, frontendValue, txRecovered.Value)
 
-		sender, _ := hex.DecodeString(frontendSenderHex)
+		sender, _ := integrationTests.TestAddressPubkeyConverter.Decode(frontendSender)
 		assert.Equal(t, sender, txRecovered.SndAddr)
 
-		receiver, _ := hex.DecodeString(frontendReceiverHex)
+		receiver, _ := integrationTests.TestAddressPubkeyConverter.Decode(frontendReceiver)
 		assert.Equal(t, receiver, txRecovered.RcvAddr)
 
-		sig, _ := hex.DecodeString(frontendSignature)
+		sig, _ := hex.DecodeString(frontendSignatureHex)
 		assert.Equal(t, sig, txRecovered.Signature)
-		assert.Equal(t, frontendData, txRecovered.Data)
+		assert.Equal(t, len(frontendData), len(txRecovered.Data))
 
 		chDone <- struct{}{}
 	})
 
-	rcvAddrBytes, _ := hex.DecodeString(frontendReceiverHex)
-	sndAddrBytes, _ := hex.DecodeString(frontendSenderHex)
-	signatureBytes, _ := hex.DecodeString(frontendSignature)
+	rcvAddrBytes, _ := integrationTests.TestAddressPubkeyConverter.Decode(frontendReceiver)
+	sndAddrBytes, _ := integrationTests.TestAddressPubkeyConverter.Decode(frontendSender)
+	signatureBytes, _ := hex.DecodeString(frontendSignatureHex)
 
 	integrationTests.MintAddress(node.AccntState, sndAddrBytes, valMinting)
 

--- a/integrationTests/multiShard/transaction/txRouting/txRouting_test.go
+++ b/integrationTests/multiShard/transaction/txRouting/txRouting_test.go
@@ -3,7 +3,6 @@ package txRouting
 import (
 	"context"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"math/big"
 	"testing"
@@ -154,7 +153,7 @@ func generateTx(sender crypto.PrivateKey, receiver crypto.PublicKey, nonce uint6
 		Data:      []byte(""),
 		Signature: nil,
 	}
-	marshalizedTxBeforeSigning, _ := json.Marshal(tx)
+	marshalizedTxBeforeSigning, _ := tx.GetFataForSigning(integrationTests.TestAddressPubkeyConverter, integrationTests.TestTxSignMarshalizer)
 	signer := ed25519SingleSig.Ed25519Signer{}
 
 	signature, _ := signer.Sign(sender, marshalizedTxBeforeSigning)

--- a/integrationTests/multiShard/transaction/txRouting/txRouting_test.go
+++ b/integrationTests/multiShard/transaction/txRouting/txRouting_test.go
@@ -153,7 +153,7 @@ func generateTx(sender crypto.PrivateKey, receiver crypto.PublicKey, nonce uint6
 		Data:      []byte(""),
 		Signature: nil,
 	}
-	marshalizedTxBeforeSigning, _ := tx.GetFataForSigning(integrationTests.TestAddressPubkeyConverter, integrationTests.TestTxSignMarshalizer)
+	marshalizedTxBeforeSigning, _ := tx.GetDataForSigning(integrationTests.TestAddressPubkeyConverter, integrationTests.TestTxSignMarshalizer)
 	signer := ed25519SingleSig.Ed25519Signer{}
 
 	signature, _ := signer.Sign(sender, marshalizedTxBeforeSigning)

--- a/integrationTests/singleShard/transaction/interceptedResolvedTx/interceptedResolvedTx_test.go
+++ b/integrationTests/singleShard/transaction/interceptedResolvedTx/interceptedResolvedTx_test.go
@@ -65,7 +65,7 @@ func TestNode_RequestInterceptTransactionWithMessengerAndWhitelist(t *testing.T)
 		GasPrice: integrationTests.MinTxGasPrice,
 	}
 
-	txBuff, _ := tx.GetFataForSigning(integrationTests.TestAddressPubkeyConverter, integrationTests.TestTxSignMarshalizer)
+	txBuff, _ := tx.GetDataForSigning(integrationTests.TestAddressPubkeyConverter, integrationTests.TestTxSignMarshalizer)
 	signer := &ed25519SingleSig.Ed25519Signer{}
 	tx.Signature, _ = signer.Sign(nRequester.OwnAccount.SkTxSign, txBuff)
 	signedTxBuff, _ := integrationTests.TestMarshalizer.Marshal(&tx)

--- a/integrationTests/singleShard/transaction/interceptedResolvedTx/interceptedResolvedTx_test.go
+++ b/integrationTests/singleShard/transaction/interceptedResolvedTx/interceptedResolvedTx_test.go
@@ -65,7 +65,7 @@ func TestNode_RequestInterceptTransactionWithMessengerAndWhitelist(t *testing.T)
 		GasPrice: integrationTests.MinTxGasPrice,
 	}
 
-	txBuff, _ := integrationTests.TestTxSignMarshalizer.Marshal(&tx)
+	txBuff, _ := tx.GetFataForSigning(integrationTests.TestAddressPubkeyConverter, integrationTests.TestTxSignMarshalizer)
 	signer := &ed25519SingleSig.Ed25519Signer{}
 	tx.Signature, _ = signer.Sign(nRequester.OwnAccount.SkTxSign, txBuff)
 	signedTxBuff, _ := integrationTests.TestMarshalizer.Marshal(&tx)

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -1103,7 +1103,7 @@ func CreateAndSendTransaction(
 		GasLimit: MinTxGasLimit*100 + uint64(len(txData)),
 	}
 
-	txBuff, _ := TestTxSignMarshalizer.Marshal(tx)
+	txBuff, _ := tx.GetFataForSigning(TestAddressPubkeyConverter, TestTxSignMarshalizer)
 	tx.Signature, _ = node.OwnAccount.SingleSigner.Sign(node.OwnAccount.SkTxSign, txBuff)
 
 	_, err := node.SendTransaction(tx)
@@ -1131,7 +1131,7 @@ func CreateAndSendTransactionWithGasLimit(
 		GasLimit: gasLimit,
 	}
 
-	txBuff, _ := TestTxSignMarshalizer.Marshal(tx)
+	txBuff, _ := tx.GetFataForSigning(TestAddressPubkeyConverter, TestTxSignMarshalizer)
 	tx.Signature, _ = node.OwnAccount.SingleSigner.Sign(node.OwnAccount.SkTxSign, txBuff)
 
 	_, _ = node.SendTransaction(tx)
@@ -1168,7 +1168,7 @@ func GenerateTransferTx(
 		GasLimit: gasLimit,
 		GasPrice: gasPrice,
 	}
-	txBuff, _ := TestTxSignMarshalizer.Marshal(&tx)
+	txBuff, _ := tx.GetFataForSigning(TestAddressPubkeyConverter, TestTxSignMarshalizer)
 	signer := &ed25519SingleSig.Ed25519Signer{}
 	tx.Signature, _ = signer.Sign(senderPrivateKey, txBuff)
 
@@ -1189,7 +1189,7 @@ func generateTx(
 		GasLimit: args.gasLimit,
 		Data:     []byte(args.data),
 	}
-	txBuff, _ := TestTxSignMarshalizer.Marshal(tx)
+	txBuff, _ := tx.GetFataForSigning(TestAddressPubkeyConverter, TestTxSignMarshalizer)
 	tx.Signature, _ = signer.Sign(skSign, txBuff)
 
 	return tx

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -1103,7 +1103,7 @@ func CreateAndSendTransaction(
 		GasLimit: MinTxGasLimit*100 + uint64(len(txData)),
 	}
 
-	txBuff, _ := tx.GetFataForSigning(TestAddressPubkeyConverter, TestTxSignMarshalizer)
+	txBuff, _ := tx.GetDataForSigning(TestAddressPubkeyConverter, TestTxSignMarshalizer)
 	tx.Signature, _ = node.OwnAccount.SingleSigner.Sign(node.OwnAccount.SkTxSign, txBuff)
 
 	_, err := node.SendTransaction(tx)
@@ -1131,7 +1131,7 @@ func CreateAndSendTransactionWithGasLimit(
 		GasLimit: gasLimit,
 	}
 
-	txBuff, _ := tx.GetFataForSigning(TestAddressPubkeyConverter, TestTxSignMarshalizer)
+	txBuff, _ := tx.GetDataForSigning(TestAddressPubkeyConverter, TestTxSignMarshalizer)
 	tx.Signature, _ = node.OwnAccount.SingleSigner.Sign(node.OwnAccount.SkTxSign, txBuff)
 
 	_, _ = node.SendTransaction(tx)
@@ -1168,7 +1168,7 @@ func GenerateTransferTx(
 		GasLimit: gasLimit,
 		GasPrice: gasPrice,
 	}
-	txBuff, _ := tx.GetFataForSigning(TestAddressPubkeyConverter, TestTxSignMarshalizer)
+	txBuff, _ := tx.GetDataForSigning(TestAddressPubkeyConverter, TestTxSignMarshalizer)
 	signer := &ed25519SingleSig.Ed25519Signer{}
 	tx.Signature, _ = signer.Sign(senderPrivateKey, txBuff)
 
@@ -1189,7 +1189,7 @@ func generateTx(
 		GasLimit: args.gasLimit,
 		Data:     []byte(args.data),
 	}
-	txBuff, _ := tx.GetFataForSigning(TestAddressPubkeyConverter, TestTxSignMarshalizer)
+	txBuff, _ := tx.GetDataForSigning(TestAddressPubkeyConverter, TestTxSignMarshalizer)
 	tx.Signature, _ = signer.Sign(skSign, txBuff)
 
 	return tx

--- a/node/nodeTesting.go
+++ b/node/nodeTesting.go
@@ -208,7 +208,7 @@ func (n *Node) generateAndSignSingleTx(
 		Data:     []byte(dataField),
 	}
 
-	marshalizedTx, err := tx.GetFataForSigning(n.addressPubkeyConverter, n.txSignMarshalizer)
+	marshalizedTx, err := tx.GetDataForSigning(n.addressPubkeyConverter, n.txSignMarshalizer)
 	if err != nil {
 		return nil, nil, errors.New("could not marshal transaction")
 	}

--- a/node/nodeTesting.go
+++ b/node/nodeTesting.go
@@ -208,7 +208,7 @@ func (n *Node) generateAndSignSingleTx(
 		Data:     []byte(dataField),
 	}
 
-	marshalizedTx, err := n.txSignMarshalizer.Marshal(&tx)
+	marshalizedTx, err := tx.GetFataForSigning(n.addressPubkeyConverter, n.txSignMarshalizer)
 	if err != nil {
 		return nil, nil, errors.New("could not marshal transaction")
 	}

--- a/process/transaction/interceptedTransaction.go
+++ b/process/transaction/interceptedTransaction.go
@@ -177,7 +177,7 @@ func (inTx *InterceptedTransaction) integrity() error {
 
 // verifySig checks if the tx is correctly signed
 func (inTx *InterceptedTransaction) verifySig() error {
-	buffCopiedTx, err := inTx.tx.GetFataForSigning(inTx.pubkeyConv, inTx.signMarshalizer)
+	buffCopiedTx, err := inTx.tx.GetDataForSigning(inTx.pubkeyConv, inTx.signMarshalizer)
 	if err != nil {
 		return err
 	}

--- a/process/transaction/interceptedTransaction.go
+++ b/process/transaction/interceptedTransaction.go
@@ -177,9 +177,7 @@ func (inTx *InterceptedTransaction) integrity() error {
 
 // verifySig checks if the tx is correctly signed
 func (inTx *InterceptedTransaction) verifySig() error {
-	copiedTx := *inTx.tx
-	copiedTx.Signature = nil
-	buffCopiedTx, err := inTx.signMarshalizer.Marshal(&copiedTx)
+	buffCopiedTx, err := inTx.tx.GetFataForSigning(inTx.pubkeyConv, inTx.signMarshalizer)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR changes the way the transactions are signed. Originally, the signature was generated by the following algorithm:
```
tx := tuple(
    nonce, //as uint64
    value, //as string
    receiver, //as byte array, encoded by the json serializer as base64 string
    sender, //as byte array, encoded by json serializer as base64 string
    gasPrice, //as uint64
    gasLimit, //as uin64
    data, //as byte array, encoded by json serializer as base64 string
)
txbuff := encode_JSON(tx)
signature := sign_ed25519(txbuff, sender_sk)
txbuff.signature = hex(signature)
```
The new algorithm can be described as follows:
```
tx := tuple(
    nonce, //as uint64
    value, //as string
    receiver, //as string, bech32 format directly
    sender, //as string, bech32 format directly
    gasPrice, //as uint64
    gasLimit, //as uin64
    data, //as byte array, encoded by json serializer as base64 string
)
txbuff := encode_JSON(tx)
signature := sign_ed25519(txbuff, sender_sk)
txbuff.signature = hex(signature)
```



 