### PR TITLE
carved out tx pool++ (revert pool++limits)

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -220,9 +220,7 @@
 
 [TxDataPool]
     Size = 900000
-    SizePerSender = 1000
     SizeInBytes = 524288000
-    SizeInBytesPerSender = 614400
     Type = "TxCache"
     Shards = 16
 

--- a/config/config.go
+++ b/config/config.go
@@ -2,12 +2,10 @@ package config
 
 // CacheConfig will map the json cache configuration
 type CacheConfig struct {
-	Type                 string `json:"type"`
-	Size                 uint32 `json:"size"`
-	SizePerSender        uint32 `json:"sizePerSender"`
-	SizeInBytes          uint32 `json:"sizeInBytes"`
-	SizeInBytesPerSender uint32 `json:"sizeInBytesPerSender"`
-	Shards               uint32 `json:"shards"`
+	Type        string `json:"type"`
+	Size        uint32 `json:"size"`
+	SizeInBytes uint32 `json:"sizeInBytes"`
+	Shards      uint32 `json:"shards"`
 }
 
 //HeadersPoolConfig will map the headers cache configuration

--- a/dataRetriever/constants.go
+++ b/dataRetriever/constants.go
@@ -2,3 +2,14 @@ package dataRetriever
 
 // TxPoolNumSendersToEvictInOneStep instructs tx pool eviction algorithm to remove this many senders when eviction takes place
 const TxPoolNumSendersToEvictInOneStep = uint32(100)
+
+// TxPoolLargeNumOfTxsForASender instructs tx pool eviction algorithm to tag a sender with more transactions than this value
+// as a "sender with a large number of transactions"
+const TxPoolLargeNumOfTxsForASender = uint32(500)
+
+// TxPoolNumTxsToEvictFromASender instructs tx pool eviction algorithm to remove this many transactions
+// for "a sender with a large number of transactions" when eviction takes place
+const TxPoolNumTxsToEvictFromASender = uint32(100)
+
+// TxPoolMinSizeInBytes is the lower limit of the tx cache / eviction parameter "sizeInBytes"
+const TxPoolMinSizeInBytes = uint32(40960)

