### PR TITLE
consensus: do not process consensus header metrics if the node is in …

### DIFF
--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -411,7 +411,9 @@ func (wrk *Worker) doJobOnMessageWithHeader(cnsMsg *consensus.Message) error {
 			err)
 	}
 
-	wrk.processReceivedHeaderMetric(cnsMsg)
+	if wrk.bootstrapper.GetNodeState() == core.NsSynchronized {
+		wrk.processReceivedHeaderMetric(cnsMsg)
+	}
 
 	errNotCritical := wrk.forkDetector.AddHeader(header, headerHash, process.BHProposed, nil, nil)
 	if errNotCritical != nil {


### PR DESCRIPTION
For nodes that are in sync, computing the proposed blocks metrics is unnecessary and in some situations incorrect, so it needs to be ignored.