### PR TITLE
Fix state of meta is stuck 

### DIFF
--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -1615,11 +1615,6 @@ func (sp *shardProcessor) requestMetaHeadersIfNeeded(hdrsAdded uint32, lastMetaH
 func (sp *shardProcessor) createMiniBlocks(haveTime func() bool) (*block.Body, error) {
 	var miniBlocks block.MiniBlockSlice
 
-	if sp.blockTracker.IsShardStuck(core.MetachainShardId) {
-		log.Warn("shardProcessor.createMiniBlocks", "error", process.ErrShardIsStuck, "shard", core.MetachainShardId)
-		return &block.Body{MiniBlocks: miniBlocks}, nil
-	}
-
 	if sp.accountsDB[state.UserAccountsState].JournalLen() != 0 {
 		log.Error("shardProcessor.createMiniBlocks", "error", process.ErrAccountStateDirty)
 		return &block.Body{MiniBlocks: miniBlocks}, nil
@@ -1648,6 +1643,11 @@ func (sp *shardProcessor) createMiniBlocks(haveTime func() bool) (*block.Body, e
 			"num txs", numTxs,
 			"num meta headers", numMetaHeaders,
 		)
+	}
+
+	if sp.blockTracker.IsShardStuck(core.MetachainShardId) {
+		log.Warn("shardProcessor.createMiniBlocks", "error", process.ErrShardIsStuck, "shard", core.MetachainShardId)
+		return &block.Body{MiniBlocks: miniBlocks}, nil
 	}
 
 	startTime = time.Now()


### PR DESCRIPTION
* Fixed situation when shards will consider metachain stuck forever if the state would be set to stuck and because there was no way to reset this state back, as all the created blocks were empty. Shards should process txs cross me where they also would include new meta blocks, so the unstuck state of metachain could be restored.