### PR TITLE
Fix checker genesis

### DIFF
--- a/genesis/checking/nodesSetupChecker.go
+++ b/genesis/checking/nodesSetupChecker.go
@@ -114,6 +114,9 @@ func (nsc *nodeSetupChecker) subtractStakedValue(
 		if check.IfNil(dh) {
 			return genesis.ErrNilDelegationHandler
 		}
+		if !bytes.Equal(dh.AddressBytes(), addressBytes) {
+			continue
+		}
 
 		addr, ok := delegated[string(dh.AddressBytes())]
 		if !ok {

--- a/genesis/checking/nodesSetupChecker_test.go
+++ b/genesis/checking/nodesSetupChecker_test.go
@@ -264,7 +264,7 @@ func TestNewNodeSetupChecker_CheckStakedAndDelegatedShouldWork(t *testing.T) {
 	nsc, _ := checking.NewNodesSetupChecker(
 		&mock.AccountsParserStub{
 			InitialAccountsCalled: func() []genesis.InitialAccountHandler {
-				return []genesis.InitialAccountHandler{iaStaked, iaDelegated}
+				return []genesis.InitialAccountHandler{iaDelegated, iaStaked}
 			},
 		},
 		nodePrice,


### PR DESCRIPTION
- Fixed the case in which the delegation is done before staking and the checker wrongly subtracted the value of a staked node.