### PR TITLE
Adjust (lower) pool size. Fix capacity allocation.

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -114,7 +114,7 @@
     [UnsignedTransactionStorage.Cache]
         Capacity = 75000
         Type = "SizeLRU"
-        SizeInBytes = 209715200 #200MB
+        SizeInBytes = 104857600 #100MB
     [UnsignedTransactionStorage.DB]
         FilePath = "UnsignedTransactions"
         Type = "LvlDBSerial"
@@ -126,7 +126,7 @@
     [RewardTxStorage.Cache]
         Capacity = 75000
         Type = "SizeLRU"
-        SizeInBytes = 104857600 #100MB
+        SizeInBytes = 52428800 #50MB
     [RewardTxStorage.DB]
         FilePath = "RewardTransactions"
         Type = "LvlDBSerial"
@@ -234,9 +234,9 @@
     SizeInBytes = 314572800 #300MB
 
 [TxDataPool]
-    Capacity = 900000
+    Capacity = 600000
     SizePerSender = 20000
-    SizeInBytes = 524288000
+    SizeInBytes = 419430400 #400MB
     SizeInBytesPerSender = 12288000
     Type = "TxCache"
     Shards = 16

--- a/dataRetriever/txpool/shardedTxPool.go
+++ b/dataRetriever/txpool/shardedTxPool.go
@@ -45,23 +45,28 @@ func NewShardedTxPool(args ArgShardedTxPool) (dataRetriever.ShardedDataCacherNot
 	}
 
 	const oneBillion = 1000000 * 1000
-	numPairs := 2*args.NumberOfShards - 1
+
+	halfOfSizeInBytes := args.Config.SizeInBytes / 2
+	halfOfCapacity := args.Config.Capacity / 2
 
 	configPrototypeSourceMe := txcache.ConfigSourceMe{
 		NumChunks:                     args.Config.Shards,
 		EvictionEnabled:               true,
-		NumBytesThreshold:             (uint32(args.Config.SizeInBytes) / numPairs) * args.NumberOfShards,
-		CountThreshold:                (args.Config.Capacity / numPairs) * args.NumberOfShards,
+		NumBytesThreshold:             uint32(halfOfSizeInBytes),
+		CountThreshold:                halfOfCapacity,
 		NumBytesPerSenderThreshold:    args.Config.SizeInBytesPerSender,
 		CountPerSenderThreshold:       args.Config.SizePerSender,
 		NumSendersToPreemptivelyEvict: dataRetriever.TxPoolNumSendersToPreemptivelyEvict,
 		MinGasPriceNanoErd:            uint32(args.MinGasPrice / oneBillion),
 	}
 
+	// Minus self shard, plus metachain
+	numCrossTxCaches := args.NumberOfShards - 1 + 1
+
 	configPrototypeDestinationMe := txcache.ConfigDestinationMe{
 		NumChunks:                   args.Config.Shards,
-		MaxNumBytes:                 uint32(args.Config.SizeInBytes) / numPairs,
-		MaxNumItems:                 args.Config.Capacity / numPairs,
+		MaxNumBytes:                 uint32(halfOfSizeInBytes) / numCrossTxCaches,
+		MaxNumItems:                 halfOfCapacity / numCrossTxCaches,
 		NumItemsToPreemptivelyEvict: dataRetriever.TxPoolNumTxsToPreemptivelyEvict,
 	}
 

--- a/dataRetriever/txpool/shardedTxPool.go
+++ b/dataRetriever/txpool/shardedTxPool.go
@@ -60,8 +60,8 @@ func NewShardedTxPool(args ArgShardedTxPool) (dataRetriever.ShardedDataCacherNot
 		MinGasPriceNanoErd:            uint32(args.MinGasPrice / oneBillion),
 	}
 
-	// Minus self shard, plus metachain
-	numCrossTxCaches := args.NumberOfShards - 1 + 1
+	//  NumberOfShards - 1 (for self shard) + 1 (for metachain)
+	numCrossTxCaches := args.NumberOfShards
 
 	configPrototypeDestinationMe := txcache.ConfigDestinationMe{
 		NumChunks:                   args.Config.Shards,

--- a/dataRetriever/txpool/shardedTxPool_test.go
+++ b/dataRetriever/txpool/shardedTxPool_test.go
@@ -87,8 +87,8 @@ func Test_NewShardedTxPool_WhenBadConfig(t *testing.T) {
 }
 
 func Test_NewShardedTxPool_ComputesCacheConfig(t *testing.T) {
-	config := storageUnit.CacheConfig{SizeInBytes: 524288000, SizeInBytesPerSender: 614400, Capacity: 900000, SizePerSender: 1000, Shards: 1}
-	args := ArgShardedTxPool{Config: config, MinGasPrice: 200000000000, NumberOfShards: 5}
+	config := storageUnit.CacheConfig{SizeInBytes: 419430400, SizeInBytesPerSender: 614400, Capacity: 600000, SizePerSender: 1000, Shards: 1}
+	args := ArgShardedTxPool{Config: config, MinGasPrice: 200000000000, NumberOfShards: 2}
 
 	poolAsInterface, err := NewShardedTxPool(args)
 	require.Nil(t, err)
@@ -96,15 +96,15 @@ func Test_NewShardedTxPool_ComputesCacheConfig(t *testing.T) {
 	pool := poolAsInterface.(*shardedTxPool)
 
 	require.Equal(t, true, pool.configPrototypeSourceMe.EvictionEnabled)
-	require.Equal(t, uint32(291271110), pool.configPrototypeSourceMe.NumBytesThreshold)
-	require.Equal(t, uint32(614400), pool.configPrototypeSourceMe.NumBytesPerSenderThreshold)
-	require.Equal(t, uint32(1000), pool.configPrototypeSourceMe.CountPerSenderThreshold)
-	require.Equal(t, uint32(100), pool.configPrototypeSourceMe.NumSendersToPreemptivelyEvict)
-	require.Equal(t, uint32(200), pool.configPrototypeSourceMe.MinGasPriceNanoErd)
-	require.Equal(t, uint32(500000), pool.configPrototypeSourceMe.CountThreshold)
+	require.Equal(t, 209715200, int(pool.configPrototypeSourceMe.NumBytesThreshold))
+	require.Equal(t, 614400, int(pool.configPrototypeSourceMe.NumBytesPerSenderThreshold))
+	require.Equal(t, 1000, int(pool.configPrototypeSourceMe.CountPerSenderThreshold))
+	require.Equal(t, 100, int(pool.configPrototypeSourceMe.NumSendersToPreemptivelyEvict))
+	require.Equal(t, 200, int(pool.configPrototypeSourceMe.MinGasPriceNanoErd))
+	require.Equal(t, 300000, int(pool.configPrototypeSourceMe.CountThreshold))
 
-	require.Equal(t, uint32(100000), pool.configPrototypeDestinationMe.MaxNumItems)
-	require.Equal(t, uint32(58254222), pool.configPrototypeDestinationMe.MaxNumBytes)
+	require.Equal(t, 150000, int(pool.configPrototypeDestinationMe.MaxNumItems))
+	require.Equal(t, 104857600, int(pool.configPrototypeDestinationMe.MaxNumBytes))
 }
 
 func Test_ShardDataStore_Or_GetTxCache(t *testing.T) {


### PR DESCRIPTION
Tx Pool capacity = 600000 items or 400 MB:
 - `[source == me]` gets 300000 items or 200 MB
 - `[source == the other, destination == me]` gets 150000 items or 100000 MB
 - `[source == meta, destination == me]` gets 150000 items or 100000 MB

Also, adjusted storage cache config for some components.