### PR TITLE
fix termui app when shuffled out or node stops

### DIFF
--- a/cmd/termui/main.go
+++ b/cmd/termui/main.go
@@ -126,7 +126,7 @@ func startTermuiViewer() error {
 		WithLoggerName:   argsConfig.logWithLoggerName,
 	}
 
-	err = provider.InitLogHandler(nodeAddress, loggerProfile, argsConfig.useWss)
+	err = provider.InitLogHandler(presenterStatusHandler, nodeAddress, loggerProfile, argsConfig.useWss)
 	if err != nil {
 		return err
 	}
@@ -137,8 +137,6 @@ func startTermuiViewer() error {
 		return err
 	}
 	chanStartTermUI <- struct{}{}
-
-	provider.StartListeningOnWebSocket(presenterStatusHandler)
 
 	waitForUserToTerminateApp()
 

--- a/cmd/termui/provider/logProvider.go
+++ b/cmd/termui/provider/logProvider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"encoding/hex"
+	"fmt"
 	"net/url"
 	"strings"
 	"time"
@@ -21,22 +22,25 @@ const (
 )
 
 // InitLogHandler will open the websocket and set the log level
-func InitLogHandler(nodeURL string, profile logger.Profile, useWss bool) error {
+func InitLogHandler(presenter PresenterHandler, nodeURL string, profile logger.Profile, useWss bool) error {
 	var err error
 	scheme := ws
 	if useWss {
 		scheme = wss
 	}
-	for {
-		webSocket, err = openWebSocket(scheme, nodeURL, profile)
-		if err == nil {
-			break
-		}
-		log.Error("init logger", "error", err)
+	go func() {
+		for {
+			webSocket, err = openWebSocket(scheme, nodeURL, profile)
+			if err != nil {
+				_, _ = presenter.Write([]byte(fmt.Sprintf("termui websocket error, retrying in %v...", retryDuration)))
+				time.Sleep(retryDuration)
+				continue
+			}
 
-		log.Info("connection not available", "duration before retrying", retryDuration)
-		time.Sleep(retryDuration)
-	}
+			startListeningOnWebSocket(presenter)
+			time.Sleep(retryDuration)
+		}
+	}()
 
 	return nil
 }
@@ -65,29 +69,26 @@ func openWebSocket(scheme string, address string, profile logger.Profile) (*webs
 	return conn, nil
 }
 
-// StartListeningOnWebSocket will listen if a new log message is received and will display it
-func StartListeningOnWebSocket(presenter PresenterHandler) {
-	go func() {
-		for {
-			msgType, message, err := webSocket.ReadMessage()
-			if msgType == websocket.CloseMessage {
-				return
-			}
-			if err == nil {
-				writeMessage(presenter, message)
-				continue
-			}
-
-			_, isConnectionClosed := err.(*websocket.CloseError)
-			if !isConnectionClosed {
-				log.Error("termui websocket error", "error", err.Error())
-			} else {
-				log.Debug("termui websocket terminated", "error", err.Error())
-			}
-
-			time.Sleep(retryDuration)
+// startListeningOnWebSocket will listen if a new log message is received and will display it
+func startListeningOnWebSocket(presenter PresenterHandler) {
+	for {
+		msgType, message, err := webSocket.ReadMessage()
+		if msgType == websocket.CloseMessage {
+			return
 		}
-	}()
+		if err == nil {
+			writeMessage(presenter, message)
+			continue
+		}
+
+		_, isConnectionClosed := err.(*websocket.CloseError)
+		if !isConnectionClosed {
+			log.Error("termui websocket error", "error", err.Error())
+		} else {
+			log.Debug("termui websocket terminated", "error", err.Error())
+		}
+		return
+	}
 }
 
 func writeMessage(presenter PresenterHandler, message []byte) {

--- a/cmd/termui/provider/logProvider.go
+++ b/cmd/termui/provider/logProvider.go
@@ -83,9 +83,9 @@ func startListeningOnWebSocket(presenter PresenterHandler) {
 
 		_, isConnectionClosed := err.(*websocket.CloseError)
 		if !isConnectionClosed {
-			log.Error("termui websocket error", "error", err.Error())
+			_, _ = presenter.Write([]byte(fmt.Sprintf("termui websocket error: %s", err.Error())))
 		} else {
-			log.Debug("termui websocket terminated", "error", err.Error())
+			_, _ = presenter.Write([]byte(fmt.Sprintf("termui websocket terminated: %s", err.Error())))
 		}
 		return
 	}


### PR DESCRIPTION
Implemented a mechanism that keeps trying to re-connect to the node when log messages are not received anymore. this could have happened when the node was shuffled out or was simply stopped.