### PR TITLE
add some delay before broadcasting cross shard data after block notar…

### DIFF
--- a/consensus/broadcast/shardChainMessenger.go
+++ b/consensus/broadcast/shardChainMessenger.go
@@ -29,7 +29,7 @@ type shardChainMessenger struct {
 	headersSubscriber    consensus.HeadersPoolSubscriber
 	delayedBroadcastData []*delayedBroadcastData
 	maxDelayCacheSize    uint32
-	mutDataForBroadcast  sync.Mutex
+	mutDataForBroadcast  sync.RWMutex
 }
 
 // ShardChainMessengerArgs holds the arguments for creating a shardChainMessenger instance
@@ -62,7 +62,7 @@ func NewShardChainMessenger(
 		headersSubscriber:    args.HeadersSubscriber,
 		delayedBroadcastData: make([]*delayedBroadcastData, 0),
 		maxDelayCacheSize:    args.MaxDelayCacheSize,
-		mutDataForBroadcast:  sync.Mutex{},
+		mutDataForBroadcast:  sync.RWMutex{},
 	}
 
 	scm.headersSubscriber.RegisterHandler(scm.headerReceived)
@@ -170,8 +170,8 @@ func (scm *shardChainMessenger) SetDataForDelayBroadcast(
 }
 
 func (scm *shardChainMessenger) headerReceived(headerHandler data.HeaderHandler, _ []byte) {
-	scm.mutDataForBroadcast.Lock()
-	defer scm.mutDataForBroadcast.Unlock()
+	scm.mutDataForBroadcast.RLock()
+	defer scm.mutDataForBroadcast.RUnlock()
 
 	if len(scm.delayedBroadcastData) == 0 {
 		return

--- a/consensus/broadcast/shardChainMessenger.go
+++ b/consensus/broadcast/shardChainMessenger.go
@@ -3,6 +3,7 @@ package broadcast
 import (
 	"bytes"
 	"sync"
+	"time"
 
 	"github.com/ElrondNetwork/elrond-go/consensus"
 	"github.com/ElrondNetwork/elrond-go/consensus/spos"
@@ -14,6 +15,8 @@ import (
 )
 
 var _ consensus.BroadcastMessenger = (*shardChainMessenger)(nil)
+
+const extraDelayForBroadcast = time.Second
 
 type delayedBroadcastData struct {
 	headerHash   []byte
@@ -185,6 +188,15 @@ func (scm *shardChainMessenger) headerReceived(headerHandler data.HeaderHandler,
 	if len(headerHashes) == 0 {
 		return
 	}
+
+	go scm.broadcastDataForHeaders(headerHashes)
+}
+
+func (scm *shardChainMessenger) broadcastDataForHeaders(headerHashes [][]byte) {
+	time.Sleep(extraDelayForBroadcast)
+
+	scm.mutDataForBroadcast.Lock()
+	defer scm.mutDataForBroadcast.Unlock()
 
 	for i := len(scm.delayedBroadcastData) - 1; i >= 0; i-- {
 		for _, headerHash := range headerHashes {

--- a/consensus/broadcast/shardChainMessenger_test.go
+++ b/consensus/broadcast/shardChainMessenger_test.go
@@ -427,7 +427,7 @@ func TestShardChainMessenger_HeaderReceivedForRegisteredDelayedDataShouldBroadca
 	mutData.Unlock()
 
 	scm.HeaderReceived(metaBlock, []byte("meta hash"))
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(time.Second + 10*time.Millisecond)
 	mutData.Lock()
 	assert.True(t, wasCalled)
 	assert.Contains(t, broadcastBuffer, miniBlocksMarshalled[1])
@@ -517,7 +517,7 @@ func TestShardChainMessenger_HeaderReceivedForNextRegisteredDelayedDataShouldBro
 	expectedSent = append(expectedSent, miniBlocksMarshalled2[1])
 
 	scm.HeaderReceived(metaBlock, []byte("meta hash"))
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(time.Second + 10*time.Millisecond)
 	mutData.Lock()
 	assert.True(t, wasCalled)
 	assert.True(t, isIncluded(expectedSent, broadcastBuffer))


### PR DESCRIPTION
The delay broadcast is propagating the cross shard data once the produced block is notarized by a metachain block and the metachain block is seen by the producer.

In some cases it seems the metachain block is seen on the destination shard after receiving the delayed broadcast, so the whitelisting is missed.

Added one second delay before propagating the cross shard data.