### PR TITLE
Fix trie snapshot concurrency

### DIFF
--- a/data/interface.go
+++ b/data/interface.go
@@ -200,8 +200,7 @@ type StorageManager interface {
 	Prune([]byte, TriePruningIdentifier)
 	CancelPrune([]byte, TriePruningIdentifier)
 	MarkForEviction([]byte, ModifiedHashes) error
-	GetDbThatContainsHash([]byte) DBWriteCacher
-	GetSnapshotThatContainsHash(rootHash []byte) DBWriteCacher
+	GetSnapshotThatContainsHash(rootHash []byte) SnapshotDbHandler
 	IsPruningEnabled() bool
 	EnterSnapshotMode()
 	ExitSnapshotMode()
@@ -240,4 +239,14 @@ type GoRoutineThrottler interface {
 	StartProcessing()
 	EndProcessing()
 	IsInterfaceNil() bool
+}
+
+// SnapshotDbHandler is used to keep track of how many references a snapshot db has
+type SnapshotDbHandler interface {
+	DBWriteCacher
+	IsInUse() bool
+	DecreaseNumReferences()
+	IncreaseNumReferences()
+	MarkForRemoval()
+	SetPath(string)
 }

--- a/data/mock/storageManagerStub.go
+++ b/data/mock/storageManagerStub.go
@@ -11,7 +11,7 @@ type StorageManagerStub struct {
 	CancelPruneCalled                 func([]byte)
 	MarkForEvictionCalled             func([]byte, data.ModifiedHashes) error
 	GetDbThatContainsHashCalled       func([]byte) data.DBWriteCacher
-	GetSnapshotThatContainsHashCalled func(rootHash []byte) data.DBWriteCacher
+	GetSnapshotThatContainsHashCalled func(rootHash []byte) data.SnapshotDbHandler
 	IsPruningEnabledCalled            func() bool
 	EnterSnapshotModeCalled           func()
 	ExitSnapshotModeCalled            func()
@@ -54,17 +54,8 @@ func (sms *StorageManagerStub) MarkForEviction(d []byte, m data.ModifiedHashes) 
 	return nil
 }
 
-// GetDbThatContainsHash --
-func (sms *StorageManagerStub) GetDbThatContainsHash(d []byte) data.DBWriteCacher {
-	if sms.GetDbThatContainsHashCalled != nil {
-		return sms.GetDbThatContainsHashCalled(d)
-	}
-
-	return nil
-}
-
 // GetSnapshotThatContainsHash --
-func (sms *StorageManagerStub) GetSnapshotThatContainsHash(d []byte) data.DBWriteCacher {
+func (sms *StorageManagerStub) GetSnapshotThatContainsHash(d []byte) data.SnapshotDbHandler {
 	if sms.GetSnapshotThatContainsHashCalled != nil {
 		return sms.GetSnapshotThatContainsHashCalled(d)
 	}

--- a/data/trie/patriciaMerkleTrie.go
+++ b/data/trie/patriciaMerkleTrie.go
@@ -329,6 +329,7 @@ func (tr *patriciaMerkleTrie) recreateFromSnapshotDb(rootHash []byte) (data.Trie
 	if db == nil {
 		return nil, ErrHashNotFound
 	}
+	defer db.DecreaseNumReferences()
 
 	newTr, newRoot, err := tr.recreateFromDb(rootHash, db, tr.trieStorage)
 	if err != nil {
@@ -340,8 +341,6 @@ func (tr *patriciaMerkleTrie) recreateFromSnapshotDb(rootHash []byte) (data.Trie
 	if err != nil {
 		return nil, err
 	}
-
-	db.DecreaseNumReferences()
 
 	return newTr, nil
 }
@@ -535,6 +534,7 @@ func (tr *patriciaMerkleTrie) GetSerializedNodes(rootHash []byte, maxBuffToSend 
 	if db == nil {
 		return nil, 0, ErrHashNotFound
 	}
+	defer db.DecreaseNumReferences()
 
 	newTsm, err := NewTrieStorageManagerWithoutPruning(db)
 	if err != nil {
@@ -579,8 +579,6 @@ func (tr *patriciaMerkleTrie) GetSerializedNodes(rootHash []byte, maxBuffToSend 
 	}
 
 	remainingSpace := maxBuffToSend - size
-
-	db.DecreaseNumReferences()
 
 	return nodes, remainingSpace, nil
 }

--- a/data/trie/patriciaMerkleTrie.go
+++ b/data/trie/patriciaMerkleTrie.go
@@ -319,6 +319,7 @@ func (tr *patriciaMerkleTrie) recreateFromMainDb(rootHash []byte) data.Trie {
 	newTr, _, err := tr.recreateFromDb(rootHash, tr.Database(), tr.trieStorage)
 	if err != nil {
 		log.Warn("trie recreate error:", "error", err, "root", hex.EncodeToString(rootHash))
+		return nil
 	}
 
 	return newTr
@@ -513,13 +514,13 @@ func getDbThatContainsHash(trieStorage data.StorageManager, rootHash []byte) dat
 	}
 
 	_, err := trieStorage.Database().Get(rootHash)
-	if err == nil {
-		return &snapshotDb{
-			DBWriteCacher: trieStorage.Database(),
-		}
+	if err != nil {
+		return nil
 	}
 
-	return nil
+	return &snapshotDb{
+		DBWriteCacher: trieStorage.Database(),
+	}
 }
 
 // GetSerializedNodes returns a batch of serialized nodes from the trie, starting from the given hash

--- a/data/trie/patriciaMerkleTrie_test.go
+++ b/data/trie/patriciaMerkleTrie_test.go
@@ -599,7 +599,7 @@ func TestPatriciaMerkleTrie_GetSerializedNodesShouldCheckFirstInSnapshotsDB(t *t
 			getDbCalled = true
 			return nil
 		},
-		GetSnapshotThatContainsHashCalled: func(rootHash []byte) data.DBWriteCacher {
+		DatabaseCalled: func() data.DBWriteCacher {
 			getSnapshotCalled = true
 			return mock.NewMemDbMock()
 		},

--- a/data/trie/snapshotDb.go
+++ b/data/trie/snapshotDb.go
@@ -1,0 +1,63 @@
+package trie
+
+import (
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go/data"
+)
+
+type snapshotDb struct {
+	data.DBWriteCacher
+	numReferences   uint32
+	shouldBeRemoved bool
+	path            string
+	mutex           sync.RWMutex
+}
+
+// DecreaseNumReferences decreases the num references counter
+func (s *snapshotDb) DecreaseNumReferences() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.numReferences--
+
+	if s.numReferences == 0 && s.shouldBeRemoved {
+		removeSnapshot(s.DBWriteCacher, s.path)
+	}
+}
+
+// IncreaseNumReferences increases the num references counter
+func (s *snapshotDb) IncreaseNumReferences() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.numReferences++
+}
+
+// MarkForRemoval marks the current db for removal. When the numReferences buffer reaches 0, the db will be removed
+func (s *snapshotDb) MarkForRemoval() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.shouldBeRemoved = true
+}
+
+// SetPath sets the db path
+func (s *snapshotDb) SetPath(path string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.path = path
+}
+
+// IsInUse returns true if the numReferences counter is greater than 0
+func (s *snapshotDb) IsInUse() bool {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if s.numReferences != 0 {
+		return true
+	}
+
+	return false
+}

--- a/data/trie/snapshotDb.go
+++ b/data/trie/snapshotDb.go
@@ -19,7 +19,9 @@ func (s *snapshotDb) DecreaseNumReferences() {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	s.numReferences--
+	if s.numReferences != 0 {
+		s.numReferences--
+	}
 
 	if s.numReferences == 0 && s.shouldBeRemoved {
 		removeSnapshot(s.DBWriteCacher, s.path)

--- a/data/trie/snapshotDb.go
+++ b/data/trie/snapshotDb.go
@@ -19,7 +19,7 @@ func (s *snapshotDb) DecreaseNumReferences() {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	if s.numReferences != 0 {
+	if s.numReferences > 0 {
 		s.numReferences--
 	}
 
@@ -54,12 +54,8 @@ func (s *snapshotDb) SetPath(path string) {
 
 // IsInUse returns true if the numReferences counter is greater than 0
 func (s *snapshotDb) IsInUse() bool {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 
-	if s.numReferences != 0 {
-		return true
-	}
-
-	return false
+	return s.numReferences > 0
 }

--- a/data/trie/trieStorageManager.go
+++ b/data/trie/trieStorageManager.go
@@ -107,6 +107,7 @@ func getSnapshotsAndSnapshotId(snapshotDbCfg config.DBConfig) ([]data.SnapshotDb
 
 	files, err := ioutil.ReadDir(snapshotDbCfg.FilePath)
 	if err != nil {
+		log.Debug("there is no snapshot in path", "path", snapshotDbCfg.FilePath)
 		return snapshots, snapshotId, err
 	}
 
@@ -142,6 +143,7 @@ func getSnapshotsAndSnapshotId(snapshotDbCfg config.DBConfig) ([]data.SnapshotDb
 			DBWriteCacher: db,
 		}
 
+		log.Debug("restored snapshot", "snapshot ID", snapshotName)
 		snapshots = append(snapshots, snapshot)
 	}
 
@@ -428,6 +430,7 @@ func (tsm *trieStorageManager) removeSnapshot() {
 	removePath := path.Join(tsm.snapshotDbCfg.FilePath, dbUniqueId)
 
 	if snapshot.IsInUse() {
+		log.Debug("snapshot is still in use", "path", removePath)
 		snapshot.MarkForRemoval()
 		snapshot.SetPath(removePath)
 

--- a/data/trie/trieStorageManager.go
+++ b/data/trie/trieStorageManager.go
@@ -423,6 +423,10 @@ func (tsm *trieStorageManager) getSnapshotDb(newDb bool) data.DBWriteCacher {
 }
 
 func (tsm *trieStorageManager) removeSnapshot() {
+	if len(tsm.snapshots) <= 0 {
+		return
+	}
+
 	dbUniqueId := strconv.Itoa(tsm.snapshotId - len(tsm.snapshots))
 
 	snapshot := tsm.snapshots[0]

--- a/epochStart/mock/storageManagerStub.go
+++ b/epochStart/mock/storageManagerStub.go
@@ -13,7 +13,7 @@ type StorageManagerStub struct {
 	CancelPruneCalled                 func([]byte)
 	MarkForEvictionCalled             func([]byte, data.ModifiedHashes) error
 	GetDbThatContainsHashCalled       func([]byte) data.DBWriteCacher
-	GetSnapshotThatContainsHashCalled func(rootHash []byte) data.DBWriteCacher
+	GetSnapshotThatContainsHashCalled func(rootHash []byte) data.SnapshotDbHandler
 	IsPruningEnabledCalled            func() bool
 	EnterSnapshotModeCalled           func()
 	ExitSnapshotModeCalled            func()
@@ -56,17 +56,8 @@ func (sms *StorageManagerStub) MarkForEviction(d []byte, m data.ModifiedHashes) 
 	return nil
 }
 
-// GetDbThatContainsHash --
-func (sms *StorageManagerStub) GetDbThatContainsHash(d []byte) data.DBWriteCacher {
-	if sms.GetDbThatContainsHashCalled != nil {
-		return sms.GetDbThatContainsHashCalled(d)
-	}
-
-	return nil
-}
-
 // GetSnapshotThatContainsHash --
-func (sms *StorageManagerStub) GetSnapshotThatContainsHash(d []byte) data.DBWriteCacher {
+func (sms *StorageManagerStub) GetSnapshotThatContainsHash(d []byte) data.SnapshotDbHandler {
 	if sms.GetSnapshotThatContainsHashCalled != nil {
 		return sms.GetSnapshotThatContainsHashCalled(d)
 	}

--- a/genesis/mock/storageManagerStub.go
+++ b/genesis/mock/storageManagerStub.go
@@ -13,7 +13,7 @@ type StorageManagerStub struct {
 	CancelPruneCalled                 func([]byte)
 	MarkForEvictionCalled             func([]byte, data.ModifiedHashes) error
 	GetDbThatContainsHashCalled       func([]byte) data.DBWriteCacher
-	GetSnapshotThatContainsHashCalled func(rootHash []byte) data.DBWriteCacher
+	GetSnapshotThatContainsHashCalled func(rootHash []byte) data.SnapshotDbHandler
 	IsPruningEnabledCalled            func() bool
 	EnterSnapshotModeCalled           func()
 	ExitSnapshotModeCalled            func()
@@ -56,17 +56,8 @@ func (sms *StorageManagerStub) MarkForEviction(d []byte, m data.ModifiedHashes) 
 	return nil
 }
 
-// GetDbThatContainsHash --
-func (sms *StorageManagerStub) GetDbThatContainsHash(d []byte) data.DBWriteCacher {
-	if sms.GetDbThatContainsHashCalled != nil {
-		return sms.GetDbThatContainsHashCalled(d)
-	}
-
-	return nil
-}
-
 // GetSnapshotThatContainsHash --
-func (sms *StorageManagerStub) GetSnapshotThatContainsHash(d []byte) data.DBWriteCacher {
+func (sms *StorageManagerStub) GetSnapshotThatContainsHash(d []byte) data.SnapshotDbHandler {
 	if sms.GetSnapshotThatContainsHashCalled != nil {
 		return sms.GetSnapshotThatContainsHashCalled(d)
 	}

--- a/update/mock/storageManagerStub.go
+++ b/update/mock/storageManagerStub.go
@@ -13,7 +13,7 @@ type StorageManagerStub struct {
 	CancelPruneCalled                 func([]byte)
 	MarkForEvictionCalled             func([]byte, data.ModifiedHashes) error
 	GetDbThatContainsHashCalled       func([]byte) data.DBWriteCacher
-	GetSnapshotThatContainsHashCalled func(rootHash []byte) data.DBWriteCacher
+	GetSnapshotThatContainsHashCalled func(rootHash []byte) data.SnapshotDbHandler
 	IsPruningEnabledCalled            func() bool
 	EnterSnapshotModeCalled           func()
 	ExitSnapshotModeCalled            func()
@@ -56,17 +56,8 @@ func (sms *StorageManagerStub) MarkForEviction(d []byte, m data.ModifiedHashes) 
 	return nil
 }
 
-// GetDbThatContainsHash --
-func (sms *StorageManagerStub) GetDbThatContainsHash(d []byte) data.DBWriteCacher {
-	if sms.GetDbThatContainsHashCalled != nil {
-		return sms.GetDbThatContainsHashCalled(d)
-	}
-
-	return nil
-}
-
 // GetSnapshotThatContainsHash --
-func (sms *StorageManagerStub) GetSnapshotThatContainsHash(d []byte) data.DBWriteCacher {
+func (sms *StorageManagerStub) GetSnapshotThatContainsHash(d []byte) data.SnapshotDbHandler {
 	if sms.GetSnapshotThatContainsHashCalled != nil {
 		return sms.GetSnapshotThatContainsHashCalled(d)
 	}


### PR DESCRIPTION
_Bug_: When GetSnapshotThatContainsHash() is called, the pointer to the snapshotDb is returned. But concurrently, the same db could have been closed and removed, thus resuting in a concurrency problem.