### PR TITLE
jailed nodes in epoch zero

### DIFF
--- a/process/mock/peerAccountHandlerMock.go
+++ b/process/mock/peerAccountHandlerMock.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"math"
 	"math/big"
 
 	"github.com/ElrondNetwork/elrond-go/data"
@@ -34,7 +35,7 @@ func (p *PeerAccountHandlerMock) GetUnStakedEpoch() uint32 {
 	if p.GetUnStakedEpochCalled != nil {
 		return p.GetUnStakedEpochCalled()
 	}
-	return 0
+	return math.MaxUint32
 }
 
 // SetUnStakedEpoch -

--- a/process/peer/process.go
+++ b/process/peer/process.go
@@ -423,7 +423,7 @@ func (vs *validatorStatistics) getValidatorDataFromLeaves(
 
 func getActualList(peerAccount state.PeerAccountHandler) string {
 	savedList := peerAccount.GetList()
-	if peerAccount.GetUnStakedEpoch() == 0 {
+	if peerAccount.GetUnStakedEpoch() == math.MaxUint32 {
 		if savedList == string(core.InactiveList) {
 			return string(core.JailedList)
 		}

--- a/process/peer/process_test.go
+++ b/process/peer/process_test.go
@@ -2157,6 +2157,7 @@ func TestValidatorsProvider_PeerAccoutToValidatorInfo(t *testing.T) {
 		},
 		NumSelectedInSuccessBlocks: 3,
 		AccumulatedFees:            big.NewInt(70),
+		UnStakedEpoch:              math.MaxUint32,
 	}
 
 	peerAccount := state.NewEmptyPeerAccount()
@@ -2236,7 +2237,7 @@ func TestValidatorStatisticsProcessor_getActualList(t *testing.T) {
 	computedInactiveList := peer.GetActualList(inactivePeer)
 	assert.Equal(t, inactiveList, computedInactiveList)
 
-	jailedPeer := &mock.PeerAccountHandlerMock{
+	inactivePeer2 := &mock.PeerAccountHandlerMock{
 		GetListCalled: func() string {
 			return inactiveList
 		},
@@ -2244,10 +2245,20 @@ func TestValidatorStatisticsProcessor_getActualList(t *testing.T) {
 			return 0
 		},
 	}
+	computedInactiveList = peer.GetActualList(inactivePeer2)
+	assert.Equal(t, inactiveList, computedInactiveList)
+
 	jailedList := string(core.JailedList)
+	jailedPeer := &mock.PeerAccountHandlerMock{
+		GetListCalled: func() string {
+			return inactiveList
+		},
+		GetUnStakedEpochCalled: func() uint32 {
+			return math.MaxUint32
+		},
+	}
 	computedJailedList := peer.GetActualList(jailedPeer)
 	assert.Equal(t, jailedList, computedJailedList)
-
 }
 
 func createMockValidatorInfo(shardId uint32, tempRating uint32, validatorSuccess uint32, validatorFailure uint32) *state.ValidatorInfo {
@@ -2315,6 +2326,7 @@ func createPeerAccounts(addrBytes0 []byte, addrBytesMeta []byte) (state.PeerAcco
 		Rating:                     51,
 		TempRating:                 61,
 		Nonce:                      7,
+		UnStakedEpoch:              math.MaxUint32,
 	}
 
 	addr = addrBytesMeta
@@ -2336,6 +2348,7 @@ func createPeerAccounts(addrBytes0 []byte, addrBytesMeta []byte) (state.PeerAcco
 		TempRating:                 611,
 		Nonce:                      8,
 		ShardId:                    core.MetachainShardId,
+		UnStakedEpoch:              math.MaxUint32,
 	}
 	return pa0, paMeta
 }

--- a/process/scToProtocol/stakingToPeer.go
+++ b/process/scToProtocol/stakingToPeer.go
@@ -219,7 +219,7 @@ func (stp *stakingToPeer) updatePeerState(
 		if stakingData.RegisterNonce == nonce && !isValidator {
 			account.SetListAndIndex(account.GetShardId(), string(core.NewList), uint32(stakingData.RegisterNonce))
 			account.SetTempRating(stp.startRating)
-			account.SetUnStakedEpoch(0)
+			account.SetUnStakedEpoch(math.MaxUint32)
 		}
 
 		if stakingData.UnStakedNonce == nonce && account.GetList() != string(core.InactiveList) {


### PR DESCRIPTION
after an unstake in epoch 0, the validatorStatus was set to jailed although it should be inactive.

- fixed validatorStatus problem if unstake in epoch zero
