### PR TITLE
bugFix/rewards-missmatch-computation

### DIFF
--- a/epochStart/metachain/rewards.go
+++ b/epochStart/metachain/rewards.go
@@ -53,13 +53,10 @@ type rewardsCreator struct {
 }
 
 type rewardInfoData struct {
-	ShardID                    uint32
-	LeaderSuccess              uint32
-	LeaderFailure              uint32
-	ValidatorSuccess           uint32
-	ValidatorFailure           uint32
-	NumSelectedInSuccessBlocks uint32
-	AccumulatedFees            *big.Int
+	numSelectedInSuccessBlocks uint32
+	accumulatedFees            *big.Int
+	address                    string
+	protocolRewards            *big.Int
 }
 
 // NewEpochStartRewardsCreator creates a new rewards creator object
@@ -121,6 +118,7 @@ func NewEpochStartRewardsCreator(args ArgsNewRewardsCreator) (*rewardsCreator, e
 
 // CreateBlockStarted announces block creation started and cleans inside data
 func (rc *rewardsCreator) clean() {
+	rc.mapRewardsPerBlockPerValidator = make(map[uint32]*big.Int)
 	rc.currTxs.Clean()
 }
 
@@ -173,10 +171,12 @@ func (rc *rewardsCreator) fillRewardsPerBlockPerNode(economicsData *block.Econom
 	for i := uint32(0); i < rc.shardCoordinator.NumberOfShards(); i++ {
 		consensusSize := big.NewInt(int64(rc.nodesConfigProvider.ConsensusGroupSize(i)))
 		rc.mapRewardsPerBlockPerValidator[i] = big.NewInt(0).Div(economicsData.RewardsPerBlock, consensusSize)
+		log.Trace("rewardsPerBlockPerValidator", "shardID", i, "value", rc.mapRewardsPerBlockPerValidator[i].String())
 	}
 
 	consensusSize := big.NewInt(int64(rc.nodesConfigProvider.ConsensusGroupSize(core.MetachainShardId)))
 	rc.mapRewardsPerBlockPerValidator[core.MetachainShardId] = big.NewInt(0).Div(economicsData.RewardsPerBlock, consensusSize)
+	log.Trace("rewardsPerBlockPerValidator", "shardID", core.MetachainShardId, "value", rc.mapRewardsPerBlockPerValidator[core.MetachainShardId].String())
 }
 
 func (rc *rewardsCreator) addValidatorRewardsToMiniBlocks(
@@ -185,8 +185,20 @@ func (rc *rewardsCreator) addValidatorRewardsToMiniBlocks(
 	miniBlocks block.MiniBlockSlice,
 ) error {
 	rwdAddrValidatorInfo := rc.computeValidatorInfoPerRewardAddress(validatorsInfo)
-	for address, rwdInfo := range rwdAddrValidatorInfo {
-		rwdTx, rwdTxHash, err := rc.createRewardFromRwdInfo([]byte(address), rwdInfo, metaBlock)
+
+	index := 0
+	listValidatorInfo := make([]*rewardInfoData, len(rwdAddrValidatorInfo))
+	for _, rwdInfo := range rwdAddrValidatorInfo {
+		listValidatorInfo[index] = rwdInfo
+		index++
+	}
+
+	sort.Slice(listValidatorInfo, func(i, j int) bool {
+		return listValidatorInfo[i].address < listValidatorInfo[j].address
+	})
+
+	for _, rwdInfo := range listValidatorInfo {
+		rwdTx, rwdTxHash, err := rc.createRewardFromRwdInfo(rwdInfo, metaBlock)
 		if err != nil {
 			return err
 		}
@@ -196,7 +208,7 @@ func (rc *rewardsCreator) addValidatorRewardsToMiniBlocks(
 
 		rc.currTxs.AddTx(rwdTxHash, rwdTx)
 
-		shardId := rc.shardCoordinator.ComputeId([]byte(address))
+		shardId := rc.shardCoordinator.ComputeId([]byte(rwdInfo.address))
 		miniBlocks[shardId].TxHashes = append(miniBlocks[shardId].TxHashes, rwdTxHash)
 	}
 
@@ -247,23 +259,22 @@ func (rc *rewardsCreator) computeValidatorInfoPerRewardAddress(
 
 	rwdAddrValidatorInfo := make(map[string]*rewardInfoData)
 
-	for shardID, shardValidatorsInfo := range validatorsInfo {
+	for _, shardValidatorsInfo := range validatorsInfo {
 		for _, validatorInfo := range shardValidatorsInfo {
 			rwdInfo, ok := rwdAddrValidatorInfo[string(validatorInfo.RewardAddress)]
 			if !ok {
 				rwdInfo = &rewardInfoData{
-					AccumulatedFees: big.NewInt(0),
+					accumulatedFees: big.NewInt(0),
+					protocolRewards: big.NewInt(0),
+					address:         string(validatorInfo.RewardAddress),
 				}
 				rwdAddrValidatorInfo[string(validatorInfo.RewardAddress)] = rwdInfo
 			}
 
-			rwdInfo.LeaderSuccess += validatorInfo.LeaderSuccess
-			rwdInfo.LeaderFailure += validatorInfo.LeaderFailure
-			rwdInfo.ValidatorFailure += validatorInfo.ValidatorFailure
-			rwdInfo.ValidatorSuccess += validatorInfo.ValidatorSuccess
-			rwdInfo.NumSelectedInSuccessBlocks += validatorInfo.NumSelectedInSuccessBlocks
-			rwdInfo.ShardID = shardID
-			rwdInfo.AccumulatedFees.Add(rwdInfo.AccumulatedFees, validatorInfo.AccumulatedFees)
+			rwdInfo.accumulatedFees.Add(rwdInfo.accumulatedFees, validatorInfo.AccumulatedFees)
+			rewardsPerBlockPerNodeForShard := rc.mapRewardsPerBlockPerValidator[validatorInfo.ShardId]
+			protocolRewardValue := big.NewInt(0).Mul(rewardsPerBlockPerNodeForShard, big.NewInt(0).SetUint64(uint64(validatorInfo.NumSelectedInSuccessBlocks)))
+			rwdInfo.protocolRewards.Add(rwdInfo.protocolRewards, protocolRewardValue)
 		}
 	}
 
@@ -271,25 +282,22 @@ func (rc *rewardsCreator) computeValidatorInfoPerRewardAddress(
 }
 
 func (rc *rewardsCreator) createRewardFromRwdInfo(
-	address []byte,
 	rwdInfo *rewardInfoData,
 	metaBlock *block.MetaBlock,
 ) (*rewardTx.RewardTx, []byte, error) {
 	rwdTx := &rewardTx.RewardTx{
 		Round:   metaBlock.GetRound(),
-		Value:   big.NewInt(0).Set(rwdInfo.AccumulatedFees),
-		RcvAddr: address,
+		Value:   big.NewInt(0).Add(rwdInfo.accumulatedFees, rwdInfo.protocolRewards),
+		RcvAddr: []byte(rwdInfo.address),
 		Epoch:   metaBlock.Epoch,
 	}
-
-	rewardsPerBlockPerNodeForShard := rc.mapRewardsPerBlockPerValidator[rwdInfo.ShardID]
-	protocolRewardValue := big.NewInt(0).Mul(rewardsPerBlockPerNodeForShard, big.NewInt(0).SetUint64(uint64(rwdInfo.NumSelectedInSuccessBlocks)))
-	rwdTx.Value.Add(rwdTx.Value, protocolRewardValue)
 
 	rwdTxHash, err := core.CalculateHash(rc.marshalizer, rc.hasher, rwdTx)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	log.Trace("rewardTx", "address", []byte(rwdInfo.address), "value", rwdTx.Value.String(), "hash", rwdTxHash)
 
 	return rwdTx, rwdTxHash, nil
 }


### PR DESCRIPTION
Fixed the wrong computation of end of epoch rewards. In case the same validator had multiple nodes in multiple shards the actual reward was calculated with NumTotalSelected divided by the last shardID set for this validator. The last shard ID set was from range over a map.