### PR TITLE
sync should be critical error in bootstrap

### DIFF
--- a/epochStart/bootstrap/epochStartMetaBlockProcessor.go
+++ b/epochStart/bootstrap/epochStartMetaBlockProcessor.go
@@ -20,8 +20,8 @@ import (
 const durationBetweenChecks = 200 * time.Millisecond
 const durationBetweenReRequests = 1 * time.Second
 const durationBetweenCheckingNumConnectedPeers = 500 * time.Millisecond
-const minNumConnectedPeers = 6
-const minNumOfPeersToConsiderBlockValid = 3
+const minNumConnectedPeers = 3
+const minNumOfPeersToConsiderBlockValid = 2
 
 var _ process.InterceptorProcessor = (*epochStartMetaBlockProcessor)(nil)
 

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -2,7 +2,6 @@ package bootstrap
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -311,23 +310,6 @@ func (e *epochStartBootstrap) Bootstrap() (Parameters, error) {
 
 	e.epochStartMeta, err = e.epochStartMetaBlockSyncer.SyncEpochStartMeta(timeToWait)
 	if err != nil {
-		// node should try to start from what he has in DB if not epoch start metablock is received in time
-		if errors.Is(err, epochStart.ErrTimeoutWaitingForMetaBlock) {
-			if !e.baseData.storageExists {
-				// genesis data
-				e.baseData.lastEpoch = 0
-				e.baseData.shardId = e.genesisShardCoordinator.SelfId()
-				e.baseData.numberOfShards = e.genesisShardCoordinator.NumberOfShards()
-			}
-
-			parameters := Parameters{
-				Epoch:       e.baseData.lastEpoch,
-				SelfShardId: e.baseData.shardId,
-				NumOfShards: e.baseData.numberOfShards,
-			}
-			return parameters, nil
-		}
-
 		return Parameters{}, err
 	}
 	log.Debug("start in epoch bootstrap: got epoch start meta header", "epoch", e.epochStartMeta.Epoch, "nonce", e.epochStartMeta.Nonce)


### PR DESCRIPTION
In case of bootstrap if syncing the epoch start metablock returns with any error, this should be treated as critical, node should not start.