### PR TITLE
P2P and antiflood fixes 2020.06.16

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -295,13 +295,13 @@
         ReservedPercent   = 20
         [Antiflood.FastReacting.PeerMaxInput]
             BaseMessagesPerInterval  = 140
-            TotalSizePerInterval = 4194304 #4MB/s
+            TotalSizePerInterval = 2097152 #2MB/s
             [Antiflood.FastReacting.PeerMaxInput.IncreaseFactor]
                 Threshold = 10 #if consensus size will exceed this value, then
                 Factor = 1     #increase the base value with [factor*consensus size]
         [Antiflood.FastReacting.BlackList]
-            ThresholdNumMessagesPerInterval = 1000
-            ThresholdSizePerInterval = 8388608 #8MB/s
+            ThresholdNumMessagesPerInterval = 700
+            ThresholdSizePerInterval = 4194304 #4MB/s
             NumFloodingRounds = 10
             PeerBanDurationInSeconds = 300
 
@@ -310,13 +310,13 @@
         ReservedPercent   = 20.0
         [Antiflood.SlowReacting.PeerMaxInput]
             BaseMessagesPerInterval = 6000
-            TotalSizePerInterval = 18874368 # 18MB/interval
+            TotalSizePerInterval = 10485760 # 10MB/interval
             [Antiflood.SlowReacting.PeerMaxInput.IncreaseFactor]
                 Threshold = 10 #if consensus size will exceed this value, then
                 Factor = 0     #increase the base value with [factor*consensus size]
         [Antiflood.SlowReacting.BlackList]
             ThresholdNumMessagesPerInterval = 10000
-            ThresholdSizePerInterval = 37748736 # 36MB/interval
+            ThresholdSizePerInterval = 20971520 # 20MB/interval
             NumFloodingRounds = 2
             PeerBanDurationInSeconds = 3600
 
@@ -324,20 +324,20 @@
         IntervalInSeconds = 1
         ReservedPercent   = 0.0
         [Antiflood.OutOfSpecs.PeerMaxInput]
-            BaseMessagesPerInterval = 2000
-            TotalSizePerInterval = 10485760 # 10MB/interval
+            BaseMessagesPerInterval = 1000
+            TotalSizePerInterval = 8388608 # 8MB/interval
             [Antiflood.OutOfSpecs.PeerMaxInput.IncreaseFactor]
                 Threshold = 0 #if consensus size will exceed this value, then
                 Factor = 0     #increase the base value with [factor*consensus size]
         [Antiflood.OutOfSpecs.BlackList]
-            ThresholdNumMessagesPerInterval = 3600
-            ThresholdSizePerInterval = 12582912 # 12MB/interval
+            ThresholdNumMessagesPerInterval = 1500
+            ThresholdSizePerInterval = 10485760 # 10MB/interval
             NumFloodingRounds = 2
             PeerBanDurationInSeconds = 3600
 
     [Antiflood.PeerMaxOutput]
         BaseMessagesPerInterval  = 75
-        TotalSizePerInterval     = 2097152 #2MB/s
+        TotalSizePerInterval     = 1048576 #1MB/s
 
     [Antiflood.Cache]
         Capacity = 7000

