### PR TITLE
Added num of shards in node/status route

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -772,7 +772,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 	}
 
 	log.Trace("initializing metrics")
-	metrics.InitMetrics(
+	err = metrics.InitMetrics(
 		coreComponents.StatusHandler,
 		cryptoParams.PublicKeyString,
 		nodeType,
@@ -782,6 +782,9 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		economicsConfig,
 		generalConfig.EpochStartConfig.RoundsPerEpoch,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = statusHandlersInfo.UpdateStorerAndMetricsForPersistentHandler(dataComponents.Store.GetStorer(dataRetriever.StatusMetricsUnit))
 	if err != nil {

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -1043,6 +1043,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		statusPollingInterval,
 		networkComponents,
 		processComponents,
+		shardCoordinator,
 	)
 	if err != nil {
 		return err

--- a/cmd/node/metrics/machineStatistics.go
+++ b/cmd/node/metrics/machineStatistics.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/appStatusPolling"
+	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/core/statistics/machine"
 )
 
 // StartMachineStatisticsPolling will start read information about current  running machini
 func StartMachineStatisticsPolling(ash core.AppStatusHandler, pollingInterval time.Duration) error {
-	if ash == nil {
+	if check.IfNil(ash) {
 		return errors.New("nil AppStatusHandler")
 	}
 
@@ -30,7 +31,7 @@ func StartMachineStatisticsPolling(ash core.AppStatusHandler, pollingInterval ti
 		return err
 	}
 
-	err = registeNetStatistics(appStatusPollingHandler)
+	err = registerNetStatistics(appStatusPollingHandler)
 	if err != nil {
 		return err
 	}
@@ -56,7 +57,7 @@ func registerMemStatistics(appStatusPollingHandler *appStatusPolling.AppStatusPo
 	})
 }
 
-func registeNetStatistics(appStatusPollingHandler *appStatusPolling.AppStatusPolling) error {
+func registerNetStatistics(appStatusPollingHandler *appStatusPolling.AppStatusPolling) error {
 	netStats := &machine.NetStatistics{}
 	go func() {
 		for {

--- a/cmd/node/metrics/metrics.go
+++ b/cmd/node/metrics/metrics.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/appStatusPolling"
+	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 )
@@ -25,7 +26,20 @@ func InitMetrics(
 	version string,
 	economicsConfig *config.EconomicsConfig,
 	roundsPerEpoch int64,
-) {
+) error {
+	if check.IfNil(appStatusHandler) {
+		return fmt.Errorf("nil AppStatusHandler when initializing metrics")
+	}
+	if check.IfNil(shardCoordinator) {
+		return fmt.Errorf("nil shard coordinator when initializing metrics")
+	}
+	if nodesConfig == nil {
+		return fmt.Errorf("nil nodes config when initializing metrics")
+	}
+	if economicsConfig == nil {
+		return fmt.Errorf("nil economics config when initializing metrics")
+	}
+
 	shardId := uint64(shardCoordinator.SelfId())
 	numOfShards := uint64(shardCoordinator.NumberOfShards())
 	roundDuration := nodesConfig.RoundDuration
@@ -89,6 +103,8 @@ func InitMetrics(
 
 	appStatusHandler.SetUInt64Value(core.MetricNumValidators, uint64(numValidators))
 	appStatusHandler.SetUInt64Value(core.MetricConsensusGroupSize, uint64(consensusGroupSize))
+
+	return nil
 }
 
 // SaveUint64Metric will save a uint64 metric in status handler
@@ -109,9 +125,17 @@ func StartStatusPolling(
 	processComponents *factory.Process,
 	shardCoordinator sharding.Coordinator,
 ) error {
-
 	if ash == nil {
 		return errors.New("nil AppStatusHandler")
+	}
+	if networkComponents == nil {
+		return errors.New("nil networkComponents")
+	}
+	if processComponents == nil {
+		return errors.New("nil processComponents")
+	}
+	if check.IfNil(shardCoordinator) {
+		return errors.New("nil shard coordinator")
 	}
 
 	appStatusPollingHandler, err := appStatusPolling.NewAppStatusPolling(ash, pollingInterval)

--- a/core/constants.go
+++ b/core/constants.go
@@ -90,6 +90,9 @@ const MetricPublicKeyBlockSign = "erd_public_key_block_sign"
 // MetricShardId is the metric for monitoring shard id of a node
 const MetricShardId = "erd_shard_id"
 
+// MetricNumShardsWithoutMetacahin is the metric for monitoring the number of shards (excluding meta)
+const MetricNumShardsWithoutMetacahin = "erd_num_shards_without_meta"
+
 // MetricTxPoolLoad is the metric for monitoring number of transactions from pool of a node
 const MetricTxPoolLoad = "erd_tx_pool_load"
 


### PR DESCRIPTION
- added new info line in node/status route that will specify the number of shards without metachain
- added number of shards and shard ID to the automatic refreshing system in order to correctly specify the shard ID if the node does not restart