### PR TITLE
Early check of app version string

### DIFF
--- a/node/heartbeat/export_test.go
+++ b/node/heartbeat/export_test.go
@@ -4,6 +4,8 @@ import (
 	"time"
 )
 
+const MaxSizeInBytes = maxSizeInBytes
+
 func (m *Monitor) GetMessages() map[string]*heartbeatMessageInfo {
 	return m.heartbeatMessages
 }

--- a/node/heartbeat/heartbeatMessageValidator.go
+++ b/node/heartbeat/heartbeatMessageValidator.go
@@ -1,15 +1,44 @@
 package heartbeat
 
+import "fmt"
+
 const maxSizeInBytes = 128
 
 func verifyLengths(heartbeat *Heartbeat) error {
-	if len(heartbeat.Pubkey) > maxSizeInBytes ||
-		len(heartbeat.Payload) > maxSizeInBytes ||
-		len(heartbeat.NodeDisplayName) > maxSizeInBytes ||
-		len(heartbeat.VersionNumber) > maxSizeInBytes ||
-		len(heartbeat.Signature) > maxSizeInBytes {
-		return ErrPropertyTooLong
+	err := VerifyHeartbeatProperyLen("Pubkey", heartbeat.Pubkey)
+	if err != nil {
+		return err
 	}
+
+	err = VerifyHeartbeatProperyLen("Payload", heartbeat.Payload)
+	if err != nil {
+		return err
+	}
+
+	err = VerifyHeartbeatProperyLen("NodeDisplayName", []byte(heartbeat.NodeDisplayName))
+	if err != nil {
+		return err
+	}
+
+	err = VerifyHeartbeatProperyLen("VersionNumber", []byte(heartbeat.VersionNumber))
+	if err != nil {
+		return err
+	}
+
+	err = VerifyHeartbeatProperyLen("Signature", heartbeat.Signature)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// VerifyHeartbeatProperyLen returns an error if the provided value is longer than accepted by the network
+func VerifyHeartbeatProperyLen(property string, value []byte) error {
+	if len(value) > maxSizeInBytes {
+		return fmt.Errorf("%w for %s", ErrPropertyTooLong, property)
+	}
+
 	return nil
 }
 

--- a/node/heartbeat/messageProcessor_test.go
+++ b/node/heartbeat/messageProcessor_test.go
@@ -411,7 +411,7 @@ func TestNewMessageProcessor_CreateHeartbeatFromP2PMessageWithTooLongLengthsShou
 	ret, err := mon.CreateHeartbeatFromP2PMessage(message)
 
 	assert.Nil(t, ret)
-	assert.Equal(t, heartbeat.ErrPropertyTooLong, err)
+	assert.True(t, errors.Is(err, heartbeat.ErrPropertyTooLong))
 }
 
 func TestNewMessageProcessor_CreateHeartbeatFromP2pNilMessageShouldErr(t *testing.T) {

--- a/node/heartbeat/sender.go
+++ b/node/heartbeat/sender.go
@@ -67,6 +67,10 @@ func NewSender(arg ArgHeartbeatSender) (*Sender, error) {
 	if check.IfNil(arg.HardforkTrigger) {
 		return nil, ErrNilHardforkTrigger
 	}
+	err := VerifyHeartbeatProperyLen("application version string", []byte(arg.VersionNumber))
+	if err != nil {
+		return nil, err
+	}
 
 	sender := &Sender{
 		peerMessenger:    arg.PeerMessenger,

--- a/node/heartbeat/sender_test.go
+++ b/node/heartbeat/sender_test.go
@@ -3,6 +3,7 @@ package heartbeat_test
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go/crypto"
@@ -125,6 +126,17 @@ func TestNewSender_NilHardforkTriggerShouldErr(t *testing.T) {
 
 	assert.Nil(t, sender)
 	assert.Equal(t, heartbeat.ErrNilHardforkTrigger, err)
+}
+
+func TestNewSender_PropertyTooLongShouldErr(t *testing.T) {
+	t.Parallel()
+
+	arg := createMockArgHeartbeatSender()
+	arg.VersionNumber = strings.Repeat("a", heartbeat.MaxSizeInBytes+1)
+	sender, err := heartbeat.NewSender(arg)
+
+	assert.Nil(t, sender)
+	assert.True(t, errors.Is(err, heartbeat.ErrPropertyTooLong))
 }
 
 func TestNewSender_ShouldWork(t *testing.T) {


### PR DESCRIPTION
- added early checking of the application version string so the application will not "silently" drop heartbeat messages
- wrapped errors in heartbeatMessageValidator.go