### PR TITLE
[Minor bug / minor fix] TxPool - fix inconsistent counters (estimators)

### DIFF
--- a/storage/txcache/maps/bucketSortedMap.go
+++ b/storage/txcache/maps/bucketSortedMap.go
@@ -108,12 +108,14 @@ func (sortedMap *BucketSortedMap) Has(key string) bool {
 }
 
 // Remove removes an element from the map
-func (sortedMap *BucketSortedMap) Remove(key string) {
+func (sortedMap *BucketSortedMap) Remove(key string) (interface{}, bool) {
 	chunk := sortedMap.getChunk(key)
 	item := chunk.removeItemByKey(key)
 	if item != nil {
 		removeFromScoreChunk(item)
 	}
+
+	return item, item != nil
 }
 
 // getChunk returns the chunk holding the given key.

--- a/storage/txcache/maps/bucketSortedMap_test.go
+++ b/storage/txcache/maps/bucketSortedMap_test.go
@@ -187,7 +187,10 @@ func TestBucketSortedMap_Remove(t *testing.T) {
 	myMap.Set(newDummyItem("a"))
 	myMap.Set(newDummyItem("b"))
 
-	myMap.Remove("b")
+	_, ok := myMap.Remove("b")
+	require.True(t, ok)
+	_, ok = myMap.Remove("x")
+	require.False(t, ok)
 
 	require.True(t, myMap.Has("a"))
 	require.False(t, myMap.Has("b"))
@@ -370,7 +373,7 @@ func TestBucketSortedMap_ClearConcurrentWithWrite(t *testing.T) {
 	go func() {
 		for j := 0; j < 10000; j++ {
 			myMap.Set(newDummyItem("foobar"))
-			myMap.Remove("foobar")
+			_, _ = myMap.Remove("foobar")
 			myMap.NotifyScoreChange(newDummyItem("foobar"), 42)
 			simulateMutationThatChangesScore(myMap, "foobar")
 		}
@@ -410,7 +413,7 @@ func TestBucketSortedMap_NoForgottenItemsOnConcurrentScoreChanges(t *testing.T) 
 		require.Equal(t, uint32(1), myMap.CountSorted())
 		require.Equal(t, uint32(1), myMap.Count())
 
-		myMap.Remove("a")
+		_, _ = myMap.Remove("a")
 
 		require.Equal(t, uint32(0), myMap.CountSorted())
 		require.Equal(t, uint32(0), myMap.Count())

--- a/storage/txcache/maps/concurrentMap.go
+++ b/storage/txcache/maps/concurrentMap.go
@@ -91,11 +91,14 @@ func (m *ConcurrentMap) Has(key string) bool {
 }
 
 // Remove removes an element from the map.
-func (m *ConcurrentMap) Remove(key string) {
+func (m *ConcurrentMap) Remove(key string) (interface{}, bool) {
 	chunk := m.getChunk(key)
 	chunk.mutex.Lock()
+	defer chunk.mutex.Unlock()
+
+	item := chunk.items[key]
 	delete(chunk.items, key)
-	chunk.mutex.Unlock()
+	return item, item != nil
 }
 
 func (m *ConcurrentMap) getChunk(key string) *concurrentMapChunk {

--- a/storage/txcache/maps/concurrentMap_test.go
+++ b/storage/txcache/maps/concurrentMap_test.go
@@ -66,7 +66,10 @@ func TestConcurrentMap_Remove(t *testing.T) {
 	myMap.SetIfAbsent("a", "a")
 	myMap.SetIfAbsent("b", "b")
 
-	myMap.Remove("b")
+	_, ok := myMap.Remove("b")
+	require.True(t, ok)
+	_, ok = myMap.Remove("x")
+	require.False(t, ok)
 
 	require.True(t, myMap.Has("a"))
 	require.False(t, myMap.Has("b"))
@@ -132,7 +135,7 @@ func TestConcurrentMap_ClearConcurrentWithWrite(t *testing.T) {
 		for j := 0; j < 10000; j++ {
 			myMap.Set("foobar", "foobar")
 			myMap.SetIfAbsent("foobar", "foobar")
-			myMap.Remove("foobar")
+			_, _ = myMap.Remove("foobar")
 		}
 
 		wg.Done()

--- a/storage/txcache/txByHashMap.go
+++ b/storage/txcache/txByHashMap.go
@@ -34,19 +34,18 @@ func (txMap *txByHashMap) addTx(tx *WrappedTransaction) bool {
 
 // removeTx removes a transaction from the map
 func (txMap *txByHashMap) removeTx(txHash string) (*WrappedTransaction, bool) {
-	tx, ok := txMap.getTx(txHash)
-	if !ok {
+	item, removed := txMap.backingMap.Remove(txHash)
+	if !removed {
 		return nil, false
 	}
 
-	// TODO / bugfix: when we concurrently try to remove the same transaction,
-	// we might end up decrementing the counters twice.
-	// Possible solution: use an "onItemRemoved" callback in the "backingMap"
-	// to decrement the counters.
+	tx := item.(*WrappedTransaction)
 
-	txMap.backingMap.Remove(txHash)
+	if removed {
 	txMap.counter.Decrement()
 	txMap.numBytes.Subtract(int64(estimateTxSize(tx)))
+	}
+
 	return tx, true
 }
 

--- a/storage/txcache/txListBySenderMap.go
+++ b/storage/txcache/txListBySenderMap.go
@@ -102,18 +102,12 @@ func (txMap *txListBySenderMap) removeTx(tx *WrappedTransaction) bool {
 }
 
 func (txMap *txListBySenderMap) removeSender(sender string) bool {
-	if !txMap.backingMap.Has(sender) {
-		return false
+	_, removed := txMap.backingMap.Remove(sender)
+	if removed {
+		txMap.counter.Decrement()
 	}
 
-	// TODO / bugfix: when we concurrently try to remove the same sender,
-	// we might end up decrementing the counter twice.
-	// Possible solution: use an "onItemRemoved" callback in the "backingMap"
-	// to decrement the counter.
-
-	txMap.backingMap.Remove(sender)
-	txMap.counter.Decrement()
-	return true
+	return removed
 }
 
 // RemoveSendersBulk removes senders, in bulk


### PR DESCRIPTION
[Original conversation in PR 1802](https://github.com/ElrondNetwork/elrond-go/pull/1802#discussion_r431027949).

Fixed some inconsistent counters for senders and transactions within the internal structures of the transactions pool. Inconsistencies could occur in case of high concurrency and / or concurrent removals (eviction plus removal due to commit / finalize). The bug was mostly benign, but if it were, say, thousands of such events, the counters would have become slightly off and therefore could have lead - in extreme cases - to OOM (since eviction would have been based on bad, low counters).

Details of the fix:
 - `txListBySenderMap.addSender()`: counter is consistent because the function is called under `txListBySenderMap`'s global mutex
 - `txListBySenderMap.removeSender()`: fixed
 - `txByHashMap.addTx()`: counter is consistent because we use "SetIfAbsent"
 - `txByHashMap.removeTx()`: fixed