### PR TITLE
fixed cleaning of header cache after the block tracker initialization

### DIFF
--- a/dataRetriever/requestHandlers/requestHandler.go
+++ b/dataRetriever/requestHandlers/requestHandler.go
@@ -334,10 +334,10 @@ func (rrh *resolverRequestHandler) RequestTrieNodes(destShardID uint32, hashes [
 	if len(unrequestedHashes) == 0 {
 		return
 	}
-	log.Debug("requesting transactions from network",
+	log.Debug("requesting trie nodes from network",
 		"topic", topic,
 		"shard", destShardID,
-		"num txs", len(unrequestedHashes),
+		"num nodes", len(unrequestedHashes),
 	)
 
 	resolver, err := rrh.resolversFinder.MetaCrossShardResolver(topic, destShardID)
@@ -352,7 +352,7 @@ func (rrh *resolverRequestHandler) RequestTrieNodes(destShardID uint32, hashes [
 
 	trieResolver, ok := resolver.(dataRetriever.TrieNodesResolver)
 	if !ok {
-		log.Warn("wrong assertion type when creating transaction resolver")
+		log.Warn("wrong assertion type when creating a trie nodes resolver")
 		return
 	}
 

--- a/debug/resolver/interceptorResolver.go
+++ b/debug/resolver/interceptorResolver.go
@@ -58,7 +58,7 @@ func (ev *event) String() string {
 }
 
 func displayTime(timestamp int64) string {
-	t := time.Unix(0, timestamp)
+	t := time.Unix(timestamp, 0)
 	return t.Format("2006-01-02 15:04:05.000")
 }
 

--- a/epochStart/bootstrap/process_test.go
+++ b/epochStart/bootstrap/process_test.go
@@ -37,12 +37,19 @@ func createPkBytes(numShards uint32) map[uint32][]byte {
 
 func createMockEpochStartBootstrapArgs() ArgsEpochStartBootstrap {
 	return ArgsEpochStartBootstrap{
-		PublicKey:                  &mock.PublicKeyStub{},
-		Marshalizer:                &mock.MarshalizerMock{},
-		TxSignMarshalizer:          &mock.MarshalizerMock{},
-		Hasher:                     &mock.HasherMock{},
-		Messenger:                  &mock.MessengerStub{},
-		GeneralConfig:              config.Config{},
+		PublicKey:         &mock.PublicKeyStub{},
+		Marshalizer:       &mock.MarshalizerMock{},
+		TxSignMarshalizer: &mock.MarshalizerMock{},
+		Hasher:            &mock.HasherMock{},
+		Messenger:         &mock.MessengerStub{},
+		GeneralConfig: config.Config{
+			WhiteListPool: config.CacheConfig{
+				Type:        "LRU",
+				Size:        10,
+				SizeInBytes: 1000,
+				Shards:      10,
+			},
+		},
 		EconomicsData:              &economics.EconomicsData{},
 		SingleSigner:               &mock.SignerStub{},
 		BlockSingleSigner:          &mock.SignerStub{},

--- a/process/interceptors/processor/miniblockInterceptorProcessor.go
+++ b/process/interceptors/processor/miniblockInterceptorProcessor.go
@@ -80,7 +80,7 @@ func (mip *MiniblockInterceptorProcessor) Save(data process.InterceptedData, _ p
 	}
 
 	if mip.isMbCrossShard(miniblock) && !mip.whiteListHandler.IsWhiteListed(data) {
-		log.Debug(
+		log.Trace(
 			"miniblock interceptor processor : cross shard miniblock for me",
 			"message", "not whitelisted will not be added in pool",
 			"type", miniblock.Type,

--- a/process/sync/baseForkDetector.go
+++ b/process/sync/baseForkDetector.go
@@ -88,7 +88,6 @@ func (bfd *baseForkDetector) removePastOrInvalidRecords() {
 func (bfd *baseForkDetector) checkBlockBasicValidity(
 	header data.HeaderHandler,
 	headerHash []byte,
-	state process.BlockHeaderState,
 ) error {
 
 	if check.IfNil(header) {
@@ -538,12 +537,12 @@ func (bfd *baseForkDetector) shouldSignalFork(
 
 	if lastForkRound != process.MinForkRound {
 		if headerInfo.epoch > lastForkEpoch {
-			log.Debug("shouldSignalFork epoch change false")
+			log.Trace("shouldSignalFork epoch change false")
 			return false
 		}
 
 		if headerInfo.epoch < lastForkEpoch {
-			log.Debug("shouldSignalFork epoch change true")
+			log.Trace("shouldSignalFork epoch change true")
 			return true
 		}
 	}
@@ -655,7 +654,7 @@ func (bfd *baseForkDetector) addHeader(
 	doJobOnBHProcessed func(data.HeaderHandler, []byte, []data.HeaderHandler, [][]byte),
 ) error {
 
-	err := bfd.checkBlockBasicValidity(header, headerHash, state)
+	err := bfd.checkBlockBasicValidity(header, headerHash)
 	if err != nil {
 		return err
 	}

--- a/process/sync/baseForkDetector_test.go
+++ b/process/sync/baseForkDetector_test.go
@@ -85,10 +85,10 @@ func TestBasicForkDetector_CheckBlockValidityShouldErrGenesisTimeMissmatch(t *te
 		genesisTime,
 	)
 
-	err := bfd.CheckBlockValidity(&block.Header{Nonce: 1, Round: round, TimeStamp: incorrectTimeStamp}, []byte("hash"), process.BHProposed)
+	err := bfd.CheckBlockValidity(&block.Header{Nonce: 1, Round: round, TimeStamp: incorrectTimeStamp}, []byte("hash"))
 	assert.Equal(t, sync.ErrGenesisTimeMissmatch, err)
 
-	err = bfd.CheckBlockValidity(&block.Header{Nonce: 1, Round: round, TimeStamp: incorrectTimeStamp}, []byte("hash"), process.BHReceived)
+	err = bfd.CheckBlockValidity(&block.Header{Nonce: 1, Round: round, TimeStamp: incorrectTimeStamp}, []byte("hash"))
 	assert.Equal(t, sync.ErrGenesisTimeMissmatch, err)
 }
 
@@ -103,7 +103,7 @@ func TestBasicForkDetector_CheckBlockValidityShouldErrLowerRoundInBlock(t *testi
 		0,
 	)
 	bfd.SetFinalCheckpoint(1, 1, nil)
-	err := bfd.CheckBlockValidity(&block.Header{PubKeysBitmap: []byte("X")}, []byte("hash"), process.BHProcessed)
+	err := bfd.CheckBlockValidity(&block.Header{PubKeysBitmap: []byte("X")}, []byte("hash"))
 	assert.Equal(t, sync.ErrLowerRoundInBlock, err)
 }
 
@@ -118,7 +118,7 @@ func TestBasicForkDetector_CheckBlockValidityShouldErrLowerNonceInBlock(t *testi
 		0,
 	)
 	bfd.SetFinalCheckpoint(2, 2, nil)
-	err := bfd.CheckBlockValidity(&block.Header{Nonce: 1, Round: 3, PubKeysBitmap: []byte("X")}, []byte("hash"), process.BHProcessed)
+	err := bfd.CheckBlockValidity(&block.Header{Nonce: 1, Round: 3, PubKeysBitmap: []byte("X")}, []byte("hash"))
 	assert.Equal(t, sync.ErrLowerNonceInBlock, err)
 }
 
@@ -132,7 +132,7 @@ func TestBasicForkDetector_CheckBlockValidityShouldErrHigherRoundInBlock(t *test
 		&mock.BlockTrackerMock{},
 		0,
 	)
-	err := bfd.CheckBlockValidity(&block.Header{Nonce: 1, Round: 2, PubKeysBitmap: []byte("X")}, []byte("hash"), process.BHProcessed)
+	err := bfd.CheckBlockValidity(&block.Header{Nonce: 1, Round: 2, PubKeysBitmap: []byte("X")}, []byte("hash"))
 	assert.Equal(t, sync.ErrHigherRoundInBlock, err)
 }
 
@@ -146,7 +146,7 @@ func TestBasicForkDetector_CheckBlockValidityShouldErrHigherNonceInBlock(t *test
 		&mock.BlockTrackerMock{},
 		0,
 	)
-	err := bfd.CheckBlockValidity(&block.Header{Nonce: 2, Round: 1, PubKeysBitmap: []byte("X")}, []byte("hash"), process.BHProcessed)
+	err := bfd.CheckBlockValidity(&block.Header{Nonce: 2, Round: 1, PubKeysBitmap: []byte("X")}, []byte("hash"))
 	assert.Equal(t, sync.ErrHigherNonceInBlock, err)
 }
 
@@ -160,7 +160,7 @@ func TestBasicForkDetector_CheckBlockValidityShouldWork(t *testing.T) {
 		&mock.BlockTrackerMock{},
 		0,
 	)
-	err := bfd.CheckBlockValidity(&block.Header{Nonce: 1, Round: 1, PubKeysBitmap: []byte("X")}, []byte("hash"), process.BHProcessed)
+	err := bfd.CheckBlockValidity(&block.Header{Nonce: 1, Round: 1, PubKeysBitmap: []byte("X")}, []byte("hash"))
 	assert.Nil(t, err)
 }
 

--- a/process/sync/export_test.go
+++ b/process/sync/export_test.go
@@ -67,8 +67,8 @@ func (bfd *baseForkDetector) FinalCheckpointRound() uint64 {
 	return bfd.finalCheckpoint().round
 }
 
-func (bfd *baseForkDetector) CheckBlockValidity(header *block.Header, headerHash []byte, state process.BlockHeaderState) error {
-	return bfd.checkBlockBasicValidity(header, headerHash, state)
+func (bfd *baseForkDetector) CheckBlockValidity(header *block.Header, headerHash []byte) error {
+	return bfd.checkBlockBasicValidity(header, headerHash)
 }
 
 func (bfd *baseForkDetector) RemovePastHeaders() {

--- a/process/track/metaBlockTrack.go
+++ b/process/track/metaBlockTrack.go
@@ -50,6 +50,7 @@ func NewMetaBlockTrack(arguments ArgMetaTracker) (*metaBlockTrack, error) {
 	mbt.blockProcessor = blockProcessorObject
 	mbt.headers = make(map[uint32]map[uint64][]*HeaderInfo)
 	mbt.headersPool.RegisterHandler(mbt.receivedHeader)
+	mbt.headersPool.Clear()
 
 	return &mbt, nil
 }

--- a/process/track/shardBlockTrack.go
+++ b/process/track/shardBlockTrack.go
@@ -51,6 +51,7 @@ func NewShardBlockTrack(arguments ArgShardTracker) (*shardBlockTrack, error) {
 	sbt.blockProcessor = blockProcessorObject
 	sbt.headers = make(map[uint32]map[uint64][]*HeaderInfo)
 	sbt.headersPool.RegisterHandler(sbt.receivedHeader)
+	sbt.headersPool.Clear()
 
 	return &sbt, nil
 }

--- a/sharding/nodesSetup.go
+++ b/sharding/nodesSetup.go
@@ -55,13 +55,12 @@ type NodesSetup struct {
 	MinNodesPerShard   uint32 `json:"minNodesPerShard"`
 	ChainID            string `json:"chainID"`
 
-	MetaChainConsensusGroupSize uint32 `json:"metaChainConsensusGroupSize"`
-	MetaChainMinNodes           uint32 `json:"metaChainMinNodes"`
+	MetaChainConsensusGroupSize uint32  `json:"metaChainConsensusGroupSize"`
+	MetaChainMinNodes           uint32  `json:"metaChainMinNodes"`
+	Hysteresis                  float32 `json:"hysteresis"`
+	Adaptivity                  bool    `json:"adaptivity"`
 
 	InitialNodes []*InitialNode `json:"initialNodes"`
-
-	Hysteresis float32 `json:"hysteresis"`
-	Adaptivity bool    `json:"adaptivity"`
 
 	nrOfShards               uint32
 	nrOfNodes                uint32


### PR DESCRIPTION
- fixed edge case when received metablocks were added in cache before the block tracker initialization leading to perpetual requests of metablocks that were actually long time received
- fixed trie node requester log prints
- fixed the event timestamp in resolver debugger
- changed some log prints into log.Trace
- changed the order of the nodesSetup fields