### PR TITLE
EN-6431: API: tx and tx status by hash routes

### DIFF
--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -33,6 +33,12 @@ type Facade struct {
 	ComputeTransactionGasLimitHandler func(tx *transaction.Transaction) (uint64, error)
 	NodeConfigCalled                  func() map[string]interface{}
 	GetQueryHandlerCalled             func(name string) (debug.QueryHandler, error)
+	GetTransactionStatusCalled        func(hash string) (string, error)
+}
+
+// GetTransactionStatus -
+func (f *Facade) GetTransactionStatus(hash string) (string, error) {
+	return f.GetTransactionStatusCalled(hash)
 }
 
 // RestApiInterface -

--- a/api/transaction/routes_test.go
+++ b/api/transaction/routes_test.go
@@ -39,8 +39,52 @@ type TransactionHashResponse struct {
 	TxHash string `json:"txHash,omitempty"`
 }
 
+type TransactionStatusResponse struct {
+	GeneralResponse
+	Status string `json:"status"`
+}
+
+type TransactionCostResponse struct {
+	GeneralResponse
+	Cost uint64 `json:"txGasUnits"`
+}
+
 func init() {
 	gin.SetMode(gin.TestMode)
+}
+
+func TestGetTransactionStatus(t *testing.T) {
+	rightHash := "hash"
+	wrongHash := "wronghash"
+	facade := mock.Facade{
+		GetTransactionStatusCalled: func(hash string) (string, error) {
+			if hash == rightHash {
+				return "pending", nil
+			}
+			return "unknown", nil
+		},
+	}
+
+	req, _ := http.NewRequest("GET", "/transaction/"+wrongHash+"/status", nil)
+	ws := startNodeServer(&facade)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := TransactionStatusResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, "unknown", response.Status)
+
+	req, _ = http.NewRequest("GET", "/transaction/"+rightHash+"/status", nil)
+	resp = httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response = TransactionStatusResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, "pending", response.Status)
 }
 
 func TestGetTransaction_WithCorrectHashShouldReturnTransaction(t *testing.T) {
@@ -345,6 +389,46 @@ func TestSendMultipleTransactions_OkPayloadShouldWork(t *testing.T) {
 	assert.True(t, sendBulkTxsWasCalled)
 }
 
+func TestComputeTransactionGasLimit(t *testing.T) {
+	t.Parallel()
+
+	expectedGasLimit := uint64(37)
+
+	facade := mock.Facade{
+		CreateTransactionHandler: func(_ uint64, _ string, _ string, _ string, _ uint64, _ uint64, _ string, _ string) (*tr.Transaction, []byte, error) {
+			return &tr.Transaction{}, nil, nil
+		},
+		ComputeTransactionGasLimitHandler: func(tx *tr.Transaction) (uint64, error) {
+			return expectedGasLimit, nil
+		},
+	}
+	ws := startNodeServer(&facade)
+
+	tx0 := transaction.SendTxRequest{
+		Sender:    "sender1",
+		Receiver:  "receiver1",
+		Value:     "100",
+		Data:      "",
+		Nonce:     0,
+		GasPrice:  0,
+		GasLimit:  0,
+		Signature: "",
+	}
+
+	jsonBytes, _ := json.Marshal(tx0)
+
+	req, _ := http.NewRequest("POST", "/transaction/cost", bytes.NewBuffer(jsonBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	transactionCostResponse := TransactionCostResponse{}
+	loadResponse(resp.Body, &transactionCostResponse)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, expectedGasLimit, transactionCostResponse.Cost)
+}
+
 func loadResponse(rsp io.Reader, destination interface{}) {
 	jsonParser := json.NewDecoder(rsp)
 	err := jsonParser.Decode(destination)
@@ -392,6 +476,7 @@ func getRoutesConfig() config.ApiRoutesConfig {
 					{Name: "/send-multiple", Open: true},
 					{Name: "/cost", Open: true},
 					{Name: "/:txhash", Open: true},
+					{Name: "/:txhash/status", Open: true},
 				},
 			},
 		},

--- a/cmd/node/config/api.toml
+++ b/cmd/node/config/api.toml
@@ -27,8 +27,8 @@
          # /address/:address will return data about a given account
         { Name = "/:address", Open = true },
 
-         # /address/:address/balance will return the balance of a given account
-         { Name = "/:address/balance", Open = true }
+        # /address/:address/balance will return the balance of a given account
+        { Name = "/:address/balance", Open = true }
 	]
 
 [APIPackages.hardfork]
