### PR TITLE
added an error message when are to many request to an observer

### DIFF
--- a/api/middleware/globalThrottler.go
+++ b/api/middleware/globalThrottler.go
@@ -28,7 +28,7 @@ func (gt *globalThrottler) MiddlewareHandlerFunc() gin.HandlerFunc {
 		select {
 		case gt.queue <- struct{}{}:
 		default:
-			c.AbortWithStatus(http.StatusTooManyRequests)
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "too many requests to observer"})
 			return
 		}
 

--- a/node/nodeTransactions.go
+++ b/node/nodeTransactions.go
@@ -205,6 +205,7 @@ func (n *Node) prepareRewardTx(tx *rewardTxData.RewardTx) (*transaction.ApiTrans
 		Round:    tx.GetRound(),
 		Epoch:    tx.GetEpoch(),
 		Value:    tx.GetValue().String(),
+		Sender:   fmt.Sprintf("%d", core.MetachainShardId),
 		Receiver: n.addressPubkeyConverter.Encode(tx.GetRcvAddr()),
 	}, nil
 }


### PR DESCRIPTION
Added metachain id in sender field for reward transactions that are returned by api route `/transaction/:hash`

Also added an return message when `code 429 [TooManyRequests]` is returned by an observer