--- a/integrationTests/longTests/antiflooding/antiflooding_test.go
+++ b/integrationTests/longTests/antiflooding/antiflooding_test.go
@@ -98,7 +98,7 @@ func createDisabledConfig() config.Config {
 }
 
 func TestAntifloodingForLargerPeriodOfTime(t *testing.T) {
-	//t.Skip("this is a long and harsh test")
+	t.Skip("this is a long and harsh test")
 
 	peers, err := integrationTests.CreateFixedNetworkOf8Peers()
 	assert.Nil(t, err)

--- a/integrationTests/longTests/antiflooding/antiflooding_test.go
+++ b/integrationTests/longTests/antiflooding/antiflooding_test.go
@@ -25,19 +25,23 @@ func createWorkableConfig() config.Config {
 			Enabled: true,
 			Cache: config.CacheConfig{
 				Type:     "LRU",
-				Capacity: 5000,
+				Capacity: 7000,
 				Shards:   16,
 			},
 			FastReacting: config.FloodPreventerConfig{
 				IntervalInSeconds: 1,
 				ReservedPercent:   20,
 				PeerMaxInput: config.AntifloodLimitsConfig{
-					BaseMessagesPerInterval: 75,
-					TotalSizePerInterval:    2097152,
+					BaseMessagesPerInterval: 140,
+					TotalSizePerInterval:    4194304,
+					IncreaseFactor: config.IncreaseFactorConfig{
+						Threshold: 10,
+						Factor:    1,
+					},
 				},
 				BlackList: config.BlackListConfig{
-					ThresholdNumMessagesPerInterval: 480,
-					ThresholdSizePerInterval:        5242880,
+					ThresholdNumMessagesPerInterval: 1000,
+					ThresholdSizePerInterval:        8388608,
 					NumFloodingRounds:               10,
 					PeerBanDurationInSeconds:        300,
 				},
@@ -46,12 +50,34 @@ func createWorkableConfig() config.Config {
 				IntervalInSeconds: 30,
 				ReservedPercent:   20,
 				PeerMaxInput: config.AntifloodLimitsConfig{
-					BaseMessagesPerInterval: 2500,
-					TotalSizePerInterval:    15728640,
+					BaseMessagesPerInterval: 6000,
+					TotalSizePerInterval:    18874368,
+					IncreaseFactor: config.IncreaseFactorConfig{
+						Threshold: 10,
+						Factor:    0,
+					},
 				},
 				BlackList: config.BlackListConfig{
-					ThresholdNumMessagesPerInterval: 6000,
+					ThresholdNumMessagesPerInterval: 10000,
 					ThresholdSizePerInterval:        37748736,
+					NumFloodingRounds:               2,
+					PeerBanDurationInSeconds:        3600,
+				},
+			},
+			OutOfSpecs: config.FloodPreventerConfig{
+				IntervalInSeconds: 1,
+				ReservedPercent:   0,
+				PeerMaxInput: config.AntifloodLimitsConfig{
+					BaseMessagesPerInterval: 2000,
+					TotalSizePerInterval:    10485760,
+					IncreaseFactor: config.IncreaseFactorConfig{
+						Threshold: 10,
+						Factor:    0,
+					},
+				},
+				BlackList: config.BlackListConfig{
+					ThresholdNumMessagesPerInterval: 3600,
+					ThresholdSizePerInterval:        12582912,
 					NumFloodingRounds:               2,
 					PeerBanDurationInSeconds:        3600,
 				},
@@ -72,7 +98,7 @@ func createDisabledConfig() config.Config {
 }
 
 func TestAntifloodingForLargerPeriodOfTime(t *testing.T) {
-	t.Skip("this is a long and harsh test")
+	//t.Skip("this is a long and harsh test")
 
 	peers, err := integrationTests.CreateFixedNetworkOf8Peers()
 	assert.Nil(t, err)

--- a/integrationTests/p2p/antiflood/common.go
+++ b/integrationTests/p2p/antiflood/common.go
@@ -58,6 +58,7 @@ func CreateTopicsAndMockInterceptors(
 			PercentReserved:           0,
 			IncreaseThreshold:         0,
 			IncreaseFactor:            0,
+			SelfPid:                   p.ID(),
 		}
 		interceptors[idx].FloodPreventer, err = floodPreventers.NewQuotaFloodPreventer(arg)
 		if err != nil {

--- a/integrationTests/p2p/antiflood/messageProcessor.go
+++ b/integrationTests/p2p/antiflood/messageProcessor.go
@@ -35,7 +35,13 @@ func (mp *MessageProcessor) ProcessReceivedMessage(message p2p.MessageP2P, fromC
 	atomic.AddUint64(&mp.sizeMessagesReceived, uint64(len(message.Data())))
 
 	if mp.FloodPreventer != nil {
-		af, _ := antiflood2.NewP2PAntiflood(&mock.PeerBlackListHandlerStub{}, &mock.TopicAntiFloodStub{}, mp.FloodPreventer)
+		dummyPid := core.PeerID("dummy peer id")
+		af, _ := antiflood2.NewP2PAntiflood(
+			dummyPid,
+			&mock.PeerBlackListHandlerStub{},
+			&mock.TopicAntiFloodStub{},
+			mp.FloodPreventer,
+		)
 		err := af.CanProcessMessage(message, fromConnectedPeer)
 		if err != nil {
 			return err

--- a/process/errors.go
+++ b/process/errors.go
@@ -790,3 +790,6 @@ var ErrOriginatorIsBlacklisted = errors.New("originator is blacklisted")
 
 // ErrShardIsStuck signals that a shard is stuck
 var ErrShardIsStuck = errors.New("shard is stuck")
+
+// ErrEmptyPeerId signals that an empy peer id has been provided
+var ErrEmptyPeerId = errors.New("empty peer id")

--- a/process/interface.go
+++ b/process/interface.go
@@ -689,7 +689,7 @@ type BlockTracker interface {
 // FloodPreventer defines the behavior of a component that is able to signal that too many events occurred
 // on a provided identifier between Reset calls
 type FloodPreventer interface {
-	IncreaseLoad(pid core.PeerID, size uint64) error
+	IncreaseLoad(fromConnectedPeer core.PeerID, originator core.PeerID, size uint64) error
 	ApplyConsensusSize(size int)
 	Reset()
 	IsInterfaceNil() bool

--- a/process/mock/floodPreventerStub.go
+++ b/process/mock/floodPreventerStub.go
@@ -4,14 +4,14 @@ import "github.com/ElrondNetwork/elrond-go/core"
 
 // FloodPreventerStub -
 type FloodPreventerStub struct {
-	IncreaseLoadCalled       func(pid core.PeerID, size uint64) error
+	IncreaseLoadCalled       func(fromConnectedPid core.PeerID, originator core.PeerID, size uint64) error
 	ApplyConsensusSizeCalled func(size int)
 	ResetCalled              func()
 }
 
 // IncreaseLoad -
-func (fps *FloodPreventerStub) IncreaseLoad(pid core.PeerID, size uint64) error {
-	return fps.IncreaseLoadCalled(pid, size)
+func (fps *FloodPreventerStub) IncreaseLoad(fromConnectedPid core.PeerID, originator core.PeerID, size uint64) error {
+	return fps.IncreaseLoadCalled(fromConnectedPid, originator, size)
 }
 
 // ApplyConsensusSize -

--- a/process/throttle/antiflood/blackList/p2pBlackListProcessor.go
+++ b/process/throttle/antiflood/blackList/p2pBlackListProcessor.go
@@ -114,7 +114,7 @@ func (pbp *p2pBlackListProcessor) AddQuota(pid core.PeerID, numReceived uint32, 
 		return
 	}
 	if pid == pbp.selfPid {
-		log.Warn("current peer should have been blacklisted",
+		log.Debug("current peer should have been blacklisted, it is under flood",
 			"name", pbp.name,
 			"total num messages", numReceived,
 			"total size", sizeReceived,

--- a/process/throttle/antiflood/factory/p2pAntifloodAndBlacklistFactory.go
+++ b/process/throttle/antiflood/factory/p2pAntifloodAndBlacklistFactory.go
@@ -101,6 +101,7 @@ func initP2PAntiFloodAndBlackList(
 	setMaxMessages(topicFloodPreventer, topicMaxMessages)
 
 	p2pAntiflood, err := antiflood.NewP2PAntiflood(
+		currentPid,
 		p2pPeerBlackList,
 		topicFloodPreventer,
 		fastReactingFloodPreventer,
@@ -205,6 +206,7 @@ func createFloodPreventer(
 		PercentReserved:           reservedPercent,
 		IncreaseThreshold:         floodPreventerConfig.PeerMaxInput.IncreaseFactor.Threshold,
 		IncreaseFactor:            floodPreventerConfig.PeerMaxInput.IncreaseFactor.Factor,
+		SelfPid:                   selfPid,
 	}
 	floodPreventer, err := floodPreventers.NewQuotaFloodPreventer(argFloodPreventer)
 	if err != nil {

--- a/process/throttle/antiflood/floodPreventers/export_test.go
+++ b/process/throttle/antiflood/floodPreventers/export_test.go
@@ -31,3 +31,10 @@ func (tfp *topicFloodPreventer) TopicMaxMessages() map[string]uint32 {
 
 	return copiedMaxMessages
 }
+
+func (qfp *quotaFloodPreventer) IncreaseLoadOnPid(pid core.PeerID, size uint64, percentReserved float32) error {
+	qfp.mutOperation.Lock()
+	defer qfp.mutOperation.Unlock()
+
+	return qfp.increaseLoad(pid, size, percentReserved)
+}


### PR DESCRIPTION
- made the close components wait in main.go happen only if the closing did not succeed
- added warnings if messenger will have unprotected topics
- changed the antiflood mechanism so a flooded peer won't further flood the network even in mildly flood scenarios