### PR TITLE
Drop connection from peers if invalid data was sent

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -294,14 +294,14 @@
         IntervalInSeconds = 1
         ReservedPercent   = 20
         [Antiflood.FastReacting.PeerMaxInput]
-            BaseMessagesPerInterval  = 90
-            TotalSizePerInterval = 2516582
+            BaseMessagesPerInterval  = 140
+            TotalSizePerInterval = 4194304 #4MB/s
             [Antiflood.FastReacting.PeerMaxInput.IncreaseFactor]
                 Threshold = 10 #if consensus size will exceed this value, then
                 Factor = 1     #increase the base value with [factor*consensus size]
         [Antiflood.FastReacting.BlackList]
-            ThresholdNumMessagesPerInterval = 180
-            ThresholdSizePerInterval = 5033164
+            ThresholdNumMessagesPerInterval = 1000
+            ThresholdSizePerInterval = 8388608 #8MB/s
             NumFloodingRounds = 10
             PeerBanDurationInSeconds = 300
 
@@ -309,14 +309,14 @@
         IntervalInSeconds = 30
         ReservedPercent   = 20.0
         [Antiflood.SlowReacting.PeerMaxInput]
-            BaseMessagesPerInterval = 3000
+            BaseMessagesPerInterval = 6000
             TotalSizePerInterval = 18874368 # 18MB/interval
             [Antiflood.SlowReacting.PeerMaxInput.IncreaseFactor]
                 Threshold = 10 #if consensus size will exceed this value, then
-                Factor = 1     #increase the base value with [factor*consensus size]
+                Factor = 0     #increase the base value with [factor*consensus size]
         [Antiflood.SlowReacting.BlackList]
-            ThresholdNumMessagesPerInterval = 6000
-            ThresholdSizePerInterval = 37748736 # 18MB/interval
+            ThresholdNumMessagesPerInterval = 10000
+            ThresholdSizePerInterval = 37748736 # 36MB/interval
             NumFloodingRounds = 2
             PeerBanDurationInSeconds = 3600
 
@@ -324,7 +324,7 @@
         IntervalInSeconds = 1
         ReservedPercent   = 0.0
         [Antiflood.OutOfSpecs.PeerMaxInput]
-            BaseMessagesPerInterval = 3000
+            BaseMessagesPerInterval = 2000
             TotalSizePerInterval = 10485760 # 10MB/interval
             [Antiflood.OutOfSpecs.PeerMaxInput.IncreaseFactor]
                 Threshold = 0 #if consensus size will exceed this value, then
@@ -336,17 +336,17 @@
             PeerBanDurationInSeconds = 3600
 
     [Antiflood.PeerMaxOutput]
-        BaseMessagesPerInterval  = 37
-        TotalSizePerInterval     = 1048576
+        BaseMessagesPerInterval  = 75
+        TotalSizePerInterval     = 2097152 #2MB/s
 
     [Antiflood.Cache]
-        Capacity = 5000
+        Capacity = 7000
         Type = "LRU"
     [Antiflood.Topic]
         DefaultMaxMessagesPerSec = 15000
-        MaxMessages = [{ Topic = "heartbeat", NumMessagesPerSec = 20 },
-                       { Topic = "shardBlocks*", NumMessagesPerSec = 20 },
-                       { Topic = "metachainBlocks", NumMessagesPerSec = 20 }]
+        MaxMessages = [{ Topic = "heartbeat", NumMessagesPerSec = 30 },
+                       { Topic = "shardBlocks*", NumMessagesPerSec = 30 },
+                       { Topic = "metachainBlocks", NumMessagesPerSec = 30 }]
     [Antiflood.WebServer]
         # SimultaneousRequests represents the number of concurrent requests accepted by the web server
         # this is a global throttler that acts on all http connections regardless of the originating source

--- a/consensus/interface.go
+++ b/consensus/interface.go
@@ -87,6 +87,7 @@ type P2PAntifloodHandler interface {
 	CanProcessMessagesOnTopic(peer core.PeerID, topic string, numMessages uint32, totalSize uint64, sequence []byte) error
 	ResetForTopic(topic string)
 	SetMaxMessagesForTopic(topic string, maxNum uint32)
+	BlacklistPeer(peer core.PeerID, reason string, duration time.Duration)
 	IsInterfaceNil() bool
 }
 

--- a/consensus/mock/p2pAntifloodHandlerStub.go
+++ b/consensus/mock/p2pAntifloodHandlerStub.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"time"
+
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 )
@@ -9,6 +11,7 @@ import (
 type P2PAntifloodHandlerStub struct {
 	CanProcessMessageCalled         func(message p2p.MessageP2P, fromConnectedPeer core.PeerID) error
 	CanProcessMessagesOnTopicCalled func(peer core.PeerID, topic string, numMessages uint32, totalSize uint64, sequence []byte) error
+	BlacklistPeerCalled             func(peer core.PeerID, reason string, duration time.Duration)
 }
 
 // ResetForTopic -
@@ -35,6 +38,13 @@ func (p2pahs *P2PAntifloodHandlerStub) CanProcessMessagesOnTopic(peer core.PeerI
 	}
 
 	return nil
+}
+
+// BlacklistPeer -
+func (p2pahs *P2PAntifloodHandlerStub) BlacklistPeer(peer core.PeerID, reason string, duration time.Duration) {
+	if p2pahs.BlacklistPeerCalled != nil {
+		p2pahs.BlacklistPeerCalled(peer, reason, duration)
+	}
 }
 
 // IsInterfaceNil -

--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -329,8 +329,8 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 		//that disseminated this message.
 
 		reason := "blacklisted due to invalid consensus message"
-		wrk.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.IntervalBlackListPeerInvalidMessage)
-		wrk.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.IntervalBlackListPeerInvalidMessage)
+		wrk.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.InvalidMessageBlacklistDuration)
+		wrk.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
 
 		return err
 	}

--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -325,6 +325,13 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 	cnsMsg := &consensus.Message{}
 	err = wrk.marshalizer.Unmarshal(cnsMsg, message.Data())
 	if err != nil {
+		//this situation is so severe that we have to black list both the message originator and the connected peer
+		//that disseminated this message.
+
+		reason := "blacklisted due to invalid consensus message"
+		wrk.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.IntervalBlackListPeerInvalidMessage)
+		wrk.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.IntervalBlackListPeerInvalidMessage)
+
 		return err
 	}
 

--- a/core/constants.go
+++ b/core/constants.go
@@ -446,6 +446,6 @@ const CommitMaxTime = time.Second
 // DefaultUnstakedEpoch represents the default epoch that is set for a validator that has not unstaked yet
 const DefaultUnstakedEpoch = math.MaxUint32
 
-// IntervalBlackListPeerInvalidMessage time to keep a peer in the black list if it sends a message that does not follow
-// the protocol
-const IntervalBlackListPeerInvalidMessage = time.Second * 3600
+// InvalidMessageBlacklistDuration represents the time to keep a peer in the black list if it sends a message that
+// does not follow the protocol: example not useing the same marshaler as the other peers
+const InvalidMessageBlacklistDuration = time.Second * 3600

--- a/core/constants.go
+++ b/core/constants.go
@@ -445,3 +445,7 @@ const CommitMaxTime = time.Second
 
 // DefaultUnstakedEpoch represents the default epoch that is set for a validator that has not unstaked yet
 const DefaultUnstakedEpoch = math.MaxUint32
+
+// IntervalBlackListPeerInvalidMessage time to keep a peer in the black list if it sends a message that does not follow
+// the protocol
+const IntervalBlackListPeerInvalidMessage = time.Second * 3600

--- a/dataRetriever/interface.go
+++ b/dataRetriever/interface.go
@@ -348,6 +348,7 @@ type RequestedItemsHandler interface {
 type P2PAntifloodHandler interface {
 	CanProcessMessage(message p2p.MessageP2P, fromConnectedPeer core.PeerID) error
 	CanProcessMessagesOnTopic(peer core.PeerID, topic string, numMessages uint32, _ uint64, sequence []byte) error
+	BlacklistPeer(peer core.PeerID, reason string, duration time.Duration)
 	IsInterfaceNil() bool
 }
 

--- a/dataRetriever/mock/p2pAntifloodHandlerStub.go
+++ b/dataRetriever/mock/p2pAntifloodHandlerStub.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"time"
+
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 )
@@ -9,6 +11,7 @@ import (
 type P2PAntifloodHandlerStub struct {
 	CanProcessMessageCalled         func(message p2p.MessageP2P, fromConnectedPeer core.PeerID) error
 	CanProcessMessagesOnTopicCalled func(peer core.PeerID, topic string, numMessages uint32, totalSize uint64, sequence []byte) error
+	BlacklistPeerCalled             func(peer core.PeerID, reason string, duration time.Duration)
 }
 
 // CanProcessMessage -
@@ -27,6 +30,13 @@ func (p2pahs *P2PAntifloodHandlerStub) CanProcessMessagesOnTopic(peer core.PeerI
 	}
 
 	return p2pahs.CanProcessMessagesOnTopicCalled(peer, topic, numMessages, totalSize, sequence)
+}
+
+// BlacklistPeer -
+func (p2pahs *P2PAntifloodHandlerStub) BlacklistPeer(peer core.PeerID, reason string, duration time.Duration) {
+	if p2pahs.BlacklistPeerCalled != nil {
+		p2pahs.BlacklistPeerCalled(peer, reason, duration)
+	}
 }
 
 // IsInterfaceNil -

