### PR TITLE
TermUI issues fix

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -889,9 +889,6 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		return err
 	}
 
-	chanLogRewrite <- true
-	chanCreateViews <- true
-
 	trieContainer, trieStorageManager := bootstrapper.GetTriesComponents()
 	triesComponents := &mainFactory.TriesComponents{
 		TriesContainer:      trieContainer,
@@ -957,6 +954,9 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 	if err != nil {
 		return err
 	}
+
+	chanLogRewrite <- true
+	chanCreateViews <- true
 
 	err = statusHandlersInfo.UpdateStorerAndMetricsForPersistentHandler(dataComponents.Store.GetStorer(dataRetriever.StatusMetricsUnit))
 	if err != nil {

--- a/cmd/node/metrics/metrics.go
+++ b/cmd/node/metrics/metrics.go
@@ -82,6 +82,7 @@ func InitMetrics(
 	appStatusHandler.SetStringValue(core.MetricDenominationCoefficient, economicsConfig.RewardsSettings.DenominationCoefficientForView)
 	appStatusHandler.SetUInt64Value(core.MetricNumConnectedPeers, initUint)
 	appStatusHandler.SetStringValue(core.MetricNumConnectedPeersClassification, initString)
+	appStatusHandler.SetStringValue(core.MetricLatestTagSoftwareVersion, initString)
 
 	appStatusHandler.SetStringValue(core.MetricP2PNumConnectedPeersClassification, initString)
 	appStatusHandler.SetStringValue(core.MetricP2PPeerInfo, initString)

--- a/cmd/termui/main.go
+++ b/cmd/termui/main.go
@@ -131,12 +131,12 @@ func startTermuiViewer() error {
 		return err
 	}
 
-	chanStartTermUI := make(chan bool)
+	chanStartTermUI := make(chan struct{})
 	err = termuiConsole.Start(chanStartTermUI)
 	if err != nil {
 		return err
 	}
-	chanStartTermUI <- true
+	chanStartTermUI <- struct{}{}
 
 	provider.StartListeningOnWebSocket(presenterStatusHandler)
 

--- a/cmd/termui/main.go
+++ b/cmd/termui/main.go
@@ -131,10 +131,12 @@ func startTermuiViewer() error {
 		return err
 	}
 
-	err = termuiConsole.Start()
+	chanStartTermUI := make(chan bool)
+	err = termuiConsole.Start(chanStartTermUI)
 	if err != nil {
 		return err
 	}
+	chanStartTermUI <- true
 
 	provider.StartListeningOnWebSocket(presenterStatusHandler)
 

--- a/process/block/metrics.go
+++ b/process/block/metrics.go
@@ -89,7 +89,7 @@ func saveMetricsForACommittedBlock(
 	shardHeader *block.Header,
 ) {
 	incrementCountAcceptedBlocks(nodesCoordinator, appStatusHandler, shardHeader)
-	appStatusHandler.SetUInt64Value(core.MetricEpochNumber, uint64(metaBlock.GetEpoch()))
+	appStatusHandler.SetUInt64Value(core.MetricEpochNumber, uint64(shardHeader.GetEpoch()))
 	appStatusHandler.SetStringValue(core.MetricCurrentBlockHash, currentBlockHash)
 	appStatusHandler.SetUInt64Value(core.MetricHighestFinalBlockInShard, highestFinalBlockNonce)
 	appStatusHandler.SetStringValue(core.MetricCrossCheckBlockHeight, fmt.Sprintf("meta %d", metaBlock.GetNonce()))

--- a/statusHandler/errors.go
+++ b/statusHandler/errors.go
@@ -25,3 +25,6 @@ var ErrNilUint64Converter = errors.New("unit64converter is nil")
 
 // ErrNilStorage signals that a nil storage has been provided
 var ErrNilStorage = errors.New("nil storage")
+
+// ErrNilTermUIStartChannel signals that a nil TermUI start channel has been provided
+var ErrNilTermUIStartChannel = errors.New("nil TermUI start channel")

--- a/statusHandler/factory/interface.go
+++ b/statusHandler/factory/interface.go
@@ -2,5 +2,5 @@ package factory
 
 //Viewer defines the actions which should be handled by a view object
 type Viewer interface {
-	Start(start chan bool) error
+	Start(start chan struct{}) error
 }

--- a/statusHandler/factory/interface.go
+++ b/statusHandler/factory/interface.go
@@ -2,5 +2,5 @@ package factory
 
 //Viewer defines the actions which should be handled by a view object
 type Viewer interface {
-	Start() error
+	Start(start chan bool) error
 }

--- a/statusHandler/view/termuic/termuiConsole.go
+++ b/statusHandler/view/termuic/termuiConsole.go
@@ -47,7 +47,10 @@ func NewTermuiConsole(presenter view.Presenter) (*TermuiConsole, error) {
 }
 
 // Start method - will start termui console
-func (tc *TermuiConsole) Start(chanStart chan bool) error {
+func (tc *TermuiConsole) Start(chanStart chan struct{}) error {
+	if chanStart == nil {
+		return statusHandler.ErrNilTermUIStartChannel
+	}
 	go func() {
 		defer ui.Close()
 		<-chanStart

--- a/statusHandler/view/termuic/termuiConsole.go
+++ b/statusHandler/view/termuic/termuiConsole.go
@@ -47,13 +47,11 @@ func NewTermuiConsole(presenter view.Presenter) (*TermuiConsole, error) {
 }
 
 // Start method - will start termui console
-func (tc *TermuiConsole) Start() error {
-	if err := ui.Init(); err != nil {
-		return err
-	}
-
+func (tc *TermuiConsole) Start(chanStart chan bool) error {
 	go func() {
 		defer ui.Close()
+		<-chanStart
+		_ = ui.Init()
 		tc.eventLoop()
 	}()
 


### PR DESCRIPTION
Fixed the following bugs:

- if the node started with TermUI and the `Ctrl+C` signal was intercepted, the node's process didn't stop as expected. Now the TermUI console will start only after the initial pre-requisites are met (start in epoch, p2p bootstrap, and so on) so the process will be stopped accordingly.
- if the node started with TermUI the log file did not contain all logs. Fixed
- if the TermUI application didn't succeed when connecting to a node, it failed. Now it will keep trying connecting until successful 
- epoch number displayed in TermUI was delayed in comparison with the epoch which was displayed in logs. Fixed by fetching the epoch displayed in TermUI from shard header instead of meta block
- latest stable software version wasn't displayed right in TermUI and an `[invalid_key]` appeared instead. Fixed by setting an initial value for that metric + delayed the start of TermUI, thing which should leave enough time for the software version to be fetched