### PR TITLE
bootStrapFrom storage if no shuffle fixed

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -570,7 +570,6 @@ type processComponentsFactoryArgs struct {
 	maxSizeInBytes            uint32
 	maxRating                 uint32
 	validatorPubkeyConverter  state.PubkeyConverter
-	epoch                     uint32
 }
 
 // NewProcessComponentsFactoryArgs initializes the arguments necessary for creating the process components
@@ -605,7 +604,6 @@ func NewProcessComponentsFactoryArgs(
 	maxRating uint32,
 	validatorPubkeyConverter state.PubkeyConverter,
 	ratingsData process.RatingsInfoHandler,
-	epoch uint32,
 ) *processComponentsFactoryArgs {
 	return &processComponentsFactoryArgs{
 		coreComponents:            coreComponents,
@@ -638,7 +636,6 @@ func NewProcessComponentsFactoryArgs(
 		maxSizeInBytes:            maxSizeInBytes,
 		maxRating:                 maxRating,
 		validatorPubkeyConverter:  validatorPubkeyConverter,
-		epoch:                     epoch,
 	}
 }
 
@@ -927,7 +924,7 @@ func newEpochStartTrigger(
 			DataPool:             args.data.Datapool,
 			Storage:              args.data.Store,
 			RequestHandler:       requestHandler,
-			Epoch:                args.epoch,
+			Epoch:                args.startEpochNum,
 			EpochStartNotifier:   args.epochStartNotifier,
 			Validity:             process.MetaBlockValidity,
 			Finality:             process.BlockFinality,
@@ -949,7 +946,7 @@ func newEpochStartTrigger(
 		argEpochStart := &metachainEpochStart.ArgsNewMetaEpochStartTrigger{
 			GenesisTime:        time.Unix(args.nodesConfig.StartTime, 0),
 			Settings:           args.epochStart,
-			Epoch:              args.epoch,
+			Epoch:              args.startEpochNum,
 			EpochStartNotifier: args.epochStartNotifier,
 			Storage:            args.data.Store,
 			Marshalizer:        args.coreData.InternalMarshalizer,

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -1008,7 +1008,6 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		ratingsConfig.General.MaxRating,
 		validatorPubkeyConverter,
 		ratingsData,
-		bootstrapParameters.Epoch,
 	)
 	processComponents, err := factory.ProcessComponentsFactory(processArgs)
 	if err != nil {
@@ -1482,7 +1481,7 @@ func createNodesCoordinator(
 	epochConfig config.EpochStartConfig,
 	currentShardID uint32,
 	chanStopNodeProcess chan endProcess.ArgEndProcess,
-	parameters bootstrap.Parameters,
+	bootstrapParameters bootstrap.Parameters,
 ) (sharding.NodesCoordinator, error) {
 	shardIDAsObserver, err := processDestinationShardAsObserver(prefsConfig)
 	if err != nil {
@@ -1504,9 +1503,9 @@ func createNodesCoordinator(
 		return nil, errWaitingValidators
 	}
 	currentEpoch := uint32(0)
-	if parameters.NodesConfig != nil {
-		nodeRegistry := parameters.NodesConfig
-		currentEpoch = parameters.Epoch
+	if bootstrapParameters.NodesConfig != nil {
+		nodeRegistry := bootstrapParameters.NodesConfig
+		currentEpoch = bootstrapParameters.Epoch
 		eligibles := nodeRegistry.EpochsConfig[fmt.Sprintf("%d", currentEpoch)].EligibleValidators
 		eligibleValidators, err = sharding.SerializableValidatorsToValidators(eligibles)
 		if err != nil {

--- a/epochStart/bootstrap/fromLocalStorage.go
+++ b/epochStart/bootstrap/fromLocalStorage.go
@@ -94,6 +94,7 @@ func (e *epochStartBootstrap) prepareEpochFromStorage() (Parameters, error) {
 			Epoch:       e.baseData.lastEpoch,
 			SelfShardId: e.baseData.shardId,
 			NumOfShards: e.baseData.numberOfShards,
+			NodesConfig: e.nodesConfig,
 		}
 		return parameters, nil
 	}

--- a/sharding/indexHashedNodesCoordinator.go
+++ b/sharding/indexHashedNodesCoordinator.go
@@ -140,7 +140,7 @@ func NewIndexHashedNodesCoordinator(arguments ArgNodesCoordinator) (*indexHashed
 	log.Info("new nodes config is set for epoch", "epoch", arguments.Epoch)
 	currentNodesConfig := ihgs.nodesConfig[arguments.Epoch]
 	if currentNodesConfig == nil {
-		return nil, ErrEpochNodesConfigDoesNotExist
+		return nil, fmt.Errorf("%w epoch=%v", ErrEpochNodesConfigDoesNotExist, arguments.Epoch)
 	}
 
 	displayNodesConfiguration(
@@ -152,7 +152,7 @@ func NewIndexHashedNodesCoordinator(arguments ArgNodesCoordinator) (*indexHashed
 
 	currentConfig := nodesConfig[arguments.Epoch]
 	if currentConfig == nil {
-		return nil, ErrEpochNodesConfigDoesNotExist
+		return nil, fmt.Errorf("%w epoch=%v", ErrEpochNodesConfigDoesNotExist, arguments.Epoch)
 	}
 
 	displayNodesConfiguration(
@@ -309,7 +309,7 @@ func (ihgs *indexHashedNodesCoordinator) ComputeConsensusGroup(
 	ihgs.mutNodesConfig.RUnlock()
 
 	if !ok {
-		return nil, ErrEpochNodesConfigDoesNotExist
+		return nil, fmt.Errorf("%w epoch=%v", ErrEpochNodesConfigDoesNotExist, epoch)
 	}
 
 	key := []byte(fmt.Sprintf(keyFormat, string(randomness), round, shardID, epoch))
@@ -360,7 +360,7 @@ func (ihgs *indexHashedNodesCoordinator) GetValidatorWithPublicKey(
 	ihgs.mutNodesConfig.RUnlock()
 
 	if !ok {
-		return nil, 0, ErrEpochNodesConfigDoesNotExist
+		return nil, 0, fmt.Errorf("%w epoch=%v", ErrEpochNodesConfigDoesNotExist, epoch)
 	}
 
 	nodesConfig.mutNodesMaps.RLock()
@@ -405,7 +405,7 @@ func (ihgs *indexHashedNodesCoordinator) GetAllEligibleValidatorsPublicKeys(epoc
 	ihgs.mutNodesConfig.RUnlock()
 
 	if !ok {
-		return nil, ErrEpochNodesConfigDoesNotExist
+		return nil, fmt.Errorf("%w epoch=%v", ErrEpochNodesConfigDoesNotExist, epoch)
 	}
 
 	nodesConfig.mutNodesMaps.RLock()
@@ -429,7 +429,7 @@ func (ihgs *indexHashedNodesCoordinator) GetAllWaitingValidatorsPublicKeys(epoch
 	ihgs.mutNodesConfig.RUnlock()
 
 	if !ok {
-		return nil, ErrEpochNodesConfigDoesNotExist
+		return nil, fmt.Errorf("%w epoch=%v", ErrEpochNodesConfigDoesNotExist, epoch)
 	}
 
 	nodesConfig.mutNodesMaps.RLock()
@@ -451,7 +451,7 @@ func (ihgs *indexHashedNodesCoordinator) GetAllLeavingValidatorsPublicKeys(epoch
 	ihgs.mutNodesConfig.RUnlock()
 
 	if !ok {
-		return nil, ErrEpochNodesConfigDoesNotExist
+		return nil, fmt.Errorf("%w epoch=%v", ErrEpochNodesConfigDoesNotExist, epoch)
 	}
 
 	nodesConfig.mutNodesMaps.RLock()
@@ -674,7 +674,7 @@ func (ihgs *indexHashedNodesCoordinator) ShardIdForEpoch(epoch uint32) (uint32, 
 	ihgs.mutNodesConfig.RUnlock()
 
 	if !ok {
-		return 0, ErrEpochNodesConfigDoesNotExist
+		return 0, fmt.Errorf("%w epoch=%v", ErrEpochNodesConfigDoesNotExist, epoch)
 	}
 
 	return nodesConfig.shardID, nil

--- a/sharding/indexHashedNodesCoordinator_test.go
+++ b/sharding/indexHashedNodesCoordinator_test.go
@@ -2,6 +2,7 @@ package sharding
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"runtime"
 	"strconv"
@@ -769,7 +770,7 @@ func TestNewIndexHashedNodesCoordinator_GetValidatorWithPublicKeyNotExistingEpoc
 	ihgs, _ := NewIndexHashedNodesCoordinator(arguments)
 
 	_, _, err := ihgs.GetValidatorWithPublicKey(arguments.EligibleNodes[0][0].PubKey(), 1)
-	require.Equal(t, ErrEpochNodesConfigDoesNotExist, err)
+	require.True(t, errors.Is(err, ErrEpochNodesConfigDoesNotExist))
 }
 
 func TestIndexHashedGroupSelector_GetAllEligibleValidatorsPublicKeys(t *testing.T) {
@@ -964,7 +965,7 @@ func TestIndexHashedNodesCoordinator_GetConsensusValidatorsPublicKeysNotExisting
 	var pKeys []string
 	randomness := []byte("randomness")
 	pKeys, err = ihgs.GetConsensusValidatorsPublicKeys(randomness, 0, 0, 1)
-	require.Equal(t, ErrEpochNodesConfigDoesNotExist, err)
+	require.True(t, errors.Is(err, ErrEpochNodesConfigDoesNotExist))
 	require.Nil(t, pKeys)
 }
 
@@ -1063,7 +1064,7 @@ func TestIndexHashedNodesCoordinator_ShardIdForEpochInvalidEpoch(t *testing.T) {
 	require.Nil(t, err)
 
 	shardId, err := ihgs.ShardIdForEpoch(1)
-	require.Equal(t, ErrEpochNodesConfigDoesNotExist, err)
+	require.True(t, errors.Is(err, ErrEpochNodesConfigDoesNotExist))
 	require.Equal(t, uint32(0), shardId)
 }
 


### PR DESCRIPTION
start in epoch with DB without the node shuffled to another shard started with the genesisNodesConfig and couldn't continue

added currentNodesConfig saved in the DB also for the case the node was not shuffled