### PR TITLE
fixed closing the bootstrap storage

### DIFF
--- a/storage/factory/bootstrapDataProvider.go
+++ b/storage/factory/bootstrapDataProvider.go
@@ -34,6 +34,17 @@ func (bdp *bootstrapDataProvider) LoadForPath(
 		return nil, nil, err
 	}
 
+	defer func() {
+		if err != nil {
+			errClose := persister.Close()
+			if errClose != nil {
+				log.Debug("encountered a non-critical error closing bootstrap persister",
+					"error", errClose,
+				)
+			}
+		}
+	}()
+
 	cacher, err := lrucache.NewCache(10)
 	if err != nil {
 		return nil, nil, err

--- a/storage/leveldb/common.go
+++ b/storage/leveldb/common.go
@@ -2,13 +2,43 @@ package leveldb
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 )
 
+const resourceUnavailable = "resource temporarily unavailable"
+const maxRetries = 10
+const timeBetweenRetries = time.Second
+
 func openLevelDB(path string, options *opt.Options) (*leveldb.DB, error) {
+	retries := 0
+	for {
+		db, err := openOneTime(path, options)
+		if err == nil {
+			return db, nil
+		}
+		if err.Error() != resourceUnavailable {
+			return nil, err
+		}
+
+		log.Debug("error opening db",
+			"error", err,
+			"path", path,
+			"retry", retries,
+		)
+
+		time.Sleep(timeBetweenRetries)
+		retries++
+		if retries > maxRetries {
+			return nil, fmt.Errorf("%w, retried %d number of times", err, maxRetries)
+		}
+	}
+}
+
+func openOneTime(path string, options *opt.Options) (*leveldb.DB, error) {
 	db, errOpen := leveldb.OpenFile(path, options)
 	if errOpen == nil {
 		return db, nil

--- a/storage/leveldb/leveldb.go
+++ b/storage/leveldb/leveldb.go
@@ -2,6 +2,7 @@ package leveldb
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"runtime"
 	"sync"
@@ -52,7 +53,7 @@ func NewDB(path string, batchDelaySeconds int, maxBatchSize int, maxOpenFiles in
 
 	db, err := openLevelDB(path, options)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w for path %s", err, path)
 	}
 
 	dbStore := &DB{
@@ -203,7 +204,10 @@ func (s *DB) Close() error {
 	s.sizeBatch = 0
 	s.mutBatch.Unlock()
 
-	s.dbClosed <- struct{}{}
+	select {
+	case s.dbClosed <- struct{}{}:
+	default:
+	}
 
 	return s.db.Close()
 }

--- a/storage/leveldb/leveldbSerial.go
+++ b/storage/leveldb/leveldbSerial.go
@@ -3,6 +3,7 @@ package leveldb
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"runtime"
 	"sync"
@@ -50,7 +51,7 @@ func NewSerialDB(path string, batchDelaySeconds int, maxBatchSize int, maxOpenFi
 
 	db, err := openLevelDB(path, options)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w for path %s", err, path)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/storage/leveldb/leveldb_test.go
+++ b/storage/leveldb/leveldb_test.go
@@ -74,6 +74,28 @@ func TestDB_DoubleOpenShouldError(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestDB_DoubleOpenButClosedInTimeShouldWork(t *testing.T) {
+	dir, _ := ioutil.TempDir("", "leveldb_temp")
+	lvdb1, err := leveldb.NewDB(dir, 10, 1, 10)
+	require.Nil(t, err)
+
+	defer func() {
+		_ = lvdb1.Close()
+		_ = os.RemoveAll(dir)
+	}()
+
+	go func() {
+		time.Sleep(time.Second * 3)
+		_ = lvdb1.Close()
+	}()
+
+	lvdb2, err := leveldb.NewDB(dir, 10, 1, 10)
+	assert.Nil(t, err)
+	assert.NotNil(t, lvdb2)
+
+	_ = lvdb2.Close()
+}
+
 func TestDB_PutNoError(t *testing.T) {
 	key, val := []byte("key"), []byte("value")
 	ldb := createLevelDb(t, 10, 1, 10)


### PR DESCRIPTION
- fixed closing the bootstrap storage if an error occurred when trying to fetch initial data from that storage
- added waiting time and retries when opening a persister. This will prevent returning immediately when encountering the "resource temporarily unavailable" error
- added a fix to the levelDB implementation so close can be called multiple times