### PR TITLE
storage: get from batch, remove with batch

### DIFF
--- a/data/state/trackableDataTrie.go
+++ b/data/state/trackableDataTrie.go
@@ -46,13 +46,13 @@ func (tdaw *TrackableDataTrie) RetrieveValue(key []byte) ([]byte, error) {
 
 	//search in dirty data cache
 	if value, found := tdaw.dirtyData[string(key)]; found {
-		log.Debug("retrieve value from dirty data", "key", key, "value", value)
+		log.Trace("retrieve value from dirty data", "key", key, "value", value)
 		return trimValue(value, tailLength)
 	}
 
 	//search in original data cache
 	if value, found := tdaw.originalData[string(key)]; found {
-		log.Debug("retrieve value from original data", "key", key, "value", value)
+		log.Trace("retrieve value from original data", "key", key, "value", value)
 		return trimValue(value, tailLength)
 	}
 
@@ -64,7 +64,7 @@ func (tdaw *TrackableDataTrie) RetrieveValue(key []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Debug("retrieve value from trie", "key", key, "value", value)
+	log.Trace("retrieve value from trie", "key", key, "value", value)
 	value, _ = trimValue(value, tailLength)
 
 	//got the value, put it originalData cache as the next fetch will run faster

--- a/data/state/trackableDataTrie.go
+++ b/data/state/trackableDataTrie.go
@@ -46,11 +46,13 @@ func (tdaw *TrackableDataTrie) RetrieveValue(key []byte) ([]byte, error) {
 
 	//search in dirty data cache
 	if value, found := tdaw.dirtyData[string(key)]; found {
+		log.Debug("retrieve value from dirty data", "key", key, "value", value)
 		return trimValue(value, tailLength)
 	}
 
 	//search in original data cache
 	if value, found := tdaw.originalData[string(key)]; found {
+		log.Debug("retrieve value from original data", "key", key, "value", value)
 		return trimValue(value, tailLength)
 	}
 
@@ -62,7 +64,7 @@ func (tdaw *TrackableDataTrie) RetrieveValue(key []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	log.Debug("retrieve value from trie", "key", key, "value", value)
 	value, _ = trimValue(value, tailLength)
 
 	//got the value, put it originalData cache as the next fetch will run faster

--- a/process/smartContract/hooks/blockChainHook.go
+++ b/process/smartContract/hooks/blockChainHook.go
@@ -176,7 +176,7 @@ func (bh *BlockChainHookImpl) GetStorageData(accountAddress []byte, index []byte
 	}
 
 	value, err := userAcc.DataTrieTracker().RetrieveValue(index)
-	log.Trace("GetStorageData ", "address", accountAddress, "key", index, "value", value, "error", err)
+	log.Trace("GetStorageData ", "address", accountAddress, "rootHash", userAcc.GetRootHash(), "key", index, "value", value, "error", err)
 	return value, err
 }
 

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -32,6 +32,8 @@ type Persister interface {
 type Batcher interface {
 	// Put inserts one entry - key, value pair - into the batch
 	Put(key []byte, val []byte) error
+	// Get returns the value from the batch
+	Get(key []byte) []byte
 	// Delete deletes the batch
 	Delete(key []byte) error
 	// Reset clears the contents of the batch

--- a/storage/leveldb/batch.go
+++ b/storage/leveldb/batch.go
@@ -1,35 +1,60 @@
 package leveldb
 
 import (
+	"sync"
+
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
+const removed = "removed"
+
 type batch struct {
-	batch *leveldb.Batch
+	batch         *leveldb.Batch
+	cachedData    map[string][]byte
+	mutCachedData sync.RWMutex
 }
 
 // NewBatch creates a batch
 func NewBatch() *batch {
 	return &batch{
-		batch: &leveldb.Batch{},
+		batch:         &leveldb.Batch{},
+		cachedData:    make(map[string][]byte),
+		mutCachedData: sync.RWMutex{},
 	}
 }
 
 // Put inserts one entry - key, value pair - into the batch
 func (b *batch) Put(key []byte, val []byte) error {
+	b.mutCachedData.Lock()
 	b.batch.Put(key, val)
+	b.cachedData[string(key)] = val
+	b.mutCachedData.Unlock()
 	return nil
 }
 
 // Delete deletes the entry for the provided key from the batch
 func (b *batch) Delete(key []byte) error {
+	b.mutCachedData.Lock()
 	b.batch.Delete(key)
+	b.cachedData[string(key)] = []byte(removed)
+	b.mutCachedData.Unlock()
 	return nil
 }
 
 // Reset clears the contents of the batch
 func (b *batch) Reset() {
+	b.mutCachedData.Lock()
 	b.batch.Reset()
+	b.cachedData = make(map[string][]byte)
+	b.mutCachedData.Unlock()
+}
+
+// Get returns the value
+func (b *batch) Get(key []byte) []byte {
+	b.mutCachedData.RLock()
+	defer b.mutCachedData.RUnlock()
+
+	return b.cachedData[string(key)]
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/storage/leveldb/batch.go
+++ b/storage/leveldb/batch.go
@@ -9,50 +9,50 @@ import (
 const removed = "removed"
 
 type batch struct {
-	batch         *leveldb.Batch
-	cachedData    map[string][]byte
-	mutCachedData sync.RWMutex
+	batch      *leveldb.Batch
+	cachedData map[string][]byte
+	mutBatch   sync.RWMutex
 }
 
 // NewBatch creates a batch
 func NewBatch() *batch {
 	return &batch{
-		batch:         &leveldb.Batch{},
-		cachedData:    make(map[string][]byte),
-		mutCachedData: sync.RWMutex{},
+		batch:      &leveldb.Batch{},
+		cachedData: make(map[string][]byte),
+		mutBatch:   sync.RWMutex{},
 	}
 }
 
 // Put inserts one entry - key, value pair - into the batch
 func (b *batch) Put(key []byte, val []byte) error {
-	b.mutCachedData.Lock()
+	b.mutBatch.Lock()
 	b.batch.Put(key, val)
 	b.cachedData[string(key)] = val
-	b.mutCachedData.Unlock()
+	b.mutBatch.Unlock()
 	return nil
 }
 
 // Delete deletes the entry for the provided key from the batch
 func (b *batch) Delete(key []byte) error {
-	b.mutCachedData.Lock()
+	b.mutBatch.Lock()
 	b.batch.Delete(key)
 	b.cachedData[string(key)] = []byte(removed)
-	b.mutCachedData.Unlock()
+	b.mutBatch.Unlock()
 	return nil
 }
 
 // Reset clears the contents of the batch
 func (b *batch) Reset() {
-	b.mutCachedData.Lock()
+	b.mutBatch.Lock()
 	b.batch.Reset()
 	b.cachedData = make(map[string][]byte)
-	b.mutCachedData.Unlock()
+	b.mutBatch.Unlock()
 }
 
 // Get returns the value
 func (b *batch) Get(key []byte) []byte {
-	b.mutCachedData.RLock()
-	defer b.mutCachedData.RUnlock()
+	b.mutBatch.RLock()
+	defer b.mutBatch.RUnlock()
 
 	return b.cachedData[string(key)]
 }

--- a/storage/leveldb/leveldb.go
+++ b/storage/leveldb/leveldb.go
@@ -1,12 +1,13 @@
 package leveldb
 
 import (
+	"bytes"
 	"os"
 	"runtime"
 	"sync"
 	"time"
 
-	"github.com/ElrondNetwork/elrond-go-logger"
+	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/opt"
@@ -94,13 +95,7 @@ func (s *DB) batchTimeoutHandle() {
 	}
 }
 
-// Put adds the value to the (key, val) storage medium
-func (s *DB) Put(key, val []byte) error {
-	err := s.batch.Put(key, val)
-	if err != nil {
-		return err
-	}
-
+func (s *DB) updateBatchWithIncrement() error {
 	s.mutBatch.Lock()
 	defer s.mutBatch.Unlock()
 
@@ -109,7 +104,7 @@ func (s *DB) Put(key, val []byte) error {
 		return nil
 	}
 
-	err = s.putBatch(s.batch)
+	err := s.putBatch(s.batch)
 	if err != nil {
 		log.Warn("leveldb putBatch", "error", err.Error())
 		return err
@@ -121,8 +116,26 @@ func (s *DB) Put(key, val []byte) error {
 	return nil
 }
 
+// Put adds the value to the (key, val) storage medium
+func (s *DB) Put(key, val []byte) error {
+	err := s.batch.Put(key, val)
+	if err != nil {
+		return err
+	}
+
+	return s.updateBatchWithIncrement()
+}
+
 // Get returns the value associated to the key
 func (s *DB) Get(key []byte) ([]byte, error) {
+	data := s.batch.Get(key)
+	if data != nil {
+		if bytes.Equal(data, []byte(removed)) {
+			return nil, storage.ErrKeyNotFound
+		}
+		return data, nil
+	}
+
 	data, err := s.db.Get(key, nil)
 	if err == leveldb.ErrNotFound {
 		return nil, storage.ErrKeyNotFound
@@ -134,8 +147,16 @@ func (s *DB) Get(key []byte) ([]byte, error) {
 	return data, nil
 }
 
-// Has returns true if the given key is present in the persistence medium
+// Has returns nil if the given key is present in the persistence medium
 func (s *DB) Has(key []byte) error {
+	data := s.batch.Get(key)
+	if data != nil {
+		if bytes.Equal(data, []byte(removed)) {
+			return storage.ErrKeyNotFound
+		}
+		return nil
+	}
+
 	has, err := s.db.Has(key, nil)
 	if err != nil {
 		return err
@@ -191,7 +212,7 @@ func (s *DB) Remove(key []byte) error {
 	_ = s.batch.Delete(key)
 	s.mutBatch.Unlock()
 
-	return s.db.Delete(key, nil)
+	return s.updateBatchWithIncrement()
 }
 
 // Destroy removes the storage medium stored data

--- a/storage/leveldb/leveldbSerial.go
+++ b/storage/leveldb/leveldbSerial.go
@@ -111,7 +111,9 @@ func (s *SerialDB) Put(key, val []byte) error {
 		return storage.ErrSerialDBIsClosed
 	}
 
+	s.mutBatch.RLock()
 	err := s.batch.Put(key, val)
+	s.mutBatch.RUnlock()
 	if err != nil {
 		return err
 	}
@@ -125,7 +127,10 @@ func (s *SerialDB) Get(key []byte) ([]byte, error) {
 		return nil, storage.ErrSerialDBIsClosed
 	}
 
+	s.mutBatch.RLock()
 	data := s.batch.Get(key)
+	s.mutBatch.RUnlock()
+
 	if data != nil {
 		if bytes.Equal(data, []byte(removed)) {
 			return nil, storage.ErrKeyNotFound
@@ -159,7 +164,10 @@ func (s *SerialDB) Has(key []byte) error {
 		return storage.ErrSerialDBIsClosed
 	}
 
+	s.mutBatch.RLock()
 	data := s.batch.Get(key)
+	s.mutBatch.RUnlock()
+
 	if data != nil {
 		if bytes.Equal(data, []byte(removed)) {
 			return storage.ErrKeyNotFound

--- a/storage/leveldb/leveldbSerial.go
+++ b/storage/leveldb/leveldbSerial.go
@@ -1,6 +1,7 @@
 package leveldb
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"runtime"
@@ -90,19 +91,8 @@ func (s *SerialDB) batchTimeoutHandle(ctx context.Context) {
 	}
 }
 
-// Put adds the value to the (key, val) storage medium
-func (s *SerialDB) Put(key, val []byte) error {
-	if s.isClosed() {
-		return storage.ErrSerialDBIsClosed
-	}
-
+func (s *SerialDB) updateBatchWithIncrement() error {
 	s.mutBatch.Lock()
-	err := s.batch.Put(key, val)
-	if err != nil {
-		s.mutBatch.Unlock()
-		return err
-	}
-
 	s.sizeBatch++
 	if s.sizeBatch < s.maxBatchSize {
 		s.mutBatch.Unlock()
@@ -110,15 +100,37 @@ func (s *SerialDB) Put(key, val []byte) error {
 	}
 	s.mutBatch.Unlock()
 
-	err = s.putBatch()
+	err := s.putBatch()
 
 	return err
+}
+
+// Put adds the value to the (key, val) storage medium
+func (s *SerialDB) Put(key, val []byte) error {
+	if s.isClosed() {
+		return storage.ErrSerialDBIsClosed
+	}
+
+	err := s.batch.Put(key, val)
+	if err != nil {
+		return err
+	}
+
+	return s.updateBatchWithIncrement()
 }
 
 // Get returns the value associated to the key
 func (s *SerialDB) Get(key []byte) ([]byte, error) {
 	if s.isClosed() {
 		return nil, storage.ErrSerialDBIsClosed
+	}
+
+	data := s.batch.Get(key)
+	if data != nil {
+		if bytes.Equal(data, []byte(removed)) {
+			return nil, storage.ErrKeyNotFound
+		}
+		return data, nil
 	}
 
 	ch := make(chan *pairResult)
@@ -141,10 +153,18 @@ func (s *SerialDB) Get(key []byte) ([]byte, error) {
 	return result.value, nil
 }
 
-// Has returns true if the given key is present in the persistence medium
+// Has returns nil if the given key is present in the persistence medium
 func (s *SerialDB) Has(key []byte) error {
 	if s.isClosed() {
 		return storage.ErrSerialDBIsClosed
+	}
+
+	data := s.batch.Get(key)
+	if data != nil {
+		if bytes.Equal(data, []byte(removed)) {
+			return storage.ErrKeyNotFound
+		}
+		return nil
 	}
 
 	ch := make(chan error)
@@ -226,17 +246,7 @@ func (s *SerialDB) Remove(key []byte) error {
 	_ = s.batch.Delete(key)
 	s.mutBatch.Unlock()
 
-	ch := make(chan error)
-	req := &delAct{
-		key:     key,
-		resChan: ch,
-	}
-
-	s.dbAccess <- req
-	result := <-ch
-	close(ch)
-
-	return result
+	return s.updateBatchWithIncrement()
 }
 
 // Destroy removes the storage medium stored data

--- a/storage/leveldb/leveldbSerial_test.go
+++ b/storage/leveldb/leveldbSerial_test.go
@@ -42,8 +42,8 @@ func TestSerialDB_GetErrorAfterPutBeforeTimeout(t *testing.T) {
 	_ = ldb.Put(key, val)
 	v, err := ldb.Get(key)
 
-	assert.Nil(t, v)
-	assert.Equal(t, storage.ErrKeyNotFound, err)
+	assert.Equal(t, val, v)
+	assert.Nil(t, err)
 }
 
 func TestSerialDB_GetErrorOnFail(t *testing.T) {

--- a/storage/leveldb/leveldb_test.go
+++ b/storage/leveldb/leveldb_test.go
@@ -90,8 +90,8 @@ func TestDB_GetErrorAfterPutBeforeTimeout(t *testing.T) {
 	err := ldb.Put(key, val)
 	assert.Nil(t, err)
 	v, err := ldb.Get(key)
-	assert.Nil(t, v)
-	assert.Equal(t, storage.ErrKeyNotFound, err)
+	assert.Equal(t, val, v)
+	assert.Nil(t, err)
 }
 
 func TestDB_GetOKAfterPutWithTimeout(t *testing.T) {

--- a/storage/leveldb/serialActions.go
+++ b/storage/leveldb/serialActions.go
@@ -24,11 +24,6 @@ type getAct struct {
 	resChan chan<- *pairResult
 }
 
-type delAct struct {
-	key     []byte
-	resChan chan<- error
-}
-
 type hasAct struct {
 	key     []byte
 	resChan chan<- error
@@ -51,12 +46,6 @@ func (g *getAct) request(s *SerialDB) {
 		err:   err,
 	}
 	g.resChan <- res
-}
-
-func (d *delAct) request(s *SerialDB) {
-	err := s.db.Delete(d.key, nil)
-
-	d.resChan <- err
 }
 
 func (h *hasAct) request(s *SerialDB) {


### PR DESCRIPTION
added a cache for batched data
Previously get was not possible to return data from batch, now it returns the data from cache.
Also remove had to go directly to disk and it could have been very disk intensive.
It is no longer required to correlate the sizes of cache and batch for storers.