### PR TITLE
Add peer info route

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -42,3 +42,6 @@ var ErrTxNotFound = errors.New("transaction was not found")
 
 // ErrQueryError signals a general query error
 var ErrQueryError = errors.New("query error")
+
+// ErrGetPidInfo signals that an error occurred while getting peer ID info
+var ErrGetPidInfo = errors.New("error getting peer id info")

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"math/big"
 
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/statistics"
 	"github.com/ElrondNetwork/elrond-go/data/state"
 	"github.com/ElrondNetwork/elrond-go/data/transaction"
@@ -35,7 +36,7 @@ type Facade struct {
 	GetQueryHandlerCalled             func(name string) (debug.QueryHandler, error)
 	GetTransactionStatusCalled        func(hash string) (string, error)
 	GetValueForKeyCalled              func(address string, key string) (string, error)
-	GetPeerInfoCalled                 func(pid string) ([]interface{}, error)
+	GetPeerInfoCalled                 func(pid string) ([]core.QueryP2PPeerInfo, error)
 }
 
 // GetTransactionStatus -
@@ -160,7 +161,7 @@ func (f *Facade) GetQueryHandler(name string) (debug.QueryHandler, error) {
 }
 
 // GetPeerInfo -
-func (f *Facade) GetPeerInfo(pid string) ([]interface{}, error) {
+func (f *Facade) GetPeerInfo(pid string) ([]core.QueryP2PPeerInfo, error) {
 	return f.GetPeerInfoCalled(pid)
 }
 

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -35,6 +35,7 @@ type Facade struct {
 	GetQueryHandlerCalled             func(name string) (debug.QueryHandler, error)
 	GetTransactionStatusCalled        func(hash string) (string, error)
 	GetValueForKeyCalled              func(address string, key string) (string, error)
+	GetPeerInfoCalled                 func(pid string) ([]interface{}, error)
 }
 
 // GetTransactionStatus -
@@ -156,6 +157,11 @@ func (f *Facade) DecodeAddressPubkey(pk string) ([]byte, error) {
 // GetQueryHandler -
 func (f *Facade) GetQueryHandler(name string) (debug.QueryHandler, error) {
 	return f.GetQueryHandlerCalled(name)
+}
+
+// GetPeerInfo -
+func (f *Facade) GetPeerInfo(pid string) ([]interface{}, error) {
+	return f.GetPeerInfoCalled(pid)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/api/node/routes.go
+++ b/api/node/routes.go
@@ -20,7 +20,15 @@ type FacadeHandler interface {
 	TpsBenchmark() *statistics.TpsBenchmark
 	StatusMetrics() external.StatusMetricsHandler
 	GetQueryHandler(name string) (debug.QueryHandler, error)
+	GetPeerInfo(pid string) ([]interface{}, error)
 	IsInterfaceNil() bool
+}
+
+// TODO remove this struct, use shared.GenericAPIResponse
+type genericApiResponse struct {
+	Data  interface{} `json:"data"`
+	Error string      `json:"error"`
+	Code  string      `json:"code"`
 }
 
 // QueryDebugRequest represents the structure on which user input for querying a debug info will validate against
@@ -60,6 +68,7 @@ func Routes(router *wrapper.RouterWrapper) {
 	router.RegisterHandler(http.MethodGet, "/status", StatusMetrics)
 	router.RegisterHandler(http.MethodGet, "/p2pstatus", P2pStatusMetrics)
 	router.RegisterHandler(http.MethodPost, "/debug", QueryDebug)
+	router.RegisterHandler(http.MethodGet, "/peerinfo", PeerInfo)
 	// placeholder for custom routes
 }
 
@@ -167,4 +176,49 @@ func QueryDebug(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"result": qh.Query(gtx.Search)})
+}
+
+// PeerInfo returns the information of a provided p2p peer ID
+func PeerInfo(c *gin.Context) {
+	ef, ok := c.MustGet("elrondFacade").(FacadeHandler)
+	if !ok {
+		c.JSON(
+			http.StatusInternalServerError,
+			genericApiResponse{
+				Data:  nil,
+				Error: "invalid app context", //TODO replace with errors.ErrInvalidAppContext.Error()
+				Code:  "internal_issue",      //TODO replace with shared.ReturnCodeInternalError
+			},
+		)
+		return
+	}
+
+	queryVals := c.Request.URL.Query()
+	pids := queryVals["pid"]
+	pid := ""
+	if len(pids) > 0 {
+		pid = pids[0]
+	}
+
+	info, err := ef.GetPeerInfo(pid)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			genericApiResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetPidInfo.Error(), err.Error()),
+				Code:  "internal error", //TODO return shared.ReturnCodeInternalError
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		genericApiResponse{
+			Data:  gin.H{"info": info},
+			Error: "",
+			Code:  "successful", //TODO replace with shared.ReturnCodeSuccess,
+		},
+	)
 }

