### PR TITLE
Scrips proxy connects meta observers

### DIFF
--- a/core/indexer/elasticsearch.go
+++ b/core/indexer/elasticsearch.go
@@ -107,7 +107,6 @@ func (ei *elasticIndexer) SaveBlock(
 	go ei.database.SaveHeader(headerHandler, signersIndexes, body, notarizedHeadersHashes, txsSizeInBytes)
 
 	if len(body.MiniBlocks) == 0 {
-		log.Debug("indexer", "error", ErrNoMiniblocks.Error())
 		return
 	}
 

--- a/core/indexer/elasticsearch_test.go
+++ b/core/indexer/elasticsearch_test.go
@@ -208,27 +208,6 @@ func TestElasticIndexer_SaveBlockNilBodyHandler(t *testing.T) {
 	require.True(t, strings.Contains(output.String(), indexer.ErrBodyTypeAssertion.Error()))
 }
 
-func TestElasticIndexer_SaveBlockNoMiniBlocks(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-
-	output := &bytes.Buffer{}
-	_ = logger.SetLogLevel("core/indexer:TRACE")
-	_ = logger.AddLogObserver(output, &logger.PlainFormatter{})
-	arguments := NewElasticIndexerArguments()
-	arguments.Url = ts.URL
-	ei, _ := indexer.NewElasticIndexer(arguments)
-
-	defer func() {
-		_ = logger.RemoveLogObserver(output)
-		_ = logger.SetLogLevel("core/indexer:INFO")
-	}()
-
-	header := &block.Header{}
-	body := &block.Body{}
-	ei.SaveBlock(body, header, nil, []uint64{0}, nil)
-	require.True(t, strings.Contains(output.String(), indexer.ErrNoMiniblocks.Error()))
-}
-
 func TestElasticIndexer_SaveRoundInfo(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 

--- a/scripts/testnet/include/config.sh
+++ b/scripts/testnet/include/config.sh
@@ -166,6 +166,17 @@ generateProxyObserverList() {
       let OBSERVER_INDEX++
     done
   done
+  # Start Meta Observers
+  for OBSERVER_IN_SHARD in `seq $META_OBSERVERCOUNT`; do
+      let "PORT = $PORT_ORIGIN_OBSERVER_REST + $OBSERVER_INDEX"
+
+      echo -n "[[Observers]]" >> config_edit.toml
+      echo -n "   ShardId = 4294967295" >> config_edit.toml
+      echo -n "   Address = \"http://127.0.0.1:$PORT\"" >> config_edit.toml
+      echo -n ""$'\n' >> config_edit.toml
+
+      let OBSERVER_INDEX++
+    done
 }
 
 updateTOMLValue() {

--- a/scripts/testnet/include/config.sh
+++ b/scripts/testnet/include/config.sh
@@ -167,11 +167,11 @@ generateProxyObserverList() {
     done
   done
   # Start Meta Observers
-  for OBSERVER_IN_SHARD in `seq $META_OBSERVERCOUNT`; do
+  for META_OBSERVER in `seq $META_OBSERVERCOUNT`; do
       let "PORT = $PORT_ORIGIN_OBSERVER_REST + $OBSERVER_INDEX"
 
       echo -n "[[Observers]]" >> config_edit.toml
-      echo -n "   ShardId = 4294967295" >> config_edit.toml
+      echo -n "   ShardId = $METASHARD_ID" >> config_edit.toml
       echo -n "   Address = \"http://127.0.0.1:$PORT\"" >> config_edit.toml
       echo -n ""$'\n' >> config_edit.toml
 

--- a/scripts/testnet/variables.sh
+++ b/scripts/testnet/variables.sh
@@ -145,3 +145,6 @@ export TOTAL_OBSERVERCOUNT=$total_observer_count
 let "total_node_count = $SHARD_VALIDATORCOUNT * $SHARDCOUNT + $META_VALIDATORCOUNT + $TOTAL_OBSERVERCOUNT"
 export TOTAL_NODECOUNT=$total_node_count
 
+# METASHARD_ID will be used to identify a shard ID as metachain
+export METASHARD_ID=4294967295
+


### PR DESCRIPTION
- Modified testnet scripts to generate setting for proxy application to connects to observer that are on metachain. 
- Also remove log.Debug(...) that is displayed when observers that are connected to `elasticsearch` database try to index a block that does not have miniblocks.