### PR TITLE
En 6508 fix logger in main

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -456,15 +456,10 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 	var err error
 	withLogFile := ctx.GlobalBool(logSaveFile.Name)
 	if withLogFile {
-		var fileForLogs *os.File
-		fileForLogs, err = prepareLogFile(workingDir)
+		_, err = prepareLogFile(workingDir)
 		if err != nil {
 			return fmt.Errorf("%w creating a log file", err)
 		}
-
-		defer func() {
-			_ = fileForLogs.Close()
-		}()
 	}
 
 	logger.ToggleCorrelation(ctx.GlobalBool(logWithCorrelation.Name))


### PR DESCRIPTION
- removed logger file closing when the startNode finished in order to capture the last error in the file. Logger file will close when the GC will try to clean-up the logger objects through a setFinalizer function (called inside the prepareLogFile function).