### PR TITLE
edgeCaseFix/staking-sc-stake-change-reward-address-stake-unstake

### DIFF
--- a/vm/systemSmartContracts/auction.go
+++ b/vm/systemSmartContracts/auction.go
@@ -711,27 +711,22 @@ func (s *stakingAuctionSC) unStake(args *vmcommon.ContractCallInput) vmcommon.Re
 }
 
 func getBLSPublicKeys(registrationData *AuctionData, args *vmcommon.ContractCallInput) ([][]byte, error) {
-	blsKeys := registrationData.BlsPubKeys
-	if len(args.Arguments) > 0 {
-		for _, argKey := range args.Arguments {
-			found := false
-			for _, blsKey := range blsKeys {
-				if bytes.Equal(argKey, blsKey) {
-					found = true
-					break
-				}
-			}
-
-			if !found {
-				log.Debug("bls key for validator not found")
-				return nil, vm.ErrBLSPublicKeyMissmatch
+	for _, argKey := range args.Arguments {
+		found := false
+		for _, blsKey := range registrationData.BlsPubKeys {
+			if bytes.Equal(argKey, blsKey) {
+				found = true
+				break
 			}
 		}
 
-		blsKeys = args.Arguments
+		if !found {
+			log.Debug("bls key for validator not found")
+			return nil, vm.ErrBLSPublicKeyMissmatch
+		}
 	}
 
-	return blsKeys, nil
+	return args.Arguments, nil
 }
 
 func (s *stakingAuctionSC) unBond(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {

--- a/vm/systemSmartContracts/auction_test.go
+++ b/vm/systemSmartContracts/auction_test.go
@@ -555,6 +555,77 @@ func TestStakingAuctionSC_ExecuteStakeUnStakeOneBlsPubKeyAndRestake(t *testing.T
 	assert.True(t, stakedData.Staked)
 }
 
+func TestStakingAuctionSC_ExecuteStakeChangeRewardAddresStakeUnStake(t *testing.T) {
+	t.Parallel()
+
+	stakerAddress := []byte("staker1")
+	stakerPubKey := []byte("bls1")
+
+	blockChainHook := &mock.BlockChainHookStub{}
+	args := createMockArgumentsForAuction()
+
+	atArgParser := vmcommon.NewAtArgumentParser()
+	eei, _ := NewVMContext(blockChainHook, hooks.NewVMCryptoHook(), atArgParser, &mock.AccountsStub{})
+
+	argsStaking := createMockStakingScArguments()
+	argsStaking.MinStakeValue = args.ValidatorSettings.GenesisNodePrice()
+	argsStaking.Eei = eei
+	argsStaking.UnBondPeriod = args.ValidatorSettings.UnBondPeriod()
+	stakingSC, _ := NewStakingSmartContract(argsStaking)
+
+	eei.SetSCAddress([]byte("addr"))
+	_ = eei.SetSystemSCContainer(&mock.SystemSCContainerStub{GetCalled: func(key []byte) (contract vm.SystemSmartContract, err error) {
+		return stakingSC, nil
+	}})
+
+	args.Eei = eei
+
+	sc, _ := NewStakingAuctionSmartContract(args)
+	arguments := CreateVmContractCallInput()
+	arguments.Function = "stake"
+	arguments.CallerAddr = stakerAddress
+	arguments.Arguments = [][]byte{big.NewInt(1).Bytes(), stakerPubKey, []byte("signed")}
+	arguments.CallValue = big.NewInt(100).Set(args.ValidatorSettings.GenesisNodePrice())
+
+	retCode := sc.Execute(arguments)
+	assert.Equal(t, vmcommon.Ok, retCode)
+
+	rewardAddress := []byte("staker2")
+	arguments.Function = "changeRewardAddress"
+	arguments.Arguments = [][]byte{rewardAddress}
+	arguments.CallValue = big.NewInt(0)
+
+	retCode = sc.Execute(arguments)
+	assert.Equal(t, vmcommon.Ok, retCode)
+
+	blsKey2 := []byte("blsKey2")
+	arguments.Function = "stake"
+	arguments.Arguments = [][]byte{big.NewInt(1).Bytes(), blsKey2, []byte("signed")}
+	arguments.CallValue = big.NewInt(100).Set(args.ValidatorSettings.GenesisNodePrice())
+	retCode = sc.Execute(arguments)
+	assert.Equal(t, vmcommon.Ok, retCode)
+
+	arguments.Function = "unStake"
+	arguments.Arguments = [][]byte{blsKey2}
+	arguments.CallValue = big.NewInt(0)
+
+	retCode = sc.Execute(arguments)
+	assert.Equal(t, vmcommon.Ok, retCode)
+
+	eei.SetSCAddress(args.StakingSCAddress)
+	marshalledData := eei.GetStorage(stakerPubKey)
+	stakedData := &StakedData{}
+	_ = json.Unmarshal(marshalledData, stakedData)
+	assert.True(t, stakedData.Staked)
+	assert.True(t, bytes.Equal(rewardAddress, stakedData.RewardAddress))
+
+	marshalledData = eei.GetStorage(blsKey2)
+	stakedData = &StakedData{}
+	_ = json.Unmarshal(marshalledData, stakedData)
+	assert.False(t, stakedData.Staked)
+	assert.True(t, bytes.Equal(rewardAddress, stakedData.RewardAddress))
+}
+
 func TestStakingAuctionSC_ExecuteStakeUnStakeUnBondBlsPubKeyAndRestake(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
It resolves the following scenario: stake a number of nodes, change reward address. Stake for another set of nodes and unstake.
It is not a critical problem - rigth now in dev a validator after the last new staked node should call a change reward address and unstake only after.