### PR TITLE
Fix antiflood self blacklisted

### DIFF
--- a/factory/networkComponents.go
+++ b/factory/networkComponents.go
@@ -52,6 +52,7 @@ func (ncf *networkComponentsFactory) Create() (*NetworkComponents, error) {
 	inAntifloodHandler, p2pPeerBlackList, errNewAntiflood := antifloodFactory.NewP2PAntiFloodAndBlackList(
 		ncf.mainConfig,
 		ncf.statusHandler,
+		netMessenger.ID(),
 	)
 	if errNewAntiflood != nil {
 		return nil, errNewAntiflood

--- a/integrationTests/longTests/antiflooding/antiflooding_test.go
+++ b/integrationTests/longTests/antiflooding/antiflooding_test.go
@@ -104,13 +104,21 @@ func createProcessors(peers []p2p.Messenger, topic string, idxBadPeers []int, id
 		var err error
 
 		if intInSlice(i, idxBadPeers) {
-			antiflood, blackListHandler, err = factory.NewP2PAntiFloodAndBlackList(createDisabledConfig(), &mock.AppStatusHandlerStub{})
+			antiflood, blackListHandler, err = factory.NewP2PAntiFloodAndBlackList(
+				createDisabledConfig(),
+				&mock.AppStatusHandlerStub{},
+				peers[i].ID(),
+			)
 			log.LogIfError(err)
 		}
 
 		if intInSlice(i, idxGoodPeers) {
 			statusHandler := &mock.AppStatusHandlerStub{}
-			antiflood, blackListHandler, err = factory.NewP2PAntiFloodAndBlackList(createWorkableConfig(), statusHandler)
+			antiflood, blackListHandler, err = factory.NewP2PAntiFloodAndBlackList(
+				createWorkableConfig(),
+				statusHandler,
+				peers[i].ID(),
+			)
 			log.LogIfError(err)
 		}
 

--- a/integrationTests/mock/peerBlackListHandlerStub.go
+++ b/integrationTests/mock/peerBlackListHandlerStub.go
@@ -10,6 +10,7 @@ import (
 type PeerBlackListHandlerStub struct {
 	AddCalled         func(pid core.PeerID) error
 	AddWithSpanCalled func(pid core.PeerID, span time.Duration) error
+	UpdateCalled      func(pid core.PeerID, span time.Duration) error
 	HasCalled         func(pid core.PeerID) bool
 	SweepCalled       func()
 }
@@ -30,6 +31,15 @@ func (pblhs *PeerBlackListHandlerStub) AddWithSpan(pid core.PeerID, span time.Du
 	}
 
 	return pblhs.AddWithSpanCalled(pid, span)
+}
+
+// Update -
+func (pblhs *PeerBlackListHandlerStub) Update(pid core.PeerID, span time.Duration) error {
+	if pblhs.UpdateCalled == nil {
+		return nil
+	}
+
+	return pblhs.UpdateCalled(pid, span)
 }
 
 // Has -

--- a/integrationTests/p2p/antiflood/blacklist/blacklist_test.go
+++ b/integrationTests/p2p/antiflood/blacklist/blacklist_test.go
@@ -167,6 +167,8 @@ func createBlacklistHandlersAndProcessors(
 			thresholdSizeReceived,
 			maxFloodingRounds,
 			time.Minute*5,
+			"",
+			peers[i].ID(),
 		)
 		log.LogIfError(err)
 	}

--- a/node/mock/peerBlackListHandler.go
+++ b/node/mock/peerBlackListHandler.go
@@ -10,6 +10,7 @@ import (
 type PeerBlackListHandlerStub struct {
 	AddCalled         func(pid core.PeerID) error
 	AddWithSpanCalled func(pid core.PeerID, span time.Duration) error
+	UpdateCalled      func(pid core.PeerID, span time.Duration) error
 	HasCalled         func(pid core.PeerID) bool
 	SweepCalled       func()
 }
@@ -25,6 +26,15 @@ func (pblhs *PeerBlackListHandlerStub) Sweep() {
 func (pblhs *PeerBlackListHandlerStub) AddWithSpan(pid core.PeerID, span time.Duration) error {
 	if pblhs.AddWithSpanCalled != nil {
 		return pblhs.AddWithSpanCalled(pid, span)
+	}
+
+	return nil
+}
+
+// Update -
+func (pblhs *PeerBlackListHandlerStub) Update(pid core.PeerID, span time.Duration) error {
+	if pblhs.UpdateCalled != nil {
+		return pblhs.UpdateCalled(pid, span)
 	}
 
 	return nil

--- a/process/interface.go
+++ b/process/interface.go
@@ -585,6 +585,7 @@ type BlackListHandler interface {
 type PeerBlackListHandler interface {
 	Add(pid core.PeerID) error
 	AddWithSpan(pid core.PeerID, span time.Duration) error
+	Update(pid core.PeerID, span time.Duration) error
 	Has(pid core.PeerID) bool
 	Sweep()
 	IsInterfaceNil() bool

--- a/process/mock/peerBlackListHandlerStub.go
+++ b/process/mock/peerBlackListHandlerStub.go
@@ -10,6 +10,7 @@ import (
 type PeerBlackListHandlerStub struct {
 	AddCalled         func(pid core.PeerID) error
 	AddWithSpanCalled func(pid core.PeerID, span time.Duration) error
+	UpdateCalled      func(pid core.PeerID, span time.Duration) error
 	HasCalled         func(pid core.PeerID) bool
 	SweepCalled       func()
 }
@@ -30,6 +31,15 @@ func (pblhs *PeerBlackListHandlerStub) AddWithSpan(pid core.PeerID, span time.Du
 	}
 
 	return pblhs.AddWithSpanCalled(pid, span)
+}
+
+// Update -
+func (pblhs *PeerBlackListHandlerStub) Update(pid core.PeerID, span time.Duration) error {
+	if pblhs.UpdateCalled == nil {
+		return nil
+	}
+
+	return pblhs.UpdateCalled(pid, span)
 }
 
 // Has -

--- a/process/throttle/antiflood/blackList/p2pBlackListProcessor.go
+++ b/process/throttle/antiflood/blackList/p2pBlackListProcessor.go
@@ -24,10 +24,13 @@ type p2pBlackListProcessor struct {
 	cacher                     storage.Cacher
 	peerBlacklistHandler       process.PeerBlackListHandler
 	banDuration                time.Duration
+	selfPid                    core.PeerID
+	name                       string
 }
 
 // NewP2PBlackListProcessor creates a new instance of p2pQuotaBlacklistProcessor able to determine
 // a flooding peer and mark it accordingly
+// TODO use argument on constructor
 func NewP2PBlackListProcessor(
 	cacher storage.Cacher,
 	peerBlacklistHandler process.PeerBlackListHandler,
@@ -35,6 +38,8 @@ func NewP2PBlackListProcessor(
 	thresholdSizeReceivedFlood uint64,
 	numFloodingRounds uint32,
 	banDuration time.Duration,
+	name string,
+	selfPid core.PeerID,
 ) (*p2pBlackListProcessor, error) {
 
 	if check.IfNil(cacher) {
@@ -63,6 +68,8 @@ func NewP2PBlackListProcessor(
 		thresholdSizeReceivedFlood: thresholdSizeReceivedFlood,
 		numFloodingRounds:          numFloodingRounds,
 		banDuration:                banDuration,
+		selfPid:                    selfPid,
+		name:                       name,
 	}, nil
 }
 
@@ -84,7 +91,7 @@ func (pbp *p2pBlackListProcessor) ResetStatistics() {
 				"peer ID", pid.Pretty(),
 				"ban period", pbp.banDuration,
 			)
-			_ = pbp.peerBlacklistHandler.AddWithSpan(pid, pbp.banDuration)
+			_ = pbp.peerBlacklistHandler.Update(pid, pbp.banDuration)
 		}
 	}
 }
@@ -103,9 +110,20 @@ func (pbp *p2pBlackListProcessor) getFloodingValue(key []byte) (uint32, bool) {
 // AddQuota checks if the received quota for an identifier has exceeded the set thresholds
 func (pbp *p2pBlackListProcessor) AddQuota(pid core.PeerID, numReceived uint32, sizeReceived uint64, _ uint32, _ uint64) {
 	isFloodingPeer := numReceived >= pbp.thresholdNumReceivedFlood || sizeReceived >= pbp.thresholdSizeReceivedFlood
-	if isFloodingPeer {
-		pbp.incrementStatsFloodingPeer(pid)
+	if !isFloodingPeer {
+		return
 	}
+	if pid == pbp.selfPid {
+		log.Warn("current peer should have self banned",
+			"name", pbp.name,
+			"total num messages", numReceived,
+			"total size", sizeReceived,
+		)
+		return
+	}
+
+	pbp.incrementStatsFloodingPeer(pid)
+
 }
 
 func (pbp *p2pBlackListProcessor) incrementStatsFloodingPeer(pid core.PeerID) {

--- a/process/throttle/antiflood/blackList/p2pBlackListProcessor.go
+++ b/process/throttle/antiflood/blackList/p2pBlackListProcessor.go
@@ -114,7 +114,7 @@ func (pbp *p2pBlackListProcessor) AddQuota(pid core.PeerID, numReceived uint32, 
 		return
 	}
 	if pid == pbp.selfPid {
-		log.Warn("current peer should have self banned",
+		log.Warn("current peer should have been blacklisted",
 			"name", pbp.name,
 			"total num messages", numReceived,
 			"total size", sizeReceived,

--- a/process/throttle/antiflood/disabled/peerBlacklistHandler.go
+++ b/process/throttle/antiflood/disabled/peerBlacklistHandler.go
@@ -24,6 +24,11 @@ func (pdbh *PeerBlacklistHandler) AddWithSpan(_ core.PeerID, _ time.Duration) er
 	return nil
 }
 
+// Update does nothing
+func (pdbh *PeerBlacklistHandler) Update(_ core.PeerID, _ time.Duration) error {
+	return nil
+}
+
 // Sweep does nothing
 func (pdbh *PeerBlacklistHandler) Sweep() {
 }

--- a/process/throttle/antiflood/factory/p2pAntifloodAndBlacklistFactory.go
+++ b/process/throttle/antiflood/factory/p2pAntifloodAndBlacklistFactory.go
@@ -33,12 +33,13 @@ const outputIdentifier = "output"
 func NewP2PAntiFloodAndBlackList(
 	config config.Config,
 	statusHandler core.AppStatusHandler,
+	currentPid core.PeerID,
 ) (process.P2PAntifloodHandler, process.PeerBlackListHandler, error) {
 	if check.IfNil(statusHandler) {
 		return nil, nil, p2p.ErrNilStatusHandler
 	}
 	if config.Antiflood.Enabled {
-		return initP2PAntiFloodAndBlackList(config, statusHandler)
+		return initP2PAntiFloodAndBlackList(config, statusHandler, currentPid)
 	}
 
 	return &disabled.AntiFlood{}, &disabled.PeerBlacklistHandler{}, nil
@@ -47,6 +48,7 @@ func NewP2PAntiFloodAndBlackList(
 func initP2PAntiFloodAndBlackList(
 	mainConfig config.Config,
 	statusHandler core.AppStatusHandler,
+	currentPid core.PeerID,
 ) (process.P2PAntifloodHandler, process.PeerBlackListHandler, error) {
 	cache := timecache.NewTimeCache(defaultSpan)
 	p2pPeerBlackList, err := timecache.NewPeerTimeCache(cache)
@@ -60,6 +62,7 @@ func initP2PAntiFloodAndBlackList(
 		statusHandler,
 		fastReactingIdentifier,
 		p2pPeerBlackList,
+		currentPid,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("%w when creating fast reacting flood preventer", err)
@@ -71,6 +74,7 @@ func initP2PAntiFloodAndBlackList(
 		statusHandler,
 		slowReactingIdentifier,
 		p2pPeerBlackList,
+		currentPid,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("%w when creating fast reacting flood preventer", err)
@@ -82,6 +86,7 @@ func initP2PAntiFloodAndBlackList(
 		statusHandler,
 		outOfSpecsIdentifier,
 		p2pPeerBlackList,
+		currentPid,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("%w when creating out of specs flood preventer", err)
@@ -155,6 +160,7 @@ func createFloodPreventer(
 	statusHandler core.AppStatusHandler,
 	quotaIdentifier string,
 	blackListHandler process.PeerBlackListHandler,
+	selfPid core.PeerID,
 ) (process.FloodPreventer, error) {
 	cacheConfig := storageFactory.GetCacherFromConfig(antifloodCacheConfig)
 	blackListCache, err := storageUnit.NewCache(cacheConfig.Type, cacheConfig.Capacity, cacheConfig.Shards, cacheConfig.SizeInBytes)
@@ -169,6 +175,8 @@ func createFloodPreventer(
 		floodPreventerConfig.BlackList.ThresholdSizePerInterval,
 		floodPreventerConfig.BlackList.NumFloodingRounds,
 		time.Duration(floodPreventerConfig.BlackList.PeerBanDurationInSeconds)*time.Second,
+		quotaIdentifier,
+		selfPid,
 	)
 	if err != nil {
 		return nil, err

--- a/process/throttle/antiflood/factory/p2pAntifloodAndBlacklistFactory_test.go
+++ b/process/throttle/antiflood/factory/p2pAntifloodAndBlacklistFactory_test.go
@@ -4,17 +4,20 @@ import (
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 	"github.com/ElrondNetwork/elrond-go/p2p/mock"
 	"github.com/ElrondNetwork/elrond-go/process/throttle/antiflood/disabled"
 	"github.com/stretchr/testify/assert"
 )
 
+const currentPid = core.PeerID("current pid")
+
 func TestNewP2PAntiFloodAndBlackList_NilStatusHandlerShouldErr(t *testing.T) {
 	t.Parallel()
 
 	cfg := config.Config{}
-	af, bl, err := NewP2PAntiFloodAndBlackList(cfg, nil)
+	af, bl, err := NewP2PAntiFloodAndBlackList(cfg, nil, currentPid)
 	assert.Nil(t, af)
 	assert.Nil(t, bl)
 	assert.Equal(t, p2p.ErrNilStatusHandler, err)
@@ -29,7 +32,7 @@ func TestNewP2PAntiFloodAndBlackList_ShouldWorkAndReturnDisabledImplementations(
 		},
 	}
 	ash := &mock.AppStatusHandlerMock{}
-	af, bl, err := NewP2PAntiFloodAndBlackList(cfg, ash)
+	af, bl, err := NewP2PAntiFloodAndBlackList(cfg, ash, currentPid)
 	assert.NotNil(t, af)
 	assert.NotNil(t, bl)
 	assert.Nil(t, err)
@@ -61,7 +64,7 @@ func TestNewP2PAntiFloodAndBlackList_ShouldWorkAndReturnOkImplementations(t *tes
 	}
 
 	ash := &mock.AppStatusHandlerMock{}
-	af, bl, err := NewP2PAntiFloodAndBlackList(cfg, ash)
+	af, bl, err := NewP2PAntiFloodAndBlackList(cfg, ash, currentPid)
 	assert.Nil(t, err)
 	assert.NotNil(t, af)
 	assert.NotNil(t, bl)

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -214,6 +214,7 @@ type SizedLRUCacheHandler interface {
 type TimeCacheHandler interface {
 	Add(key string) error
 	AddWithSpan(key string, span time.Duration) error
+	Update(key string, span time.Duration) error
 	Has(key string) bool
 	Sweep()
 	IsInterfaceNil() bool

--- a/storage/mock/timeCacheStub.go
+++ b/storage/mock/timeCacheStub.go
@@ -6,6 +6,7 @@ import "time"
 type TimeCacheStub struct {
 	AddCalled         func(key string) error
 	AddWithSpanCalled func(key string, span time.Duration) error
+	UpdateCalled      func(key string, span time.Duration) error
 	HasCalled         func(key string) bool
 	SweepCalled       func()
 }
@@ -23,6 +24,15 @@ func (tcs *TimeCacheStub) Add(key string) error {
 func (tcs *TimeCacheStub) AddWithSpan(key string, span time.Duration) error {
 	if tcs.AddWithSpanCalled != nil {
 		return tcs.AddWithSpanCalled(key, span)
+	}
+
+	return nil
+}
+
+// Update -
+func (tcs *TimeCacheStub) Update(key string, span time.Duration) error {
+	if tcs.UpdateCalled != nil {
+		return tcs.UpdateCalled(key, span)
 	}
 
 	return nil

--- a/storage/timecache/export_test.go
+++ b/storage/timecache/export_test.go
@@ -1,7 +1,5 @@
 package timecache
 
-import "time"
-
 func (tc *TimeCache) Keys() []string {
 	tc.mut.Lock()
 	defer tc.mut.Unlock()
@@ -14,27 +12,18 @@ func (tc *TimeCache) Keys() []string {
 	return keys
 }
 
-func (tc *TimeCache) KeyTime(key string) (time.Time, bool) {
+func (tc *TimeCache) Value(key string) (*span, bool) {
 	tc.mut.Lock()
 	defer tc.mut.Unlock()
 
 	val, ok := tc.data[key]
 
-	return val.timestamp, ok
-}
-
-func (tc *TimeCache) KeySpan(key string) (time.Duration, bool) {
-	tc.mut.Lock()
-	defer tc.mut.Unlock()
-
-	val, ok := tc.data[key]
-
-	return val.span, ok
+	return val, ok
 }
 
 func (tc *TimeCache) ClearMap() {
 	tc.mut.Lock()
 	defer tc.mut.Unlock()
 
-	tc.data = make(map[string]span)
+	tc.data = make(map[string]*span)
 }

--- a/storage/timecache/peerTimeCache.go
+++ b/storage/timecache/peerTimeCache.go
@@ -29,9 +29,15 @@ func (ptc *peerTimeCache) Add(pid core.PeerID) error {
 }
 
 // AddWithSpan will call the inner time cache method with the provided pid as string
-// TODO maybe add a new function that will replace existing data with the larger span (between existing and providing)
 func (ptc *peerTimeCache) AddWithSpan(pid core.PeerID, duration time.Duration) error {
 	return ptc.timeCache.AddWithSpan(string(pid), duration)
+}
+
+// Update will add the pid and provided duration if not exists
+// If the record exists, will update the duration if the provided duration is larger than existing
+// Also, it will reset the contained timestamp to time.Now
+func (ptc *peerTimeCache) Update(pid core.PeerID, duration time.Duration) error {
+	return ptc.timeCache.Update(string(pid), duration)
 }
 
 // Sweep will call the inner time cache method

--- a/storage/timecache/peerTimeCache_test.go
+++ b/storage/timecache/peerTimeCache_test.go
@@ -37,6 +37,7 @@ func TestPeerTimeCache_Methods(t *testing.T) {
 	unexpectedErr := errors.New("unexpected error")
 	addWasCalled := false
 	addWithSpanWasCalled := false
+	updateWasCalled := false
 	hasWasCalled := false
 	sweepWasCalled := false
 	ptc, _ := NewPeerTimeCache(&mock.TimeCacheStub{
@@ -56,6 +57,14 @@ func TestPeerTimeCache_Methods(t *testing.T) {
 			addWithSpanWasCalled = true
 			return nil
 		},
+		UpdateCalled: func(key string, span time.Duration) error {
+			if key != string(pid) {
+				return unexpectedErr
+			}
+
+			updateWasCalled = true
+			return nil
+		},
 		HasCalled: func(key string) bool {
 			if key != string(pid) {
 				return false
@@ -71,11 +80,13 @@ func TestPeerTimeCache_Methods(t *testing.T) {
 
 	assert.Nil(t, ptc.Add(pid))
 	assert.Nil(t, ptc.AddWithSpan(pid, time.Second))
+	assert.Nil(t, ptc.Update(pid, time.Second))
 	assert.True(t, ptc.Has(pid))
 	ptc.Sweep()
 
 	assert.True(t, addWasCalled)
 	assert.True(t, addWithSpanWasCalled)
+	assert.True(t, updateWasCalled)
 	assert.True(t, hasWasCalled)
 	assert.True(t, sweepWasCalled)
 }


### PR DESCRIPTION
- removed self ban situation when observers try to send more data than can handle
- added a new functionality on peer blacklist handler that will update the ban duration if the ban duration is higher than existing