--- a/dataRetriever/resolvers/headerResolver.go
+++ b/dataRetriever/resolvers/headerResolver.go
@@ -115,7 +115,7 @@ func (hdrRes *HeaderResolver) ProcessReceivedMessage(message p2p.MessageP2P, fro
 	hdrRes.throttler.StartProcessing()
 	defer hdrRes.throttler.EndProcessing()
 
-	rd, err := hdrRes.parseReceivedMessage(message)
+	rd, err := hdrRes.parseReceivedMessage(message, fromConnectedPeer)
 	if err != nil {
 		return err
 	}

--- a/dataRetriever/resolvers/messageProcessor.go
+++ b/dataRetriever/resolvers/messageProcessor.go
@@ -42,10 +42,10 @@ func (mp *messageProcessor) parseReceivedMessage(message p2p.MessageP2P, fromCon
 	rd := &dataRetriever.RequestData{}
 	err := rd.UnmarshalWith(mp.marshalizer, message)
 	if err != nil {
-		//this situation is so severe that we need to black list de peers
+		//this situation is so severe that we need to black list the peers
 		reason := "unmarshalable data got on request topic " + mp.topic
-		mp.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.IntervalBlackListPeerInvalidMessage)
-		mp.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.IntervalBlackListPeerInvalidMessage)
+		mp.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.InvalidMessageBlacklistDuration)
+		mp.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
 
 		return nil, err
 	}