--- a/api/node/routes.go
+++ b/api/node/routes.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go/api/errors"
 	"github.com/ElrondNetwork/elrond-go/api/wrapper"
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/statistics"
 	"github.com/ElrondNetwork/elrond-go/debug"
 	"github.com/ElrondNetwork/elrond-go/heartbeat/data"
@@ -14,13 +15,15 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const pidQueryParam = "pid"
+
 // FacadeHandler interface defines methods that can be used from `elrondFacade` context variable
 type FacadeHandler interface {
 	GetHeartbeats() ([]data.PubKeyHeartbeat, error)
 	TpsBenchmark() *statistics.TpsBenchmark
 	StatusMetrics() external.StatusMetricsHandler
 	GetQueryHandler(name string) (debug.QueryHandler, error)
-	GetPeerInfo(pid string) ([]interface{}, error)
+	GetPeerInfo(pid string) ([]core.QueryP2PPeerInfo, error)
 	IsInterfaceNil() bool
 }
 
@@ -194,7 +197,7 @@ func PeerInfo(c *gin.Context) {
 	}
 
 	queryVals := c.Request.URL.Query()
-	pids := queryVals["pid"]
+	pids := queryVals[pidQueryParam]
 	pid := ""
 	if len(pids) > 0 {
 		pid = pids[0]

--- a/cmd/node/config/api.toml
+++ b/cmd/node/config/api.toml
@@ -16,7 +16,10 @@
         { Name = "/p2pstatus", Open = true },
 
         # /node/debug will return the debug information after the query has been interpreted
-        { Name = "/debug", Open = true }
+        { Name = "/debug", Open = true },
+
+        # /node/peerinfo will return the p2p peer info of the provided pid
+        { Name = "/peerinfo", Open = true }
 	]
 
 [APIPackages.address]

--- a/consensus/interface.go
+++ b/consensus/interface.go
@@ -77,6 +77,7 @@ type NetworkShardingCollector interface {
 	UpdatePeerIdPublicKey(pid core.PeerID, pk []byte)
 	UpdatePublicKeyShardId(pk []byte, shardId uint32)
 	UpdatePeerIdShardId(pid core.PeerID, shardId uint32)
+	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo
 	IsInterfaceNil() bool
 }
 

--- a/consensus/mock/networkShardingCollectorStub.go
+++ b/consensus/mock/networkShardingCollectorStub.go
@@ -9,6 +9,7 @@ type NetworkShardingCollectorStub struct {
 	UpdatePeerIdPublicKeyCalled  func(pid core.PeerID, pk []byte)
 	UpdatePublicKeyShardIdCalled func(pk []byte, shardId uint32)
 	UpdatePeerIdShardIdCalled    func(pid core.PeerID, shardId uint32)
+	GetPeerInfoCalled            func(pid core.PeerID) core.P2PPeerInfo
 }
 
 // UpdatePeerIdPublicKey -
