### PR TITLE
En 6453 fix trie sync

### DIFF
--- a/data/mock/cacherMock.go
+++ b/data/mock/cacherMock.go
@@ -1,0 +1,118 @@
+package mock
+
+import "sync"
+
+// CacherMock -
+type CacherMock struct {
+	mut     sync.Mutex
+	dataMap map[string]interface{}
+}
+
+// Clear -
+func (cm *CacherMock) Clear() {
+	cm.mut.Lock()
+	defer cm.mut.Unlock()
+
+	cm.dataMap = make(map[string]interface{})
+}
+
+// Put -
+func (cm *CacherMock) Put(key []byte, value interface{}) (evicted bool) {
+	cm.mut.Lock()
+	defer cm.mut.Unlock()
+
+	cm.dataMap[string(key)] = value
+
+	return false
+}
+
+// Get -
+func (cm *CacherMock) Get(key []byte) (value interface{}, ok bool) {
+	cm.mut.Lock()
+	defer cm.mut.Unlock()
+
+	val, ok := cm.dataMap[string(key)]
+
+	return val, ok
+}
+
+// Has -
+func (cm *CacherMock) Has(key []byte) bool {
+	cm.mut.Lock()
+	defer cm.mut.Unlock()
+
+	_, ok := cm.dataMap[string(key)]
+
+	return ok
+}
+
+// Peek -
+func (cm *CacherMock) Peek(key []byte) (value interface{}, ok bool) {
+	cm.mut.Lock()
+	defer cm.mut.Unlock()
+
+	val, ok := cm.dataMap[string(key)]
+
+	return val, ok
+}
+
+// HasOrAdd -
+func (cm *CacherMock) HasOrAdd(key []byte, value interface{}) (bool, bool) {
+	cm.mut.Lock()
+	defer cm.mut.Unlock()
+
+	_, ok := cm.dataMap[string(key)]
+	if !ok {
+		cm.dataMap[string(key)] = value
+	}
+
+	return ok, false
+}
+
+// Remove -
+func (cm *CacherMock) Remove(key []byte) {
+	cm.mut.Lock()
+	defer cm.mut.Unlock()
+
+	delete(cm.dataMap, string(key))
+}
+
+// RemoveOldest -
+func (cm *CacherMock) RemoveOldest() {
+	panic("implement me")
+}
+
+// Keys -
+func (cm *CacherMock) Keys() [][]byte {
+	keys := make([][]byte, len(cm.dataMap))
+	idx := 0
+	for k := range cm.dataMap {
+		keys[idx] = []byte(k)
+		idx++
+	}
+
+	return keys
+}
+
+// Len -
+func (cm *CacherMock) Len() int {
+	cm.mut.Lock()
+	defer cm.mut.Unlock()
+
+	return len(cm.dataMap)
+}
+
+// MaxSize -
+func (cm *CacherMock) MaxSize() int {
+	return 10000
+}
+
+// RegisterHandler -
+func (cm *CacherMock) RegisterHandler(func(key []byte, value interface{})) {
+	return
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (cm *CacherMock) IsInterfaceNil() bool {
+	return cm == nil
+}

--- a/data/trie/branchNode.go
+++ b/data/trie/branchNode.go
@@ -275,6 +275,8 @@ func (bn *branchNode) commit(force bool, level byte, maxTrieLevelInMemory uint, 
 		return err
 	}
 	if uint(level) == maxTrieLevelInMemory {
+		log.Trace("collapse branch node on commit")
+
 		var collapsed node
 		collapsed, err = bn.getCollapsed()
 		if err != nil {
@@ -690,6 +692,7 @@ func (bn *branchNode) loadChildren(getNode func([]byte) (node, error)) ([][]byte
 		}
 
 		existingChildren = append(existingChildren, child)
+		log.Trace("load branch node child", "child hash", bn.EncodedChildren[i])
 		bn.children[i] = child
 	}
 

--- a/data/trie/extensionNode.go
+++ b/data/trie/extensionNode.go
@@ -187,6 +187,8 @@ func (en *extensionNode) commit(force bool, level byte, maxTrieLevelInMemory uin
 		return err
 	}
 	if uint(level) == maxTrieLevelInMemory {
+		log.Trace("collapse extension node on commit")
+
 		var collapsed node
 		collapsed, err = en.getCollapsed()
 		if err != nil {
@@ -561,6 +563,7 @@ func (en *extensionNode) loadChildren(getNode func([]byte) (node, error)) ([][]b
 	if err != nil {
 		return [][]byte{en.EncodedChild}, nil, nil
 	}
+	log.Trace("load extension node child", "child hash", en.EncodedChild)
 	en.child = child
 
 	return nil, []node{child}, nil

--- a/data/trie/sync.go
+++ b/data/trie/sync.go
@@ -157,6 +157,7 @@ func (ts *trieSyncer) checkIfSynced() (bool, error) {
 			if err != nil {
 				return false, err
 			}
+			log.Trace("loaded children for node", "hash", currentNode.getHash())
 
 			if len(currentMissingNodes) > 0 {
 				for _, hash := range currentMissingNodes {
@@ -259,8 +260,10 @@ func (ts *trieSyncer) trieNodeIntercepted(hash []byte, val interface{}) {
 	ts.mutOperation.Lock()
 	defer ts.mutOperation.Unlock()
 
-	_, ok := ts.nodesForTrie[string(hash)]
-	if !ok {
+	log.Trace("trie node intercepted", "hash", hash)
+
+	n, ok := ts.nodesForTrie[string(hash)]
+	if !ok || n.received {
 		return
 	}
 

--- a/data/trie/sync_test.go
+++ b/data/trie/sync_test.go
@@ -1,0 +1,36 @@
+package trie
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/data/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrieSync_InterceptedNodeShouldNotBeAddedToNodesForTrieIfNodeReceived(t *testing.T) {
+	t.Parallel()
+
+	marsh, hasher := getTestMarshAndHasher()
+	ts, err := NewTrieSyncer(&mock.RequestHandlerStub{}, &mock.CacherMock{}, &patriciaMerkleTrie{}, 0, "trieNodes")
+	assert.Nil(t, err)
+	assert.NotNil(t, ts)
+
+	bn, collapsedBn := getBnAndCollapsedBn(marsh, hasher)
+	encodedNode, err := collapsedBn.getEncodedNode()
+	assert.Nil(t, err)
+
+	interceptedNode, err := NewInterceptedTrieNode(encodedNode, marsh, hasher)
+	assert.Nil(t, err)
+
+	hash := "nodeHash"
+	ts.nodesForTrie[hash] = trieNodeInfo{
+		trieNode: bn,
+		received: true,
+	}
+
+	ts.trieNodeIntercepted([]byte(hash), interceptedNode)
+
+	nodeInfo, ok := ts.nodesForTrie[hash]
+	assert.True(t, ok)
+	assert.Equal(t, bn, nodeInfo.trieNode)
+}


### PR DESCRIPTION
When intercepting the same node, do not override in nodesForTrie cache.