### PR TITLE
Fix fork detector after double sign

### DIFF
--- a/consensus/spos/bls/constants.go
+++ b/consensus/spos/bls/constants.go
@@ -35,7 +35,7 @@ const (
 )
 
 // waitingAllSigsMaxTimeThreshold specifies the max allocated time for waiting all signatures from the total time of the subround signature
-const waitingAllSigsMaxTimeThreshold = 0.75
+const waitingAllSigsMaxTimeThreshold = 0.5
 
 // processingThresholdPercent specifies the max allocated time for processing the block as a percentage of the total time of the round
 const processingThresholdPercent = 85

--- a/process/sync/baseForkDetector.go
+++ b/process/sync/baseForkDetector.go
@@ -549,7 +549,8 @@ func (bfd *baseForkDetector) shouldSignalFork(
 
 	higherHashForSameRound := headerInfo.round == lastForkRound &&
 		bytes.Compare(headerInfo.hash, lastForkHash) > 0
-	shouldSignalFork := headerInfo.round > lastForkRound || higherHashForSameRound
+	higherNonceReceived := bfd.highestNonceReceived() > headerInfo.nonce
+	shouldSignalFork := headerInfo.round > lastForkRound || (higherHashForSameRound && !higherNonceReceived)
 
 	return shouldSignalFork
 }


### PR DESCRIPTION
* Reduced time to wait after all signatures from 75% to 50% from signature total subround time (this will give more time for broadcast block to reach to all peers in useful time, instead of collecting more signatures. The problem is more evident in metachain where consensus group = eligible list, and if only one signature is missing the proposer will wait until 75% of signature subround time is reached)

* Fixed a situation when two valid blocks with the same nonce and the same round (double signed situation) could triggered forks with bad consequences. (now, if there are two blocks with the same round and the same nonce, the fork is not triggered anymore if meantime was received a proposed block with a higher nonce)