### PR TITLE
fixed empty validator statistics

### DIFF
--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -1197,6 +1197,8 @@ func (mp *metaProcessor) updateState(lastMetaBlock data.HeaderHandler) {
 		return
 	}
 
+	mp.validatorStatisticsProcessor.SetLastFinalizedRootHash(lastMetaBlock.GetValidatorStatsRootHash())
+
 	prevHeader, errNotCritical := process.GetMetaHeaderFromStorage(lastMetaBlock.GetPrevHash(), mp.marshalizer, mp.store)
 	if errNotCritical != nil {
 		log.Debug("could not get meta header from storage")
@@ -1222,8 +1224,6 @@ func (mp *metaProcessor) updateState(lastMetaBlock data.HeaderHandler) {
 		prevHeader.GetValidatorStatsRootHash(),
 		mp.accountsDB[state.PeerAccountsState],
 	)
-
-	mp.validatorStatisticsProcessor.SetLastFinalizedRootHash(prevHeader.GetValidatorStatsRootHash())
 }
 
 func (mp *metaProcessor) getLastSelfNotarizedHeaderByShard(


### PR DESCRIPTION
validator statistics was queried from the peerAccountTrie with a "lastFinalizedRootHash" which was 2 blocks behind. In some cases, the next block was ready to be committed and the 3rd block behind was pruned.

- fixed validator statistics is empty by querying the trie with the previous block's rootHash (lastMetaBlock) not two blocks (prevHeader) behind
