### PR TITLE
reactivate size check marshalizer

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -392,7 +392,7 @@
 #     0 disables the feature.
 [Marshalizer]
    Type = "gogo protobuf"
-   SizeCheckDelta = 0
+   SizeCheckDelta = 10
 
 # The marshalizer used for smartcontracts data exchange
 [VmMarshalizer]


### PR DESCRIPTION
Activated size check marshalizer. Now messages that are propagated over p2p network that are bigger with 10% than the expected size will be rejected.