@@ -24,6 +25,11 @@ func (nscs *NetworkShardingCollectorStub) UpdatePublicKeyShardId(pk []byte, shar
 // UpdatePeerIdShardId -
 func (nscs *NetworkShardingCollectorStub) UpdatePeerIdShardId(pid core.PeerID, shardId uint32) {
 	nscs.UpdatePeerIdShardIdCalled(pid, shardId)
+}
+
+// GetPeerInfo -
+func (nscs *NetworkShardingCollectorStub) GetPeerInfo(pid core.PeerID) core.P2PPeerInfo {
+	return nscs.GetPeerInfoCalled(pid)
 }
 
 // IsInterfaceNil -

--- a/core/p2pCore.go
+++ b/core/p2pCore.go
@@ -28,4 +28,5 @@ const (
 type P2PPeerInfo struct {
 	PeerType P2PPeerType
 	ShardID  uint32
+	PkBytes  []byte
 }

--- a/core/p2pCore.go
+++ b/core/p2pCore.go
@@ -30,3 +30,12 @@ type P2PPeerInfo struct {
 	ShardID  uint32
 	PkBytes  []byte
 }
+
+// QueryP2PPeerInfo represents a DTO used in exporting p2p peer info after a query
+type QueryP2PPeerInfo struct {
+	IsBlacklisted bool     `json:"isblacklisted"`
+	Pid           string   `json:"pid"`
+	Pk            string   `json:"pk"`
+	PeerType      string   `json:"peertype"`
+	Addresses     []string `json:"addresses"`
+}

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -3,6 +3,7 @@ package facade
 import (
 	"math/big"
 
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data/state"
 	"github.com/ElrondNetwork/elrond-go/data/transaction"
 	"github.com/ElrondNetwork/elrond-go/debug"
@@ -58,7 +59,7 @@ type NodeHandler interface {
 	DecodeAddressPubkey(pk string) ([]byte, error)
 
 	GetQueryHandler(name string) (debug.QueryHandler, error)
-	GetPeerInfo(pid string) ([]interface{}, error)
+	GetPeerInfo(pid string) ([]core.QueryP2PPeerInfo, error)
 }
 
 // ApiResolver defines a structure capable of resolving REST API requests

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -58,6 +58,7 @@ type NodeHandler interface {
 	DecodeAddressPubkey(pk string) ([]byte, error)
 
 	GetQueryHandler(name string) (debug.QueryHandler, error)
+	GetPeerInfo(pid string) ([]interface{}, error)
 }
 
 // ApiResolver defines a structure capable of resolving REST API requests

--- a/facade/mock/nodeStub.go
+++ b/facade/mock/nodeStub.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"math/big"
 
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data/state"
 	"github.com/ElrondNetwork/elrond-go/data/transaction"
 	"github.com/ElrondNetwork/elrond-go/debug"
@@ -33,7 +34,7 @@ type NodeStub struct {
 	GetQueryHandlerCalled                          func(name string) (debug.QueryHandler, error)
 	GetTransactionStatusCalled                     func(hash string) (string, error)
 	GetValueForKeyCalled                           func(address string, key string) (string, error)
-	GetPeerInfoCalled                              func(pid string) ([]interface{}, error)
+	GetPeerInfoCalled                              func(pid string) ([]core.QueryP2PPeerInfo, error)
 }
 
 // GetValueForKey -
@@ -131,12 +132,12 @@ func (ns *NodeStub) GetQueryHandler(name string) (debug.QueryHandler, error) {
 }
 
 // GetPeerInfo -
-func (ns *NodeStub) GetPeerInfo(pid string) ([]interface{}, error) {
+func (ns *NodeStub) GetPeerInfo(pid string) ([]core.QueryP2PPeerInfo, error) {
 	if ns.GetPeerInfoCalled != nil {
 		return ns.GetPeerInfoCalled(pid)
 	}
 
-	return make([]interface{}, 0), nil
+	return make([]core.QueryP2PPeerInfo, 0), nil
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/facade/mock/nodeStub.go
+++ b/facade/mock/nodeStub.go
@@ -33,6 +33,7 @@ type NodeStub struct {
 	GetQueryHandlerCalled                          func(name string) (debug.QueryHandler, error)
 	GetTransactionStatusCalled                     func(hash string) (string, error)
 	GetValueForKeyCalled                           func(address string, key string) (string, error)
+	GetPeerInfoCalled                              func(pid string) ([]interface{}, error)
 }
 
 // GetValueForKey -
@@ -127,6 +128,15 @@ func (ns *NodeStub) GetQueryHandler(name string) (debug.QueryHandler, error) {
 	}
 
 	return nil, nil
+}
+
+// GetPeerInfo -
+func (ns *NodeStub) GetPeerInfo(pid string) ([]interface{}, error) {
+	if ns.GetPeerInfoCalled != nil {
+		return ns.GetPeerInfoCalled(pid)
+	}
+
+	return make([]interface{}, 0), nil
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/api/validator"
 	"github.com/ElrondNetwork/elrond-go/api/vmValues"
 	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/core/statistics"
 	"github.com/ElrondNetwork/elrond-go/data/state"
@@ -310,7 +311,7 @@ func (nf *nodeFacade) GetQueryHandler(name string) (debug.QueryHandler, error) {
 }
 
 // GetPeerInfo returns the peer info of a provided pid
-func (nf *nodeFacade) GetPeerInfo(pid string) ([]interface{}, error) {
+func (nf *nodeFacade) GetPeerInfo(pid string) ([]core.QueryP2PPeerInfo, error) {
 	return nf.node.GetPeerInfo(pid)
 }
 

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -309,6 +309,11 @@ func (nf *nodeFacade) GetQueryHandler(name string) (debug.QueryHandler, error) {
 	return nf.node.GetQueryHandler(name)
 }
 
+// GetPeerInfo returns the peer info of a provided pid
+func (nf *nodeFacade) GetPeerInfo(pid string) ([]interface{}, error) {
+	return nf.node.GetPeerInfo(pid)
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (nf *nodeFacade) IsInterfaceNil() bool {
 	return nf == nil

--- a/facade/nodeFacade_test.go
+++ b/facade/nodeFacade_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/core/statistics"
 	"github.com/ElrondNetwork/elrond-go/data/state"
@@ -562,11 +563,13 @@ func TestElrondNodeFacade_GetQueryHandler(t *testing.T) {
 func TestNodeFacade_GetPeerInfo(t *testing.T) {
 	t.Parallel()
 
-	pinfo := []interface{}{"pinfo"}
+	pinfo := core.QueryP2PPeerInfo{
+		Pid: "pid",
+	}
 	arg := createMockArguments()
 	arg.Node = &mock.NodeStub{
-		GetPeerInfoCalled: func(pid string) ([]interface{}, error) {
-			return pinfo, nil
+		GetPeerInfoCalled: func(pid string) ([]core.QueryP2PPeerInfo, error) {
+			return []core.QueryP2PPeerInfo{pinfo}, nil
 		},
 	}
 	nf, _ := NewNodeFacade(arg)
@@ -574,5 +577,5 @@ func TestNodeFacade_GetPeerInfo(t *testing.T) {
 	val, err := nf.GetPeerInfo("")
 
 	assert.Nil(t, err)
-	assert.Equal(t, pinfo, val)
+	assert.Equal(t, []core.QueryP2PPeerInfo{pinfo}, val)
 }

--- a/facade/nodeFacade_test.go
+++ b/facade/nodeFacade_test.go
@@ -558,3 +558,21 @@ func TestElrondNodeFacade_GetQueryHandler(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, wasCalled)
 }
+
+func TestNodeFacade_GetPeerInfo(t *testing.T) {
+	t.Parallel()
+
+	pinfo := []interface{}{"pinfo"}
+	arg := createMockArguments()
+	arg.Node = &mock.NodeStub{
+		GetPeerInfoCalled: func(pid string) ([]interface{}, error) {
+			return pinfo, nil
+		},
+	}
+	nf, _ := NewNodeFacade(arg)
+
+	val, err := nf.GetPeerInfo("")
+
+	assert.Nil(t, err)
+	assert.Equal(t, pinfo, val)
+}

--- a/heartbeat/interface.go
+++ b/heartbeat/interface.go
@@ -21,7 +21,7 @@ type P2PMessenger interface {
 	HasTopic(name string) bool
 	HasTopicValidator(name string) bool
 	RegisterMessageProcessor(topic string, handler p2p.MessageProcessor) error
-	PeerAddress(pid core.PeerID) string
+	PeerAddresses(pid core.PeerID) []string
 	IsConnectedToTheNetwork() bool
 	ID() core.PeerID
 	IsInterfaceNil() bool

--- a/heartbeat/mock/messengerStub.go
+++ b/heartbeat/mock/messengerStub.go
@@ -16,7 +16,7 @@ type MessengerStub struct {
 	BroadcastCalled                  func(topic string, buff []byte)
 	RegisterMessageProcessorCalled   func(topic string, handler p2p.MessageProcessor) error
 	BootstrapCalled                  func() error
-	PeerAddressCalled                func(pid core.PeerID) string
+	PeerAddressesCalled              func(pid core.PeerID) []string
 	BroadcastOnChannelBlockingCalled func(channel string, topic string, buff []byte) error
 	IsConnectedToTheNetworkCalled    func() bool
 }
@@ -92,8 +92,8 @@ func (ms *MessengerStub) Bootstrap() error {
 }
 
 // PeerAddress -
-func (ms *MessengerStub) PeerAddress(pid core.PeerID) string {
-	return ms.PeerAddressCalled(pid)
+func (ms *MessengerStub) PeerAddresses(pid core.PeerID) []string {
+	return ms.PeerAddressesCalled(pid)
 }
 
 // BroadcastOnChannelBlocking -

--- a/integrationTests/mock/networkShardingCollectorMock.go
+++ b/integrationTests/mock/networkShardingCollectorMock.go
@@ -47,6 +47,11 @@ func (nscm *networkShardingCollectorMock) UpdatePeerIdShardId(pid core.PeerID, s
 	nscm.mutFallbackPidShardMap.Unlock()
 }
 
+// GetPeerInfo -
+func (nscm *networkShardingCollectorMock) GetPeerInfo(_ core.PeerID) core.P2PPeerInfo {
+	return core.P2PPeerInfo{}
+}
+
 // IsInterfaceNil -
 func (nscm *networkShardingCollectorMock) IsInterfaceNil() bool {
 	return nscm == nil

--- a/node/errors.go
+++ b/node/errors.go
@@ -165,3 +165,6 @@ var ErrNilApiTransactionByHashThrottler = errors.New("nil api transaction by has
 
 // ErrSystemBusyTxHash signals that too many requests occur in the same time on the transaction by hash provider
 var ErrSystemBusyTxHash = errors.New("system busy. try again later")
+
+// ErrUnknownPeerID signals that the provided peer is unknown by the current node
+var ErrUnknownPeerID = errors.New("unknown peer ID")

--- a/node/interface.go
+++ b/node/interface.go
@@ -18,9 +18,10 @@ type P2PMessenger interface {
 	HasTopic(name string) bool
 	HasTopicValidator(name string) bool
 	RegisterMessageProcessor(topic string, handler p2p.MessageProcessor) error
-	PeerAddress(pid core.PeerID) string
+	PeerAddresses(pid core.PeerID) []string
 	IsConnectedToTheNetwork() bool
 	ID() core.PeerID
+	Peers() []core.PeerID
 	IsInterfaceNil() bool
 }
 
@@ -30,6 +31,7 @@ type NetworkShardingCollector interface {
 	UpdatePeerIdPublicKey(pid core.PeerID, pk []byte)
 	UpdatePublicKeyShardId(pk []byte, shardId uint32)
 	UpdatePeerIdShardId(pid core.PeerID, shardId uint32)
+	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo
 	IsInterfaceNil() bool
 }
 

--- a/node/mock/messengerStub.go
+++ b/node/mock/messengerStub.go
@@ -16,9 +16,10 @@ type MessengerStub struct {
 	BroadcastCalled                  func(topic string, buff []byte)
 	RegisterMessageProcessorCalled   func(topic string, handler p2p.MessageProcessor) error
 	BootstrapCalled                  func() error
-	PeerAddressCalled                func(pid core.PeerID) string
+	PeerAddressesCalled              func(pid core.PeerID) []string
 	BroadcastOnChannelBlockingCalled func(channel string, topic string, buff []byte) error
 	IsConnectedToTheNetworkCalled    func() bool
+	PeersCalled                      func() []core.PeerID
 }
 
 // ID -
@@ -73,9 +74,9 @@ func (ms *MessengerStub) Bootstrap() error {
 	return ms.BootstrapCalled()
 }
 
-// PeerAddress -
-func (ms *MessengerStub) PeerAddress(pid core.PeerID) string {
-	return ms.PeerAddressCalled(pid)
+// PeerAddresses -
+func (ms *MessengerStub) PeerAddresses(pid core.PeerID) []string {
+	return ms.PeerAddressesCalled(pid)
 }
 
 // BroadcastOnChannelBlocking -
@@ -86,6 +87,15 @@ func (ms *MessengerStub) BroadcastOnChannelBlocking(channel string, topic string
 // IsConnectedToTheNetwork -
 func (ms *MessengerStub) IsConnectedToTheNetwork() bool {
 	return ms.IsConnectedToTheNetworkCalled()
+}
+
+// Peers -
+func (ms *MessengerStub) Peers() []core.PeerID {
+	if ms.PeersCalled != nil {
+		return ms.PeersCalled()
+	}
+
+	return make([]core.PeerID, 0)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/node/mock/networkShardingCollectorStub.go
+++ b/node/mock/networkShardingCollectorStub.go
@@ -9,6 +9,7 @@ type NetworkShardingCollectorStub struct {
 	UpdatePeerIdPublicKeyCalled  func(pid core.PeerID, pk []byte)
 	UpdatePublicKeyShardIdCalled func(pk []byte, shardId uint32)
 	UpdatePeerIdShardIdCalled    func(pid core.PeerID, shardId uint32)
+	GetPeerInfoCalled            func(pid core.PeerID) core.P2PPeerInfo
 }
 
 // UpdatePeerIdPublicKey -
@@ -24,6 +25,11 @@ func (nscs *NetworkShardingCollectorStub) UpdatePublicKeyShardId(pk []byte, shar
 // UpdatePeerIdShardId -
 func (nscs *NetworkShardingCollectorStub) UpdatePeerIdShardId(pid core.PeerID, shardId uint32) {
 	nscs.UpdatePeerIdShardIdCalled(pid, shardId)
+}
+
+// GetPeerInfo -
+func (nscs *NetworkShardingCollectorStub) GetPeerInfo(pid core.PeerID) core.P2PPeerInfo {
+	return nscs.GetPeerInfoCalled(pid)
 }
 
 // IsInterfaceNil -

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -58,16 +58,6 @@ func getPrivateKey() *mock.PrivateKeyStub {
 	return &mock.PrivateKeyStub{}
 }
 
-func containString(search string, list []string) bool {
-	for _, str := range list {
-		if str == search {
-			return true
-		}
-	}
-
-	return false
-}
-
 func getMessenger() *mock.MessengerStub {
 	messenger := &mock.MessengerStub{
 		CloseCalled: func() error {
@@ -1895,4 +1885,79 @@ func TestNode_GetQueryHandlerShouldWork(t *testing.T) {
 
 	assert.Equal(t, qhRecovered, qh)
 	assert.Nil(t, err)
+}
+
+func TestNode_GetPeerInfoUnknownPeerShouldErr(t *testing.T) {
+	t.Parallel()
+
+	n, _ := node.NewNode(
+		node.WithMessenger(&mock.MessengerStub{
+			PeersCalled: func() []core.PeerID {
+				return make([]core.PeerID, 0)
+			},
+		}),
+	)
+
+	pid := "pid"
+	vals, err := n.GetPeerInfo(pid)
+
+	assert.Nil(t, vals)
+	assert.True(t, errors.Is(err, node.ErrUnknownPeerID))
+}
+
+func TestNode_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	pid1 := "pid1"
+	pid2 := "pid2"
+	n, _ := node.NewNode(
+		node.WithMessenger(&mock.MessengerStub{
+			PeersCalled: func() []core.PeerID {
+				//return them unsorted
+				return []core.PeerID{core.PeerID(pid2), core.PeerID(pid1)}
+			},
+			PeerAddressesCalled: func(pid core.PeerID) []string {
+				return []string{"addr" + string(pid)}
+			},
+		}),
+		node.WithNetworkShardingCollector(&mock.NetworkShardingCollectorStub{
+			GetPeerInfoCalled: func(pid core.PeerID) core.P2PPeerInfo {
+				return core.P2PPeerInfo{
+					PeerType: 0,
+					ShardID:  0,
+					PkBytes:  pid.Bytes(),
+				}
+			},
+		}),
+		node.WithValidatorPubkeyConverter(mock.NewPubkeyConverterMock(32)),
+		node.WithPeerBlackListHandler(&mock.PeerBlackListHandlerStub{
+			HasCalled: func(pid core.PeerID) bool {
+				return pid == core.PeerID(pid1)
+			},
+		}),
+	)
+
+	vals, err := n.GetPeerInfo("3sf1k") //will return both pids, sorted
+
+	assert.Nil(t, err)
+	require.Equal(t, 2, len(vals))
+
+	expected := []interface{}{
+		node.QueryP2PPeerInfo{
+			Pid:           core.PeerID(pid1).Pretty(),
+			Addresses:     []string{"addr" + pid1},
+			Pk:            hex.EncodeToString([]byte(pid1)),
+			IsBlacklisted: true,
+			PeerType:      core.UnknownPeer.String(),
+		},
+		node.QueryP2PPeerInfo{
+			Pid:           core.PeerID(pid2).Pretty(),
+			Addresses:     []string{"addr" + pid2},
+			Pk:            hex.EncodeToString([]byte(pid2)),
+			IsBlacklisted: false,
+			PeerType:      core.UnknownPeer.String(),
+		},
+	}
+
+	assert.Equal(t, expected, vals)
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1942,15 +1942,15 @@ func TestNode_ShouldWork(t *testing.T) {
 	assert.Nil(t, err)
 	require.Equal(t, 2, len(vals))
 
-	expected := []interface{}{
-		node.QueryP2PPeerInfo{
+	expected := []core.QueryP2PPeerInfo{
+		{
 			Pid:           core.PeerID(pid1).Pretty(),
 			Addresses:     []string{"addr" + pid1},
 			Pk:            hex.EncodeToString([]byte(pid1)),
 			IsBlacklisted: true,
 			PeerType:      core.UnknownPeer.String(),
 		},
-		node.QueryP2PPeerInfo{
+		{
 			Pid:           core.PeerID(pid2).Pretty(),
 			Addresses:     []string{"addr" + pid2},
 			Pk:            hex.EncodeToString([]byte(pid2)),

--- a/p2p/libp2p/netMessenger.go
+++ b/p2p/libp2p/netMessenger.go
@@ -523,25 +523,26 @@ func (netMes *networkMessenger) ConnectedAddresses() []string {
 	return conns
 }
 
-// PeerAddress returns the peer's address or empty string if the peer is unknown
-func (netMes *networkMessenger) PeerAddress(pid core.PeerID) string {
+// PeerAddresses returns the peer's addresses or empty slice if the peer is unknown
+func (netMes *networkMessenger) PeerAddresses(pid core.PeerID) []string {
 	h := netMes.p2pHost
+	result := make([]string, 0)
 
 	//check if the peer is connected to return it's connected address
 	for _, c := range h.Network().Conns() {
 		if string(c.RemotePeer()) == string(pid.Bytes()) {
-			return c.RemoteMultiaddr().String()
+			result = append(result, c.RemoteMultiaddr().String())
+			break
 		}
 	}
 
 	//check in peerstore (maybe it is known but not connected)
 	addresses := h.Peerstore().Addrs(peer.ID(pid.Bytes()))
-	if len(addresses) == 0 {
-		return ""
+	for _, addr := range addresses {
+		result = append(result, addr.String())
 	}
 
-	//return the first address from multi address slice
-	return addresses[0].String()
+	return result
 }
 
 // ConnectedPeersOnTopic returns the connected peers on a provided topic

--- a/p2p/libp2p/netMessenger_test.go
+++ b/p2p/libp2p/netMessenger_test.go
@@ -670,11 +670,13 @@ func TestLibp2pMessenger_PeerAddressConnectedPeerShouldWork(t *testing.T) {
 		_ = mes3.Close()
 	}()
 
-	adr1Recov := mes2.PeerAddress(mes1.ID())
+	addressesRecov := mes2.PeerAddresses(mes1.ID())
 	for _, addr := range mes1.Addresses() {
-		if strings.Contains(addr, adr1Recov) {
-			//address returned is valid, test is successful
-			return
+		for _, addrRecov := range addressesRecov {
+			if strings.Contains(addr, addrRecov) {
+				//address returned is valid, test is successful
+				return
+			}
 		}
 	}
 
@@ -708,11 +710,13 @@ func TestLibp2pMessenger_PeerAddressDisconnectedPeerShouldWork(t *testing.T) {
 
 	assert.False(t, mes2.IsConnected(mes1.ID()))
 
-	adr1Recov := mes2.PeerAddress(mes1.ID())
+	addressesRecov := mes2.PeerAddresses(mes1.ID())
 	for _, addr := range mes1.Addresses() {
-		if strings.Contains(addr, adr1Recov) {
-			//address returned is valid, test is successful
-			return
+		for _, addrRecov := range addressesRecov {
+			if strings.Contains(addr, addrRecov) {
+				//address returned is valid, test is successful
+				return
+			}
 		}
 	}
 
@@ -726,8 +730,8 @@ func TestLibp2pMessenger_PeerAddressUnknownPeerShouldReturnEmpty(t *testing.T) {
 		_ = mes1.Close()
 	}()
 
-	adr1Recov := mes1.PeerAddress("unknown peer")
-	assert.Equal(t, "", adr1Recov)
+	adr1Recov := mes1.PeerAddresses("unknown peer")
+	assert.Equal(t, 0, len(adr1Recov))
 }
 
 //------- ConnectedPeersOnTopic

--- a/p2p/memp2p/messenger.go
+++ b/p2p/memp2p/messenger.go
@@ -143,9 +143,9 @@ func (messenger *Messenger) ConnectedAddresses() []string {
 	return messenger.network.ListAddressesExceptOne(messenger.ID())
 }
 
-// PeerAddress creates the address string from a given peer ID.
-func (messenger *Messenger) PeerAddress(pid core.PeerID) string {
-	return fmt.Sprintf("/memp2p/%s", string(pid))
+// PeerAddresses creates the address string from a given peer ID.
+func (messenger *Messenger) PeerAddresses(pid core.PeerID) []string {
+	return []string{fmt.Sprintf("/memp2p/%s", string(pid))}
 }
 
 // ConnectedPeersOnTopic returns a slice of IDs belonging to the peers in the

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -77,9 +77,8 @@ type Messenger interface {
 	// Messenger is currently connected.
 	ConnectedAddresses() []string
 
-	// PeerAddress builds an address for the given peer ID, e.g.
-	// ConnectToPeer(PeerAddress(somePeerID)).
-	PeerAddress(pid core.PeerID) string
+	// PeerAddresses returns the known addresses for the provided peer ID
+	PeerAddresses(pid core.PeerID) []string
 
 	// ConnectedPeersOnTopic returns the IDs of the peers to which the Messenger
 	// is currently connected, but filtered by a topic they are registered to.

--- a/sharding/networksharding/peerShardMapper.go
+++ b/sharding/networksharding/peerShardMapper.go
@@ -1,6 +1,7 @@
 package networksharding
 
 import (
+	"encoding/hex"
 	"sync"
 
 	logger "github.com/ElrondNetwork/elrond-go-logger"
@@ -83,7 +84,6 @@ func NewPeerShardMapper(
 // It also returns the type of provided peer
 func (psm *PeerShardMapper) GetPeerInfo(pid core.PeerID) core.P2PPeerInfo {
 	var pInfo *core.P2PPeerInfo
-	var pk []byte
 	var ok bool
 
 	defer func() {
@@ -91,22 +91,20 @@ func (psm *PeerShardMapper) GetPeerInfo(pid core.PeerID) core.P2PPeerInfo {
 			log.Trace("PeerShardMapper.GetPeerInfo",
 				"peer type", pInfo.PeerType.String(),
 				"pid", p2p.PeerIdToShortString(pid),
-				"pk", pk,
+				"pk", hex.EncodeToString(pInfo.PkBytes),
 			)
 		}
 	}()
 
-	pInfo, pk, ok = psm.getPeerInfoWithNodesCoordinator(pid)
+	pInfo, ok = psm.getPeerInfoWithNodesCoordinator(pid)
 	if ok {
 		return *pInfo
 	}
 
-	shardId, ok := psm.getShardIDSearchingPkInFallbackCache(pk)
+	shardId, ok := psm.getShardIDSearchingPkInFallbackCache(pInfo.PkBytes)
 	if ok {
-		pInfo = &core.P2PPeerInfo{
-			PeerType: core.ObserverPeer,
-			ShardID:  shardId,
-		}
+		pInfo.PeerType = core.ObserverPeer
+		pInfo.ShardID = shardId
 
 		return *pInfo
 	}
@@ -115,13 +113,14 @@ func (psm *PeerShardMapper) GetPeerInfo(pid core.PeerID) core.P2PPeerInfo {
 	return *pInfo
 }
 
-func (psm *PeerShardMapper) getPeerInfoWithNodesCoordinator(pid core.PeerID) (*core.P2PPeerInfo, []byte, bool) {
+func (psm *PeerShardMapper) getPeerInfoWithNodesCoordinator(pid core.PeerID) (*core.P2PPeerInfo, bool) {
 	pkObj, ok := psm.peerIdPk.Get([]byte(pid))
 	if !ok {
 		return &core.P2PPeerInfo{
 			PeerType: core.UnknownPeer,
 			ShardID:  0,
-		}, nil, false
+			PkBytes:  nil,
+		}, false
 	}
 
 	pkBuff, ok := pkObj.([]byte)
@@ -131,7 +130,8 @@ func (psm *PeerShardMapper) getPeerInfoWithNodesCoordinator(pid core.PeerID) (*c
 		return &core.P2PPeerInfo{
 			PeerType: core.UnknownPeer,
 			ShardID:  0,
-		}, nil, false
+			PkBytes:  nil,
+		}, false
 	}
 
 	psm.mutEpoch.RLock()
@@ -143,13 +143,15 @@ func (psm *PeerShardMapper) getPeerInfoWithNodesCoordinator(pid core.PeerID) (*c
 		return &core.P2PPeerInfo{
 			PeerType: core.UnknownPeer,
 			ShardID:  0,
-		}, pkBuff, false
+			PkBytes:  pkBuff,
+		}, false
 	}
 
 	return &core.P2PPeerInfo{
 		PeerType: core.ValidatorPeer,
 		ShardID:  shardId,
-	}, pkBuff, true
+		PkBytes:  pkBuff,
+	}, true
 }
 
 func (psm *PeerShardMapper) getShardIDSearchingPkInFallbackCache(pkBuff []byte) (shardId uint32, ok bool) {
@@ -180,6 +182,7 @@ func (psm *PeerShardMapper) getPeerInfoSearchingPidInFallbackCache(pid core.Peer
 		return &core.P2PPeerInfo{
 			PeerType: core.UnknownPeer,
 			ShardID:  0,
+			PkBytes:  nil,
 		}
 	}
 
@@ -190,12 +193,14 @@ func (psm *PeerShardMapper) getPeerInfoSearchingPidInFallbackCache(pid core.Peer
 		return &core.P2PPeerInfo{
 			PeerType: core.UnknownPeer,
 			ShardID:  0,
+			PkBytes:  nil,
 		}
 	}
 
 	return &core.P2PPeerInfo{
 		PeerType: core.ObserverPeer,
 		ShardID:  shard,
+		PkBytes:  nil,
 	}
 }
 

--- a/sharding/networksharding/peerShardMapper.go
+++ b/sharding/networksharding/peerShardMapper.go
@@ -119,7 +119,6 @@ func (psm *PeerShardMapper) getPeerInfoWithNodesCoordinator(pid core.PeerID) (*c
 		return &core.P2PPeerInfo{
 			PeerType: core.UnknownPeer,
 			ShardID:  0,
-			PkBytes:  nil,
 		}, false
 	}
 
@@ -130,7 +129,6 @@ func (psm *PeerShardMapper) getPeerInfoWithNodesCoordinator(pid core.PeerID) (*c
 		return &core.P2PPeerInfo{
 			PeerType: core.UnknownPeer,
 			ShardID:  0,
-			PkBytes:  nil,
 		}, false
 	}
 
@@ -182,7 +180,6 @@ func (psm *PeerShardMapper) getPeerInfoSearchingPidInFallbackCache(pid core.Peer
 		return &core.P2PPeerInfo{
 			PeerType: core.UnknownPeer,
 			ShardID:  0,
-			PkBytes:  nil,
 		}
 	}
 
@@ -193,14 +190,12 @@ func (psm *PeerShardMapper) getPeerInfoSearchingPidInFallbackCache(pid core.Peer
 		return &core.P2PPeerInfo{
 			PeerType: core.UnknownPeer,
 			ShardID:  0,
-			PkBytes:  nil,
 		}
 	}
 
 	return &core.P2PPeerInfo{
 		PeerType: core.ObserverPeer,
 		ShardID:  shard,
-		PkBytes:  nil,
 	}
 }
 

--- a/sharding/networksharding/peerShardMapper_test.go
+++ b/sharding/networksharding/peerShardMapper_test.go
@@ -329,6 +329,7 @@ func TestPeerShardMapper_GetPeerInfoNodesCoordinatorHasTheShardId(t *testing.T) 
 	expectedPeerInfo := core.P2PPeerInfo{
 		PeerType: core.ValidatorPeer,
 		ShardID:  shardId,
+		PkBytes:  pk,
 	}
 
 	assert.Equal(t, expectedPeerInfo, peerInfo)
@@ -381,6 +382,7 @@ func TestPeerShardMapper_GetPeerInfoNodesCoordinatorDoesntHaveItShouldReturnFrom
 	expectedPeerInfo := core.P2PPeerInfo{
 		PeerType: core.ObserverPeer,
 		ShardID:  shardId,
+		PkBytes:  pk,
 	}
 
 	assert.Equal(t, expectedPeerInfo, peerInfo)
@@ -527,6 +529,7 @@ func TestPeerShardMapper_GetPeerInfoShouldWorkConcurrently(t *testing.T) {
 			expectedPeerInfo := core.P2PPeerInfo{
 				PeerType: core.ObserverPeer,
 				ShardID:  shardId,
+				PkBytes:  pk,
 			}
 
 			assert.Equal(t, expectedPeerInfo, peerInfo)


### PR DESCRIPTION
- added peer info route that will output information for a provided peer (or part of a peer) like: known addresses, its hex public key, if is black listed or not.
Usage: `http://127.0.0.1:8080/node/peerinfo?pid=[part of the pid]`