--- a/dataRetriever/resolvers/miniblockResolver.go
+++ b/dataRetriever/resolvers/miniblockResolver.go
@@ -89,7 +89,7 @@ func (mbRes *miniblockResolver) ProcessReceivedMessage(message p2p.MessageP2P, f
 	mbRes.throttler.StartProcessing()
 	defer mbRes.throttler.EndProcessing()
 
-	rd, err := mbRes.parseReceivedMessage(message)
+	rd, err := mbRes.parseReceivedMessage(message, fromConnectedPeer)
 	if err != nil {
 		return err
 	}

--- a/dataRetriever/resolvers/transactionResolver.go
+++ b/dataRetriever/resolvers/transactionResolver.go
@@ -94,7 +94,7 @@ func (txRes *TxResolver) ProcessReceivedMessage(message p2p.MessageP2P, fromConn
 	txRes.throttler.StartProcessing()
 	defer txRes.throttler.EndProcessing()
 
-	rd, err := txRes.parseReceivedMessage(message)
+	rd, err := txRes.parseReceivedMessage(message, fromConnectedPeer)
 	if err != nil {
 		return err
 	}

--- a/dataRetriever/resolvers/trieNodeResolver.go
+++ b/dataRetriever/resolvers/trieNodeResolver.go
@@ -71,7 +71,7 @@ func (tnRes *TrieNodeResolver) ProcessReceivedMessage(message p2p.MessageP2P, fr
 	tnRes.throttler.StartProcessing()
 	defer tnRes.throttler.EndProcessing()
 
-	rd, err := tnRes.parseReceivedMessage(message)
+	rd, err := tnRes.parseReceivedMessage(message, fromConnectedPeer)
 	if err != nil {
 		return err
 	}

--- a/epochStart/bootstrap/disabled/disabledAntiFloodHandler.go
+++ b/epochStart/bootstrap/disabled/disabledAntiFloodHandler.go
@@ -1,6 +1,8 @@
 package disabled
 
 import (
+	"time"
+
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/p2p"
@@ -34,6 +36,10 @@ func (a *antiFloodHandler) ApplyConsensusSize(_ int) {
 // SetDebugger returns nil
 func (a *antiFloodHandler) SetDebugger(_ process.AntifloodDebugger) error {
 	return nil
+}
+
+// BlacklistPeer does nothing
+func (a *antiFloodHandler) BlacklistPeer(_ core.PeerID, _ string, _ time.Duration) {
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/epochStart/bootstrap/interface.go
+++ b/epochStart/bootstrap/interface.go
@@ -37,6 +37,7 @@ type Messenger interface {
 	dataRetriever.TopicHandler
 	UnregisterMessageProcessor(topic string) error
 	UnregisterAllMessageProcessors() error
+	UnjoinAllTopics() error
 	ConnectedPeers() []core.PeerID
 }
 

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -283,7 +283,7 @@ func (e *epochStartBootstrap) Bootstrap() (Parameters, error) {
 	}
 
 	defer func() {
-		log.Debug("unregistering all message processor")
+		log.Debug("unregistering all message processor and un-joining all topics")
 		errMessenger := e.messenger.UnregisterAllMessageProcessors()
 		log.LogIfError(errMessenger)
 

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -286,6 +286,9 @@ func (e *epochStartBootstrap) Bootstrap() (Parameters, error) {
 		log.Debug("unregistering all message processor")
 		errMessenger := e.messenger.UnregisterAllMessageProcessors()
 		log.LogIfError(errMessenger)
+
+		errMessenger = e.messenger.UnjoinAllTopics()
+		log.LogIfError(errMessenger)
 	}()
 
 	var err error

--- a/epochStart/mock/messengerStub.go
+++ b/epochStart/mock/messengerStub.go
@@ -9,6 +9,7 @@ import (
 type MessengerStub struct {
 	ConnectedPeersCalled           func() []core.PeerID
 	RegisterMessageProcessorCalled func(topic string, handler p2p.MessageProcessor) error
+	UnjoinAllTopicsCalled          func() error
 }
 
 // ConnectedPeersOnTopic -
@@ -52,6 +53,15 @@ func (m *MessengerStub) UnregisterMessageProcessor(_ string) error {
 
 // UnregisterAllMessageProcessors -
 func (m *MessengerStub) UnregisterAllMessageProcessors() error {
+	return nil
+}
+
+// UnjoinAllTopics -
+func (m *MessengerStub) UnjoinAllTopics() error {
+	if m.UnjoinAllTopicsCalled != nil {
+		return m.UnjoinAllTopicsCalled()
+	}
+
 	return nil
 }
 

--- a/factory/interface.go
+++ b/factory/interface.go
@@ -1,6 +1,8 @@
 package factory
 
 import (
+	"time"
+
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/epochStart"
@@ -33,5 +35,6 @@ type P2PAntifloodHandler interface {
 	SetMaxMessagesForTopic(topic string, maxNum uint32)
 	SetDebugger(debugger process.AntifloodDebugger) error
 	ApplyConsensusSize(size int)
+	BlacklistPeer(peer core.PeerID, reason string, duration time.Duration)
 	IsInterfaceNil() bool
 }

--- a/go.mod
+++ b/go.mod
@@ -26,11 +26,11 @@ require (
 	github.com/jbenet/goprocess v0.1.4
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/libp2p/go-libp2p v0.9.2
-	github.com/libp2p/go-libp2p-core v0.5.6
+	github.com/libp2p/go-libp2p-core v0.5.7
 	github.com/libp2p/go-libp2p-discovery v0.4.0
 	github.com/libp2p/go-libp2p-kad-dht v0.8.0
 	github.com/libp2p/go-libp2p-kbucket v0.4.2
-	github.com/libp2p/go-libp2p-pubsub v0.3.1
+	github.com/libp2p/go-libp2p-pubsub v0.3.3-0.20200615073058-8945f91465bc
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/mr-tron/base58 v1.1.3
 	github.com/multiformats/go-multiaddr v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,7 @@ github.com/beevik/ntp v0.2.0 h1:sGsd+kAXzT0bfVfzJfce04g+dSRfrs+tbQW8lweuYgw=
 github.com/beevik/ntp v0.2.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
 github.com/benbjohnson/clock v1.0.1 h1:lVM1R/o5khtrr7t3qAr+sS6uagZOP+7iprc7gS3V9CE=
 github.com/benbjohnson/clock v1.0.1/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
+github.com/benbjohnson/clock v1.0.2/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32/go.mod h1:DrZx5ec/dmnfpw9KyYoQyYo7d0KEvTkk/5M/vbZjAr8=
 github.com/btcsuite/btcd v0.0.0-20190523000118-16327141da8c/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
 github.com/btcsuite/btcd v0.0.0-20190824003749-130ea5bddde3/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
@@ -220,6 +221,8 @@ github.com/libp2p/go-conn-security-multistream v0.2.0 h1:uNiDjS58vrvJTg9jO6bySd1
 github.com/libp2p/go-conn-security-multistream v0.2.0/go.mod h1:hZN4MjlNetKD3Rq5Jb/P5ohUnFLNzEAR4DLSzpn2QLU=
 github.com/libp2p/go-eventbus v0.1.0 h1:mlawomSAjjkk97QnYiEmHsLu7E136+2oCWSHRUvMfzQ=
 github.com/libp2p/go-eventbus v0.1.0/go.mod h1:vROgu5cs5T7cv7POWlWxBaVLxfSegC5UGQf8A2eEmx4=
+github.com/libp2p/go-eventbus v0.2.1 h1:VanAdErQnpTioN2TowqNcOijf6YwhuODe4pPKSDpxGc=
+github.com/libp2p/go-eventbus v0.2.1/go.mod h1:jc2S4SoEVPP48H9Wpzm5aiGwUCBMfGhVhhBjyhhCJs8=
 github.com/libp2p/go-flow-metrics v0.0.1/go.mod h1:Iv1GH0sG8DtYN3SVJ2eG221wMiNpZxBdp967ls1g+k8=
 github.com/libp2p/go-flow-metrics v0.0.2/go.mod h1:HeoSNUrOJVK1jEpDqVEiUOIXqhbnS27omG0uWU5slZs=
 github.com/libp2p/go-flow-metrics v0.0.3 h1:8tAs/hSdNvUiLgtlSy3mxwxWP4I9y/jlkPFT7epKdeM=
@@ -251,6 +254,7 @@ github.com/libp2p/go-libp2p-circuit v0.2.2 h1:87RLabJ9lrhoiSDDZyCJ80ZlI5TLJMwfyo
 github.com/libp2p/go-libp2p-circuit v0.2.2/go.mod h1:nkG3iE01tR3FoQ2nMm06IUrCpCyJp1Eo4A1xYdpjfs4=
 github.com/libp2p/go-libp2p-connmgr v0.2.3 h1:v7skKI9n+0obPpzMIO6aIlOSdQOmhxTf40cbpzqaGMQ=
 github.com/libp2p/go-libp2p-connmgr v0.2.3/go.mod h1:Gqjg29zI8CwXX21zRxy6gOg8VYu3zVerJRt2KyktzH4=
+github.com/libp2p/go-libp2p-connmgr v0.2.4/go.mod h1:YV0b/RIm8NGPnnNWM7hG9Q38OeQiQfKhHCCs1++ufn0=
 github.com/libp2p/go-libp2p-core v0.0.1/go.mod h1:g/VxnTZ/1ygHxH3dKok7Vno1VfpvGcGip57wjTU4fco=
 github.com/libp2p/go-libp2p-core v0.0.4/go.mod h1:jyuCQP356gzfCFtRKyvAbNkyeuxb7OlyhWZ3nls5d2I=
 github.com/libp2p/go-libp2p-core v0.2.0/go.mod h1:X0eyB0Gy93v0DZtSYbEM7RnMChm9Uv3j7yRXjO77xSI=
@@ -269,6 +273,8 @@ github.com/libp2p/go-libp2p-core v0.5.4/go.mod h1:uN7L2D4EvPCvzSH5SrhR72UWbnSGpt
 github.com/libp2p/go-libp2p-core v0.5.5/go.mod h1:vj3awlOr9+GMZJFH9s4mpt9RHHgGqeHCopzbYKZdRjM=
 github.com/libp2p/go-libp2p-core v0.5.6 h1:IxFH4PmtLlLdPf4fF/i129SnK/C+/v8WEX644MxhC48=
 github.com/libp2p/go-libp2p-core v0.5.6/go.mod h1:txwbVEhHEXikXn9gfC7/UDDw7rkxuX0bJvM49Ykaswo=
+github.com/libp2p/go-libp2p-core v0.5.7 h1:QK3xRwFxqd0Xd9bSZL+8yZ8ncZZbl6Zngd/+Y+A6sgQ=
+github.com/libp2p/go-libp2p-core v0.5.7/go.mod h1:txwbVEhHEXikXn9gfC7/UDDw7rkxuX0bJvM49Ykaswo=
 github.com/libp2p/go-libp2p-crypto v0.1.0/go.mod h1:sPUokVISZiy+nNuTTH/TY+leRSxnFj/2GLjtOTW90hI=
 github.com/libp2p/go-libp2p-discovery v0.2.0/go.mod h1:s4VGaxYMbw4+4+tsoQTqh7wfxg97AEdo4GYBt6BadWg=
 github.com/libp2p/go-libp2p-discovery v0.3.0 h1:+JnYBRLzZQtRq0mK3xhyjBwHytLmJXMTZkQfbw+UrGA=
@@ -306,6 +312,8 @@ github.com/libp2p/go-libp2p-pnet v0.2.0 h1:J6htxttBipJujEjz1y0a5+eYoiPcFHhSYHH6n
 github.com/libp2p/go-libp2p-pnet v0.2.0/go.mod h1:Qqvq6JH/oMZGwqs3N1Fqhv8NVhrdYcO0BW4wssv21LA=
 github.com/libp2p/go-libp2p-pubsub v0.3.1 h1:7Hyv2d8BK/x1HGRJTZ8X++VQEP+WqDTSwpUSZGTVLYA=
 github.com/libp2p/go-libp2p-pubsub v0.3.1/go.mod h1:TxPOBuo1FPdsTjFnv+FGZbNbWYsp74Culx+4ViQpato=
+github.com/libp2p/go-libp2p-pubsub v0.3.3-0.20200615073058-8945f91465bc h1:w1iig/EQDzxPcvduerJ5aA1/yuOsvTQYXRikigQqZtw=
+github.com/libp2p/go-libp2p-pubsub v0.3.3-0.20200615073058-8945f91465bc/go.mod h1:Uss7/Cfz872KggNb+doCVPHeCDmXB7z500m/R8DaAUk=
 github.com/libp2p/go-libp2p-record v0.1.2 h1:M50VKzWnmUrk/M5/Dz99qO9Xh4vs8ijsK+7HkJvRP+0=
 github.com/libp2p/go-libp2p-record v0.1.2/go.mod h1:pal0eNcT5nqZaTV7UGhqeGqxFgGdsU/9W//C8dqjQDk=
 github.com/libp2p/go-libp2p-routing-helpers v0.2.3/go.mod h1:795bh+9YeoFl99rMASoiVgHdi5bjack0N1+AFAdbvBw=

--- a/heartbeat/componentHandler/heartbeatHandler.go
+++ b/heartbeat/componentHandler/heartbeatHandler.go
@@ -40,7 +40,6 @@ type ArgHeartbeat struct {
 	PrivKey                  crypto.PrivateKey
 	HardforkTrigger          heartbeat.HardforkTrigger
 	AntifloodHandler         heartbeat.P2PAntifloodHandler
-	PeerBlackListHandler     heartbeat.PeerBlackListHandler
 	ValidatorPubkeyConverter core.PubkeyConverter
 	EpochStartTrigger        sharding.EpochHandler
 	EpochStartRegistration   sharding.EpochStartEventNotifier
@@ -173,7 +172,6 @@ func (hbh *HeartbeatHandler) create() error {
 		Timer:                              timer,
 		AntifloodHandler:                   arg.AntifloodHandler,
 		HardforkTrigger:                    arg.HardforkTrigger,
-		PeerBlackListHandler:               arg.PeerBlackListHandler,
 		ValidatorPubkeyConverter:           arg.ValidatorPubkeyConverter,
 		HeartbeatRefreshIntervalInSec:      arg.HeartbeatConfig.HeartbeatRefreshIntervalInSec,
 		HideInactiveValidatorIntervalInSec: arg.HeartbeatConfig.HideInactiveValidatorIntervalInSec,

--- a/heartbeat/componentHandler/heartbeatHandler_test.go
+++ b/heartbeat/componentHandler/heartbeatHandler_test.go
@@ -39,7 +39,6 @@ func createMockArgument() ArgHeartbeat {
 		PrivKey:                  &mock.PrivateKeyStub{},
 		HardforkTrigger:          &mock.HardforkTriggerStub{},
 		AntifloodHandler:         &mock.P2PAntifloodHandlerStub{},
-		PeerBlackListHandler:     &mock.PeerBlackListHandlerStub{},
 		ValidatorPubkeyConverter: mock.NewPubkeyConverterMock(32),
 		EpochStartTrigger:        &mock.EpochStartTriggerStub{},
 		EpochStartRegistration:   &mock.EpochStartNotifierStub{},

--- a/heartbeat/errors.go
+++ b/heartbeat/errors.go
@@ -77,9 +77,6 @@ var ErrNilHardforkTrigger = errors.New("nil hardfork trigger")
 // ErrHeartbeatPidMismatch signals that a received hearbeat did not come from the correct originator
 var ErrHeartbeatPidMismatch = errors.New("heartbeat peer id mismatch")
 
-// ErrNilBlackListHandler signals that a nil black list handler was provided
-var ErrNilBlackListHandler = errors.New("nil black list handler")
-
 // ErrNilPubkeyConverter signals that a nil public key converter has been provided
 var ErrNilPubkeyConverter = errors.New("trying to use a nil pubkey converter")
 

--- a/heartbeat/interface.go
+++ b/heartbeat/interface.go
@@ -71,6 +71,7 @@ type NetworkShardingCollector interface {
 type P2PAntifloodHandler interface {
 	CanProcessMessage(message p2p.MessageP2P, fromConnectedPeer core.PeerID) error
 	CanProcessMessagesOnTopic(peer core.PeerID, topic string, numMessages uint32, totalSize uint64, sequence []byte) error
+	BlacklistPeer(peer core.PeerID, reason string, duration time.Duration)
 	IsInterfaceNil() bool
 }
 

--- a/heartbeat/mock/p2pAntifloodHandlerStub.go
+++ b/heartbeat/mock/p2pAntifloodHandlerStub.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"time"
+
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 )
@@ -9,6 +11,7 @@ import (
 type P2PAntifloodHandlerStub struct {
 	CanProcessMessageCalled         func(message p2p.MessageP2P, fromConnectedPeer core.PeerID) error
 	CanProcessMessagesOnTopicCalled func(peer core.PeerID, topic string, numMessages uint32, totalSize uint64, sequence []byte) error
+	BlacklistPeerCalled             func(peer core.PeerID, reason string, duration time.Duration)
 }
 
 // ResetForTopic -
@@ -35,6 +38,13 @@ func (p2pahs *P2PAntifloodHandlerStub) CanProcessMessagesOnTopic(peer core.PeerI
 	}
 
 	return p2pahs.CanProcessMessagesOnTopicCalled(peer, topic, numMessages, totalSize, sequence)
+}
+
+// BlacklistPeer -
+func (p2pahs *P2PAntifloodHandlerStub) BlacklistPeer(peer core.PeerID, reason string, duration time.Duration) {
+	if p2pahs.BlacklistPeerCalled != nil {
+		p2pahs.BlacklistPeerCalled(peer, reason, duration)
+	}
 }
 
 // IsInterfaceNil -

--- a/heartbeat/process/monitor.go
+++ b/heartbeat/process/monitor.go
@@ -269,8 +269,8 @@ func (m *Monitor) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedPe
 		//that disseminated this message.
 
 		reason := "blacklisted due to invalid heartbeat message"
-		m.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.IntervalBlackListPeerInvalidMessage)
-		m.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.IntervalBlackListPeerInvalidMessage)
+		m.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.InvalidMessageBlacklistDuration)
+		m.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
 
 		return err
 	}
@@ -284,8 +284,8 @@ func (m *Monitor) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedPe
 		//this situation is so severe that we have to black list both the message originator and the connected peer
 		//that disseminated this message.
 		reason := "blacklisted due to inconsistent heartbeat message"
-		m.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.IntervalBlackListPeerInvalidMessage)
-		m.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.IntervalBlackListPeerInvalidMessage)
+		m.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.InvalidMessageBlacklistDuration)
+		m.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
 
 		return fmt.Errorf("%w heartbeat pid %s, message pid %s",
 			heartbeat.ErrHeartbeatPidMismatch,

--- a/heartbeat/process/monitor.go
+++ b/heartbeat/process/monitor.go
@@ -32,7 +32,6 @@ type ArgHeartbeatMonitor struct {
 	Timer                              heartbeat.Timer
 	AntifloodHandler                   heartbeat.P2PAntifloodHandler
 	HardforkTrigger                    heartbeat.HardforkTrigger
-	PeerBlackListHandler               heartbeat.PeerBlackListHandler
 	ValidatorPubkeyConverter           core.PubkeyConverter
 	HeartbeatRefreshIntervalInSec      uint32
 	HideInactiveValidatorIntervalInSec uint32
@@ -56,7 +55,6 @@ type Monitor struct {
 	timer                              heartbeat.Timer
 	antifloodHandler                   heartbeat.P2PAntifloodHandler
 	hardforkTrigger                    heartbeat.HardforkTrigger
-	peerBlackListHandler               heartbeat.PeerBlackListHandler
 	validatorPubkeyConverter           core.PubkeyConverter
 	heartbeatRefreshIntervalInSec      uint32
 	hideInactiveValidatorIntervalInSec uint32
@@ -88,9 +86,6 @@ func NewMonitor(arg ArgHeartbeatMonitor) (*Monitor, error) {
 	if check.IfNil(arg.HardforkTrigger) {
 		return nil, heartbeat.ErrNilHardforkTrigger
 	}
-	if check.IfNil(arg.PeerBlackListHandler) {
-		return nil, fmt.Errorf("%w in NewMonitor", heartbeat.ErrNilBlackListHandler)
-	}
 	if check.IfNil(arg.ValidatorPubkeyConverter) {
 		return nil, heartbeat.ErrNilPubkeyConverter
 	}
@@ -113,7 +108,6 @@ func NewMonitor(arg ArgHeartbeatMonitor) (*Monitor, error) {
 		timer:                              arg.Timer,
 		antifloodHandler:                   arg.AntifloodHandler,
 		hardforkTrigger:                    arg.HardforkTrigger,
-		peerBlackListHandler:               arg.PeerBlackListHandler,
 		validatorPubkeyConverter:           arg.ValidatorPubkeyConverter,
 		heartbeatRefreshIntervalInSec:      arg.HeartbeatRefreshIntervalInSec,
 		hideInactiveValidatorIntervalInSec: arg.HideInactiveValidatorIntervalInSec,
@@ -271,6 +265,13 @@ func (m *Monitor) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedPe
 
 	hbRecv, err := m.messageHandler.CreateHeartbeatFromP2PMessage(message)
 	if err != nil {
+		//this situation is so severe that we have to black list both the message originator and the connected peer
+		//that disseminated this message.
+
+		reason := "blacklisted due to invalid heartbeat message"
+		m.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.IntervalBlackListPeerInvalidMessage)
+		m.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.IntervalBlackListPeerInvalidMessage)
+
 		return err
 	}
 
@@ -282,13 +283,9 @@ func (m *Monitor) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedPe
 	if !bytes.Equal(hbRecv.Pid, message.Peer().Bytes()) {
 		//this situation is so severe that we have to black list both the message originator and the connected peer
 		//that disseminated this message.
-		_ = m.peerBlackListHandler.Add(message.Peer())
-		_ = m.peerBlackListHandler.Add(fromConnectedPeer)
-
-		log.Debug("blacklisted due to inconsistent heartbeat message",
-			"message originator", p2p.PeerIdToShortString(message.Peer()),
-			"from connected peer", p2p.PeerIdToShortString(fromConnectedPeer),
-		)
+		reason := "blacklisted due to inconsistent heartbeat message"
+		m.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.IntervalBlackListPeerInvalidMessage)
+		m.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.IntervalBlackListPeerInvalidMessage)
 
 		return fmt.Errorf("%w heartbeat pid %s, message pid %s",
 			heartbeat.ErrHeartbeatPidMismatch,

--- a/heartbeat/process/monitorEdgeCases_test.go
+++ b/heartbeat/process/monitorEdgeCases_test.go
@@ -32,7 +32,6 @@ func createMonitor(
 		Timer:                              timer,
 		AntifloodHandler:                   createMockP2PAntifloodHandler(),
 		HardforkTrigger:                    &mock.HardforkTriggerStub{},
-		PeerBlackListHandler:               &mock.PeerBlackListHandlerStub{},
 		ValidatorPubkeyConverter:           mock.NewPubkeyConverterMock(32),
 		HeartbeatRefreshIntervalInSec:      1,
 		HideInactiveValidatorIntervalInSec: 600,

--- a/integrationTests/mock/nilAntifloodHandler.go
+++ b/integrationTests/mock/nilAntifloodHandler.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"time"
+
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -36,6 +38,10 @@ func (nah *NilAntifloodHandler) SetDebugger(_ process.AntifloodDebugger) error {
 
 // ApplyConsensusSize does nothing
 func (nah *NilAntifloodHandler) ApplyConsensusSize(_ int) {
+}
+
+// BlacklistPeer does nothing
+func (nah *NilAntifloodHandler) BlacklistPeer(_ core.PeerID, _ string, _ time.Duration) {
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/integrationTests/mock/p2pAntifloodHandlerStub.go
+++ b/integrationTests/mock/p2pAntifloodHandlerStub.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"time"
+
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 )
@@ -9,6 +11,7 @@ import (
 type P2PAntifloodHandlerStub struct {
 	CanProcessMessageCalled         func(message p2p.MessageP2P, fromConnectedPeer core.PeerID) error
 	CanProcessMessagesOnTopicCalled func(peer core.PeerID, topic string, numMessages uint32, totalSize uint64, sequence []byte) error
+	BlacklistPeerCalled             func(peer core.PeerID, reason string, duration time.Duration)
 }
 
 // ResetForTopic -
@@ -35,6 +38,13 @@ func (p2pahs *P2PAntifloodHandlerStub) CanProcessMessagesOnTopic(peer core.PeerI
 	}
 
 	return p2pahs.CanProcessMessagesOnTopicCalled(peer, topic, numMessages, totalSize, sequence)
+}
+
+// BlacklistPeer -
+func (p2pahs *P2PAntifloodHandlerStub) BlacklistPeer(peer core.PeerID, reason string, duration time.Duration) {
+	if p2pahs.BlacklistPeerCalled != nil {
+		p2pahs.BlacklistPeerCalled(peer, reason, duration)
+	}
 }
 
 // IsInterfaceNil -

--- a/integrationTests/node/heartbeat/heartbeat_test.go
+++ b/integrationTests/node/heartbeat/heartbeat_test.go
@@ -274,7 +274,6 @@ func createMonitor(maxDurationPeerUnresponsive time.Duration) *process.Monitor {
 			},
 		},
 		HardforkTrigger:                    &mock.HardforkTriggerStub{},
-		PeerBlackListHandler:               &mock.PeerBlackListHandlerStub{},
 		ValidatorPubkeyConverter:           integrationTests.TestValidatorPubkeyConverter,
 		HeartbeatRefreshIntervalInSec:      1,
 		HideInactiveValidatorIntervalInSec: 600,

--- a/integrationTests/p2p/pubsub/messageProcessor.go
+++ b/integrationTests/p2p/pubsub/messageProcessor.go
@@ -36,6 +36,20 @@ func (mp *messageProcessor) Messages(pid core.PeerID) []p2p.MessageP2P {
 	return mp.messages[pid]
 }
 
+// AllMessages -
+func (mp *messageProcessor) AllMessages() []p2p.MessageP2P {
+	result := make([]p2p.MessageP2P, 0)
+
+	mp.mutMessages.Lock()
+	defer mp.mutMessages.Unlock()
+
+	for _, messages := range mp.messages {
+		result = append(result, messages...)
+	}
+
+	return result
+}
+
 // IsInterfaceNil -
 func (mp *messageProcessor) IsInterfaceNil() bool {
 	return mp == nil

--- a/integrationTests/p2p/pubsub/unjoin_test.go
+++ b/integrationTests/p2p/pubsub/unjoin_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/integrationTests"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 	"github.com/stretchr/testify/assert"

--- a/integrationTests/p2p/pubsub/unjoin_test.go
+++ b/integrationTests/p2p/pubsub/unjoin_test.go
@@ -1,0 +1,89 @@
+package peerDisconnecting
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-go/integrationTests"
+	"github.com/ElrondNetwork/elrond-go/p2p"
+	"github.com/stretchr/testify/assert"
+)
+
+const durationBootstrapping = time.Second * 2
+const durationTraverseNetwork = time.Second * 2
+const durationUnjoin = time.Second * 2
+
+func TestPubsubUnjoinShouldWork(t *testing.T) {
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	peers, _ := integrationTests.CreateFixedNetworkOf8Peers()
+	defer func() {
+		integrationTests.ClosePeers(peers)
+	}()
+
+	topic := "test_topic"
+	processors := make([]*messageProcessor, 0, len(peers))
+	for _, p := range peers {
+		_ = p.CreateTopic(topic, true)
+		//    processors = append(processors, newMessageProcessor())
+		//    _ = p.RegisterMessageProcessor(topic, processors[idx])
+	}
+
+	printConnections(peers)
+
+	fmt.Println("bootstrapping nodes")
+	time.Sleep(durationBootstrapping)
+
+	//a message should traverse the network
+	fmt.Println("sending the message that should traverse the whole network")
+	//sender := peers[4]
+	//sender.Broadcast(topic, []byte("message 1"))
+
+	time.Sleep(durationTraverseNetwork)
+
+	for _, mp := range processors {
+		assert.Equal(t, 1, len(mp.AllMessages()))
+	}
+
+	printConnections(peers)
+
+	blockedIdxs := []int{3, 6, 2, 5}
+	//node 3 unjoins the topic, which should prevent the propagation of the messages on peers 3, 6, 2 and 5
+	err := peers[3].UnregisterAllMessageProcessors()
+	assert.Nil(t, err)
+
+	err = peers[3].UnjoinAllTopics()
+	assert.Nil(t, err)
+
+	time.Sleep(durationUnjoin * 10)
+
+	printConnections(peers)
+
+	fmt.Println("sending the message that should traverse half the network")
+	//sender.Broadcast(topic, []byte("message 2"))
+
+	time.Sleep(durationTraverseNetwork)
+
+	for idx, mp := range processors {
+		if integrationTests.IsIntInSlice(idx, blockedIdxs) {
+			assert.Equal(t, 1, len(mp.AllMessages()))
+			continue
+		}
+
+		assert.Equal(t, 2, len(mp.AllMessages()))
+	}
+}
+
+func printConnections(peers []p2p.Messenger) {
+	for idx, peer := range peers {
+		fmt.Printf("peer %d: %s is connected to:\n", idx, peer.ID().Pretty())
+
+		for _, addr := range peer.ConnectedAddresses() {
+			fmt.Printf(" %s\n", addr)
+		}
+	}
+}

--- a/node/interface.go
+++ b/node/interface.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"io"
+	"time"
 
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/p2p"
@@ -41,6 +42,7 @@ type P2PAntifloodHandler interface {
 	ResetForTopic(topic string)
 	SetMaxMessagesForTopic(topic string, maxNum uint32)
 	ApplyConsensusSize(size int)
+	BlacklistPeer(peer core.PeerID, reason string, duration time.Duration)
 	IsInterfaceNil() bool
 }
 

--- a/node/mock/p2pAntifloodHandlerStub.go
+++ b/node/mock/p2pAntifloodHandlerStub.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"time"
+
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 )
@@ -10,6 +12,7 @@ type P2PAntifloodHandlerStub struct {
 	CanProcessMessageCalled         func(message p2p.MessageP2P, fromConnectedPeer core.PeerID) error
 	CanProcessMessagesOnTopicCalled func(peer core.PeerID, topic string, numMessages uint32, totalSize uint64, sequence []byte) error
 	ApplyConsensusSizeCalled        func(size int)
+	BlacklistPeerCalled             func(peer core.PeerID, reason string, duration time.Duration)
 }
 
 // ResetForTopic -
@@ -43,6 +46,13 @@ func (p2pahs *P2PAntifloodHandlerStub) CanProcessMessagesOnTopic(peer core.PeerI
 	}
 
 	return p2pahs.CanProcessMessagesOnTopicCalled(peer, topic, numMessages, totalSize, sequence)
+}
+
+// BlacklistPeer -
+func (p2pahs *P2PAntifloodHandlerStub) BlacklistPeer(peer core.PeerID, reason string, duration time.Duration) {
+	if p2pahs.BlacklistPeerCalled != nil {
+		p2pahs.BlacklistPeerCalled(peer, reason, duration)
+	}
 }
 
 // IsInterfaceNil -

--- a/node/node.go
+++ b/node/node.go
@@ -958,7 +958,6 @@ func (n *Node) StartHeartbeat(hbConfig config.HeartbeatConfig, versionNumber str
 		PrivKey:                  n.privKey,
 		HardforkTrigger:          n.hardforkTrigger,
 		AntifloodHandler:         n.inputAntifloodHandler,
-		PeerBlackListHandler:     n.peerBlackListHandler,
 		ValidatorPubkeyConverter: n.validatorPubkeyConverter,
 		EpochStartTrigger:        n.epochStartTrigger,
 		EpochStartRegistration:   n.epochStartRegistrationHandler,

--- a/p2p/errors.go
+++ b/p2p/errors.go
@@ -19,14 +19,14 @@ var ErrTopicAlreadyExists = errors.New("topic already exists")
 // ErrTopicValidatorOperationNotSupported signals that an unsupported validator operation occurred
 var ErrTopicValidatorOperationNotSupported = errors.New("topic validator operation is not supported")
 
-// ErrChannelAlreadyExists signals that the channel is already defined (and used)
-var ErrChannelAlreadyExists = errors.New("channel already exists")
-
 // ErrChannelDoesNotExist signals that a requested channel does not exist
 var ErrChannelDoesNotExist = errors.New("channel does not exist")
 
 // ErrChannelCanNotBeDeleted signals that a channel can not be deleted (might be the default channel)
 var ErrChannelCanNotBeDeleted = errors.New("channel can not be deleted")
+
+// ErrChannelCanNotBeReAdded signals that a channel can not be re added as it is the default channel
+var ErrChannelCanNotBeReAdded = errors.New("channel can not be re added")
 
 // ErrNilMessage signals that a nil message has been received
 var ErrNilMessage = errors.New("nil message")

--- a/p2p/issues/pubsub_349/main.go
+++ b/p2p/issues/pubsub_349/main.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/libp2p/go-libp2p"
+	libp2pCrypto "github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+)
+
+type messenger struct {
+	host   host.Host
+	pb     *pubsub.PubSub
+	topic  *pubsub.Topic
+	subscr *pubsub.Subscription
+}
+
+func newMessenger() *messenger {
+	address := fmt.Sprintf("/ip4/0.0.0.0/tcp/0")
+	opts := []libp2p.Option{
+		libp2p.ListenAddrStrings(address),
+		libp2p.Identity(createP2PPrivKey()),
+		libp2p.DefaultMuxers,
+		libp2p.DefaultSecurity,
+		libp2p.DefaultTransports,
+		//we need the disable relay option in order to save the node's bandwidth as much as possible
+		libp2p.DisableRelay(),
+		libp2p.NATPortMap(),
+	}
+
+	h, _ := libp2p.New(context.Background(), opts...)
+
+	optsPS := []pubsub.Option{
+		pubsub.WithMessageSigning(true),
+	}
+	pb, _ := pubsub.NewGossipSub(context.Background(), h, optsPS...)
+
+	return &messenger{
+		host: h,
+		pb:   pb,
+	}
+}
+
+func createP2PPrivKey() *libp2pCrypto.Secp256k1PrivateKey {
+	prvKey, _ := ecdsa.GenerateKey(btcec.S256(), rand.Reader)
+	return (*libp2pCrypto.Secp256k1PrivateKey)(prvKey)
+}
+
+func (m *messenger) connectTo(target *messenger) {
+	addr := peer.AddrInfo{
+		ID:    target.host.ID(),
+		Addrs: target.host.Addrs(),
+	}
+
+	err := m.host.Connect(context.Background(), addr)
+	if err != nil {
+		fmt.Println("error connecting to peer: " + err.Error())
+	}
+}
+
+func (m *messenger) joinTopic(topic string) {
+	m.topic, _ = m.pb.Join(topic)
+	m.subscr, _ = m.topic.Subscribe()
+
+	go func() {
+		for {
+			msg, err := m.subscr.Next(context.Background())
+			if err != nil {
+				return
+			}
+
+			fmt.Printf("%s: got message %s\n", m.host.ID().Pretty(), string(msg.Data))
+		}
+	}()
+
+}
+
+func main() {
+	fmt.Println("creating 8 host connected statically...")
+	peers := create8ConnectedPeers()
+
+	defer func() {
+		for _, p := range peers {
+			_ = p.host.Close()
+		}
+	}()
+
+	fmt.Println()
+
+	for _, p := range peers {
+		p.joinTopic("test")
+	}
+
+	go func() {
+		time.Sleep(time.Second * 2)
+		//TODO uncomment these 2 lines to make the pubsub create connections
+		//peers[3].subscr.Cancel()
+		//_ = peers[3].topic.Close()
+	}()
+
+	for i := 0; i < 10; i++ {
+		printConnections(peers)
+		fmt.Println()
+		time.Sleep(time.Second)
+	}
+}
+
+func printConnections(peers []*messenger) {
+	for _, p := range peers {
+		fmt.Printf(" %s is connected to %d peers\n", p.host.ID().Pretty(), len(p.host.Network().Peers()))
+	}
+}
+
+// create8ConnectedPeers assembles a network as following:
+//
+//                             0------------------- 1
+//                             |                    |
+//        2 ------------------ 3 ------------------ 4
+//        |                    |                    |
+//        5                    6                    7
+func create8ConnectedPeers() []*messenger {
+	peers := make([]*messenger, 0)
+	for i := 0; i < 8; i++ {
+		p := newMessenger()
+		fmt.Printf("%d - created peer %s\n", i, p.host.ID().Pretty())
+
+		peers = append(peers, p)
+	}
+
+	connections := map[int][]int{
+		0: {1, 3},
+		1: {4},
+		2: {5, 3},
+		3: {4, 6},
+		4: {7},
+	}
+
+	createConnections(peers, connections)
+
+	return peers
+}
+
+func createConnections(peers []*messenger, connections map[int][]int) {
+	for pid, connectTo := range connections {
+		connectPeerToOthers(peers, pid, connectTo)
+	}
+}
+
+func connectPeerToOthers(peers []*messenger, idx int, connectToIdxes []int) {
+	for _, connectToIdx := range connectToIdxes {
+		peers[idx].connectTo(peers[connectToIdx])
+	}
+}

--- a/p2p/libp2p/netMessenger.go
+++ b/p2p/libp2p/netMessenger.go
@@ -84,6 +84,7 @@ type networkMessenger struct {
 	mutTopics           sync.RWMutex
 	processors          map[string]p2p.MessageProcessor
 	topics              map[string]*pubsub.Topic
+	subscriptions       map[string]*pubsub.Subscription
 	outgoingPLB         p2p.ChannelLoadBalancer
 	poc                 *peersOnChannel
 	goRoutinesThrottler *throttler.NumGoRoutinesThrottler
@@ -176,6 +177,7 @@ func createMessenger(
 		p2pHost:           NewConnectableHost(p2pHost),
 		processors:        make(map[string]p2p.MessageProcessor),
 		topics:            make(map[string]*pubsub.Topic),
+		subscriptions:     make(map[string]*pubsub.Subscription),
 		outgoingPLB:       loadBalancer.NewOutgoingChannelLoadBalancer(),
 		peerShardResolver: &unknownPeerShardResolver{},
 		messageIdCacher:   &disabled.Cacher{},
@@ -239,7 +241,7 @@ func (netMes *networkMessenger) createPubSub(withMessageSigning bool) error {
 		return err
 	}
 
-	go func(pubsub *pubsub.PubSub, plb p2p.ChannelLoadBalancer) {
+	go func(plb p2p.ChannelLoadBalancer) {
 		for {
 			select {
 			case <-time.After(durationBetweenSends):
@@ -269,7 +271,7 @@ func (netMes *networkMessenger) createPubSub(withMessageSigning bool) error {
 				log.Trace("error sending data", "error", errPublish)
 			}
 		}
-	}(netMes.pb, netMes.outgoingPLB)
+	}(netMes.outgoingPLB)
 
 	return nil
 }
@@ -575,6 +577,7 @@ func (netMes *networkMessenger) CreateTopic(name string, createChannelForTopic b
 		return fmt.Errorf("%w for topic %s", err, name)
 	}
 
+	netMes.subscriptions[name] = subscrRequest
 	if createChannelForTopic {
 		err = netMes.outgoingPLB.AddChannel(name)
 	}
@@ -585,6 +588,10 @@ func (netMes *networkMessenger) CreateTopic(name string, createChannelForTopic b
 		for {
 			_, errSubscrNext = subscrRequest.Next(netMes.ctx)
 			if errSubscrNext != nil {
+				log.Debug("closed subscription",
+					"topic", subscrRequest.Topic(),
+					"err", errSubscrNext,
+				)
 				return
 			}
 		}
@@ -728,9 +735,32 @@ func (netMes *networkMessenger) UnregisterAllMessageProcessors() error {
 			return err
 		}
 
-		netMes.processors[topic] = nil
+		delete(netMes.processors, topic)
 	}
 	return nil
+}
+
+// UnjoinAllTopics call close on all topics
+func (netMes *networkMessenger) UnjoinAllTopics() error {
+	netMes.mutMessageIdCacher.Lock()
+	defer netMes.mutMessageIdCacher.Unlock()
+
+	var errFound error
+	for topicName, t := range netMes.topics {
+		subscr := netMes.subscriptions[topicName]
+		if subscr != nil {
+			subscr.Cancel()
+		}
+
+		err := t.Close()
+		if err != nil {
+			errFound = err
+		}
+
+		delete(netMes.topics, topicName)
+	}
+
+	return errFound
 }
 
 // UnregisterMessageProcessor unregisters a message processes on a topic

--- a/p2p/libp2p/netMessenger.go
+++ b/p2p/libp2p/netMessenger.go
@@ -755,6 +755,10 @@ func (netMes *networkMessenger) UnjoinAllTopics() error {
 
 		err := t.Close()
 		if err != nil {
+			log.Warn("error closing topic",
+				"topic", topicName,
+				"error", err,
+			)
 			errFound = err
 		}
 

--- a/p2p/libp2p/netMessenger.go
+++ b/p2p/libp2p/netMessenger.go
@@ -695,12 +695,14 @@ func (netMes *networkMessenger) pubsubCallback(handler p2p.MessageProcessor) fun
 			return false
 		}
 
-		err = handler.ProcessReceivedMessage(wrappedMsg, core.PeerID(pid))
+		fromConnectedPeer := core.PeerID(pid)
+		err = handler.ProcessReceivedMessage(wrappedMsg, fromConnectedPeer)
 		if err != nil {
 			log.Trace("p2p validator",
 				"error", err.Error(),
 				"topics", message.TopicIDs,
-				"pid", p2p.MessageOriginatorPid(wrappedMsg),
+				"originator", p2p.MessageOriginatorPid(wrappedMsg),
+				"from connected peer", p2p.PeerIdToShortString(fromConnectedPeer),
 				"seq no", p2p.MessageOriginatorSeq(wrappedMsg),
 			)
 
@@ -774,7 +776,8 @@ func (netMes *networkMessenger) directMessageHandler(message p2p.MessageP2P, fro
 			log.Trace("p2p validator",
 				"error", err.Error(),
 				"topics", msg.Topics(),
-				"pid", p2p.MessageOriginatorPid(msg),
+				"originator", p2p.MessageOriginatorPid(msg),
+				"from connected peer", p2p.PeerIdToShortString(fromConnectedPeer),
 				"seq no", p2p.MessageOriginatorSeq(msg),
 			)
 		}

--- a/p2p/libp2p/netMessenger_test.go
+++ b/p2p/libp2p/netMessenger_test.go
@@ -1332,3 +1332,5 @@ func TestNetworkMessenger_PubsubCallbackReturnsFalseIfHandlerErrors(t *testing.T
 
 	_ = mes.Close()
 }
+
+//TODO(now, Iulian) add UnjoinAllTopics unit tests

--- a/p2p/libp2p/netMessenger_test.go
+++ b/p2p/libp2p/netMessenger_test.go
@@ -1333,4 +1333,30 @@ func TestNetworkMessenger_PubsubCallbackReturnsFalseIfHandlerErrors(t *testing.T
 	_ = mes.Close()
 }
 
-//TODO(now, Iulian) add UnjoinAllTopics unit tests
+func TestNetworkMessenger_UnjoinAllTopicsShouldWork(t *testing.T) {
+	args := libp2p.ArgsNetworkMessenger{
+		ListenAddress: libp2p.ListenLocalhostAddrWithIp4AndTcp,
+		P2pConfig: config.P2PConfig{
+			Node: config.NodeConfig{
+				Port: "0",
+			},
+			KadDhtPeerDiscovery: config.KadDhtPeerDiscoveryConfig{
+				Enabled: false,
+			},
+			Sharding: config.ShardingConfig{
+				Type: p2p.NilListSharder,
+			},
+		},
+	}
+
+	mes, _ := libp2p.NewNetworkMessenger(args)
+
+	topic := "topic"
+	_ = mes.CreateTopic(topic, true)
+	assert.True(t, mes.HasTopic(topic))
+
+	err := mes.UnjoinAllTopics()
+	assert.Nil(t, err)
+
+	assert.False(t, mes.HasTopic(topic))
+}

--- a/p2p/loadBalancer/outgoingChannelLoadBalancer.go
+++ b/p2p/loadBalancer/outgoingChannelLoadBalancer.go
@@ -64,14 +64,18 @@ func (oplb *OutgoingChannelLoadBalancer) appendChannel(channel string) {
 	}()
 }
 
-// AddChannel adds a new channel to the throttler
+// AddChannel adds a new channel to the throttler, if it does not exists
 func (oplb *OutgoingChannelLoadBalancer) AddChannel(channel string) error {
+	if channel == defaultSendChannel {
+		return p2p.ErrChannelCanNotBeReAdded
+	}
+
 	oplb.mut.Lock()
 	defer oplb.mut.Unlock()
 
 	for _, name := range oplb.names {
 		if name == channel {
-			return p2p.ErrChannelAlreadyExists
+			return nil
 		}
 	}
 

--- a/p2p/loadBalancer/outgoingChannelLoadBalancer_test.go
+++ b/p2p/loadBalancer/outgoingChannelLoadBalancer_test.go
@@ -86,10 +86,10 @@ func TestOutgoingChannelLoadBalancer_AddChannelDefaultChannelShouldErr(t *testin
 
 	err := oclb.AddChannel(loadBalancer.DefaultSendChannel())
 
-	assert.Equal(t, p2p.ErrChannelAlreadyExists, err)
+	assert.Equal(t, p2p.ErrChannelCanNotBeReAdded, err)
 }
 
-func TestOutgoingChannelLoadBalancer_AddChannelReAddChannelShouldErr(t *testing.T) {
+func TestOutgoingChannelLoadBalancer_AddChannelReAddChannelShouldDoNothing(t *testing.T) {
 	t.Parallel()
 
 	oclb := loadBalancer.NewOutgoingChannelLoadBalancer()
@@ -97,7 +97,8 @@ func TestOutgoingChannelLoadBalancer_AddChannelReAddChannelShouldErr(t *testing.
 	_ = oclb.AddChannel("test")
 	err := oclb.AddChannel("test")
 
-	assert.Equal(t, p2p.ErrChannelAlreadyExists, err)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(oclb.Chans()))
 }
 
 //------- RemoveChannel

--- a/p2p/mock/eventBusStub.go
+++ b/p2p/mock/eventBusStub.go
@@ -1,11 +1,16 @@
 package mock
 
-import "github.com/libp2p/go-libp2p-core/event"
+import (
+	"reflect"
+
+	"github.com/libp2p/go-libp2p-core/event"
+)
 
 // EventBusStub -
 type EventBusStub struct {
-	SubscribeCalled func(eventType interface{}, opts ...event.SubscriptionOpt) (event.Subscription, error)
-	EmitterCalled   func(eventType interface{}, opts ...event.EmitterOpt) (event.Emitter, error)
+	SubscribeCalled        func(eventType interface{}, opts ...event.SubscriptionOpt) (event.Subscription, error)
+	EmitterCalled          func(eventType interface{}, opts ...event.EmitterOpt) (event.Emitter, error)
+	GetAllEventTypesCalled func() []reflect.Type
 }
 
 // Subscribe -
@@ -24,4 +29,13 @@ func (ebs *EventBusStub) Emitter(eventType interface{}, opts ...event.EmitterOpt
 	}
 
 	return nil, nil
+}
+
+// GetAllEventTypes -
+func (ebs *EventBusStub) GetAllEventTypes() []reflect.Type {
+	if ebs.GetAllEventTypesCalled != nil {
+		return ebs.GetAllEventTypesCalled()
+	}
+
+	return make([]reflect.Type, 0)
 }

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -142,6 +142,7 @@ type Messenger interface {
 	SetPeerBlackListHandler(handler PeerBlacklistHandler) error
 	GetConnectedPeersInfo() *ConnectedPeersInfo
 	SetMessageIdsCacher(cacher Cacher) error
+	UnjoinAllTopics() error
 
 	// IsInterfaceNil returns true if there is no value under the interface
 	IsInterfaceNil() bool

--- a/process/interceptors/multiDataInterceptor.go
+++ b/process/interceptors/multiDataInterceptor.go
@@ -89,8 +89,8 @@ func (mdi *MultiDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, 
 
 		//this situation is so severe that we need to black list de peers
 		reason := "unmarshalable data got on topic " + mdi.topic
-		mdi.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.IntervalBlackListPeerInvalidMessage)
-		mdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.IntervalBlackListPeerInvalidMessage)
+		mdi.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.InvalidMessageBlacklistDuration)
+		mdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
 
 		return err
 	}
@@ -164,8 +164,8 @@ func (mdi *MultiDataInterceptor) interceptedData(dataBuff []byte, originator cor
 	if err != nil {
 		//this situation is so severe that we need to black list de peers
 		reason := "can not create object from received bytes, topic " + mdi.topic
-		mdi.antifloodHandler.BlacklistPeer(originator, reason, core.IntervalBlackListPeerInvalidMessage)
-		mdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.IntervalBlackListPeerInvalidMessage)
+		mdi.antifloodHandler.BlacklistPeer(originator, reason, core.InvalidMessageBlacklistDuration)
+		mdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
 
 		return nil, err
 	}

--- a/process/interceptors/multiDataInterceptor_test.go
+++ b/process/interceptors/multiDataInterceptor_test.go
@@ -182,6 +182,9 @@ func TestMultiDataInterceptor_ProcessReceivedMessageUnmarshalFailsShouldErr(t *t
 	t.Parallel()
 
 	errExpeced := errors.New("expected error")
+	originatorPid := core.PeerID("originator")
+	originatorBlackListed := false
+	fromConnectedPeerBlackListed := false
 	mdi, _ := interceptors.NewMultiDataInterceptor(
 		testTopic,
 		&mock.MarshalizerStub{
@@ -192,16 +195,28 @@ func TestMultiDataInterceptor_ProcessReceivedMessageUnmarshalFailsShouldErr(t *t
 		&mock.InterceptedDataFactoryStub{},
 		&mock.InterceptorProcessorStub{},
 		createMockThrottler(),
-		&mock.P2PAntifloodHandlerStub{},
+		&mock.P2PAntifloodHandlerStub{
+			BlacklistPeerCalled: func(peer core.PeerID, reason string, duration time.Duration) {
+				if peer == originatorPid {
+					originatorBlackListed = true
+				}
+				if peer == fromConnectedPeerId {
+					fromConnectedPeerBlackListed = true
+				}
+			},
+		},
 		&mock.WhiteListHandlerStub{},
 	)
 
 	msg := &mock.P2PMessageMock{
 		DataField: []byte("data to be processed"),
+		PeerField: originatorPid,
 	}
 	err := mdi.ProcessReceivedMessage(msg, fromConnectedPeerId)
 
 	assert.Equal(t, errExpeced, err)
+	assert.True(t, originatorBlackListed)
+	assert.True(t, fromConnectedPeerBlackListed)
 }
 
 func TestMultiDataInterceptor_ProcessReceivedMessageUnmarshalReturnsEmptySliceShouldErr(t *testing.T) {
@@ -239,6 +254,9 @@ func TestMultiDataInterceptor_ProcessReceivedCreateFailsShouldErr(t *testing.T) 
 	processCalledNum := int32(0)
 	throttler := createMockThrottler()
 	errExpected := errors.New("expected err")
+	originatorPid := core.PeerID("originator")
+	originatorBlackListed := false
+	fromConnectedPeerBlackListed := false
 	mdi, _ := interceptors.NewMultiDataInterceptor(
 		testTopic,
 		marshalizer,
@@ -249,13 +267,23 @@ func TestMultiDataInterceptor_ProcessReceivedCreateFailsShouldErr(t *testing.T) 
 		},
 		createMockInterceptorStub(&checkCalledNum, &processCalledNum),
 		throttler,
-		&mock.P2PAntifloodHandlerStub{},
+		&mock.P2PAntifloodHandlerStub{
+			BlacklistPeerCalled: func(peer core.PeerID, reason string, duration time.Duration) {
+				if peer == originatorPid {
+					originatorBlackListed = true
+				}
+				if peer == fromConnectedPeerId {
+					fromConnectedPeerBlackListed = true
+				}
+			},
+		},
 		&mock.WhiteListHandlerStub{},
 	)
 
 	dataField, _ := marshalizer.Marshal(&batch.Batch{Data: buffData})
 	msg := &mock.P2PMessageMock{
 		DataField: dataField,
+		PeerField: originatorPid,
 	}
 	err := mdi.ProcessReceivedMessage(msg, fromConnectedPeerId)
 
@@ -266,6 +294,8 @@ func TestMultiDataInterceptor_ProcessReceivedCreateFailsShouldErr(t *testing.T) 
 	assert.Equal(t, int32(0), atomic.LoadInt32(&processCalledNum))
 	assert.Equal(t, int32(1), throttler.StartProcessingCount())
 	assert.Equal(t, int32(1), throttler.EndProcessingCount())
+	assert.True(t, originatorBlackListed)
+	assert.True(t, fromConnectedPeerBlackListed)
 }
 
 func TestMultiDataInterceptor_ProcessReceivedPartiallyCorrectDataShouldErr(t *testing.T) {

--- a/process/interceptors/singleDataInterceptor.go
+++ b/process/interceptors/singleDataInterceptor.go
@@ -78,10 +78,10 @@ func (sdi *SingleDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P,
 	if err != nil {
 		sdi.throttler.EndProcessing()
 
-		//this situation is so severe that we need to black list de peers
+		//this situation is so severe that we need to black list the peers
 		reason := "can not create object from received bytes, topic " + sdi.topic
-		sdi.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.IntervalBlackListPeerInvalidMessage)
-		sdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.IntervalBlackListPeerInvalidMessage)
+		sdi.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.InvalidMessageBlacklistDuration)
+		sdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
 
 		return err
 	}

--- a/process/interceptors/singleDataInterceptor.go
+++ b/process/interceptors/singleDataInterceptor.go
@@ -77,6 +77,12 @@ func (sdi *SingleDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P,
 	interceptedData, err := sdi.factory.Create(message.Data())
 	if err != nil {
 		sdi.throttler.EndProcessing()
+
+		//this situation is so severe that we need to black list de peers
+		reason := "can not create object from received bytes, topic " + sdi.topic
+		sdi.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.IntervalBlackListPeerInvalidMessage)
+		sdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.IntervalBlackListPeerInvalidMessage)
+
 		return err
 	}
 

--- a/process/interface.go
+++ b/process/interface.go
@@ -711,6 +711,7 @@ type P2PAntifloodHandler interface {
 	CanProcessMessagesOnTopic(pid core.PeerID, topic string, numMessages uint32, totalSize uint64, sequence []byte) error
 	ApplyConsensusSize(size int)
 	SetDebugger(debugger AntifloodDebugger) error
+	BlacklistPeer(peer core.PeerID, reason string, duration time.Duration)
 	IsInterfaceNil() bool
 }
 

--- a/process/mock/antifloodDebuggerStub.go
+++ b/process/mock/antifloodDebuggerStub.go
@@ -1,0 +1,30 @@
+package mock
+
+import "github.com/ElrondNetwork/elrond-go/core"
+
+// AntifloodDebuggerStub -
+type AntifloodDebuggerStub struct {
+	AddDataCalled func(pid core.PeerID, topic string, numRejected uint32, sizeRejected uint64, sequence []byte, isBlacklisted bool)
+	CloseCalled   func() error
+}
+
+// AddData -
+func (ads *AntifloodDebuggerStub) AddData(pid core.PeerID, topic string, numRejected uint32, sizeRejected uint64, sequence []byte, isBlacklisted bool) {
+	if ads.AddDataCalled != nil {
+		ads.AddDataCalled(pid, topic, numRejected, sizeRejected, sequence, isBlacklisted)
+	}
+}
+
+// Close -
+func (ads *AntifloodDebuggerStub) Close() error {
+	if ads.CloseCalled != nil {
+		return ads.CloseCalled()
+	}
+
+	return nil
+}
+
+// IsInterfaceNil -
+func (ads *AntifloodDebuggerStub) IsInterfaceNil() bool {
+	return ads == nil
+}

--- a/process/mock/p2pAntifloodHandlerStub.go
+++ b/process/mock/p2pAntifloodHandlerStub.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"time"
+
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -12,6 +14,7 @@ type P2PAntifloodHandlerStub struct {
 	CanProcessMessagesOnTopicCalled func(peer core.PeerID, topic string, numMessages uint32, totalSize uint64, sequence []byte) error
 	ApplyConsensusSizeCalled        func(size int)
 	SetDebuggerCalled               func(debugger process.AntifloodDebugger) error
+	BlacklistPeerCalled             func(peer core.PeerID, reason string, duration time.Duration)
 }
 
 // CanProcessMessage -
@@ -44,6 +47,13 @@ func (p2pahs *P2PAntifloodHandlerStub) SetDebugger(debugger process.AntifloodDeb
 	}
 
 	return nil
+}
+
+// BlacklistPeer -
+func (p2pahs *P2PAntifloodHandlerStub) BlacklistPeer(peer core.PeerID, reason string, duration time.Duration) {
+	if p2pahs.BlacklistPeerCalled != nil {
+		p2pahs.BlacklistPeerCalled(peer, reason, duration)
+	}
 }
 
 // IsInterfaceNil -

--- a/process/throttle/antiflood/disabled/antiflood.go
+++ b/process/throttle/antiflood/disabled/antiflood.go
@@ -1,6 +1,8 @@
 package disabled
 
 import (
+	"time"
+
 	"github.com/ElrondNetwork/elrond-go/consensus"
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/p2p"
@@ -38,6 +40,10 @@ func (af *AntiFlood) ApplyConsensusSize(_ int) {
 // SetDebugger returns nil
 func (af *AntiFlood) SetDebugger(_ process.AntifloodDebugger) error {
 	return nil
+}
+
+// BlacklistPeer does nothing
+func (af *AntiFlood) BlacklistPeer(_ core.PeerID, _ string, _ time.Duration) {
 }
 
 // IsInterfaceNil return true if there is no value under the interface

--- a/process/throttle/antiflood/p2pAntiflood.go
+++ b/process/throttle/antiflood/p2pAntiflood.go
@@ -3,6 +3,7 @@ package antiflood
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/core"
@@ -181,6 +182,26 @@ func (af *p2pAntiflood) SetDebugger(debugger process.AntifloodDebugger) error {
 	af.mutDebugger.Unlock()
 
 	return nil
+}
+
+// BlacklistPeer will add a peer to the black list
+func (af *p2pAntiflood) BlacklistPeer(peer core.PeerID, reason string, duration time.Duration) {
+	err := af.blacklistHandler.AddWithSpan(peer, duration)
+	if err != nil {
+		log.Warn("error adding in blacklist",
+			"pid", peer.Pretty(),
+			"time", duration,
+			"reason", reason,
+			"error", "err",
+		)
+		return
+	}
+
+	log.Debug("blacklisted peer",
+		"pid", peer.Pretty(),
+		"time", duration,
+		"reason", reason,
+	)
 }
 
 // Close will call the close function on all sub components


### PR DESCRIPTION
- a peer that sends invalid message (that can not be unmarshaled) will be directly added to the black list
- implemented unjoin functionality (pending fixing tests)