@@ -42,9 +42,9 @@
          # /network/status will return metrics related to current status of the chain (epoch, nonce, round)
         { Name = "/status", Open = true },
 
-         # /network/config will return metrics related to current configuration of the network (number of shards,
-         # consensus group size and so on)
-         { Name = "/config", Open = true }
+        # /network/config will return metrics related to current configuration of the network (number of shards,
+        # consensus group size and so on)
+        { Name = "/config", Open = true }
 	]
 
 [APIPackages.log]
@@ -89,4 +89,7 @@
 
          # /transaction/:txhash will return the transaction in JSON format based on its hash
          { Name = "/:txhash", Open = true }
+
+         # /transaction/:txhash/status will return the status of a transaction based on its hash
+         { Name = "/:txhash/status", Open = true }
 	]

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/core/random"
 	"github.com/ElrondNetwork/elrond-go/core/serviceContainer"
 	"github.com/ElrondNetwork/elrond-go/core/statistics"
+	"github.com/ElrondNetwork/elrond-go/core/throttler"
 	"github.com/ElrondNetwork/elrond-go/crypto"
 	"github.com/ElrondNetwork/elrond-go/crypto/signing/mcl"
 	"github.com/ElrondNetwork/elrond-go/data"
@@ -85,6 +86,7 @@ const (
 	defaultShardString           = "Shard"
 	metachainShardName           = "metachain"
 	secondsToWaitForP2PBootstrap = 20
+	maxNumGoRoutinesTxsByHashApi = 10
 )
 
 var (
@@ -1898,6 +1900,11 @@ func createNode(
 		return nil, err
 	}
 
+	apiTxsByHashThrottler, err := throttler.NewNumGoRoutinesThrottler(maxNumGoRoutinesTxsByHashApi)
+	if err != nil {
+		return nil, err
+	}
+
 	var nd *node.Node
 	nd, err = node.NewNode(
 		node.WithMessenger(network.NetMessenger),
@@ -1957,6 +1964,7 @@ func createNode(
 		node.WithSignatureSize(config.ValidatorPubkeyConverter.SignatureLength),
 		node.WithPublicKeySize(config.ValidatorPubkeyConverter.Length),
 		node.WithNodeStopChannel(chanStopNodeProcess),
+		node.WithApiTransactionByHashThrottler(apiTxsByHashThrottler),
 	)
 	if err != nil {
 		return nil, errors.New("error creating node: " + err.Error())

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -33,6 +33,9 @@ type NodeHandler interface {
 	//GetTransaction gets the transaction
 	GetTransaction(hash string) (*transaction.Transaction, error)
 
+	//GetTransactionStatus gets the transaction status
+	GetTransactionStatus(hash string) (string, error)
+
 	// GetAccount returns an accountResponse containing information
 	//  about the account corelated with provided address
 	GetAccount(address string) (state.UserAccountHandler, error)

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -65,9 +65,9 @@ type nodeFacade struct {
 	syncer                 ntp.SyncTimer
 	tpsBenchmark           *statistics.TpsBenchmark
 	config                 config.FacadeConfig
-	restAPIServerDebugMode bool
 	wsAntifloodConfig      config.WebServerAntifloodConfig
 	apiRoutesConfig        config.ApiRoutesConfig
+	restAPIServerDebugMode bool
 }
 
 // NewNodeFacade creates a new Facade with a NodeWrapper
@@ -236,6 +236,11 @@ func (nf *nodeFacade) SendBulkTransactions(txs []*transaction.Transaction) (uint
 // GetTransaction gets the transaction with a specified hash
 func (nf *nodeFacade) GetTransaction(hash string) (*transaction.Transaction, error) {
 	return nf.node.GetTransaction(hash)
+}
+
+// GetTransactionStatus gets the current transaction status, given a specific tx hash
+func (nf *nodeFacade) GetTransactionStatus(hash string) (string, error) {
+	return nf.node.GetTransactionStatus(hash)
 }
 
 // ComputeTransactionGasLimit will estimate how many gas a transaction will consume

--- a/node/errors.go
+++ b/node/errors.go
@@ -156,3 +156,9 @@ var ErrQueryHandlerAlreadyExists = errors.New("query handler already exists")
 
 // ErrEmptyQueryHandlerName signals that an empty string can not be used to be used in the query handler container
 var ErrEmptyQueryHandlerName = errors.New("empty query handler name")
+
+// ErrNilApiTransactionByHashThrottler signals that a nil API transaction by hash throttler has been provided
+var ErrNilApiTransactionByHashThrottler = errors.New("nil api transaction by hash throttler")
+
+// ErrSystemBusyTxHash signals that too many requests occur in the same time on the transaction by hash provider
+var ErrSystemBusyTxHash = errors.New("system busy. try again later")

--- a/node/interface.go
+++ b/node/interface.go
@@ -58,3 +58,11 @@ type HardforkTrigger interface {
 	IsSelfTrigger() bool
 	IsInterfaceNil() bool
 }
+
+// Throttler can monitor the number of the currently running go routines
+type Throttler interface {
+	CanProcess() bool
+	StartProcessing()
+	EndProcessing()
+	IsInterfaceNil() bool
+}

--- a/node/mock/throttlerStub.go
+++ b/node/mock/throttlerStub.go
@@ -1,0 +1,40 @@
+package mock
+
+// ThrottlerStub -
+type ThrottlerStub struct {
+	CanProcessCalled      func() bool
+	StartProcessingCalled func()
+	EndProcessingCalled   func()
+	StartWasCalled        bool
+	EndWasCalled          bool
+}
+
+// CanProcess -
+func (ts *ThrottlerStub) CanProcess() bool {
+	if ts.CanProcessCalled != nil {
+		return ts.CanProcessCalled()
+	}
+
+	return true
+}
+
+// StartProcessing -
+func (ts *ThrottlerStub) StartProcessing() {
+	ts.StartWasCalled = true
+	if ts.StartProcessingCalled != nil {
+		ts.StartProcessingCalled()
+	}
+}
+
+// EndProcessing -
+func (ts *ThrottlerStub) EndProcessing() {
+	ts.EndWasCalled = true
+	if ts.EndProcessingCalled != nil {
+		ts.EndProcessingCalled()
+	}
+}
+
+// IsInterfaceNil -
+func (ts *ThrottlerStub) IsInterfaceNil() bool {
+	return ts == nil
+}

--- a/node/node.go
+++ b/node/node.go
@@ -92,6 +92,7 @@ type Node struct {
 	validatorsProvider            process.ValidatorsProvider
 	whiteListRequest              process.WhiteListHandler
 	whiteListerVerifiedTxs        process.WhiteListHandler
+	apiTransactionByHashThrottler Throttler
 
 	pubKey            crypto.PublicKey
 	privKey           crypto.PrivateKey
@@ -893,11 +894,6 @@ func (n *Node) CreateTransaction(
 	}
 
 	return tx, txHash, nil
-}
-
-//GetTransaction gets the transaction
-func (n *Node) GetTransaction(_ string) (*transaction.Transaction, error) {
-	return nil, fmt.Errorf("not yet implemented")
 }
 
 // GetAccount will return account details for a given address

--- a/node/nodeTransactions.go
+++ b/node/nodeTransactions.go
@@ -1,0 +1,135 @@
+package node
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ElrondNetwork/elrond-go/data/transaction"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
+)
+
+// GetTransaction gets the transaction
+func (n *Node) GetTransaction(txHash string) (*transaction.Transaction, error) {
+	if !n.apiTransactionByHashThrottler.CanProcess() {
+		return nil, ErrSystemBusyTxHash
+	}
+
+	n.apiTransactionByHashThrottler.StartProcessing()
+	defer n.apiTransactionByHashThrottler.EndProcessing()
+
+	hash, err := hex.DecodeString(txHash)
+	if err != nil {
+		return nil, err
+	}
+
+	txBytes, found := n.getTxFromDataPool(hash)
+	if found {
+		return n.convertBytesToTransaction(txBytes)
+	}
+
+	txBytes, found = n.getTxFromStorage(hash)
+	if found {
+		return n.convertBytesToTransaction(txBytes)
+	}
+
+	return nil, fmt.Errorf("transaction not found")
+}
+
+// GetTransactionStatus gets the transaction status
+func (n *Node) GetTransactionStatus(txHash string) (string, error) {
+	if !n.apiTransactionByHashThrottler.CanProcess() {
+		return "", ErrSystemBusyTxHash
+	}
+
+	n.apiTransactionByHashThrottler.StartProcessing()
+	defer n.apiTransactionByHashThrottler.EndProcessing()
+
+	hash, err := hex.DecodeString(txHash)
+	if err != nil {
+		return "", err
+	}
+
+	_, foundInDataPool := n.getTxFromDataPool(hash)
+	if foundInDataPool {
+		return "received", nil
+	}
+
+	foundInStorage := n.isTxInStorage(hash)
+	if foundInStorage {
+		return "executed", nil
+	}
+
+	return "unknown", nil
+}
+
+func (n *Node) getTxFromDataPool(hash []byte) ([]byte, bool) {
+	txsPool := n.dataPool.Transactions()
+	txBytes, found := txsPool.SearchFirstData(hash)
+	if found && txBytes != nil {
+		return txBytes.([]byte), true
+	}
+
+	rewardTxsPool := n.dataPool.RewardTransactions()
+	txBytes, found = rewardTxsPool.SearchFirstData(hash)
+	if found && txBytes != nil {
+		return txBytes.([]byte), true
+	}
+
+	unsignedTxsPool := n.dataPool.UnsignedTransactions()
+	txBytes, found = unsignedTxsPool.SearchFirstData(hash)
+	if found && txBytes != nil {
+		return txBytes.([]byte), true
+	}
+
+	return nil, false
+}
+
+func (n *Node) isTxInStorage(hash []byte) bool {
+	txsStorer := n.store.GetStorer(dataRetriever.TransactionUnit)
+	err := txsStorer.Has(hash)
+	if err == nil {
+		return true
+	}
+
+	rewardTxsStorer := n.store.GetStorer(dataRetriever.RewardTransactionUnit)
+	err = rewardTxsStorer.Has(hash)
+	if err == nil {
+		return true
+	}
+
+	unsignedTransactionsStorer := n.store.GetStorer(dataRetriever.UnsignedTransactionUnit)
+	err = unsignedTransactionsStorer.Has(hash)
+	return err == nil
+}
+
+func (n *Node) getTxFromStorage(hash []byte) ([]byte, bool) {
+	txsStorer := n.store.GetStorer(dataRetriever.TransactionUnit)
+	txBytes, err := txsStorer.SearchFirst(hash)
+	if err == nil {
+		return txBytes, true
+	}
+
+	rewardTxsStorer := n.store.GetStorer(dataRetriever.RewardTransactionUnit)
+	txBytes, err = rewardTxsStorer.SearchFirst(hash)
+	if err == nil {
+		return txBytes, true
+	}
+
+	unsignedTransactionsStorer := n.store.GetStorer(dataRetriever.UnsignedTransactionUnit)
+	txBytes, err = unsignedTransactionsStorer.SearchFirst(hash)
+	if err == nil {
+		return txBytes, true
+	}
+
+	return nil, false
+}
+
+func (n *Node) convertBytesToTransaction(txBytes []byte) (*transaction.Transaction, error) {
+	var tx transaction.Transaction
+	err := n.internalMarshalizer.Unmarshal(&tx, txBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tx, nil
+}

--- a/node/nodeTransactions_test.go
+++ b/node/nodeTransactions_test.go
@@ -1,0 +1,533 @@
+package node_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/data/transaction"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
+	"github.com/ElrondNetwork/elrond-go/node"
+	"github.com/ElrondNetwork/elrond-go/node/mock"
+	"github.com/ElrondNetwork/elrond-go/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNode_GetTransactionStatus_ThrottlerCannotProcessShouldErr(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return false
+		},
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+	)
+	_, err := n.GetTransactionStatus("aaa")
+	assert.Equal(t, node.ErrSystemBusyTxHash, err)
+}
+
+func TestNode_GetTransactionStatus_InvalidHashShouldErr(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+	)
+	_, err := n.GetTransactionStatus("zzz")
+	assert.Error(t, err)
+}
+
+func TestNode_GetTransactionStatus_ShouldFindInTxCacheAndReturnReceived(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled: getCacherHandler(true),
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+		node.WithDataPool(dataPool),
+	)
+	res, err := n.GetTransactionStatus("aaaa")
+	assert.NoError(t, err)
+	assert.Equal(t, "received", res)
+}
+
+func TestNode_GetTransactionStatus_ShouldFindInRwdTxCacheAndReturnReceived(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled:       getCacherHandler(false),
+		RewardTransactionsCalled: getCacherHandler(true),
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+		node.WithDataPool(dataPool),
+	)
+	res, err := n.GetTransactionStatus("aaaa")
+	assert.NoError(t, err)
+	assert.Equal(t, "received", res)
+}
+
+func TestNode_GetTransactionStatus_ShouldFindInUnsignedTxCacheAndReturnReceived(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled:         getCacherHandler(false),
+		RewardTransactionsCalled:   getCacherHandler(false),
+		UnsignedTransactionsCalled: getCacherHandler(true),
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+		node.WithDataPool(dataPool),
+	)
+	res, err := n.GetTransactionStatus("aaaa")
+	assert.NoError(t, err)
+	assert.Equal(t, "received", res)
+}
+
+func TestNode_GetTransactionStatus_ShouldFindInTxStorageAndReturnExecuted(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled:         getCacherHandler(false),
+		RewardTransactionsCalled:   getCacherHandler(false),
+		UnsignedTransactionsCalled: getCacherHandler(false),
+	}
+	storer := &mock.ChainStorerMock{
+		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
+			return getStorerStub(true)
+		},
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+		node.WithDataPool(dataPool),
+		node.WithDataStore(storer),
+	)
+	res, err := n.GetTransactionStatus("aaaa")
+	assert.NoError(t, err)
+	assert.Equal(t, "executed", res)
+}
+
+func TestNode_GetTransactionStatus_ShouldFindInRwdTxStorageAndReturnExecuted(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled:         getCacherHandler(false),
+		RewardTransactionsCalled:   getCacherHandler(false),
+		UnsignedTransactionsCalled: getCacherHandler(false),
+	}
+	storer := &mock.ChainStorerMock{
+		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
+			if unitType == dataRetriever.TransactionUnit {
+				return getStorerStub(false)
+			}
+
+			return getStorerStub(true)
+		},
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+		node.WithDataPool(dataPool),
+		node.WithDataStore(storer),
+	)
+	res, err := n.GetTransactionStatus("aaaa")
+	assert.NoError(t, err)
+	assert.Equal(t, "executed", res)
+}
+
+func TestNode_GetTransactionStatus_ShouldFindInUnsignedTxStorageAndReturnExecuted(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled:         getCacherHandler(false),
+		RewardTransactionsCalled:   getCacherHandler(false),
+		UnsignedTransactionsCalled: getCacherHandler(false),
+	}
+	storer := &mock.ChainStorerMock{
+		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
+			switch unitType {
+			case dataRetriever.UnsignedTransactionUnit:
+				return getStorerStub(true)
+			default:
+				return getStorerStub(false)
+			}
+		},
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+		node.WithDataPool(dataPool),
+		node.WithDataStore(storer),
+	)
+	res, err := n.GetTransactionStatus("aaaa")
+	assert.NoError(t, err)
+	assert.Equal(t, "executed", res)
+}
+
+func TestNode_GetTransactionStatus_ShouldNotFindAndReturnUnknown(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled:         getCacherHandler(false),
+		RewardTransactionsCalled:   getCacherHandler(false),
+		UnsignedTransactionsCalled: getCacherHandler(false),
+	}
+	storer := &mock.ChainStorerMock{
+		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
+			return getStorerStub(false)
+		},
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+		node.WithDataPool(dataPool),
+		node.WithDataStore(storer),
+	)
+	res, err := n.GetTransactionStatus("aaaa")
+	assert.NoError(t, err)
+	assert.Equal(t, "unknown", res)
+}
+
+func TestNode_GetTransaction_ThrottlerCannotProcessShouldErr(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return false
+		},
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+	)
+	_, err := n.GetTransaction("aaa")
+	assert.Equal(t, node.ErrSystemBusyTxHash, err)
+}
+
+func TestNode_GetTransaction_InvalidHashShouldErr(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+	)
+	_, err := n.GetTransaction("zzz")
+	assert.Error(t, err)
+}
+
+func TestNode_GetTransaction_ShouldFindInTxCacheAndReturnReceived(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled: getCacherHandler(true),
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+		node.WithDataPool(dataPool),
+		node.WithInternalMarshalizer(&mock.MarshalizerFake{}, 0),
+	)
+	expectedTx, _ := getDummyTx()
+	tx, err := n.GetTransaction("aaaa")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedTx.Nonce, tx.Nonce)
+}
+
+func TestNode_GetTransaction_ShouldFindInRwdTxCacheAndReturnReceived(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled:       getCacherHandler(false),
+		RewardTransactionsCalled: getCacherHandler(true),
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+		node.WithDataPool(dataPool),
+		node.WithInternalMarshalizer(&mock.MarshalizerFake{}, 0),
+	)
+	expectedTx, _ := getDummyTx()
+	tx, err := n.GetTransaction("aaaa")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedTx.Nonce, tx.Nonce)
+}
+
+func TestNode_GetTransaction_ShouldFindInUnsignedTxCacheAndReturnReceived(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled:         getCacherHandler(false),
+		RewardTransactionsCalled:   getCacherHandler(false),
+		UnsignedTransactionsCalled: getCacherHandler(true),
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+		node.WithDataPool(dataPool),
+		node.WithInternalMarshalizer(&mock.MarshalizerFake{}, 0),
+	)
+	expectedTx, _ := getDummyTx()
+	tx, err := n.GetTransaction("aaaa")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedTx.Nonce, tx.Nonce)
+}
+
+func TestNode_GetTransaction_ShouldFindInTxStorageAndReturnExecuted(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled:         getCacherHandler(false),
+		RewardTransactionsCalled:   getCacherHandler(false),
+		UnsignedTransactionsCalled: getCacherHandler(false),
+	}
+	storer := &mock.ChainStorerMock{
+		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
+			return getStorerStub(true)
+		},
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+		node.WithDataPool(dataPool),
+		node.WithDataStore(storer),
+		node.WithInternalMarshalizer(&mock.MarshalizerFake{}, 0),
+	)
+	expectedTx, _ := getDummyTx()
+	tx, err := n.GetTransaction("aaaa")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedTx.Nonce, tx.Nonce)
+}
+
+func TestNode_GetTransaction_ShouldFindInRwdTxStorageAndReturnExecuted(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled:         getCacherHandler(false),
+		RewardTransactionsCalled:   getCacherHandler(false),
+		UnsignedTransactionsCalled: getCacherHandler(false),
+	}
+	storer := &mock.ChainStorerMock{
+		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
+			if unitType == dataRetriever.TransactionUnit {
+				return getStorerStub(false)
+			}
+
+			return getStorerStub(true)
+		},
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+		node.WithDataPool(dataPool),
+		node.WithDataStore(storer),
+		node.WithInternalMarshalizer(&mock.MarshalizerFake{}, 0),
+	)
+	expectedTx, _ := getDummyTx()
+	tx, err := n.GetTransaction("aaaa")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedTx.Nonce, tx.Nonce)
+}
+
+func TestNode_GetTransaction_ShouldFindInUnsignedTxStorageAndReturnExecuted(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled:         getCacherHandler(false),
+		RewardTransactionsCalled:   getCacherHandler(false),
+		UnsignedTransactionsCalled: getCacherHandler(false),
+	}
+	storer := &mock.ChainStorerMock{
+		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
+			switch unitType {
+			case dataRetriever.UnsignedTransactionUnit:
+				return getStorerStub(true)
+			default:
+				return getStorerStub(false)
+			}
+		},
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+		node.WithDataPool(dataPool),
+		node.WithDataStore(storer),
+		node.WithInternalMarshalizer(&mock.MarshalizerFake{}, 0),
+	)
+	expectedTx, _ := getDummyTx()
+	tx, err := n.GetTransaction("aaaa")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedTx.Nonce, tx.Nonce)
+}
+
+func TestNode_GetTransaction_ShouldFindInStorageButErrorUnmarshaling(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("error unmarshalling")
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled:         getCacherHandler(false),
+		RewardTransactionsCalled:   getCacherHandler(false),
+		UnsignedTransactionsCalled: getCacherHandler(false),
+	}
+	storer := &mock.ChainStorerMock{
+		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
+			switch unitType {
+			case dataRetriever.UnsignedTransactionUnit:
+				return getStorerStub(true)
+			default:
+				return getStorerStub(false)
+			}
+		},
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+		node.WithDataPool(dataPool),
+		node.WithDataStore(storer),
+		node.WithInternalMarshalizer(&mock.MarshalizerMock{
+			UnmarshalHandler: func(_ interface{}, _ []byte) error {
+				return expectedErr
+			},
+		}, 0),
+	)
+	tx, err := n.GetTransaction("aaaa")
+	assert.Nil(t, tx)
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestNode_GetTransaction_ShouldNotFindAndReturnUnknown(t *testing.T) {
+	t.Parallel()
+
+	throttler := &mock.ThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled:         getCacherHandler(false),
+		RewardTransactionsCalled:   getCacherHandler(false),
+		UnsignedTransactionsCalled: getCacherHandler(false),
+	}
+	storer := &mock.ChainStorerMock{
+		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
+			return getStorerStub(false)
+		},
+	}
+	n, _ := node.NewNode(
+		node.WithApiTransactionByHashThrottler(throttler),
+		node.WithDataPool(dataPool),
+		node.WithDataStore(storer),
+	)
+	tx, err := n.GetTransaction("aaaa")
+	assert.Nil(t, tx)
+	assert.Error(t, err)
+}
+
+func getCacherHandler(find bool) func() dataRetriever.ShardedDataCacherNotifier {
+	return func() dataRetriever.ShardedDataCacherNotifier {
+		return &mock.ShardedDataStub{
+			SearchFirstDataCalled: func(_ []byte) (interface{}, bool) {
+				if find {
+					_, txBytes := getDummyTx()
+					return txBytes, true
+				}
+
+				return nil, false
+			},
+		}
+	}
+}
+
+func getStorerStub(find bool) storage.Storer {
+	return &mock.StorerStub{
+		HasCalled: func(_ []byte) error {
+			if !find {
+				return errors.New("key not found")
+			}
+			return nil
+		},
+		SearchFirstCalled: func(_ []byte) ([]byte, error) {
+			if !find {
+				return nil, errors.New("key not found")
+			}
+			_, txBytes := getDummyTx()
+			return txBytes, nil
+		},
+	}
+}
+
+func getDummyTx() (*transaction.Transaction, []byte) {
+	tx := transaction.Transaction{Nonce: 37}
+	marshalizer := &mock.MarshalizerFake{}
+	txBytes, _ := marshalizer.Marshal(&tx)
+	return &tx, txBytes
+}

--- a/node/options.go
+++ b/node/options.go
@@ -661,3 +661,14 @@ func WithNodeStopChannel(channel chan endProcess.ArgEndProcess) Option {
 		return nil
 	}
 }
+
+// WithApiTransactionByHashThrottler sets up the api transaction by hash throttler
+func WithApiTransactionByHashThrottler(throttler Throttler) Option {
+	return func(n *Node) error {
+		if throttler == nil {
+			return ErrNilApiTransactionByHashThrottler
+		}
+		n.apiTransactionByHashThrottler = throttler
+		return nil
+	}
+}


### PR DESCRIPTION
Added (and extended) routes:
- `/transaction/:txhash` - will return the transaction in `json` format (if found)
- `/transaction/:txhash/status` - will return the transaction's status ("received", "executed" or "unknown")

Also added a number of goroutines throttler to these APIs to avoid too many requests