--- a/dataRetriever/factory/txpool/txPoolFactory_test.go
+++ b/dataRetriever/factory/txpool/txPoolFactory_test.go
@@ -10,22 +10,22 @@ import (
 
 func Test_CreateNewTxPool_ShardedData(t *testing.T) {
 	config := storageUnit.CacheConfig{Type: storageUnit.FIFOShardedCache, Size: 100, SizeInBytes: 40960, Shards: 1}
-	args := txpool.ArgShardedTxPool{Config: config, MinGasPrice: 200000000000, NumberOfShards: 1}
+	args := txpool.ArgShardedTxPool{Config: config, MinGasPrice: 100000000000000, NumberOfShards: 1}
 
 	txPool, err := CreateTxPool(args)
 	require.Nil(t, err)
 	require.NotNil(t, txPool)
 
 	config = storageUnit.CacheConfig{Type: storageUnit.LRUCache, Size: 100, SizeInBytes: 40960, Shards: 1}
-	args = txpool.ArgShardedTxPool{Config: config, MinGasPrice: 200000000000, NumberOfShards: 1}
+	args = txpool.ArgShardedTxPool{Config: config, MinGasPrice: 100000000000000, NumberOfShards: 1}
 	txPool, err = CreateTxPool(args)
 	require.Nil(t, err)
 	require.NotNil(t, txPool)
 }
 
 func Test_CreateNewTxPool_ShardedTxPool(t *testing.T) {
-	config := storageUnit.CacheConfig{Size: 100, SizePerSender: 1, SizeInBytes: 40960, SizeInBytesPerSender: 40960, Shards: 1}
-	args := txpool.ArgShardedTxPool{Config: config, MinGasPrice: 200000000000, NumberOfShards: 1}
+	config := storageUnit.CacheConfig{Size: 100, SizeInBytes: 40960, Shards: 1}
+	args := txpool.ArgShardedTxPool{Config: config, MinGasPrice: 100000000000000, NumberOfShards: 1}
 
 	txPool, err := CreateTxPool(args)
 	require.Nil(t, err)

--- a/dataRetriever/txpool/argShardedTxPool.go
+++ b/dataRetriever/txpool/argShardedTxPool.go
@@ -18,26 +18,20 @@ type ArgShardedTxPool struct {
 func (args *ArgShardedTxPool) verify() error {
 	config := args.Config
 
-	if config.SizeInBytes == 0 {
-		return fmt.Errorf("%w: config.SizeInBytes is not valid", dataRetriever.ErrCacheConfigInvalidSizeInBytes)
+	if config.SizeInBytes < dataRetriever.TxPoolMinSizeInBytes {
+		return fmt.Errorf("%w: config.SizeInBytes is less than [dataRetriever.TxPoolMinSizeInBytes]", dataRetriever.ErrCacheConfigInvalidSizeInBytes)
 	}
-	if config.SizeInBytesPerSender == 0 {
-		return fmt.Errorf("%w: config.SizeInBytesPerSender is not valid", dataRetriever.ErrCacheConfigInvalidSizeInBytes)
+	if config.Size < 1 {
+		return fmt.Errorf("%w: config.Size is less than 1", dataRetriever.ErrCacheConfigInvalidSize)
 	}
-	if config.Size == 0 {
-		return fmt.Errorf("%w: config.Size is not valid", dataRetriever.ErrCacheConfigInvalidSize)
+	if config.Shards < 1 {
+		return fmt.Errorf("%w: config.Shards (map chunks) is less than 1", dataRetriever.ErrCacheConfigInvalidShards)
 	}
-	if config.SizePerSender == 0 {
-		return fmt.Errorf("%w: config.SizePerSender is not valid", dataRetriever.ErrCacheConfigInvalidSize)
+	if args.MinGasPrice < 1 {
+		return fmt.Errorf("%w: MinGasPrice is less than 1", dataRetriever.ErrCacheConfigInvalidEconomics)
 	}
-	if config.Shards == 0 {
-		return fmt.Errorf("%w: config.Shards (map chunks) is not valid", dataRetriever.ErrCacheConfigInvalidShards)
-	}
-	if args.MinGasPrice == 0 {
-		return fmt.Errorf("%w: MinGasPrice is not valid", dataRetriever.ErrCacheConfigInvalidEconomics)
-	}
-	if args.NumberOfShards == 0 {
-		return fmt.Errorf("%w: NumberOfShards is not valid", dataRetriever.ErrCacheConfigInvalidSharding)
+	if args.NumberOfShards < 1 {
+		return fmt.Errorf("%w: NumberOfShards is less than 1", dataRetriever.ErrCacheConfigInvalidSharding)
 	}
 
 	return nil

--- a/dataRetriever/txpool/shardedTxPool_test.go
+++ b/dataRetriever/txpool/shardedTxPool_test.go
@@ -24,42 +24,28 @@ func Test_NewShardedTxPool(t *testing.T) {
 }
 
 func Test_NewShardedTxPool_WhenBadConfig(t *testing.T) {
-	goodArgs := ArgShardedTxPool{Config: storageUnit.CacheConfig{Size: 100, SizePerSender: 10, SizeInBytes: 409600, SizeInBytesPerSender: 40960, Shards: 16}, MinGasPrice: 200000000000, NumberOfShards: 1}
+	goodArgs := ArgShardedTxPool{Config: storageUnit.CacheConfig{Size: 100, SizeInBytes: 40960, Shards: 16}, MinGasPrice: 100000000000000, NumberOfShards: 1}
 
 	args := goodArgs
-	args.Config.SizeInBytes = 0
+	args.Config = storageUnit.CacheConfig{SizeInBytes: 1}
 	pool, err := NewShardedTxPool(args)
 	require.Nil(t, pool)
 	require.NotNil(t, err)
 	require.Errorf(t, err, dataRetriever.ErrCacheConfigInvalidSizeInBytes.Error())
 
 	args = goodArgs
-	args.Config.SizeInBytesPerSender = 0
-	pool, err = NewShardedTxPool(args)
-	require.Nil(t, pool)
-	require.NotNil(t, err)
-	require.Errorf(t, err, dataRetriever.ErrCacheConfigInvalidSizeInBytes.Error())
-
-	args = goodArgs
-	args.Config.Size = 0
-	pool, err = NewShardedTxPool(args)
-	require.Nil(t, pool)
-	require.NotNil(t, err)
-	require.Errorf(t, err, dataRetriever.ErrCacheConfigInvalidSize.Error())
-
-	args = goodArgs
-	args.Config.SizePerSender = 0
-	pool, err = NewShardedTxPool(args)
-	require.Nil(t, pool)
-	require.NotNil(t, err)
-	require.Errorf(t, err, dataRetriever.ErrCacheConfigInvalidSize.Error())
-
-	args = goodArgs
-	args.Config.Shards = 0
+	args.Config = storageUnit.CacheConfig{SizeInBytes: 40960, Size: 1}
 	pool, err = NewShardedTxPool(args)
 	require.Nil(t, pool)
 	require.NotNil(t, err)
 	require.Errorf(t, err, dataRetriever.ErrCacheConfigInvalidShards.Error())
+
+	args = goodArgs
+	args.Config = storageUnit.CacheConfig{SizeInBytes: 40960, Shards: 1}
+	pool, err = NewShardedTxPool(args)
+	require.Nil(t, pool)
+	require.NotNil(t, err)
+	require.Errorf(t, err, dataRetriever.ErrCacheConfigInvalidSize.Error())
 
 	args = goodArgs
 	args.MinGasPrice = 0
@@ -77,8 +63,8 @@ func Test_NewShardedTxPool_WhenBadConfig(t *testing.T) {
 }
 
 func Test_NewShardedTxPool_ComputesCacheConfig(t *testing.T) {
-	config := storageUnit.CacheConfig{SizeInBytes: 524288000, SizeInBytesPerSender: 614400, Size: 900000, SizePerSender: 1000, Shards: 1}
-	args := ArgShardedTxPool{Config: config, MinGasPrice: 200000000000, NumberOfShards: 5}
+	config := storageUnit.CacheConfig{SizeInBytes: 524288000, Size: 900000, Shards: 1}
+	args := ArgShardedTxPool{Config: config, MinGasPrice: 100000000000000, NumberOfShards: 5}
 
 	poolAsInterface, err := NewShardedTxPool(args)
 	require.Nil(t, err)
@@ -87,11 +73,11 @@ func Test_NewShardedTxPool_ComputesCacheConfig(t *testing.T) {
 
 	require.Equal(t, true, pool.cacheConfigPrototype.EvictionEnabled)
 	require.Equal(t, uint32(58254222), pool.cacheConfigPrototype.NumBytesThreshold)
-	require.Equal(t, uint32(614400), pool.cacheConfigPrototype.NumBytesPerSenderThreshold)
 	require.Equal(t, uint32(100000), pool.cacheConfigPrototype.CountThreshold)
-	require.Equal(t, uint32(1000), pool.cacheConfigPrototype.CountPerSenderThreshold)
 	require.Equal(t, uint32(100), pool.cacheConfigPrototype.NumSendersToEvictInOneStep)
-	require.Equal(t, uint32(200), pool.cacheConfigPrototype.MinGasPriceNanoErd)
+	require.Equal(t, uint32(500), pool.cacheConfigPrototype.LargeNumOfTxsForASender)
+	require.Equal(t, uint32(100), pool.cacheConfigPrototype.NumTxsToEvictFromASender)
+	require.Equal(t, uint32(100), pool.cacheConfigPrototype.MinGasPriceMicroErd)
 	require.Equal(t, uint32(291271110), pool.cacheConfigPrototypeForSelfShard.NumBytesThreshold)
 	require.Equal(t, uint32(500000), pool.cacheConfigPrototypeForSelfShard.CountThreshold)
 }
@@ -175,7 +161,7 @@ func Test_AddData_CallsOnAddedHandlers(t *testing.T) {
 
 	// Second addition is ignored (txhash-based deduplication)
 	pool.AddData([]byte("hash-1"), createTx("alice", 42), "1")
-	pool.AddData([]byte("hash-1"), createTx("alice", 42), "1")
+	pool.AddData([]byte("hash-1"), createTx("whatever", 43), "1")
 
 	waitABit()
 	require.Equal(t, uint32(1), atomic.LoadUint32(&numAdded))
@@ -318,8 +304,8 @@ func Test_NotImplementedFunctions(t *testing.T) {
 }
 
 func Test_routeToCacheUnions(t *testing.T) {
-	config := storageUnit.CacheConfig{Size: 100, SizePerSender: 10, SizeInBytes: 409600, SizeInBytesPerSender: 40960, Shards: 16}
-	args := ArgShardedTxPool{Config: config, MinGasPrice: 200000000000, NumberOfShards: 4, SelfShardID: 42}
+	config := storageUnit.CacheConfig{Size: 100, SizeInBytes: 40960, Shards: 16}
+	args := ArgShardedTxPool{Config: config, MinGasPrice: 100000000000000, NumberOfShards: 4, SelfShardID: 42}
 	poolAsInterface, _ := NewShardedTxPool(args)
 	pool := poolAsInterface.(*shardedTxPool)
 
@@ -333,8 +319,8 @@ func Test_routeToCacheUnions(t *testing.T) {
 }
 
 func Test_getCacheConfig(t *testing.T) {
-	config := storageUnit.CacheConfig{Size: 150, SizePerSender: 1, SizeInBytes: 61440, SizeInBytesPerSender: 40960, Shards: 16}
-	args := ArgShardedTxPool{Config: config, MinGasPrice: 200000000000, NumberOfShards: 8, SelfShardID: 4}
+	config := storageUnit.CacheConfig{Size: 150, SizeInBytes: 61440, Shards: 16}
+	args := ArgShardedTxPool{Config: config, MinGasPrice: 100000000000000, NumberOfShards: 8, SelfShardID: 4}
 	poolAsInterface, _ := NewShardedTxPool(args)
 	pool := poolAsInterface.(*shardedTxPool)
 
@@ -367,7 +353,7 @@ type thisIsNotATransaction struct {
 }
 
 func newTxPoolToTest() (dataRetriever.ShardedDataCacherNotifier, error) {
-	config := storageUnit.CacheConfig{Size: 100, SizePerSender: 10, SizeInBytes: 409600, SizeInBytesPerSender: 40960, Shards: 16}
-	args := ArgShardedTxPool{Config: config, MinGasPrice: 200000000000, NumberOfShards: 4}
+	config := storageUnit.CacheConfig{Size: 100, SizeInBytes: 40960, Shards: 16}
+	args := ArgShardedTxPool{Config: config, MinGasPrice: 100000000000000, NumberOfShards: 4}
 	return NewShardedTxPool(args)
 }

--- a/epochStart/metachain/epochStartData_test.go
+++ b/epochStart/metachain/epochStartData_test.go
@@ -102,13 +102,11 @@ func createTxPool(selfShardID uint32) (dataRetriever.ShardedDataCacherNotifier, 
 	return txpool.NewShardedTxPool(
 		txpool.ArgShardedTxPool{
 			Config: storageUnit.CacheConfig{
-				Size:                 100000,
-				SizePerSender:        1000,
-				SizeInBytes:          1000000000,
-				SizeInBytesPerSender: 10000000,
-				Shards:               16,
+				Size:        100000,
+				SizeInBytes: 1000000000,
+				Shards:      16,
 			},
-			MinGasPrice:    200000000000,
+			MinGasPrice:    100000000000000,
 			NumberOfShards: 1,
 			SelfShardID:    selfShardID,
 		},

--- a/genesis/mock/poolsHolderMock.go
+++ b/genesis/mock/poolsHolderMock.go
@@ -30,13 +30,11 @@ func NewPoolsHolderMock() *PoolsHolderMock {
 	phf.transactions, _ = txpool.NewShardedTxPool(
 		txpool.ArgShardedTxPool{
 			Config: storageUnit.CacheConfig{
-				Size:                 100000,
-				SizePerSender:        1000,
-				SizeInBytes:          1000000000,
-				SizeInBytesPerSender: 10000000,
-				Shards:               16,
+				Size:        10000,
+				SizeInBytes: 1000000000,
+				Shards:      16,
 			},
-			MinGasPrice:    200000000000,
+			MinGasPrice:    100000000000000,
 			NumberOfShards: 1,
 		},
 	)

--- a/integrationTests/consensus/testInitializer.go
+++ b/integrationTests/consensus/testInitializer.go
@@ -163,13 +163,11 @@ func createTestShardDataPool() dataRetriever.PoolsHolder {
 	txPool, _ := txpool.NewShardedTxPool(
 		txpool.ArgShardedTxPool{
 			Config: storageUnit.CacheConfig{
-				Size:                 100000,
-				SizePerSender:        1000,
-				SizeInBytes:          1000000000,
-				SizeInBytesPerSender: 10000000,
-				Shards:               16,
+				Size:        100000,
+				SizeInBytes: 1000000000,
+				Shards:      1,
 			},
-			MinGasPrice:    200000000000,
+			MinGasPrice:    100000000000000,
 			NumberOfShards: 1,
 		},
 	)

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"math/big"
 	"strings"
 	"sync"
@@ -1988,11 +1987,9 @@ func createTxPool(selfShardID uint32) (dataRetriever.ShardedDataCacherNotifier, 
 	return txpool.NewShardedTxPool(
 		txpool.ArgShardedTxPool{
 			Config: storageUnit.CacheConfig{
-				Size:                 100000,
-				SizePerSender:        math.MaxUint32,
-				SizeInBytes:          1000000000,
-				SizeInBytesPerSender: math.MaxUint32,
-				Shards:               16,
+				Size:        100000,
+				SizeInBytes: 1000000000,
+				Shards:      16,
 			},
 			MinGasPrice:    200000000000,
 			NumberOfShards: 1,

--- a/process/block/preprocess/transactions_test.go
+++ b/process/block/preprocess/transactions_test.go
@@ -1057,13 +1057,11 @@ func createTxPool() (dataRetriever.ShardedDataCacherNotifier, error) {
 	return txpool.NewShardedTxPool(
 		txpool.ArgShardedTxPool{
 			Config: storageUnit.CacheConfig{
-				Size:                 100000,
-				SizePerSender:        1000,
-				SizeInBytes:          1000000000,
-				SizeInBytesPerSender: 10000000,
-				Shards:               16,
+				Size:        100000,
+				SizeInBytes: 1000000000,
+				Shards:      1,
 			},
-			MinGasPrice:    200000000000,
+			MinGasPrice:    100000000000000,
 			NumberOfShards: 1,
 		},
 	)

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -49,13 +49,11 @@ func createTestShardDataPool() dataRetriever.PoolsHolder {
 	txPool, _ := txpool.NewShardedTxPool(
 		txpool.ArgShardedTxPool{
 			Config: storageUnit.CacheConfig{
-				Size:                 100000,
-				SizePerSender:        1000,
-				SizeInBytes:          1000000000,
-				SizeInBytesPerSender: 10000000,
-				Shards:               16,
+				Size:        100000,
+				SizeInBytes: 1000000000,
+				Shards:      1,
 			},
-			MinGasPrice:    200000000000,
+			MinGasPrice:    100000000000000,
 			NumberOfShards: 1,
 		},
 	)

--- a/process/coordinator/process_test.go
+++ b/process/coordinator/process_test.go
@@ -2541,13 +2541,11 @@ func createTxPool() (dataRetriever.ShardedDataCacherNotifier, error) {
 	return txpool.NewShardedTxPool(
 		txpool.ArgShardedTxPool{
 			Config: storageUnit.CacheConfig{
-				Size:                 100000,
-				SizePerSender:        1000,
-				SizeInBytes:          1000000000,
-				SizeInBytesPerSender: 10000000,
-				Shards:               16,
+				Size:        100000,
+				SizeInBytes: 1000000000,
+				Shards:      1,
 			},
-			MinGasPrice:    200000000000,
+			MinGasPrice:    100000000000000,
 			NumberOfShards: 1,
 		},
 	)

--- a/process/mock/poolsHolderMock.go
+++ b/process/mock/poolsHolderMock.go
@@ -30,13 +30,11 @@ func NewPoolsHolderMock() *PoolsHolderMock {
 	phf.transactions, _ = txpool.NewShardedTxPool(
 		txpool.ArgShardedTxPool{
 			Config: storageUnit.CacheConfig{
-				Size:                 100000,
-				SizePerSender:        1000,
-				SizeInBytes:          1000000000,
-				SizeInBytesPerSender: 10000000,
-				Shards:               16,
+				Size:        10000,
+				SizeInBytes: 1000000000,
+				Shards:      16,
 			},
-			MinGasPrice:    200000000000,
+			MinGasPrice:    100000000000000,
 			NumberOfShards: 1,
 		},
 	)

--- a/storage/factory/common.go
+++ b/storage/factory/common.go
@@ -13,12 +13,10 @@ const allFiles = -1
 // GetCacherFromConfig will return the cache config needed for storage unit from a config came from the toml file
 func GetCacherFromConfig(cfg config.CacheConfig) storageUnit.CacheConfig {
 	return storageUnit.CacheConfig{
-		Size:                 cfg.Size,
-		SizePerSender:        cfg.SizePerSender,
-		SizeInBytes:          cfg.SizeInBytes,
-		SizeInBytesPerSender: cfg.SizeInBytesPerSender,
-		Type:                 storageUnit.CacheType(cfg.Type),
-		Shards:               cfg.Shards,
+		Size:        cfg.Size,
+		SizeInBytes: cfg.SizeInBytes,
+		Type:        storageUnit.CacheType(cfg.Type),
+		Shards:      cfg.Shards,
 	}
 }
 

--- a/storage/storageUnit/storageunit.go
+++ b/storage/storageUnit/storageunit.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/hashing"
@@ -67,12 +67,10 @@ type UnitConfig struct {
 
 // CacheConfig holds the configurable elements of a cache
 type CacheConfig struct {
-	Type                 CacheType
-	SizeInBytes          uint32
-	SizeInBytesPerSender uint32
-	Size                 uint32
-	SizePerSender        uint32
-	Shards               uint32
+	Type        CacheType
+	SizeInBytes uint32
+	Size        uint32
+	Shards      uint32
 }
 
 // DBConfig holds the configurable elements of a database

--- a/storage/txcache/config.go
+++ b/storage/txcache/config.go
@@ -1,49 +1,14 @@
 package txcache
 
-import "fmt"
-
 // CacheConfig holds cache configuration
 type CacheConfig struct {
 	Name                       string
 	NumChunksHint              uint32
 	EvictionEnabled            bool
 	NumBytesThreshold          uint32
-	NumBytesPerSenderThreshold uint32
 	CountThreshold             uint32
-	CountPerSenderThreshold    uint32
 	NumSendersToEvictInOneStep uint32
-	MinGasPriceNanoErd         uint32
-}
-
-func (config *CacheConfig) verify() error {
-	if len(config.Name) == 0 {
-		return fmt.Errorf("%w: config.Name is invalid", errInvalidCacheConfig)
-	}
-	if config.NumChunksHint == 0 {
-		return fmt.Errorf("%w: config.NumChunksHint is invalid", errInvalidCacheConfig)
-	}
-	if config.NumBytesPerSenderThreshold == 0 {
-		return fmt.Errorf("%w: config.NumBytesPerSenderThreshold is invalid", errInvalidCacheConfig)
-	}
-	if config.CountPerSenderThreshold == 0 {
-		return fmt.Errorf("%w: config.CountPerSenderThreshold is invalid", errInvalidCacheConfig)
-	}
-	if config.MinGasPriceNanoErd == 0 {
-		return fmt.Errorf("%w: config.MinGasPriceNanoErd is invalid", errInvalidCacheConfig)
-	}
-	if config.EvictionEnabled {
-		if config.NumBytesThreshold == 0 {
-			return fmt.Errorf("%w: config.NumBytesThreshold is invalid", errInvalidCacheConfig)
-		}
-
-		if config.CountThreshold == 0 {
-			return fmt.Errorf("%w: config.CountThreshold is invalid", errInvalidCacheConfig)
-		}
-
-		if config.NumSendersToEvictInOneStep == 0 {
-			return fmt.Errorf("%w: config.NumSendersToEvictInOneStep is invalid", errInvalidCacheConfig)
-		}
-	}
-
-	return nil
+	LargeNumOfTxsForASender    uint32
+	NumTxsToEvictFromASender   uint32
+	MinGasPriceMicroErd        uint32
 }

--- a/storage/txcache/disabledCache.go
+++ b/storage/txcache/disabledCache.go
@@ -1,11 +1,5 @@
 package txcache
 
-import (
-	"github.com/ElrondNetwork/elrond-go/storage"
-)
-
-var _ storage.Cacher = (*DisabledCache)(nil)
-
 // DisabledCache represents a disabled cache
 type DisabledCache struct {
 }
@@ -86,10 +80,10 @@ func (cache *DisabledCache) Remove(key []byte) {
 func (cache *DisabledCache) RemoveOldest() {
 }
 
-// Keys returns an empty slice
-func (cache *DisabledCache) Keys() txHashes {
-	return make([][]byte, 0)
-}
+//// Keys returns an empty slice
+//func (cache *DisabledCache) Keys() txHashes {
+//	return make([][]byte, 0)
+//}
 
 // MaxSize returns zero
 func (cache *DisabledCache) MaxSize() int {

--- a/storage/txcache/disabledCache_test.go
+++ b/storage/txcache/disabledCache_test.go
@@ -54,9 +54,6 @@ func TestDisabledCache_DoesNothing(t *testing.T) {
 	cache.Remove([]byte{})
 	cache.RemoveOldest()
 
-	keys := cache.Keys()
-	require.Equal(t, 0, len(keys))
-
 	maxSize := cache.MaxSize()
 	require.Equal(t, 0, maxSize)
 

--- a/storage/txcache/errors.go
+++ b/storage/txcache/errors.go
@@ -2,7 +2,8 @@ package txcache
 
 import "fmt"
 
-var errTxNotFound = fmt.Errorf("tx not found in cache")
-var errMapsSyncInconsistency = fmt.Errorf("maps sync inconsistency between 'txByHash' and 'txListBySender'")
-var errTxDuplicated = fmt.Errorf("duplicated tx")
-var errInvalidCacheConfig = fmt.Errorf("invalid cache config")
+// ErrTxNotFound signals that the transactions was not found in the cache
+var ErrTxNotFound = fmt.Errorf("tx not found in cache")
+
+// ErrMapsSyncInconsistency signals that there's an inconsistency between the internal maps on which the cache relies
+var ErrMapsSyncInconsistency = fmt.Errorf("maps sync inconsistency between 'txByHash' and 'txListBySender'")

--- a/storage/txcache/eviction.go
+++ b/storage/txcache/eviction.go
@@ -11,7 +11,12 @@ func (cache *TxCache) doEviction() {
 		return
 	}
 
-	if !cache.isCapacityExceeded() {
+	tooManyBytes := cache.areThereTooManyBytes()
+	tooManyTxs := cache.areThereTooManyTxs()
+	tooManySenders := cache.areThereTooManySenders()
+
+	isCapacityExceeded := tooManyBytes || tooManyTxs || tooManySenders
+	if !isCapacityExceeded {
 		return
 	}
 
@@ -25,9 +30,15 @@ func (cache *TxCache) doEviction() {
 
 	stopWatch := cache.monitorEvictionStart()
 
-	if cache.isCapacityExceeded() {
+	if tooManyTxs {
 		cache.makeSnapshotOfSenders()
-		journal.passOneNumSteps, journal.passOneNumTxs, journal.passOneNumSenders = cache.evictSendersInLoop()
+		journal.passOneNumTxs, journal.passOneNumSenders = cache.evictHighNonceTransactions()
+		journal.evictionPerformed = true
+	}
+
+	if cache.shouldContinueEvictingSenders() {
+		cache.makeSnapshotOfSenders()
+		journal.passTwoNumSteps, journal.passTwoNumTxs, journal.passTwoNumSenders = cache.evictSendersInLoop()
 		journal.evictionPerformed = true
 	}
 
@@ -42,10 +53,6 @@ func (cache *TxCache) makeSnapshotOfSenders() {
 
 func (cache *TxCache) destroySnapshotOfSenders() {
 	cache.evictionSnapshotOfSenders = nil
-}
-
-func (cache *TxCache) isCapacityExceeded() bool {
-	return cache.areThereTooManyBytes() || cache.areThereTooManySenders() || cache.areThereTooManyTxs()
 }
 
 func (cache *TxCache) areThereTooManyBytes() bool {
@@ -66,15 +73,53 @@ func (cache *TxCache) areThereTooManyTxs() bool {
 	return tooManyTxs
 }
 
+func (cache *TxCache) shouldContinueEvictingSenders() bool {
+	return cache.areThereTooManyTxs() || cache.areThereTooManySenders() || cache.areThereTooManyBytes()
+}
+
+// evictHighNonceTransactions removes transactions from the cache
+// For senders with many transactions (> "LargeNumOfTxsForASender"), evict "NumTxsToEvictFromASender" transactions
+// Also makes sure that there's no sender with 0 transactions
+func (cache *TxCache) evictHighNonceTransactions() (uint32, uint32) {
+	threshold := cache.config.LargeNumOfTxsForASender
+	numTxsToEvict := cache.config.NumTxsToEvictFromASender
+
+	// Heuristics: estimate that ~10% of senders have more transactions than the threshold
+	sendersToEvictInitialCapacity := len(cache.evictionSnapshotOfSenders)/10 + 1
+	txsToEvictInitialCapacity := sendersToEvictInitialCapacity * int(numTxsToEvict)
+
+	sendersToEvict := make([]string, 0, sendersToEvictInitialCapacity)
+	txsToEvict := make([][]byte, 0, txsToEvictInitialCapacity)
+
+	for _, txList := range cache.evictionSnapshotOfSenders {
+		if txList.HasMoreThan(threshold) {
+			txsToEvictForSender := txList.RemoveHighNonceTxs(numTxsToEvict)
+			txsToEvict = append(txsToEvict, txsToEvictForSender...)
+		}
+
+		if txList.IsEmpty() {
+			sendersToEvict = append(sendersToEvict, txList.sender)
+		}
+	}
+
+	// Note that, at this very moment, high nonce transactions have been evicted from senders' lists,
+	// but not yet from the map of transactions.
+	//
+	// This may cause slight inconsistencies, such as:
+	// - if a tx previously (recently) removed from the sender's list ("RemoveHighNonceTxs") arrives again at the pool,
+	// before the execution of "doEvictItems", the tx will be ignored as it still exists (for a short time) in the map of transactions.
+	return cache.doEvictItems(txsToEvict, sendersToEvict)
+}
+
 // This is called concurrently by two goroutines: the eviction one and the sweeping one
-func (cache *TxCache) doEvictItems(txsToEvict txHashes, sendersToEvict []string) (countTxs uint32, countSenders uint32) {
+func (cache *TxCache) doEvictItems(txsToEvict [][]byte, sendersToEvict []string) (countTxs uint32, countSenders uint32) {
 	countTxs = cache.txByHash.RemoveTxsBulk(txsToEvict)
 	countSenders = cache.txListBySender.RemoveSendersBulk(sendersToEvict)
 	return
 }
 
 func (cache *TxCache) evictSendersInLoop() (uint32, uint32, uint32) {
-	return cache.evictSendersWhile(cache.isCapacityExceeded)
+	return cache.evictSendersWhile(cache.shouldContinueEvictingSenders)
 }
 
 // evictSendersWhileTooManyTxs removes transactions in a loop, as long as "shouldContinue" is true
@@ -116,7 +161,7 @@ func (cache *TxCache) evictSendersWhile(shouldContinue func() bool) (step uint32
 // This is called concurrently by two goroutines: the eviction one and the sweeping one
 func (cache *TxCache) evictSendersAndTheirTxs(listsToEvict []*txListForSender) (uint32, uint32) {
 	sendersToEvict := make([]string, 0, len(listsToEvict))
-	txsToEvict := make(txHashes, 0, approximatelyCountTxInLists(listsToEvict))
+	txsToEvict := make([][]byte, 0, approximatelyCountTxInLists(listsToEvict))
 
 	for _, txList := range listsToEvict {
 		sendersToEvict = append(sendersToEvict, txList.sender)

--- a/storage/txcache/eviction_test.go
+++ b/storage/txcache/eviction_test.go
@@ -9,21 +9,71 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEviction_EvictSendersWhileTooManyTxs(t *testing.T) {
+func TestEviction_EvictHighNonceTransactions(t *testing.T) {
 	config := CacheConfig{
-		Name:                       "untitled",
-		NumChunksHint:              16,
-		CountThreshold:             100,
-		CountPerSenderThreshold:    math.MaxUint32,
-		NumSendersToEvictInOneStep: 20,
-		NumBytesThreshold:          math.MaxUint32,
-		NumBytesPerSenderThreshold: math.MaxUint32,
-		MinGasPriceNanoErd:         100,
+		NumChunksHint:            16,
+		CountThreshold:           400,
+		LargeNumOfTxsForASender:  50,
+		NumTxsToEvictFromASender: 25,
+		MinGasPriceMicroErd:      100,
 	}
 
-	cache, err := NewTxCache(config)
-	require.Nil(t, err)
-	require.NotNil(t, cache)
+	cache := NewTxCache(config)
+
+	for index := 0; index < 200; index++ {
+		cache.AddTx(createTx([]byte{'a', byte(index)}, "alice", uint64(index)))
+	}
+
+	for index := 0; index < 200; index++ {
+		cache.AddTx(createTx([]byte{'b', byte(index)}, "bob", uint64(index)))
+	}
+
+	cache.AddTx(createTx([]byte("hash-carol"), "carol", uint64(1)))
+
+	require.Equal(t, int64(3), cache.txListBySender.counter.Get())
+	require.Equal(t, int64(401), cache.txByHash.counter.Get())
+
+	cache.makeSnapshotOfSenders()
+	nTxs, nSenders := cache.evictHighNonceTransactions()
+
+	require.Equal(t, uint32(50), nTxs)
+	require.Equal(t, uint32(0), nSenders)
+	require.Equal(t, int64(3), cache.txListBySender.counter.Get())
+	require.Equal(t, int64(351), cache.txByHash.counter.Get())
+}
+
+func TestEviction_EvictHighNonceTransactions_CoverEmptiedSenderList(t *testing.T) {
+	config := CacheConfig{
+		NumChunksHint:            1,
+		CountThreshold:           0,
+		LargeNumOfTxsForASender:  0,
+		NumTxsToEvictFromASender: 1,
+		MinGasPriceMicroErd:      100,
+	}
+
+	cache := NewTxCache(config)
+	cache.AddTx(createTx([]byte("hash-alice"), "alice", uint64(1)))
+	require.Equal(t, int64(1), cache.CountSenders())
+
+	cache.makeSnapshotOfSenders()
+
+	// Alice is also removed from the map of senders, since it has no transaction left
+	nTxs, nSenders := cache.evictHighNonceTransactions()
+	require.Equal(t, uint32(1), nTxs)
+	require.Equal(t, uint32(1), nSenders)
+	require.Equal(t, int64(0), cache.CountSenders())
+}
+
+func TestEviction_EvictSendersWhileTooManyTxs(t *testing.T) {
+	config := CacheConfig{
+		NumChunksHint:              16,
+		CountThreshold:             100,
+		NumSendersToEvictInOneStep: 20,
+		NumBytesThreshold:          math.MaxUint32,
+		MinGasPriceMicroErd:        100,
+	}
+
+	cache := NewTxCache(config)
 
 	// 200 senders, each with 1 transaction
 	for index := 0; index < 200; index++ {
@@ -48,24 +98,19 @@ func TestEviction_EvictSendersWhileTooManyBytes(t *testing.T) {
 	numBytesPerTx := uint32(1000)
 
 	config := CacheConfig{
-		Name:                       "untitled",
 		NumChunksHint:              16,
 		CountThreshold:             math.MaxUint32,
-		CountPerSenderThreshold:    math.MaxUint32,
 		NumBytesThreshold:          numBytesPerTx * 100,
-		NumBytesPerSenderThreshold: math.MaxUint32,
 		NumSendersToEvictInOneStep: 20,
-		MinGasPriceNanoErd:         100,
+		MinGasPriceMicroErd:        100,
 	}
 
-	cache, err := NewTxCache(config)
-	require.Nil(t, err)
-	require.NotNil(t, cache)
+	cache := NewTxCache(config)
 
 	// 200 senders, each with 1 transaction
 	for index := 0; index < 200; index++ {
 		sender := string(createFakeSenderAddress(index))
-		cache.AddTx(createTxWithParams([]byte{byte(index)}, sender, uint64(1), uint64(numBytesPerTx), 10000, 100*oneBillion))
+		cache.AddTx(createTxWithParams([]byte{byte(index)}, sender, uint64(1), uint64(numBytesPerTx), 10000, 100*oneTrilion))
 	}
 
 	require.Equal(t, int64(200), cache.txListBySender.counter.Get())
@@ -83,28 +128,24 @@ func TestEviction_EvictSendersWhileTooManyBytes(t *testing.T) {
 
 func TestEviction_DoEvictionDoneInPassTwo_BecauseOfCount(t *testing.T) {
 	config := CacheConfig{
-		Name:                       "untitled",
 		NumChunksHint:              16,
 		NumBytesThreshold:          math.MaxUint32,
-		NumBytesPerSenderThreshold: math.MaxUint32,
 		CountThreshold:             2,
-		CountPerSenderThreshold:    math.MaxUint32,
 		NumSendersToEvictInOneStep: 2,
-		MinGasPriceNanoErd:         100,
+		MinGasPriceMicroErd:        100,
 	}
 
-	cache, err := NewTxCache(config)
-	require.Nil(t, err)
-	require.NotNil(t, cache)
-
-	cache.AddTx(createTxWithParams([]byte("hash-alice"), "alice", uint64(1), 1000, 100000, 100*oneBillion))
-	cache.AddTx(createTxWithParams([]byte("hash-bob"), "bob", uint64(1), 1000, 100000, 100*oneBillion))
-	cache.AddTx(createTxWithParams([]byte("hash-carol"), "carol", uint64(1), 1000, 100000, 700*oneBillion))
+	cache := NewTxCache(config)
+	cache.AddTx(createTxWithParams([]byte("hash-alice"), "alice", uint64(1), 1000, 100000, 100*oneTrilion))
+	cache.AddTx(createTxWithParams([]byte("hash-bob"), "bob", uint64(1), 1000, 100000, 100*oneTrilion))
+	cache.AddTx(createTxWithParams([]byte("hash-carol"), "carol", uint64(1), 1000, 100000, 700*oneTrilion))
 
 	cache.doEviction()
-	require.Equal(t, uint32(2), cache.evictionJournal.passOneNumTxs)
-	require.Equal(t, uint32(2), cache.evictionJournal.passOneNumSenders)
-	require.Equal(t, uint32(1), cache.evictionJournal.passOneNumSteps)
+	require.Equal(t, uint32(0), cache.evictionJournal.passOneNumTxs)
+	require.Equal(t, uint32(0), cache.evictionJournal.passOneNumSenders)
+	require.Equal(t, uint32(2), cache.evictionJournal.passTwoNumTxs)
+	require.Equal(t, uint32(2), cache.evictionJournal.passTwoNumSenders)
+	require.Equal(t, uint32(1), cache.evictionJournal.passTwoNumSteps)
 
 	// Alice and Bob evicted. Carol still there.
 	_, ok := cache.GetByTxHash([]byte("hash-carol"))
@@ -115,32 +156,28 @@ func TestEviction_DoEvictionDoneInPassTwo_BecauseOfCount(t *testing.T) {
 
 func TestEviction_DoEvictionDoneInPassTwo_BecauseOfSize(t *testing.T) {
 	config := CacheConfig{
-		Name:                       "untitled",
 		NumChunksHint:              16,
 		CountThreshold:             math.MaxUint32,
-		CountPerSenderThreshold:    math.MaxUint32,
 		NumBytesThreshold:          1000,
-		NumBytesPerSenderThreshold: math.MaxUint32,
 		NumSendersToEvictInOneStep: 2,
-		MinGasPriceNanoErd:         100,
+		MinGasPriceMicroErd:        100,
 	}
 
-	cache, err := NewTxCache(config)
-	require.Nil(t, err)
-	require.NotNil(t, cache)
-
-	cache.AddTx(createTxWithParams([]byte("hash-alice"), "alice", uint64(1), 800, 100000, 100*oneBillion))
-	cache.AddTx(createTxWithParams([]byte("hash-bob"), "bob", uint64(1), 500, 100000, 100*oneBillion))
-	cache.AddTx(createTxWithParams([]byte("hash-carol"), "carol", uint64(1), 200, 100000, 700*oneBillion))
+	cache := NewTxCache(config)
+	cache.AddTx(createTxWithParams([]byte("hash-alice"), "alice", uint64(1), 800, 100000, 100*oneTrilion))
+	cache.AddTx(createTxWithParams([]byte("hash-bob"), "bob", uint64(1), 500, 100000, 100*oneTrilion))
+	cache.AddTx(createTxWithParams([]byte("hash-carol"), "carol", uint64(1), 200, 100000, 700*oneTrilion))
 
 	require.InDelta(t, float64(19.50394606), cache.getRawScoreOfSender("alice"), delta)
 	require.InDelta(t, float64(23.68494667), cache.getRawScoreOfSender("bob"), delta)
 	require.InDelta(t, float64(100), cache.getRawScoreOfSender("carol"), delta)
 
 	cache.doEviction()
-	require.Equal(t, uint32(2), cache.evictionJournal.passOneNumTxs)
-	require.Equal(t, uint32(2), cache.evictionJournal.passOneNumSenders)
-	require.Equal(t, uint32(1), cache.evictionJournal.passOneNumSteps)
+	require.Equal(t, uint32(0), cache.evictionJournal.passOneNumTxs)
+	require.Equal(t, uint32(0), cache.evictionJournal.passOneNumSenders)
+	require.Equal(t, uint32(2), cache.evictionJournal.passTwoNumTxs)
+	require.Equal(t, uint32(2), cache.evictionJournal.passTwoNumSenders)
+	require.Equal(t, uint32(1), cache.evictionJournal.passTwoNumSteps)
 
 	// Alice and Bob evicted (lower score). Carol still there.
 	_, ok := cache.GetByTxHash([]byte("hash-carol"))
@@ -151,19 +188,12 @@ func TestEviction_DoEvictionDoneInPassTwo_BecauseOfSize(t *testing.T) {
 
 func TestEviction_doEvictionDoesNothingWhenAlreadyInProgress(t *testing.T) {
 	config := CacheConfig{
-		Name:                       "untitled",
 		NumChunksHint:              1,
 		CountThreshold:             0,
 		NumSendersToEvictInOneStep: 1,
-		NumBytesPerSenderThreshold: math.MaxUint32,
-		CountPerSenderThreshold:    math.MaxUint32,
-		MinGasPriceNanoErd:         100,
 	}
 
-	cache, err := NewTxCache(config)
-	require.Nil(t, err)
-	require.NotNil(t, cache)
-
+	cache := NewTxCache(config)
 	cache.AddTx(createTx([]byte("hash-alice"), "alice", uint64(1)))
 
 	cache.isEvictionInProgress.Set()
@@ -174,19 +204,12 @@ func TestEviction_doEvictionDoesNothingWhenAlreadyInProgress(t *testing.T) {
 
 func TestEviction_evictSendersInLoop_CoverLoopBreak_WhenSmallBatch(t *testing.T) {
 	config := CacheConfig{
-		Name:                       "untitled",
 		NumChunksHint:              1,
 		CountThreshold:             0,
 		NumSendersToEvictInOneStep: 42,
-		NumBytesPerSenderThreshold: math.MaxUint32,
-		CountPerSenderThreshold:    math.MaxUint32,
-		MinGasPriceNanoErd:         100,
 	}
 
-	cache, err := NewTxCache(config)
-	require.Nil(t, err)
-	require.NotNil(t, cache)
-
+	cache := NewTxCache(config)
 	cache.AddTx(createTx([]byte("hash-alice"), "alice", uint64(1)))
 
 	cache.makeSnapshotOfSenders()
@@ -199,19 +222,12 @@ func TestEviction_evictSendersInLoop_CoverLoopBreak_WhenSmallBatch(t *testing.T)
 
 func TestEviction_evictSendersWhile_ShouldContinueBreak(t *testing.T) {
 	config := CacheConfig{
-		Name:                       "untitled",
 		NumChunksHint:              1,
 		CountThreshold:             0,
 		NumSendersToEvictInOneStep: 1,
-		NumBytesPerSenderThreshold: math.MaxUint32,
-		CountPerSenderThreshold:    math.MaxUint32,
-		MinGasPriceNanoErd:         100,
 	}
 
-	cache, err := NewTxCache(config)
-	require.Nil(t, err)
-	require.NotNil(t, cache)
-
+	cache := NewTxCache(config)
 	cache.AddTx(createTx([]byte("hash-alice"), "alice", uint64(1)))
 	cache.AddTx(createTx([]byte("hash-bob"), "bob", uint64(1)))
 
@@ -231,24 +247,19 @@ func TestEviction_evictSendersWhile_ShouldContinueBreak(t *testing.T) {
 // ~1 second on average laptop.
 func Test_AddWithEviction_UniformDistribution_25000x10(t *testing.T) {
 	config := CacheConfig{
-		Name:                       "untitled",
 		NumChunksHint:              16,
 		EvictionEnabled:            true,
 		NumBytesThreshold:          1000000000,
 		CountThreshold:             240000,
 		NumSendersToEvictInOneStep: dataRetriever.TxPoolNumSendersToEvictInOneStep,
-		NumBytesPerSenderThreshold: math.MaxUint32,
-		CountPerSenderThreshold:    math.MaxUint32,
-		MinGasPriceNanoErd:         100,
+		LargeNumOfTxsForASender:    1000,
+		NumTxsToEvictFromASender:   250,
 	}
 
 	numSenders := 25000
 	numTxsPerSender := 10
 
-	cache, err := NewTxCache(config)
-	require.Nil(t, err)
-	require.NotNil(t, cache)
-
+	cache := NewTxCache(config)
 	addManyTransactionsWithUniformDistribution(cache, numSenders, numTxsPerSender)
 
 	// Sometimes (due to map iteration non-determinism), more eviction happens - one more step of 100 senders.
@@ -257,7 +268,7 @@ func Test_AddWithEviction_UniformDistribution_25000x10(t *testing.T) {
 }
 
 func Test_EvictSendersAndTheirTxs_Concurrently(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 	var wg sync.WaitGroup
 
 	for i := 0; i < 10; i++ {

--- a/storage/txcache/maps/bucketSortedMap_test.go
+++ b/storage/txcache/maps/bucketSortedMap_test.go
@@ -241,7 +241,7 @@ func TestBucketSortedMap_GetSnapshotAscending(t *testing.T) {
 	myMap := NewBucketSortedMap(4, 100)
 
 	snapshot := myMap.GetSnapshotAscending()
-	require.Equal(t, []BucketSortedMapItem{}, snapshot)
+	require.ElementsMatch(t, []BucketSortedMapItem{}, snapshot)
 
 	a := newScoredDummyItem("a", 15)
 	b := newScoredDummyItem("b", 101)
@@ -256,14 +256,14 @@ func TestBucketSortedMap_GetSnapshotAscending(t *testing.T) {
 	simulateMutationThatChangesScore(myMap, "c")
 
 	snapshot = myMap.GetSnapshotAscending()
-	require.Equal(t, []BucketSortedMapItem{c, a, b}, snapshot)
+	require.ElementsMatch(t, []BucketSortedMapItem{c, a, b}, snapshot)
 }
 
 func TestBucketSortedMap_GetSnapshotDescending(t *testing.T) {
 	myMap := NewBucketSortedMap(4, 100)
 
 	snapshot := myMap.GetSnapshotDescending()
-	require.Equal(t, []BucketSortedMapItem{}, snapshot)
+	require.ElementsMatch(t, []BucketSortedMapItem{}, snapshot)
 
 	a := newScoredDummyItem("a", 15)
 	b := newScoredDummyItem("b", 101)
@@ -278,7 +278,7 @@ func TestBucketSortedMap_GetSnapshotDescending(t *testing.T) {
 	simulateMutationThatChangesScore(myMap, "c")
 
 	snapshot = myMap.GetSnapshotDescending()
-	require.Equal(t, []BucketSortedMapItem{b, a, c}, snapshot)
+	require.ElementsMatch(t, []BucketSortedMapItem{b, a, c}, snapshot)
 }
 
 func TestBucketSortedMap_AddManyItems(t *testing.T) {

--- a/storage/txcache/monitoring.go
+++ b/storage/txcache/monitoring.go
@@ -93,11 +93,14 @@ type evictionJournal struct {
 	evictionPerformed bool
 	passOneNumTxs     uint32
 	passOneNumSenders uint32
-	passOneNumSteps   uint32
+	passTwoNumTxs     uint32
+	passTwoNumSenders uint32
+	passTwoNumSteps   uint32
 }
 
 func (journal *evictionJournal) display() {
-	log.Debug("Eviction.pass1:", "txs", journal.passOneNumTxs, "senders", journal.passOneNumSenders, "steps", journal.passOneNumSteps)
+	log.Debug("Eviction.pass1:", "txs", journal.passOneNumTxs, "senders", journal.passOneNumSenders)
+	log.Debug("Eviction.pass2:", "txs", journal.passTwoNumTxs, "senders", journal.passTwoNumSenders, "steps", journal.passTwoNumSteps)
 }
 
 func (cache *TxCache) diagnose() {

--- a/storage/txcache/monitoring_test.go
+++ b/storage/txcache/monitoring_test.go
@@ -9,19 +9,13 @@ import (
 
 func TestMonitoring_numTxAddedAndRemovedDuringEviction(t *testing.T) {
 	config := CacheConfig{
-		Name:                       "untitled",
 		NumChunksHint:              16,
 		CountThreshold:             math.MaxUint32,
 		NumBytesThreshold:          math.MaxUint32,
 		NumSendersToEvictInOneStep: 1,
-		NumBytesPerSenderThreshold: math.MaxUint32,
-		CountPerSenderThreshold:    math.MaxUint32,
-		MinGasPriceNanoErd:         100,
 	}
 
-	cache, err := NewTxCache(config)
-	require.Nil(t, err)
-	require.NotNil(t, cache)
+	cache := NewTxCache(config)
 
 	cache.isEvictionInProgress.Set()
 
@@ -41,19 +35,13 @@ func TestMonitoring_numTxAddedAndRemovedDuringEviction(t *testing.T) {
 
 func TestMonitoring_numTxAddedAndRemovedBetweenSelections(t *testing.T) {
 	config := CacheConfig{
-		Name:                       "untitled",
 		NumChunksHint:              16,
 		CountThreshold:             math.MaxUint32,
 		NumBytesThreshold:          math.MaxUint32,
 		NumSendersToEvictInOneStep: 1,
-		NumBytesPerSenderThreshold: math.MaxUint32,
-		CountPerSenderThreshold:    math.MaxUint32,
-		MinGasPriceNanoErd:         100,
 	}
 
-	cache, err := NewTxCache(config)
-	require.Nil(t, err)
-	require.NotNil(t, cache)
+	cache := NewTxCache(config)
 
 	require.Equal(t, int64(0), cache.numTxAddedBetweenSelections.Get())
 

--- a/storage/txcache/sweeping_test.go
+++ b/storage/txcache/sweeping_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSweeping_CollectSweepable(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	cache.AddTx(createTx([]byte("alice-42"), "alice", 42))
 	cache.AddTx(createTx([]byte("bob-42"), "bob", 42))
@@ -50,7 +50,7 @@ func TestSweeping_CollectSweepable(t *testing.T) {
 }
 
 func TestSweeping_WhenSendersEscapeCollection(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	cache.AddTx(createTx([]byte("alice-42"), "alice", 42))
 	cache.AddTx(createTx([]byte("bob-42"), "bob", 42))
@@ -95,7 +95,7 @@ func TestSweeping_WhenSendersEscapeCollection(t *testing.T) {
 }
 
 func TestSweeping_SweepSweepable(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	cache.AddTx(createTx([]byte("alice-42"), "alice", 42))
 	cache.AddTx(createTx([]byte("bob-42"), "bob", 42))

--- a/storage/txcache/txByHashMap.go
+++ b/storage/txcache/txByHashMap.go
@@ -57,7 +57,7 @@ func (txMap *txByHashMap) getTx(txHash string) (*WrappedTransaction, bool) {
 }
 
 // RemoveTxsBulk removes transactions, in bulk
-func (txMap *txByHashMap) RemoveTxsBulk(txHashes txHashes) uint32 {
+func (txMap *txByHashMap) RemoveTxsBulk(txHashes [][]byte) uint32 {
 	oldCount := uint32(txMap.counter.Get())
 
 	for _, txHash := range txHashes {
@@ -65,7 +65,6 @@ func (txMap *txByHashMap) RemoveTxsBulk(txHashes txHashes) uint32 {
 	}
 
 	newCount := uint32(txMap.counter.Get())
-	// TODO: Check this for overflow as well, then fix in EN-6299
 	numRemoved := oldCount - newCount
 	return numRemoved
 }
@@ -86,9 +85,9 @@ func (txMap *txByHashMap) clear() {
 	txMap.counter.Set(0)
 }
 
-func (txMap *txByHashMap) keys() txHashes {
+func (txMap *txByHashMap) keys() [][]byte {
 	keys := txMap.backingMap.Keys()
-	keysAsBytes := make(txHashes, len(keys))
+	keysAsBytes := make([][]byte, len(keys))
 	for i := 0; i < len(keys); i++ {
 		keysAsBytes[i] = []byte(keys[i])
 	}

--- a/storage/txcache/txCache.go
+++ b/storage/txcache/txCache.go
@@ -10,8 +10,6 @@ import (
 
 var _ storage.Cacher = (*TxCache)(nil)
 
-type txHashes = [][]byte
-
 // TxCache represents a cache-like structure (it has a fixed capacity and implements an eviction mechanism) for holding transactions
 type TxCache struct {
 	name                          string
@@ -31,13 +29,8 @@ type TxCache struct {
 }
 
 // NewTxCache creates a new transaction cache
-func NewTxCache(config CacheConfig) (*TxCache, error) {
+func NewTxCache(config CacheConfig) *TxCache {
 	log.Debug("NewTxCache", "config", config)
-
-	err := config.verify()
-	if err != nil {
-		return nil, err
-	}
 
 	// Note: for simplicity, we use the same "numChunksHint" for both internal concurrent maps
 	numChunksHint := config.NumChunksHint
@@ -51,7 +44,7 @@ func NewTxCache(config CacheConfig) (*TxCache, error) {
 	}
 
 	txCache.initSweepable()
-	return txCache, nil
+	return txCache
 }
 
 // AddTx adds a transaction in the cache
@@ -69,14 +62,10 @@ func (cache *TxCache) AddTx(tx *WrappedTransaction) (ok bool, added bool) {
 	}
 
 	ok = true
-	added, evicted := cache.txListBySender.addTx(tx)
+	added = cache.txByHash.addTx(tx)
 	if added {
-		cache.txByHash.addTx(tx)
+		cache.txListBySender.addTx(tx)
 		cache.monitorTxAddition()
-	}
-
-	if len(evicted) > 0 {
-		cache.txByHash.RemoveTxsBulk(evicted)
 	}
 
 	return
@@ -153,7 +142,7 @@ func (cache *TxCache) doAfterSelection() {
 func (cache *TxCache) RemoveTxByHash(txHash []byte) error {
 	tx, ok := cache.txByHash.removeTx(string(txHash))
 	if !ok {
-		return errTxNotFound
+		return ErrTxNotFound
 	}
 
 	cache.monitorTxRemoval()
@@ -161,7 +150,7 @@ func (cache *TxCache) RemoveTxByHash(txHash []byte) error {
 	found := cache.txListBySender.removeTx(tx)
 	if !found {
 		cache.onRemoveTxInconsistency(txHash)
-		return errMapsSyncInconsistency
+		return ErrMapsSyncInconsistency
 	}
 
 	return nil
@@ -245,7 +234,7 @@ func (cache *TxCache) RemoveOldest() {
 }
 
 // Keys returns the tx hashes in the cache
-func (cache *TxCache) Keys() txHashes {
+func (cache *TxCache) Keys() [][]byte {
 	return cache.txByHash.keys()
 }
 

--- a/storage/txcache/txCache_test.go
+++ b/storage/txcache/txCache_test.go
@@ -1,7 +1,6 @@
 package txcache
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -14,73 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_NewTxCache(t *testing.T) {
-	config := CacheConfig{
-		Name:                       "test",
-		NumChunksHint:              16,
-		NumBytesPerSenderThreshold: math.MaxUint32,
-		CountPerSenderThreshold:    math.MaxUint32,
-		MinGasPriceNanoErd:         100,
-	}
-
-	withEvictionConfig := CacheConfig{
-		Name:                       "test",
-		NumChunksHint:              16,
-		NumBytesPerSenderThreshold: math.MaxUint32,
-		CountPerSenderThreshold:    math.MaxUint32,
-		MinGasPriceNanoErd:         100,
-		EvictionEnabled:            true,
-		NumBytesThreshold:          math.MaxUint32,
-		CountThreshold:             math.MaxUint32,
-		NumSendersToEvictInOneStep: 100,
-	}
-
-	cache, err := NewTxCache(config)
-	require.Nil(t, err)
-	require.NotNil(t, cache)
-
-	badConfig := config
-	badConfig.Name = ""
-	requireErrorOnNewTxCache(t, badConfig, errInvalidCacheConfig, "config.Name")
-
-	badConfig = config
-	badConfig.NumChunksHint = 0
-	requireErrorOnNewTxCache(t, badConfig, errInvalidCacheConfig, "config.NumChunksHint")
-
-	badConfig = config
-	badConfig.NumBytesPerSenderThreshold = 0
-	requireErrorOnNewTxCache(t, badConfig, errInvalidCacheConfig, "config.NumBytesPerSenderThreshold")
-
-	badConfig = config
-	badConfig.CountPerSenderThreshold = 0
-	requireErrorOnNewTxCache(t, badConfig, errInvalidCacheConfig, "config.CountPerSenderThreshold")
-
-	badConfig = config
-	badConfig.MinGasPriceNanoErd = 0
-	requireErrorOnNewTxCache(t, badConfig, errInvalidCacheConfig, "config.MinGasPriceNanoErd")
-
-	badConfig = withEvictionConfig
-	badConfig.NumBytesThreshold = 0
-	requireErrorOnNewTxCache(t, badConfig, errInvalidCacheConfig, "config.NumBytesThreshold")
-
-	badConfig = withEvictionConfig
-	badConfig.CountThreshold = 0
-	requireErrorOnNewTxCache(t, badConfig, errInvalidCacheConfig, "config.CountThreshold")
-
-	badConfig = withEvictionConfig
-	badConfig.NumSendersToEvictInOneStep = 0
-	requireErrorOnNewTxCache(t, badConfig, errInvalidCacheConfig, "config.NumSendersToEvictInOneStep")
-}
-
-func requireErrorOnNewTxCache(t *testing.T, config CacheConfig, errExpected error, errPartialMessage string) {
-	cache, errReceived := NewTxCache(config)
-	require.Nil(t, cache)
-	require.True(t, errors.Is(errReceived, errExpected))
-	require.Contains(t, errReceived.Error(), errPartialMessage)
-}
-
 func Test_AddTx(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	tx := createTx([]byte("hash-1"), "alice", 1)
 
@@ -99,7 +33,7 @@ func Test_AddTx(t *testing.T) {
 }
 
 func Test_AddNilTx_DoesNothing(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	txHash := []byte("hash-1")
 
@@ -112,46 +46,8 @@ func Test_AddNilTx_DoesNothing(t *testing.T) {
 	require.Nil(t, foundTx)
 }
 
-func Test_AddTx_AppliesSizeConstraintsPerSenderForNumTransactions(t *testing.T) {
-	cache := newCacheToTest(math.MaxUint32, 3)
-
-	cache.AddTx(createTx([]byte("tx-alice-1"), "alice", 1))
-	cache.AddTx(createTx([]byte("tx-alice-2"), "alice", 2))
-	cache.AddTx(createTx([]byte("tx-alice-4"), "alice", 4))
-	cache.AddTx(createTx([]byte("tx-bob-1"), "bob", 1))
-	cache.AddTx(createTx([]byte("tx-bob-2"), "bob", 2))
-	require.Equal(t, []string{"tx-alice-1", "tx-alice-2", "tx-alice-4"}, cache.getHashesForSender("alice"))
-	require.Equal(t, []string{"tx-bob-1", "tx-bob-2"}, cache.getHashesForSender("bob"))
-	require.True(t, cache.areInternalMapsConsistent())
-
-	cache.AddTx(createTx([]byte("tx-alice-3"), "alice", 3))
-	require.Equal(t, []string{"tx-alice-1", "tx-alice-2", "tx-alice-3"}, cache.getHashesForSender("alice"))
-	require.Equal(t, []string{"tx-bob-1", "tx-bob-2"}, cache.getHashesForSender("bob"))
-	require.True(t, cache.areInternalMapsConsistent())
-}
-
-func Test_AddTx_AppliesSizeConstraintsPerSenderForNumBytes(t *testing.T) {
-	cache := newCacheToTest(1024, math.MaxUint32)
-
-	cache.AddTx(createTxWithParams([]byte("tx-alice-1"), "alice", 1, 128, 42, 42))
-	cache.AddTx(createTxWithParams([]byte("tx-alice-2"), "alice", 2, 512, 42, 42))
-	cache.AddTx(createTxWithParams([]byte("tx-alice-4"), "alice", 3, 256, 42, 42))
-	cache.AddTx(createTxWithParams([]byte("tx-bob-1"), "bob", 1, 512, 42, 42))
-	cache.AddTx(createTxWithParams([]byte("tx-bob-2"), "bob", 2, 513, 42, 42))
-
-	require.Equal(t, []string{"tx-alice-1", "tx-alice-2", "tx-alice-4"}, cache.getHashesForSender("alice"))
-	require.Equal(t, []string{"tx-bob-1"}, cache.getHashesForSender("bob"))
-	require.True(t, cache.areInternalMapsConsistent())
-
-	cache.AddTx(createTxWithParams([]byte("tx-alice-3"), "alice", 3, 256, 42, 42))
-	cache.AddTx(createTxWithParams([]byte("tx-bob-2"), "bob", 3, 512, 42, 42))
-	require.Equal(t, []string{"tx-alice-1", "tx-alice-2", "tx-alice-3"}, cache.getHashesForSender("alice"))
-	require.Equal(t, []string{"tx-bob-1", "tx-bob-2"}, cache.getHashesForSender("bob"))
-	require.True(t, cache.areInternalMapsConsistent())
-}
-
 func Test_RemoveByTxHash(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	cache.AddTx(createTx([]byte("hash-1"), "alice", 1))
 	cache.AddTx(createTx([]byte("hash-2"), "alice", 2))
@@ -170,7 +66,7 @@ func Test_RemoveByTxHash(t *testing.T) {
 }
 
 func Test_CountTx_And_Len(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	cache.AddTx(createTx([]byte("hash-1"), "alice", 1))
 	cache.AddTx(createTx([]byte("hash-2"), "alice", 2))
@@ -181,7 +77,7 @@ func Test_CountTx_And_Len(t *testing.T) {
 }
 
 func Test_GetByTxHash_And_Peek_And_Get(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	txHash := []byte("hash-1")
 	tx := createTx(txHash, "alice", 1)
@@ -209,13 +105,13 @@ func Test_GetByTxHash_And_Peek_And_Get(t *testing.T) {
 }
 
 func Test_RemoveByTxHash_Error_WhenMissing(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 	err := cache.RemoveTxByHash([]byte("missing"))
-	require.Equal(t, err, errTxNotFound)
+	require.Equal(t, err, ErrTxNotFound)
 }
 
 func Test_RemoveByTxHash_Error_WhenMapsInconsistency(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	txHash := []byte("hash-1")
 	tx := createTx(txHash, "alice", 1)
@@ -225,11 +121,11 @@ func Test_RemoveByTxHash_Error_WhenMapsInconsistency(t *testing.T) {
 	cache.txListBySender.removeTx(tx)
 
 	err := cache.RemoveTxByHash(txHash)
-	require.Equal(t, err, errMapsSyncInconsistency)
+	require.Equal(t, err, ErrMapsSyncInconsistency)
 }
 
 func Test_Clear(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1))
 	cache.AddTx(createTx([]byte("hash-bob-7"), "bob", 7))
@@ -241,7 +137,7 @@ func Test_Clear(t *testing.T) {
 }
 
 func Test_ForEachTransaction(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1))
 	cache.AddTx(createTx([]byte("hash-bob-7"), "bob", 7))
@@ -254,7 +150,7 @@ func Test_ForEachTransaction(t *testing.T) {
 }
 
 func Test_SelectTransactions_Dummy(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	cache.AddTx(createTx([]byte("hash-alice-4"), "alice", 4))
 	cache.AddTx(createTx([]byte("hash-alice-3"), "alice", 3))
@@ -270,7 +166,7 @@ func Test_SelectTransactions_Dummy(t *testing.T) {
 }
 
 func Test_SelectTransactions_BreaksAtNonceGaps(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1))
 	cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2))
@@ -291,7 +187,7 @@ func Test_SelectTransactions_BreaksAtNonceGaps(t *testing.T) {
 }
 
 func Test_SelectTransactions(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	// Add "nSenders" * "nTransactionsPerSender" transactions in the cache (in reversed nonce order)
 	nSenders := 1000
@@ -328,7 +224,7 @@ func Test_SelectTransactions(t *testing.T) {
 }
 
 func Test_Keys(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	cache.AddTx(createTx([]byte("alice-x"), "alice", 42))
 	cache.AddTx(createTx([]byte("alice-y"), "alice", 43))
@@ -345,48 +241,38 @@ func Test_Keys(t *testing.T) {
 
 func Test_AddWithEviction_UniformDistributionOfTxsPerSender(t *testing.T) {
 	config := CacheConfig{
-		Name:                       "untitled",
 		NumChunksHint:              16,
 		EvictionEnabled:            true,
 		NumBytesThreshold:          math.MaxUint32,
 		CountThreshold:             100,
 		NumSendersToEvictInOneStep: 1,
-		NumBytesPerSenderThreshold: math.MaxUint32,
-		CountPerSenderThreshold:    math.MaxUint32,
-		MinGasPriceNanoErd:         100,
+		LargeNumOfTxsForASender:    math.MaxUint32,
+		NumTxsToEvictFromASender:   0,
 	}
 
 	// 11 * 10
-	cache, err := NewTxCache(config)
-	require.Nil(t, err)
-	require.NotNil(t, cache)
-
+	cache := NewTxCache(config)
 	addManyTransactionsWithUniformDistribution(cache, 11, 10)
 	require.LessOrEqual(t, cache.CountTx(), int64(100))
 
 	config = CacheConfig{
-		Name:                       "untitled",
 		NumChunksHint:              16,
 		EvictionEnabled:            true,
 		NumBytesThreshold:          math.MaxUint32,
 		CountThreshold:             250000,
 		NumSendersToEvictInOneStep: 1,
-		NumBytesPerSenderThreshold: math.MaxUint32,
-		CountPerSenderThreshold:    math.MaxUint32,
-		MinGasPriceNanoErd:         100,
+		LargeNumOfTxsForASender:    math.MaxUint32,
+		NumTxsToEvictFromASender:   0,
 	}
 
 	// 100 * 1000
-	cache, err = NewTxCache(config)
-	require.Nil(t, err)
-	require.NotNil(t, cache)
-
+	cache = NewTxCache(config)
 	addManyTransactionsWithUniformDistribution(cache, 100, 1000)
 	require.LessOrEqual(t, cache.CountTx(), int64(250000))
 }
 
 func Test_NotImplementedFunctions(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	evicted := cache.Put(nil, nil)
 	require.False(t, evicted)
@@ -404,7 +290,7 @@ func Test_NotImplementedFunctions(t *testing.T) {
 }
 
 func Test_IsInterfaceNil(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 	require.False(t, check.IfNil(cache))
 
 	makeNil := func() storage.Cacher {
@@ -416,11 +302,11 @@ func Test_IsInterfaceNil(t *testing.T) {
 }
 
 func TestTxCache_ConcurrentMutationAndSelection(t *testing.T) {
-	cache := newUnconstrainedCacheToTest()
+	cache := newCacheToTest()
 
 	// Alice will quickly move between two score buckets (chunks)
-	cheapTransaction := createTxWithParams([]byte("alice-x-o"), "alice", 0, 128, 50000, 100*oneBillion)
-	expensiveTransaction := createTxWithParams([]byte("alice-x-1"), "alice", 1, 128, 50000, 300*oneBillion)
+	cheapTransaction := createTxWithParams([]byte("alice-x-o"), "alice", 0, 128, 50000, 100*oneTrilion)
+	expensiveTransaction := createTxWithParams([]byte("alice-x-1"), "alice", 1, 128, 50000, 300*oneTrilion)
 	cache.AddTx(cheapTransaction)
 	cache.AddTx(expensiveTransaction)
 
@@ -453,32 +339,6 @@ func TestTxCache_ConcurrentMutationAndSelection(t *testing.T) {
 	require.False(t, timedOut, "Timed out. Perhaps deadlock?")
 }
 
-func newUnconstrainedCacheToTest() *TxCache {
-	cache, err := NewTxCache(CacheConfig{
-		Name:                       "test",
-		NumChunksHint:              16,
-		NumBytesPerSenderThreshold: math.MaxUint32,
-		CountPerSenderThreshold:    math.MaxUint32,
-		MinGasPriceNanoErd:         100,
-	})
-	if err != nil {
-		panic(fmt.Sprintf("newUnconstrainedCacheToTest(): %s", err))
-	}
-
-	return cache
-}
-
-func newCacheToTest(numBytesPerSenderThreshold uint32, countPerSenderThreshold uint32) *TxCache {
-	cache, err := NewTxCache(CacheConfig{
-		Name:                       "test",
-		NumChunksHint:              16,
-		NumBytesPerSenderThreshold: numBytesPerSenderThreshold,
-		CountPerSenderThreshold:    countPerSenderThreshold,
-		MinGasPriceNanoErd:         100,
-	})
-	if err != nil {
-		panic(fmt.Sprintf("newCacheToTest(): %s", err))
-	}
-
-	return cache
+func newCacheToTest() *TxCache {
+	return NewTxCache(CacheConfig{Name: "test", NumChunksHint: 16, MinGasPriceMicroErd: 100})
 }

--- a/storage/txcache/txListBySenderMap.go
+++ b/storage/txcache/txListBySenderMap.go
@@ -25,10 +25,10 @@ func newTxListBySenderMap(nChunksHint uint32, cacheConfig CacheConfig) txListByS
 }
 
 // addTx adds a transaction in the map, in the corresponding list (selected by its sender)
-func (txMap *txListBySenderMap) addTx(tx *WrappedTransaction) (bool, txHashes) {
+func (txMap *txListBySenderMap) addTx(tx *WrappedTransaction) {
 	sender := string(tx.Tx.GetSndAddr())
 	listForSender := txMap.getOrAddListForSender(sender)
-	return listForSender.AddTx(tx)
+	listForSender.AddTx(tx)
 }
 
 func (txMap *txListBySenderMap) getOrAddListForSender(sender string) *txListForSender {
@@ -75,8 +75,8 @@ func (txMap *txListBySenderMap) removeTx(tx *WrappedTransaction) bool {
 	}
 
 	isFound := listForSender.RemoveTx(tx)
-	isEmpty := listForSender.IsEmpty()
-	if isEmpty {
+
+	if listForSender.IsEmpty() {
 		txMap.removeSender(sender)
 	}
 

--- a/storage/txcache/txListBySenderMap_test.go
+++ b/storage/txcache/txListBySenderMap_test.go
@@ -2,7 +2,6 @@ package txcache
 
 import (
 	"fmt"
-	"math"
 	"sync"
 	"testing"
 
@@ -23,21 +22,17 @@ func TestSendersMap_AddTx_IncrementsCounter(t *testing.T) {
 func TestSendersMap_RemoveTx_AlsoRemovesSenderWhenNoTransactionLeft(t *testing.T) {
 	myMap := newSendersMapToTest()
 
-	txAlice1 := createTx([]byte("a1"), "alice", uint64(1))
-	txAlice2 := createTx([]byte("a2"), "alice", uint64(2))
+	txAlice1 := createTx([]byte("a"), "alice", uint64(1))
+	txAlice2 := createTx([]byte("a"), "alice", uint64(2))
 	txBob := createTx([]byte("b"), "bob", uint64(1))
 
 	myMap.addTx(txAlice1)
 	myMap.addTx(txAlice2)
 	myMap.addTx(txBob)
 	require.Equal(t, int64(2), myMap.counter.Get())
-	require.Equal(t, uint64(2), myMap.testGetListForSender("alice").countTx())
-	require.Equal(t, uint64(1), myMap.testGetListForSender("bob").countTx())
 
 	myMap.removeTx(txAlice1)
 	require.Equal(t, int64(2), myMap.counter.Get())
-	require.Equal(t, uint64(1), myMap.testGetListForSender("alice").countTx())
-	require.Equal(t, uint64(1), myMap.testGetListForSender("bob").countTx())
 
 	myMap.removeTx(txAlice2)
 	// All alice's transactions have been removed now
@@ -176,8 +171,5 @@ func createTxListBySenderMap(numSenders int) txListBySenderMap {
 }
 
 func newSendersMapToTest() txListBySenderMap {
-	return newTxListBySenderMap(4, CacheConfig{
-		NumBytesPerSenderThreshold: math.MaxUint32,
-		CountPerSenderThreshold:    math.MaxUint32,
-	})
+	return newTxListBySenderMap(4, CacheConfig{})
 }

--- a/storage/txcache/txListForSender.go
+++ b/storage/txcache/txListForSender.go
@@ -45,15 +45,14 @@ func newTxListForSender(sender string, cacheConfig *CacheConfig, onScoreChange s
 
 // AddTx adds a transaction in sender's list
 // This is a "sorted" insert
-func (listForSender *txListForSender) AddTx(tx *WrappedTransaction) (bool, txHashes) {
+func (listForSender *txListForSender) AddTx(tx *WrappedTransaction) {
 	// We don't allow concurrent interceptor goroutines to mutate a given sender's list
 	listForSender.mutex.Lock()
 	defer listForSender.mutex.Unlock()
 
-	insertionPlace, err := listForSender.findInsertionPlace(tx)
-	if err != nil {
-		return false, nil
-	}
+	nonce := tx.Tx.GetNonce()
+	gasPrice := tx.Tx.GetGasPrice()
+	insertionPlace := listForSender.findInsertionPlace(nonce, gasPrice)
 
 	if insertionPlace == nil {
 		listForSender.items.PushFront(tx)
@@ -62,82 +61,32 @@ func (listForSender *txListForSender) AddTx(tx *WrappedTransaction) (bool, txHas
 	}
 
 	listForSender.onAddedTransaction(tx)
-	evicted := listForSender.applySizeConstraints()
-	listForSender.triggerScoreChange()
-
-	return true, evicted
-}
-
-// This function should only be used in critical section (listForSender.mutex)
-func (listForSender *txListForSender) applySizeConstraints() txHashes {
-	evictedTxHashes := make(txHashes, 0)
-
-	// Iterate back to front
-	for element := listForSender.items.Back(); element != nil; element = element.Prev() {
-		if !listForSender.isCapacityExceeded() {
-			break
-		}
-
-		listForSender.items.Remove(element)
-		listForSender.onRemovedListElement(element)
-
-		// Keep track of removed transactions
-		value := element.Value.(*WrappedTransaction)
-		evictedTxHashes = append(evictedTxHashes, value.TxHash)
-	}
-
-	return evictedTxHashes
-}
-
-func (listForSender *txListForSender) isCapacityExceeded() bool {
-	maxBytes := int64(listForSender.cacheConfig.NumBytesPerSenderThreshold)
-	maxNumTxs := uint64(listForSender.cacheConfig.CountPerSenderThreshold)
-	tooManyBytes := listForSender.totalBytes.Get() > maxBytes
-	tooManyTxs := listForSender.countTx() > maxNumTxs
-
-	return tooManyBytes || tooManyTxs
 }
 
 func (listForSender *txListForSender) onAddedTransaction(tx *WrappedTransaction) {
 	listForSender.totalBytes.Add(int64(estimateTxSize(tx)))
 	listForSender.totalGas.Add(int64(estimateTxGas(tx)))
 	listForSender.totalFee.Add(int64(estimateTxFee(tx)))
-}
-
-func (listForSender *txListForSender) triggerScoreChange() {
 	listForSender.onScoreChange(listForSender)
 }
 
 // This function should only be used in critical section (listForSender.mutex)
-func (listForSender *txListForSender) findInsertionPlace(incomingTx *WrappedTransaction) (*list.Element, error) {
-	incomingNonce := incomingTx.Tx.GetNonce()
-	incomingGasPrice := incomingTx.Tx.GetGasPrice()
-
+func (listForSender *txListForSender) findInsertionPlace(incomingNonce uint64, incomingGasPrice uint64) *list.Element {
 	for element := listForSender.items.Back(); element != nil; element = element.Prev() {
-		currentTx := element.Value.(*WrappedTransaction)
-		currentTxNonce := currentTx.Tx.GetNonce()
-		currentTxGasPrice := currentTx.Tx.GetGasPrice()
+		tx := element.Value.(*WrappedTransaction).Tx
+		nonce := tx.GetNonce()
+		gasPrice := tx.GetGasPrice()
 
-		if incomingTx.sameAs(currentTx) {
-			// The incoming transaction will be discarded
-			return nil, errTxDuplicated
+		if nonce == incomingNonce && gasPrice > incomingGasPrice {
+			return element
 		}
 
-		if currentTxNonce == incomingNonce && currentTxGasPrice > incomingGasPrice {
-			// The incoming transaction will be placed right after the existing one, which has same nonce but higher price.
-			// If the nonces are the same, but the incoming gas price is higher or equal, the search loop continues.
-			return element, nil
-		}
-
-		if currentTxNonce < incomingNonce {
-			// We've found the first transaction with a lower nonce than the incoming one,
-			// thus the incoming transaction will be placed right after this one.
-			return element, nil
+		if nonce < incomingNonce {
+			return element
 		}
 	}
 
-	// The incoming transaction will be inserted at the head of the list.
-	return nil, nil
+	return nil
 }
 
 // RemoveTx removes a transaction from the sender's list
@@ -151,7 +100,6 @@ func (listForSender *txListForSender) RemoveTx(tx *WrappedTransaction) bool {
 	if isFound {
 		listForSender.items.Remove(marker)
 		listForSender.onRemovedListElement(marker)
-		listForSender.triggerScoreChange()
 	}
 
 	return isFound
@@ -163,6 +111,32 @@ func (listForSender *txListForSender) onRemovedListElement(element *list.Element
 	listForSender.totalBytes.Subtract(int64(estimateTxSize(value)))
 	listForSender.totalGas.Subtract(int64(estimateTxGas(value)))
 	listForSender.totalFee.Subtract(int64(estimateTxFee(value)))
+	listForSender.onScoreChange(listForSender)
+}
+
+// RemoveHighNonceTxs removes "count" transactions from the back of the list
+func (listForSender *txListForSender) RemoveHighNonceTxs(count uint32) [][]byte {
+	listForSender.mutex.Lock()
+	defer listForSender.mutex.Unlock()
+
+	removedTxHashes := make([][]byte, count)
+
+	index := uint32(0)
+	var previous *list.Element
+	for element := listForSender.items.Back(); element != nil && count > index; element = previous {
+		// Remove node
+		previous = element.Prev()
+		listForSender.items.Remove(element)
+		listForSender.onRemovedListElement(element)
+
+		// Keep track of removed transaction
+		value := element.Value.(*WrappedTransaction)
+		removedTxHashes[index] = value.TxHash
+
+		index++
+	}
+
+	return removedTxHashes
 }
 
 // This function should only be used in critical section (listForSender.mutex)
@@ -181,6 +155,11 @@ func (listForSender *txListForSender) findListElementWithTx(txToFind *WrappedTra
 	}
 
 	return nil
+}
+
+// HasMoreThan checks whether the list has more items than specified
+func (listForSender *txListForSender) HasMoreThan(count uint32) bool {
+	return uint32(listForSender.countTxWithLock()) > count
 }
 
 // IsEmpty checks whether the list is empty
@@ -246,11 +225,11 @@ func (listForSender *txListForSender) selectBatchTo(isFirstBatch bool, destinati
 }
 
 // getTxHashes returns the hashes of transactions in the list
-func (listForSender *txListForSender) getTxHashes() txHashes {
+func (listForSender *txListForSender) getTxHashes() [][]byte {
 	listForSender.mutex.RLock()
 	defer listForSender.mutex.RUnlock()
 
-	result := make(txHashes, 0, listForSender.countTx())
+	result := make([][]byte, 0, listForSender.countTx())
 
 	for element := listForSender.items.Front(); element != nil; element = element.Next() {
 		value := element.Value.(*WrappedTransaction)

--- a/storage/txcache/txListForSenderAsSortedMapItem.go
+++ b/storage/txcache/txListForSenderAsSortedMapItem.go
@@ -13,10 +13,10 @@ type senderScoreParams struct {
 	count uint64
 	// Size is in bytes
 	size uint64
-	// Fee is in nano ERD
+	// Fee is in micro ERD
 	fee uint64
 	gas uint64
-	// Price is in nano ERD
+	// Price is in micro ERD
 	minGasPrice uint32
 }
 
@@ -41,7 +41,7 @@ func (listForSender *txListForSender) computeRawScore() float64 {
 	gas := listForSender.totalGas.GetUint64()
 	size := listForSender.totalBytes.GetUint64()
 	count := listForSender.countTx()
-	minGasPrice := listForSender.cacheConfig.MinGasPriceNanoErd
+	minGasPrice := listForSender.cacheConfig.MinGasPriceMicroErd
 
 	return computeSenderScore(senderScoreParams{count: count, size: size, fee: fee, gas: gas, minGasPrice: minGasPrice})
 }
@@ -59,8 +59,8 @@ func (listForSender *txListForSender) computeRawScore() float64 {
 // For asymptoticScore, see (https://en.wikipedia.org/wiki/Logistic_function)
 //
 // Where:
-//  - PPUAvg: average gas points (fee) per processing unit, in nano ERD
-//  - PPUMin: minimum gas points (fee) per processing unit (given by economics.toml), in nano ERD
+//  - PPUAvg: average gas points (fee) per processing unit, in micro ERD
+//  - PPUMin: minimum gas points (fee) per processing unit (given by economics.toml), in micro ERD
 //  - txCount: number of transactions
 //  - txSize: size of transactions, in kB (1000 bytes)
 //

--- a/storage/txcache/txListForSenderAsSortedMapItem_test.go
+++ b/storage/txcache/txListForSenderAsSortedMapItem_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func TestSenderAsBucketSortedMapItem_ComputeScore(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 
-	list.AddTx(createTxWithParams([]byte("a"), ".", 1, 1000, 200000, 100*oneBillion))
-	list.AddTx(createTxWithParams([]byte("b"), ".", 1, 500, 100000, 100*oneBillion))
-	list.AddTx(createTxWithParams([]byte("c"), ".", 1, 500, 100000, 100*oneBillion))
+	list.AddTx(createTxWithParams([]byte("a"), ".", 1, 1000, 200000, 100*oneTrilion))
+	list.AddTx(createTxWithParams([]byte("b"), ".", 1, 500, 100000, 100*oneTrilion))
+	list.AddTx(createTxWithParams([]byte("c"), ".", 1, 500, 100000, 100*oneTrilion))
 
 	require.Equal(t, uint64(3), list.countTx())
 	require.Equal(t, int64(2000), list.totalBytes.Get())
@@ -22,11 +22,11 @@ func TestSenderAsBucketSortedMapItem_ComputeScore(t *testing.T) {
 }
 
 func TestSenderAsBucketSortedMapItem_ScoreFluctuatesDeterministicallyWhenTransactionsAreAddedOrRemoved(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 
-	A := createTxWithParams([]byte("A"), ".", 1, 1000, 200000, 100*oneBillion)
-	B := createTxWithParams([]byte("b"), ".", 1, 500, 100000, 100*oneBillion)
-	C := createTxWithParams([]byte("c"), ".", 1, 500, 100000, 100*oneBillion)
+	A := createTxWithParams([]byte("A"), ".", 1, 1000, 200000, 100*oneTrilion)
+	B := createTxWithParams([]byte("b"), ".", 1, 500, 100000, 100*oneTrilion)
+	C := createTxWithParams([]byte("c"), ".", 1, 500, 100000, 100*oneTrilion)
 
 	scoreNone := int(list.ComputeScore())
 	list.AddTx(A)
@@ -55,23 +55,23 @@ func TestSenderAsBucketSortedMapItem_ScoreFluctuatesDeterministicallyWhenTransac
 }
 
 func Test_computeSenderScore(t *testing.T) {
-	score := computeSenderScore(senderScoreParams{count: 14000, size: kBToBytes(100000), fee: toNanoERD(300), gas: 2500000000, minGasPrice: 100})
+	score := computeSenderScore(senderScoreParams{count: 14000, size: kBToBytes(100000), fee: toMicroERD(300000), gas: 2500000000, minGasPrice: 100})
 	require.InDelta(t, float64(0.1789683371), score, delta)
 
-	score = computeSenderScore(senderScoreParams{count: 19000, size: kBToBytes(3000), fee: toNanoERD(2300), gas: 19000000000, minGasPrice: 100})
+	score = computeSenderScore(senderScoreParams{count: 19000, size: kBToBytes(3000), fee: toMicroERD(2300000), gas: 19000000000, minGasPrice: 100})
 	require.InDelta(t, float64(0.2517997181), score, delta)
 
-	score = computeSenderScore(senderScoreParams{count: 3, size: kBToBytes(2), fee: toNanoERD(0.04), gas: 400000, minGasPrice: 100})
+	score = computeSenderScore(senderScoreParams{count: 3, size: kBToBytes(2), fee: toMicroERD(40), gas: 400000, minGasPrice: 100})
 	require.InDelta(t, float64(5.795382396), score, delta)
 
-	score = computeSenderScore(senderScoreParams{count: 1, size: kBToBytes(0.3), fee: toNanoERD(0.05), gas: 100000, minGasPrice: 100})
+	score = computeSenderScore(senderScoreParams{count: 1, size: kBToBytes(0.3), fee: toMicroERD(50), gas: 100000, minGasPrice: 100})
 	require.InDelta(t, float64(100), score, delta)
 }
 
 func Benchmark_computeSenderScore(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for j := uint64(0); j < 10000000; j++ {
-			computeSenderScore(senderScoreParams{count: j, size: (j + 1) * 500, fee: toNanoERD(float64(0.011) * float64(j)), gas: 100000 * j})
+			computeSenderScore(senderScoreParams{count: j, size: (j + 1) * 500, fee: toMicroERD(11 * j), gas: 100000 * j})
 		}
 	}
 }

--- a/storage/txcache/txListForSender_test.go
+++ b/storage/txcache/txListForSender_test.go
@@ -8,18 +8,26 @@ import (
 )
 
 func TestListForSender_AddTx_Sorts(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 
 	list.AddTx(createTx([]byte("a"), ".", 1))
 	list.AddTx(createTx([]byte("c"), ".", 3))
 	list.AddTx(createTx([]byte("d"), ".", 4))
 	list.AddTx(createTx([]byte("b"), ".", 2))
 
-	require.Equal(t, []string{"a", "b", "c", "d"}, list.getTxHashesAsStrings())
+	txHashes := list.getTxHashes()
+
+	require.Equal(t, 4, list.items.Len())
+	require.Equal(t, 4, len(txHashes))
+
+	require.Equal(t, []byte("a"), txHashes[0])
+	require.Equal(t, []byte("b"), txHashes[1])
+	require.Equal(t, []byte("c"), txHashes[2])
+	require.Equal(t, []byte("d"), txHashes[3])
 }
 
 func TestListForSender_AddTx_GivesPriorityToHigherGas(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 
 	list.AddTx(createTxWithParams([]byte("a"), ".", 1, 128, 42, 42))
 	list.AddTx(createTxWithParams([]byte("b"), ".", 3, 128, 42, 100))
@@ -27,87 +35,20 @@ func TestListForSender_AddTx_GivesPriorityToHigherGas(t *testing.T) {
 	list.AddTx(createTxWithParams([]byte("d"), ".", 2, 128, 42, 42))
 	list.AddTx(createTxWithParams([]byte("e"), ".", 3, 128, 42, 101))
 
-	require.Equal(t, []string{"a", "d", "e", "b", "c"}, list.getTxHashesAsStrings())
-}
+	txHashes := list.getTxHashes()
 
-func TestListForSender_AddTx_SortsCorrectlyWhenSameNonceSamePrice(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	require.Equal(t, 5, list.items.Len())
+	require.Equal(t, 5, len(txHashes))
 
-	list.AddTx(createTxWithParams([]byte("a"), ".", 1, 128, 42, 42))
-	list.AddTx(createTxWithParams([]byte("b"), ".", 3, 128, 42, 100))
-	list.AddTx(createTxWithParams([]byte("c"), ".", 3, 128, 42, 100))
-	list.AddTx(createTxWithParams([]byte("d"), ".", 3, 128, 42, 98))
-	list.AddTx(createTxWithParams([]byte("e"), ".", 3, 128, 42, 101))
-	list.AddTx(createTxWithParams([]byte("f"), ".", 2, 128, 42, 42))
-	list.AddTx(createTxWithParams([]byte("g"), ".", 3, 128, 42, 99))
-
-	// In case of same-nonce, same-price transactions, the newer one has priority
-	require.Equal(t, []string{"a", "f", "e", "c", "b", "g", "d"}, list.getTxHashesAsStrings())
-}
-
-func TestListForSender_AddTx_IgnoresDuplicates(t *testing.T) {
-	list := newUnconstrainedListToTest()
-
-	added, _ := list.AddTx(createTx([]byte("tx1"), ".", 1))
-	require.True(t, added)
-	added, _ = list.AddTx(createTx([]byte("tx2"), ".", 2))
-	require.True(t, added)
-	added, _ = list.AddTx(createTx([]byte("tx3"), ".", 3))
-	require.True(t, added)
-	added, _ = list.AddTx(createTx([]byte("tx2"), ".", 2))
-	require.False(t, added)
-}
-
-func TestListForSender_AddTx_AppliesSizeConstraintsForNumTransactions(t *testing.T) {
-	list := newListToTest(math.MaxUint32, 3)
-
-	list.AddTx(createTx([]byte("tx1"), ".", 1))
-	list.AddTx(createTx([]byte("tx5"), ".", 5))
-	list.AddTx(createTx([]byte("tx4"), ".", 4))
-	list.AddTx(createTx([]byte("tx2"), ".", 2))
-	require.Equal(t, []string{"tx1", "tx2", "tx4"}, list.getTxHashesAsStrings())
-
-	_, evicted := list.AddTx(createTx([]byte("tx3"), ".", 3))
-	require.Equal(t, []string{"tx1", "tx2", "tx3"}, list.getTxHashesAsStrings())
-	require.Equal(t, []string{"tx4"}, hashesAsStrings(evicted))
-
-	// Gives priority to higher gas - though undesirably to some extent, "tx3" is evicted
-	_, evicted = list.AddTx(createTxWithParams([]byte("tx2++"), ".", 2, 128, 42, 42))
-	require.Equal(t, []string{"tx1", "tx2++", "tx2"}, list.getTxHashesAsStrings())
-	require.Equal(t, []string{"tx3"}, hashesAsStrings(evicted))
-
-	// Though Undesirably to some extent, "tx3++"" is added, then evicted
-	_, evicted = list.AddTx(createTxWithParams([]byte("tx3++"), ".", 3, 128, 42, 42))
-	require.Equal(t, []string{"tx1", "tx2++", "tx2"}, list.getTxHashesAsStrings())
-	require.Equal(t, []string{"tx3++"}, hashesAsStrings(evicted))
-}
-
-func TestListForSender_AddTx_AppliesSizeConstraintsForNumBytes(t *testing.T) {
-	list := newListToTest(1024, math.MaxUint32)
-
-	list.AddTx(createTxWithParams([]byte("tx1"), ".", 1, 128, 42, 42))
-	list.AddTx(createTxWithParams([]byte("tx2"), ".", 2, 512, 42, 42))
-	list.AddTx(createTxWithParams([]byte("tx3"), ".", 3, 256, 42, 42))
-	_, evicted := list.AddTx(createTxWithParams([]byte("tx5"), ".", 4, 256, 42, 42))
-	require.Equal(t, []string{"tx1", "tx2", "tx3"}, list.getTxHashesAsStrings())
-	require.Equal(t, []string{"tx5"}, hashesAsStrings(evicted))
-
-	_, evicted = list.AddTx(createTxWithParams([]byte("tx5--"), ".", 4, 128, 42, 42))
-	require.Equal(t, []string{"tx1", "tx2", "tx3", "tx5--"}, list.getTxHashesAsStrings())
-	require.Equal(t, []string{}, hashesAsStrings(evicted))
-
-	_, evicted = list.AddTx(createTxWithParams([]byte("tx4"), ".", 4, 128, 42, 42))
-	require.Equal(t, []string{"tx1", "tx2", "tx3", "tx4"}, list.getTxHashesAsStrings())
-	require.Equal(t, []string{"tx5--"}, hashesAsStrings(evicted))
-
-	// Gives priority to higher gas - though undesirably to some extent, "tx4" is evicted
-	_, evicted = list.AddTx(createTxWithParams([]byte("tx3++"), ".", 3, 256, 42, 100))
-	require.Equal(t, []string{"tx1", "tx2", "tx3++", "tx3"}, list.getTxHashesAsStrings())
-	require.Equal(t, []string{"tx4"}, hashesAsStrings(evicted))
+	require.Equal(t, []byte("a"), txHashes[0])
+	require.Equal(t, []byte("d"), txHashes[1])
+	require.Equal(t, []byte("e"), txHashes[2])
+	require.Equal(t, []byte("b"), txHashes[3])
+	require.Equal(t, []byte("c"), txHashes[4])
 }
 
 func TestListForSender_findTx(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 
 	txA := createTx([]byte("A"), ".", 41)
 	txANewer := createTx([]byte("ANewer"), ".", 41)
@@ -122,10 +63,6 @@ func TestListForSender_findTx(t *testing.T) {
 	elementWithB := list.findListElementWithTx(txB)
 	noElementWithD := list.findListElementWithTx(txD)
 
-	require.NotNil(t, elementWithA)
-	require.NotNil(t, elementWithANewer)
-	require.NotNil(t, elementWithB)
-
 	require.Equal(t, txA, elementWithA.Value.(*WrappedTransaction))
 	require.Equal(t, txANewer, elementWithANewer.Value.(*WrappedTransaction))
 	require.Equal(t, txB, elementWithB.Value.(*WrappedTransaction))
@@ -133,7 +70,7 @@ func TestListForSender_findTx(t *testing.T) {
 }
 
 func TestListForSender_findTx_CoverNonceComparisonOptimization(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 	list.AddTx(createTx([]byte("A"), ".", 42))
 
 	// Find one with a lower nonce, not added to cache
@@ -142,7 +79,7 @@ func TestListForSender_findTx_CoverNonceComparisonOptimization(t *testing.T) {
 }
 
 func TestListForSender_RemoveTransaction(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 	tx := createTx([]byte("a"), ".", 1)
 
 	list.AddTx(tx)
@@ -153,15 +90,46 @@ func TestListForSender_RemoveTransaction(t *testing.T) {
 }
 
 func TestListForSender_RemoveTransaction_NoPanicWhenTxMissing(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 	tx := createTx([]byte(""), ".", 1)
 
 	list.RemoveTx(tx)
 	require.Equal(t, 0, list.items.Len())
 }
 
+func TestListForSender_RemoveHighNonceTransactions(t *testing.T) {
+	list := newListToTest()
+
+	for index := 0; index < 100; index++ {
+		list.AddTx(createTx([]byte{byte(index)}, ".", uint64(index)))
+	}
+
+	list.RemoveHighNonceTxs(50)
+	require.Equal(t, 50, list.items.Len())
+
+	list.RemoveHighNonceTxs(20)
+	require.Equal(t, 30, list.items.Len())
+
+	list.RemoveHighNonceTxs(30)
+	require.Equal(t, 0, list.items.Len())
+}
+
+func TestListForSender_RemoveHighNonceTransactions_NoPanicWhenCornerCases(t *testing.T) {
+	list := newListToTest()
+
+	for index := 0; index < 100; index++ {
+		list.AddTx(createTx([]byte{byte(index)}, ".", uint64(index)))
+	}
+
+	list.RemoveHighNonceTxs(0)
+	require.Equal(t, 100, list.items.Len())
+
+	list.RemoveHighNonceTxs(500)
+	require.Equal(t, 0, list.items.Len())
+}
+
 func TestListForSender_SelectBatchTo(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 
 	for index := 0; index < 100; index++ {
 		list.AddTx(createTx([]byte{byte(index)}, ".", uint64(index)))
@@ -190,7 +158,7 @@ func TestListForSender_SelectBatchTo(t *testing.T) {
 }
 
 func TestListForSender_SelectBatchTo_NoPanicWhenCornerCases(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 
 	for index := 0; index < 100; index++ {
 		list.AddTx(createTx([]byte{byte(index)}, ".", uint64(index)))
@@ -208,7 +176,7 @@ func TestListForSender_SelectBatchTo_NoPanicWhenCornerCases(t *testing.T) {
 }
 
 func TestListForSender_SelectBatchTo_WhenInitialGap(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 
 	list.notifyAccountNonce(1)
 
@@ -239,7 +207,7 @@ func TestListForSender_SelectBatchTo_WhenInitialGap(t *testing.T) {
 }
 
 func TestListForSender_SelectBatchTo_WhenGracePeriodWithGapResolve(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 
 	list.notifyAccountNonce(1)
 
@@ -272,7 +240,7 @@ func TestListForSender_SelectBatchTo_WhenGracePeriodWithGapResolve(t *testing.T)
 }
 
 func TestListForSender_SelectBatchTo_WhenGracePeriodWithNoGapResolve(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 
 	list.notifyAccountNonce(1)
 
@@ -304,7 +272,7 @@ func TestListForSender_SelectBatchTo_WhenGracePeriodWithNoGapResolve(t *testing.
 }
 
 func TestListForSender_NotifyAccountNonce(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 
 	require.Equal(t, uint64(0), list.accountNonce.Get())
 	require.False(t, list.accountNonceKnown.IsSet())
@@ -316,21 +284,21 @@ func TestListForSender_NotifyAccountNonce(t *testing.T) {
 }
 
 func TestListForSender_hasInitialGap(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 	list.notifyAccountNonce(42)
 
 	// No transaction, no gap
 	require.False(t, list.hasInitialGap())
 	// One gap
-	list.AddTx(createTx([]byte("tx-43"), ".", 43))
+	list.AddTx(createTx([]byte("tx-44"), ".", 43))
 	require.True(t, list.hasInitialGap())
 	// Resolve gap
-	list.AddTx(createTx([]byte("tx-42"), ".", 42))
+	list.AddTx(createTx([]byte("tx-44"), ".", 42))
 	require.False(t, list.hasInitialGap())
 }
 
 func TestListForSender_getTxHashes(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 	require.Len(t, list.getTxHashes(), 0)
 
 	list.AddTx(createTx([]byte("A"), ".", 1))
@@ -342,11 +310,12 @@ func TestListForSender_getTxHashes(t *testing.T) {
 }
 
 func TestListForSender_DetectRaceConditions(t *testing.T) {
-	list := newUnconstrainedListToTest()
+	list := newListToTest()
 
 	go func() {
 		// These are called concurrently with addition: during eviction, during removal etc.
 		approximatelyCountTxInLists([]*txListForSender{list})
+		list.HasMoreThan(42)
 		list.IsEmpty()
 	}()
 
@@ -355,18 +324,6 @@ func TestListForSender_DetectRaceConditions(t *testing.T) {
 	}()
 }
 
-func newUnconstrainedListToTest() *txListForSender {
-	return newTxListForSender(".", &CacheConfig{
-		NumBytesPerSenderThreshold: math.MaxUint32,
-		CountPerSenderThreshold:    math.MaxUint32,
-		MinGasPriceNanoErd:         100,
-	}, func(value *txListForSender) {})
-}
-
-func newListToTest(numBytesThreshold uint32, countThreshold uint32) *txListForSender {
-	return newTxListForSender(".", &CacheConfig{
-		NumBytesPerSenderThreshold: numBytesThreshold,
-		CountPerSenderThreshold:    countThreshold,
-		MinGasPriceNanoErd:         100,
-	}, func(value *txListForSender) {})
+func newListToTest() *txListForSender {
+	return newTxListForSender(".", &CacheConfig{MinGasPriceMicroErd: 100}, func(value *txListForSender) {})
 }

--- a/storage/txcache/txMeasures.go
+++ b/storage/txcache/txMeasures.go
@@ -14,14 +14,15 @@ func estimateTxGas(tx *WrappedTransaction) uint64 {
 	return gasLimit
 }
 
-// estimateTxFee returns an approximation for the cost of a transaction, in nano ERD
+// estimateTxFee returns an approximation for the cost of a transaction, in micro ERD (1/1000000 ERD)
 // TODO: switch to integer operations (as opposed to float operations).
 // TODO: do not assume the order of magnitude of minGasPrice.
 func estimateTxFee(tx *WrappedTransaction) uint64 {
-	// In order to obtain the result as nano ERD (not as "atomic" 10^-18 ERD), we have to divide by 10^9
-	// In order to have better precision, we divide the factors by 10^6, and 10^3 respectively
-	gasLimit := float32(tx.Tx.GetGasLimit()) / 1000000
-	gasPrice := float32(tx.Tx.GetGasPrice()) / 1000
-	feeInNanoERD := gasLimit * gasPrice
-	return uint64(feeInNanoERD)
+	// In order to obtain the result as micro ERD, we have to divide by 10^12, one trillion (since ~1 ERD accounts for ~10^18 gas currency units at the ~minimum price)
+	// In order to have better precision, we divide each of the factors by 10^6, one million
+	const SquareRootOfOneTrillion = 1000000
+	gasLimit := float32(tx.Tx.GetGasLimit()) / SquareRootOfOneTrillion
+	gasPrice := float32(tx.Tx.GetGasPrice()) / SquareRootOfOneTrillion
+	feeInMicroERD := gasLimit * gasPrice
+	return uint64(feeInMicroERD)
 }

--- a/storage/txcache/wrappedTransaction.go
+++ b/storage/txcache/wrappedTransaction.go
@@ -1,10 +1,6 @@
 package txcache
 
-import (
-	"bytes"
-
-	"github.com/ElrondNetwork/elrond-go/data"
-)
+import "github.com/ElrondNetwork/elrond-go/data"
 
 // WrappedTransaction contains a transaction, its hash and extra information
 type WrappedTransaction struct {
@@ -12,8 +8,4 @@ type WrappedTransaction struct {
 	TxHash          []byte
 	SenderShardID   uint32
 	ReceiverShardID uint32
-}
-
-func (wrappedTx *WrappedTransaction) sameAs(another *WrappedTransaction) bool {
-	return bytes.Equal(wrappedTx.TxHash, another.TxHash)
 }

--- a/update/mock/poolsHolderMock.go
+++ b/update/mock/poolsHolderMock.go
@@ -29,13 +29,11 @@ func NewPoolsHolderMock() *PoolsHolderMock {
 	phf.transactions, _ = txpool.NewShardedTxPool(
 		txpool.ArgShardedTxPool{
 			Config: storageUnit.CacheConfig{
-				Size:                 100000,
-				SizePerSender:        1000,
-				SizeInBytes:          1000000000,
-				SizeInBytesPerSender: 10000000,
-				Shards:               16,
+				Size:        10000,
+				SizeInBytes: 1000000000,
+				Shards:      16,
 			},
-			MinGasPrice:    200000000000,
+			MinGasPrice:    100000000000000,
 			NumberOfShards: 1,
 		},
 	)


### PR DESCRIPTION
- Reverted the transaction cache to its code base before the merging of the transaction pool improvements.