### PR TITLE
get rewards txs from pool before commitEpochStart method

### DIFF
--- a/core/indexer/common.go
+++ b/core/indexer/common.go
@@ -140,10 +140,6 @@ func (cm *commonProcessor) buildTransaction(
 	header data.HeaderHandler,
 	txStatus string,
 ) *Transaction {
-	gasPriceBig := big.NewInt(0).SetUint64(tx.GasPrice)
-	gasLimitBig := big.NewInt(0).SetUint64(tx.GasLimit)
-	gasUsed := big.NewInt(0).Mul(gasPriceBig, gasLimitBig).String()
-
 	return &Transaction{
 		Hash:          hex.EncodeToString(txHash),
 		MBHash:        hex.EncodeToString(mbHash),
@@ -160,7 +156,7 @@ func (cm *commonProcessor) buildTransaction(
 		Signature:     hex.EncodeToString(tx.Signature),
 		Timestamp:     time.Duration(header.GetTimeStamp()),
 		Status:        txStatus,
-		GasUsed:       gasUsed,
+		GasUsed:       tx.GasLimit,
 	}
 }
 
@@ -354,17 +350,14 @@ func prepareTxUpdate(tx *Transaction) ([]byte, []byte) {
 		return nil, nil
 	}
 
-	gasPriceBig := big.NewInt(0).SetUint64(tx.GasPrice)
-	gasLimitBig := big.NewInt(0).SetUint64(tx.GasLimit)
-	gas := big.NewInt(0).Mul(gasPriceBig, gasLimitBig).String()
-	if tx.GasUsed == gas {
+	if tx.GasUsed == tx.GasLimit {
 		// do not update gasUsed because it is the same with gasUsed when transaction was saved first time in database
 		serializedData = []byte(fmt.Sprintf(`{ "doc" : { "log" : %s, "scResults" : %s, "status": "%s", "timestamp": %s } }`,
 			string(marshalizedLog), string(scResults), tx.Status, string(marshalizedTimestamp)))
 	} else {
 		// update gasUsed because was changed (is a smart contract operation)
-		serializedData = []byte(fmt.Sprintf(`{ "doc" : { "log" : %s, "scResults" : %s, "status": "%s", "timestamp": %s, "gasUsed" : "%s" } }`,
-			string(marshalizedLog), string(scResults), tx.Status, string(marshalizedTimestamp), tx.GasUsed))
+		serializedData = []byte(fmt.Sprintf(`{ "doc" : { "log" : %s, "scResults" : %s, "status": "%s", "timestamp": %s, "gasUsed" : %s } }`,
+			string(marshalizedLog), string(scResults), tx.Status, string(marshalizedTimestamp), fmt.Sprintf("%d", tx.GasUsed)))
 	}
 
 	return meta, serializedData

--- a/core/indexer/data.go
+++ b/core/indexer/data.go
@@ -21,11 +21,11 @@ type Transaction struct {
 	SenderShard          uint32        `json:"senderShard"`
 	GasPrice             uint64        `json:"gasPrice"`
 	GasLimit             uint64        `json:"gasLimit"`
+	GasUsed              uint64        `json:"gasUsed"`
 	Data                 string        `json:"data"`
 	Signature            string        `json:"signature"`
 	Timestamp            time.Duration `json:"timestamp"`
 	Status               string        `json:"status"`
-	GasUsed              string        `json:"gasUsed"`
 	SmartContractResults []ScResult    `json:"scResults"`
 	Log                  TxLog         `json:"-"`
 }

--- a/core/indexer/elasticsearchDatabase_test.go
+++ b/core/indexer/elasticsearchDatabase_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/data"
 	dataBlock "github.com/ElrondNetwork/elrond-go/data/block"
 	"github.com/ElrondNetwork/elrond-go/data/receipt"
+	"github.com/ElrondNetwork/elrond-go/data/rewardTx"
 	"github.com/ElrondNetwork/elrond-go/data/smartContractResult"
 	"github.com/ElrondNetwork/elrond-go/data/transaction"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
@@ -387,14 +388,14 @@ func TestUpdateTransaction(t *testing.T) {
 
 	txHash1 := []byte("txHash1")
 	tx1 := &transaction.Transaction{
-		GasPrice: 1,
+		GasPrice: 10,
 		GasLimit: 500,
 	}
 	txHash2 := []byte("txHash2")
 	sndAddr := []byte("snd")
 	tx2 := &transaction.Transaction{
-		GasLimit: 1,
-		GasPrice: 500,
+		GasPrice: 10,
+		GasLimit: 500,
 		SndAddr:  sndAddr,
 	}
 	txHash3 := []byte("txHash3")
@@ -420,6 +421,15 @@ func TestUpdateTransaction(t *testing.T) {
 		Value:          big.NewInt(150),
 	}
 
+	rTx1Hash := []byte("rTxHash1")
+	rTx1 := &rewardTx.RewardTx{
+		Round: 1113,
+	}
+	rTx2Hash := []byte("rTxHash2")
+	rTx2 := &rewardTx.RewardTx{
+		Round: 1114,
+	}
+
 	body := &dataBlock.Body{
 		MiniBlocks: []*dataBlock.MiniBlock{
 			{
@@ -429,6 +439,10 @@ func TestUpdateTransaction(t *testing.T) {
 			{
 				TxHashes: [][]byte{txHash3},
 				Type:     dataBlock.TxBlock,
+			},
+			{
+				Type:     dataBlock.RewardsBlock,
+				TxHashes: [][]byte{rTx1Hash, rTx2Hash},
 			},
 			{
 				TxHashes: [][]byte{recHash1},
@@ -446,6 +460,8 @@ func TestUpdateTransaction(t *testing.T) {
 		string(txHash2):  tx2,
 		string(txHash3):  tx3,
 		string(recHash1): rec1,
+		string(rTx1Hash): rTx1,
+		string(rTx2Hash): rTx2,
 	}
 
 	body.MiniBlocks[0].ReceiverShardID = 1

--- a/core/indexer/processTransactions.go
+++ b/core/indexer/processTransactions.go
@@ -69,8 +69,9 @@ func (tdp *txDatabaseProcessor) prepareTransactionsForDatabase(
 		gasUsed := big.NewInt(0).SetUint64(tx.GasPrice)
 		gasUsed.Mul(gasUsed, big.NewInt(0).SetUint64(tx.GasLimit))
 		gasUsed.Sub(gasUsed, rec.Value)
+		gasUsed.Div(gasUsed, big.NewInt(0).SetUint64(tx.GasPrice))
 
-		tx.GasUsed = gasUsed.String()
+		tx.GasUsed = gasUsed.Uint64()
 	}
 
 	countScResults := make(map[string]int)
@@ -116,10 +117,8 @@ func (tdp *txDatabaseProcessor) addScResultInfoInTx(scr *smartContractResult.Sma
 	tx.SmartContractResults = append(tx.SmartContractResults, dbScResult)
 
 	if dbScResult.GasLimit != 0 && dbScResult.Value != "0" {
-		gasUsed := big.NewInt(0).SetUint64(tx.GasPrice)
-		gasUsed.Mul(gasUsed, big.NewInt(0).SetUint64(tx.GasLimit))
-		gasUsed.Sub(gasUsed, scr.Value)
-		tx.GasUsed = gasUsed.String()
+		gasUsed := tx.GasLimit - scr.GasLimit
+		tx.GasUsed = gasUsed
 	}
 
 	return tx

--- a/core/indexer/processTransactions_test.go
+++ b/core/indexer/processTransactions_test.go
@@ -19,9 +19,15 @@ func TestPrepareTransactionsForDatabase(t *testing.T) {
 	t.Parallel()
 
 	txHash1 := []byte("txHash1")
-	tx1 := &transaction.Transaction{}
+	tx1 := &transaction.Transaction{
+		GasLimit: 100,
+		GasPrice: 100,
+	}
 	txHash2 := []byte("txHash2")
-	tx2 := &transaction.Transaction{}
+	tx2 := &transaction.Transaction{
+		GasLimit: 100,
+		GasPrice: 100,
+	}
 	txHash3 := []byte("txHash3")
 	tx3 := &transaction.Transaction{}
 	txHash4 := []byte("txHash4")

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -1003,6 +1003,9 @@ func (mp *metaProcessor) CommitBlock(
 		return err
 	}
 
+	// must be called before commitEpochStart
+	rewardsTxs := mp.getRewardsTxs(header, body)
+
 	mp.commitEpochStart(header, body)
 	headerHash := mp.hasher.Compute(string(marshalizedHeader))
 	mp.saveMetaHeader(header, headerHash, marshalizedHeader)
@@ -1012,8 +1015,6 @@ func (mp *metaProcessor) CommitBlock(
 	if err != nil {
 		return err
 	}
-
-	rewardsTxs := mp.getRewardsTxs(header, body)
 
 	mp.validatorStatisticsProcessor.DisplayRatings(header.GetEpoch())
 


### PR DESCRIPTION
Bug fix : rewards transactions was not indexed anymore because method that gets rewards transactions from pool was called after transactions was removed from pool.
FIX : call the method that reads the transactions before they are removed from the pool

Also the field 'gasUsed' of structure Transaction that is saved in elasticsearch database  is now calculated in gas units. To convert the field 'gasUsed'  in ERD must by multiply with gas price.