### PR TITLE
EN 6813 p2p debugger

### DIFF
--- a/debug/p2p/export_test.go
+++ b/debug/p2p/export_test.go
@@ -21,7 +21,7 @@ func newTestP2PDebugger(
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	pd.cancelFunc = cancelFunc
 
-	go pd.doStats(ctx)
+	go pd.continuouslyPrintStatistics(ctx)
 
 	return pd
 }

--- a/debug/p2p/export_test.go
+++ b/debug/p2p/export_test.go
@@ -1,0 +1,27 @@
+package p2p
+
+import (
+	"context"
+
+	"github.com/ElrondNetwork/elrond-go/core"
+)
+
+func newTestP2PDebugger(
+	selfPeerId core.PeerID,
+	shouldProcessDataFn func() bool,
+	printStringFn func(string),
+) *p2pDebugger {
+	pd := &p2pDebugger{
+		selfPeerId: selfPeerId,
+		data:       make(map[string]*metric),
+	}
+	pd.shouldProcessDataFn = shouldProcessDataFn
+	pd.printStringFn = printStringFn
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	pd.cancelFunc = cancelFunc
+
+	go pd.doStats(ctx)
+
+	return pd
+}

--- a/debug/p2p/p2pDebugger.go
+++ b/debug/p2p/p2pDebugger.go
@@ -1,0 +1,213 @@
+package p2p
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-go/core"
+	"github.com/ElrondNetwork/elrond-go/display"
+)
+
+var log = logger.GetOrCreate("debug/p2p")
+
+const printTimeOneSecond = time.Second //if this needs to be changed, remember to divide the values when computing metrics
+
+type metric struct {
+	topic string
+
+	incomingSize         uint64
+	incomingNum          uint32
+	incomingRejectedSize uint64
+	incomingRejectedNum  uint32
+
+	outgoingSize         uint64
+	outgoingNum          uint32
+	outgoingRejectedSize uint64
+	outgoingRejectedNum  uint32
+}
+
+func (m *metric) stringify() []string {
+	return []string{
+		m.topic,
+		fmt.Sprintf("%d / %s/s", m.incomingNum, core.ConvertBytes(m.incomingSize)),
+		fmt.Sprintf("%d / %s/s", m.incomingRejectedNum, core.ConvertBytes(m.incomingRejectedSize)),
+		fmt.Sprintf("%d / %s/s", m.outgoingNum, core.ConvertBytes(m.outgoingSize)),
+		fmt.Sprintf("%d / %s/s", m.outgoingRejectedNum, core.ConvertBytes(m.outgoingRejectedSize)),
+	}
+}
+
+type p2pDebugger struct {
+	selfPeerId          core.PeerID
+	mut                 sync.Mutex
+	data                map[string]*metric
+	cancelFunc          func()
+	shouldProcessDataFn func() bool
+	printStringFn       func(data string)
+}
+
+// NewP2PDebugger creates a new p2p debug instance
+func NewP2PDebugger(selfPeerId core.PeerID) *p2pDebugger {
+	pd := &p2pDebugger{
+		selfPeerId: selfPeerId,
+		data:       make(map[string]*metric),
+	}
+	pd.shouldProcessDataFn = pd.checkLogTrace
+	pd.printStringFn = pd.printLog
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	pd.cancelFunc = cancelFunc
+
+	go pd.doStats(ctx)
+
+	return pd
+}
+
+func (pd *p2pDebugger) checkLogTrace() bool {
+	return log.GetLevel() == logger.LogTrace
+}
+
+func (pd *p2pDebugger) printLog(data string) {
+	log.Trace(fmt.Sprintf("p2p topic stats for %s\n", pd.selfPeerId.Pretty()) + data)
+}
+
+// AddIncomingMessage adds a new incoming message stats in metrics structs
+func (pd *p2pDebugger) AddIncomingMessage(topic string, size uint64, isRejected bool) {
+	if !pd.shouldProcessDataFn() {
+		return
+	}
+
+	pd.mut.Lock()
+	defer pd.mut.Unlock()
+
+	m := pd.getMetric(topic)
+	m.incomingNum++
+	m.incomingSize += size
+	if isRejected {
+		m.incomingRejectedNum++
+		m.incomingRejectedSize += size
+	}
+}
+
+// AddOutgoingMessage adds a new outgoing message stats in metrics structs
+func (pd *p2pDebugger) AddOutgoingMessage(topic string, size uint64, isRejected bool) {
+	if !pd.shouldProcessDataFn() {
+		return
+	}
+
+	pd.mut.Lock()
+	defer pd.mut.Unlock()
+
+	m := pd.getMetric(topic)
+	m.outgoingNum++
+	m.outgoingSize += size
+	if isRejected {
+		m.outgoingRejectedNum++
+		m.outgoingRejectedSize += size
+	}
+}
+
+func (pd *p2pDebugger) getMetric(topic string) *metric {
+	m, ok := pd.data[topic]
+	if !ok {
+		m = &metric{
+			topic: topic,
+		}
+		pd.data[topic] = m
+	}
+
+	return m
+}
+
+func (pd *p2pDebugger) doStats(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(printTimeOneSecond):
+		}
+
+		if !pd.shouldProcessDataFn() {
+			continue
+		}
+
+		str := pd.doStatsString()
+		pd.printStringFn(str)
+	}
+}
+
+func (pd *p2pDebugger) doStatsString() string {
+	header := []string{
+		"Topic",
+		"Incoming (num / size)",
+		"Incoming rejected (num / size)",
+		"Outgoing (num / size)",
+		"Outgoing rejected (num / size)",
+	}
+
+	pd.mut.Lock()
+	defer pd.mut.Unlock()
+
+	metrics := make([]*metric, 0, len(pd.data))
+	total := &metric{
+		topic: "TOTAL",
+	}
+	for _, m := range pd.data {
+		metrics = append(metrics, m)
+
+		total.incomingSize += m.incomingSize
+		total.incomingNum += m.incomingNum
+		total.incomingRejectedSize += m.incomingRejectedSize
+		total.incomingRejectedNum += m.incomingRejectedNum
+		total.outgoingSize += m.outgoingSize
+		total.outgoingNum += m.outgoingNum
+		total.outgoingRejectedSize += m.outgoingRejectedSize
+		total.outgoingRejectedNum += m.outgoingRejectedNum
+	}
+
+	sort.Slice(metrics, func(i, j int) bool {
+		//sort descending by incomingSize + outgoingSize and alphabetically
+		mi := metrics[i]
+		mj := metrics[j]
+
+		miSize := mi.outgoingSize + mi.incomingSize
+		mjSize := mj.outgoingSize + mj.incomingSize
+
+		if miSize == mjSize {
+			return mi.topic < mj.topic
+		}
+
+		return miSize > mjSize
+	})
+
+	lines := make([]*display.LineData, 0, len(metrics)+1)
+	for idx, m := range metrics {
+		horizontalLineAfter := idx == len(metrics)-1
+		lines = append(lines, display.NewLineData(horizontalLineAfter, m.stringify()))
+	}
+	lines = append(lines, display.NewLineData(false, total.stringify()))
+
+	pd.data = make(map[string]*metric)
+
+	tab, err := display.CreateTableString(header, lines)
+	if err != nil {
+		return "error creating p2p stats table: " + err.Error()
+	}
+
+	return tab
+}
+
+// Close will stop any go routines launched by this instance
+func (pd *p2pDebugger) Close() error {
+	pd.cancelFunc()
+
+	return nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (pd *p2pDebugger) IsInterfaceNil() bool {
+	return pd == nil
+}

--- a/debug/p2p/p2pDebugger_test.go
+++ b/debug/p2p/p2pDebugger_test.go
@@ -1,0 +1,227 @@
+package p2p
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go/core"
+	"github.com/ElrondNetwork/elrond-go/core/check"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewP2PDebugger(t *testing.T) {
+	t.Parallel()
+
+	pd := NewP2PDebugger("")
+
+	assert.False(t, check.IfNil(pd))
+}
+
+//------- AddIncomingMessage
+
+func TestP2pDebugger_AddIncomingMessageShouldNotProcessWillNotAdd(t *testing.T) {
+	t.Parallel()
+
+	pd := NewP2PDebugger("")
+	pd.shouldProcessDataFn = func() bool {
+		return false
+	}
+
+	topic := "topic"
+	size := uint64(3857)
+	pd.AddIncomingMessage(topic, size, false)
+
+	m := pd.data[topic]
+	assert.Nil(t, m)
+}
+
+func TestP2pDebugger_AddIncomingMessage(t *testing.T) {
+	t.Parallel()
+
+	pd := NewP2PDebugger("")
+	pd.shouldProcessDataFn = func() bool {
+		return true
+	}
+
+	topic := "topic"
+	size := uint64(3857)
+	pd.AddIncomingMessage(topic, size, false)
+
+	m := pd.data[topic]
+	require.NotNil(t, m)
+
+	expectedMetric := &metric{
+		topic:                topic,
+		incomingSize:         size,
+		incomingNum:          1,
+		incomingRejectedSize: 0,
+		incomingRejectedNum:  0,
+		outgoingSize:         0,
+		outgoingNum:          0,
+		outgoingRejectedSize: 0,
+		outgoingRejectedNum:  0,
+	}
+	assert.Equal(t, expectedMetric, m)
+
+	pd.AddIncomingMessage(topic, size, true)
+
+	expectedMetric = &metric{
+		topic:                topic,
+		incomingSize:         size + size,
+		incomingNum:          2,
+		incomingRejectedSize: size,
+		incomingRejectedNum:  1,
+		outgoingSize:         0,
+		outgoingNum:          0,
+		outgoingRejectedSize: 0,
+		outgoingRejectedNum:  0,
+	}
+	assert.Equal(t, expectedMetric, m)
+}
+
+//------- AddOutgoingMessage
+
+func TestP2pDebugger_AddOutgoingMessageShouldNotProcessWillNotAdd(t *testing.T) {
+	t.Parallel()
+
+	pd := NewP2PDebugger("")
+	pd.shouldProcessDataFn = func() bool {
+		return false
+	}
+
+	topic := "topic"
+	size := uint64(3857)
+	pd.AddOutgoingMessage(topic, size, false)
+
+	m := pd.data[topic]
+	assert.Nil(t, m)
+}
+
+func TestP2pDebugger_AddOutgoingMessage(t *testing.T) {
+	t.Parallel()
+
+	pd := NewP2PDebugger("")
+	pd.shouldProcessDataFn = func() bool {
+		return true
+	}
+
+	topic := "topic"
+	size := uint64(3857)
+	pd.AddOutgoingMessage(topic, size, false)
+
+	m := pd.data[topic]
+	require.NotNil(t, m)
+
+	expectedMetric := &metric{
+		topic:                topic,
+		incomingSize:         0,
+		incomingNum:          0,
+		incomingRejectedSize: 0,
+		incomingRejectedNum:  0,
+		outgoingSize:         size,
+		outgoingNum:          1,
+		outgoingRejectedSize: 0,
+		outgoingRejectedNum:  0,
+	}
+	assert.Equal(t, expectedMetric, m)
+
+	pd.AddOutgoingMessage(topic, size, true)
+
+	expectedMetric = &metric{
+		topic:                topic,
+		incomingSize:         0,
+		incomingNum:          0,
+		incomingRejectedSize: 0,
+		incomingRejectedNum:  0,
+		outgoingSize:         size + size,
+		outgoingNum:          2,
+		outgoingRejectedSize: size,
+		outgoingRejectedNum:  1,
+	}
+	assert.Equal(t, expectedMetric, m)
+}
+
+//------- doStats
+
+func TestP2pDebugger_doStatsShouldNotPrint(t *testing.T) {
+	t.Parallel()
+
+	pd := NewP2PDebugger("")
+	pd.shouldProcessDataFn = func() bool {
+		return false
+	}
+	numPrintWasCalled := int32(0)
+	pd.printStringFn = func(data string) {
+		atomic.AddInt32(&numPrintWasCalled, 1)
+	}
+
+	time.Sleep(printTimeOneSecond * 3)
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&numPrintWasCalled))
+}
+
+func TestP2pDebugger_doStatsShouldPrint(t *testing.T) {
+	t.Parallel()
+
+	pd := NewP2PDebugger("")
+	pd.shouldProcessDataFn = func() bool {
+		return true
+	}
+	numPrintWasCalled := int32(0)
+	pd.printStringFn = func(data string) {
+		atomic.AddInt32(&numPrintWasCalled, 1)
+	}
+
+	time.Sleep(printTimeOneSecond*3 + time.Millisecond*100)
+
+	assert.Equal(t, int32(3), atomic.LoadInt32(&numPrintWasCalled))
+}
+
+func TestP2pDebugger_doStatsCloseShouldStop(t *testing.T) {
+	t.Parallel()
+
+	pd := NewP2PDebugger("")
+	pd.shouldProcessDataFn = func() bool {
+		return true
+	}
+	numPrintWasCalled := int32(0)
+	pd.printStringFn = func(data string) {
+		atomic.AddInt32(&numPrintWasCalled, 1)
+	}
+
+	time.Sleep(printTimeOneSecond*3 + time.Millisecond*100)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&numPrintWasCalled))
+
+	err := pd.Close()
+	assert.Nil(t, err)
+
+	time.Sleep(printTimeOneSecond*3 + time.Millisecond*100)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&numPrintWasCalled))
+}
+
+func TestP2pDebugger_doStatsString(t *testing.T) {
+	t.Parallel()
+
+	pd := NewP2PDebugger("")
+	pd.shouldProcessDataFn = func() bool {
+		return true
+	}
+
+	topic1 := "testTopic1"
+	size1 := uint64(3 * 1048576) //3MB
+	topic2 := "testTopic2"
+	size2 := uint64(5 * 1024) //5kB
+	pd.AddIncomingMessage(topic1, size1, false)
+	pd.AddOutgoingMessage(topic2, size2, false)
+
+	str := pd.doStatsString()
+
+	assert.True(t, strings.Contains(str, topic1))
+	assert.True(t, strings.Contains(str, core.ConvertBytes(size1)))
+
+	assert.True(t, strings.Contains(str, topic2))
+	assert.True(t, strings.Contains(str, core.ConvertBytes(size2)))
+}

--- a/debug/p2p/p2pDebugger_test.go
+++ b/debug/p2p/p2pDebugger_test.go
@@ -12,6 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func mockPrintFn(string) {}
+func shouldCompute() bool {
+	return true
+}
+func shouldNotCompute() bool {
+	return false
+}
+
 func TestNewP2PDebugger(t *testing.T) {
 	t.Parallel()
 
@@ -25,10 +33,11 @@ func TestNewP2PDebugger(t *testing.T) {
 func TestP2pDebugger_AddIncomingMessageShouldNotProcessWillNotAdd(t *testing.T) {
 	t.Parallel()
 
-	pd := NewP2PDebugger("")
-	pd.shouldProcessDataFn = func() bool {
-		return false
-	}
+	pd := newTestP2PDebugger(
+		"",
+		shouldNotCompute,
+		mockPrintFn,
+	)
 
 	topic := "topic"
 	size := uint64(3857)
@@ -41,10 +50,11 @@ func TestP2pDebugger_AddIncomingMessageShouldNotProcessWillNotAdd(t *testing.T) 
 func TestP2pDebugger_AddIncomingMessage(t *testing.T) {
 	t.Parallel()
 
-	pd := NewP2PDebugger("")
-	pd.shouldProcessDataFn = func() bool {
-		return true
-	}
+	pd := newTestP2PDebugger(
+		"",
+		shouldCompute,
+		mockPrintFn,
+	)
 
 	topic := "topic"
 	size := uint64(3857)
@@ -87,10 +97,11 @@ func TestP2pDebugger_AddIncomingMessage(t *testing.T) {
 func TestP2pDebugger_AddOutgoingMessageShouldNotProcessWillNotAdd(t *testing.T) {
 	t.Parallel()
 
-	pd := NewP2PDebugger("")
-	pd.shouldProcessDataFn = func() bool {
-		return false
-	}
+	pd := newTestP2PDebugger(
+		"",
+		shouldNotCompute,
+		mockPrintFn,
+	)
 
 	topic := "topic"
 	size := uint64(3857)
@@ -103,10 +114,11 @@ func TestP2pDebugger_AddOutgoingMessageShouldNotProcessWillNotAdd(t *testing.T) 
 func TestP2pDebugger_AddOutgoingMessage(t *testing.T) {
 	t.Parallel()
 
-	pd := NewP2PDebugger("")
-	pd.shouldProcessDataFn = func() bool {
-		return true
-	}
+	pd := newTestP2PDebugger(
+		"",
+		shouldCompute,
+		mockPrintFn,
+	)
 
 	topic := "topic"
 	size := uint64(3857)
@@ -149,14 +161,14 @@ func TestP2pDebugger_AddOutgoingMessage(t *testing.T) {
 func TestP2pDebugger_doStatsShouldNotPrint(t *testing.T) {
 	t.Parallel()
 
-	pd := NewP2PDebugger("")
-	pd.shouldProcessDataFn = func() bool {
-		return false
-	}
 	numPrintWasCalled := int32(0)
-	pd.printStringFn = func(data string) {
-		atomic.AddInt32(&numPrintWasCalled, 1)
-	}
+	_ = newTestP2PDebugger(
+		"",
+		shouldNotCompute,
+		func(data string) {
+			atomic.AddInt32(&numPrintWasCalled, 1)
+		},
+	)
 
 	time.Sleep(printTimeOneSecond * 3)
 
@@ -166,14 +178,14 @@ func TestP2pDebugger_doStatsShouldNotPrint(t *testing.T) {
 func TestP2pDebugger_doStatsShouldPrint(t *testing.T) {
 	t.Parallel()
 
-	pd := NewP2PDebugger("")
-	pd.shouldProcessDataFn = func() bool {
-		return true
-	}
 	numPrintWasCalled := int32(0)
-	pd.printStringFn = func(data string) {
-		atomic.AddInt32(&numPrintWasCalled, 1)
-	}
+	_ = newTestP2PDebugger(
+		"",
+		shouldCompute,
+		func(data string) {
+			atomic.AddInt32(&numPrintWasCalled, 1)
+		},
+	)
 
 	time.Sleep(printTimeOneSecond*3 + time.Millisecond*100)
 
@@ -183,14 +195,14 @@ func TestP2pDebugger_doStatsShouldPrint(t *testing.T) {
 func TestP2pDebugger_doStatsCloseShouldStop(t *testing.T) {
 	t.Parallel()
 
-	pd := NewP2PDebugger("")
-	pd.shouldProcessDataFn = func() bool {
-		return true
-	}
 	numPrintWasCalled := int32(0)
-	pd.printStringFn = func(data string) {
-		atomic.AddInt32(&numPrintWasCalled, 1)
-	}
+	pd := newTestP2PDebugger(
+		"",
+		shouldCompute,
+		func(data string) {
+			atomic.AddInt32(&numPrintWasCalled, 1)
+		},
+	)
 
 	time.Sleep(printTimeOneSecond*3 + time.Millisecond*100)
 	assert.Equal(t, int32(3), atomic.LoadInt32(&numPrintWasCalled))
@@ -205,10 +217,11 @@ func TestP2pDebugger_doStatsCloseShouldStop(t *testing.T) {
 func TestP2pDebugger_doStatsString(t *testing.T) {
 	t.Parallel()
 
-	pd := NewP2PDebugger("")
-	pd.shouldProcessDataFn = func() bool {
-		return true
-	}
+	pd := newTestP2PDebugger(
+		"",
+		shouldCompute,
+		mockPrintFn,
+	)
 
 	topic1 := "testTopic1"
 	size1 := uint64(3 * 1048576) //3MB

--- a/debug/p2p/p2pDebugger_test.go
+++ b/debug/p2p/p2pDebugger_test.go
@@ -156,9 +156,9 @@ func TestP2pDebugger_AddOutgoingMessage(t *testing.T) {
 	assert.Equal(t, expectedMetric, m)
 }
 
-//------- doStats
+//------- continuouslyPrintStatistics
 
-func TestP2pDebugger_doStatsShouldNotPrint(t *testing.T) {
+func TestP2pDebugger_continuouslyPrintStatisticsShouldNotPrint(t *testing.T) {
 	t.Parallel()
 
 	numPrintWasCalled := int32(0)
@@ -170,12 +170,12 @@ func TestP2pDebugger_doStatsShouldNotPrint(t *testing.T) {
 		},
 	)
 
-	time.Sleep(printTimeOneSecond * 3)
+	time.Sleep(printInterval * 3)
 
 	assert.Equal(t, int32(0), atomic.LoadInt32(&numPrintWasCalled))
 }
 
-func TestP2pDebugger_doStatsShouldPrint(t *testing.T) {
+func TestP2pDebugger_continuouslyPrintStatisticsShouldPrint(t *testing.T) {
 	t.Parallel()
 
 	numPrintWasCalled := int32(0)
@@ -187,12 +187,12 @@ func TestP2pDebugger_doStatsShouldPrint(t *testing.T) {
 		},
 	)
 
-	time.Sleep(printTimeOneSecond*3 + time.Millisecond*100)
+	time.Sleep(printInterval*3 + time.Millisecond*100)
 
 	assert.Equal(t, int32(3), atomic.LoadInt32(&numPrintWasCalled))
 }
 
-func TestP2pDebugger_doStatsCloseShouldStop(t *testing.T) {
+func TestP2pDebugger_continuouslyPrintStatisticsCloseShouldStop(t *testing.T) {
 	t.Parallel()
 
 	numPrintWasCalled := int32(0)
@@ -204,17 +204,17 @@ func TestP2pDebugger_doStatsCloseShouldStop(t *testing.T) {
 		},
 	)
 
-	time.Sleep(printTimeOneSecond*3 + time.Millisecond*100)
+	time.Sleep(printInterval*3 + time.Millisecond*100)
 	assert.Equal(t, int32(3), atomic.LoadInt32(&numPrintWasCalled))
 
 	err := pd.Close()
 	assert.Nil(t, err)
 
-	time.Sleep(printTimeOneSecond*3 + time.Millisecond*100)
+	time.Sleep(printInterval*3 + time.Millisecond*100)
 	assert.Equal(t, int32(3), atomic.LoadInt32(&numPrintWasCalled))
 }
 
-func TestP2pDebugger_doStatsString(t *testing.T) {
+func TestP2pDebugger_statsToString(t *testing.T) {
 	t.Parallel()
 
 	pd := newTestP2PDebugger(
@@ -230,7 +230,7 @@ func TestP2pDebugger_doStatsString(t *testing.T) {
 	pd.AddIncomingMessage(topic1, size1, false)
 	pd.AddOutgoingMessage(topic2, size2, false)
 
-	str := pd.doStatsString()
+	str := pd.statsToString(1)
 
 	assert.True(t, strings.Contains(str, topic1))
 	assert.True(t, strings.Contains(str, core.ConvertBytes(size1)))

--- a/integrationTests/longTests/antiflooding/antiflooding_test.go
+++ b/integrationTests/longTests/antiflooding/antiflooding_test.go
@@ -56,6 +56,20 @@ func createWorkableConfig() config.Config {
 					PeerBanDurationInSeconds:        3600,
 				},
 			},
+			OutOfSpecs: config.FloodPreventerConfig{
+				IntervalInSeconds: 1,
+				ReservedPercent:   0,
+				PeerMaxInput: config.AntifloodLimitsConfig{
+					BaseMessagesPerInterval: 1000,
+					TotalSizePerInterval:    8388608,
+				},
+				BlackList: config.BlackListConfig{
+					ThresholdNumMessagesPerInterval: 1500,
+					ThresholdSizePerInterval:        10485760,
+					NumFloodingRounds:               2,
+					PeerBanDurationInSeconds:        3600,
+				},
+			},
 			Topic: config.TopicAntifloodConfig{
 				DefaultMaxMessagesPerSec: 10000,
 			},

--- a/p2p/libp2p/export_test.go
+++ b/p2p/libp2p/export_test.go
@@ -27,8 +27,8 @@ func (netMes *networkMessenger) SetPeerDiscoverer(discoverer p2p.PeerDiscoverer)
 	netMes.peerDiscoverer = discoverer
 }
 
-func (netMes *networkMessenger) PubsubCallback(handler p2p.MessageProcessor) func(ctx context.Context, pid peer.ID, message *pubsub.Message) bool {
-	return netMes.pubsubCallback(handler)
+func (netMes *networkMessenger) PubsubCallback(handler p2p.MessageProcessor, topic string) func(ctx context.Context, pid peer.ID, message *pubsub.Message) bool {
+	return netMes.pubsubCallback(handler, topic)
 }
 
 func (ds *directSender) ProcessReceivedDirectMessage(message *pubsub_pb.Message, fromConnectedPeer peer.ID) error {

--- a/p2p/libp2p/netMessenger_test.go
+++ b/p2p/libp2p/netMessenger_test.go
@@ -471,7 +471,7 @@ func TestLibp2pMessenger_BroadcastOnChannelBlockingShouldLimitNumberOfGoRoutines
 	}
 
 	msg := []byte("test message")
-	numBroadcasts := 2 * libp2p.BroadcastGoRoutines
+	numBroadcasts := libp2p.BroadcastGoRoutines + 1
 
 	ch := make(chan *p2p.SendableData)
 

--- a/p2p/libp2p/netMessenger_test.go
+++ b/p2p/libp2p/netMessenger_test.go
@@ -1203,7 +1203,7 @@ func TestNetworkMessenger_MessageIdsCacherShouldPreventReprocessing(t *testing.T
 		},
 	}
 
-	callBackFunc := mes.PubsubCallback(handler)
+	callBackFunc := mes.PubsubCallback(handler, "")
 	ctx := context.Background()
 	pid := peer.ID(mes.ID())
 	msg := &pubsub.Message{
@@ -1256,7 +1256,7 @@ func TestNetworkMessenger_PubsubCallbackNotMessageNotValidShouldNotCallHandler(t
 		},
 	}
 
-	callBackFunc := mes.PubsubCallback(handler)
+	callBackFunc := mes.PubsubCallback(handler, "")
 	ctx := context.Background()
 	pid := peer.ID(mes.ID())
 	msg := &pubsub.Message{
@@ -1308,7 +1308,7 @@ func TestNetworkMessenger_PubsubCallbackReturnsFalseIfHandlerErrors(t *testing.T
 		},
 	}
 
-	callBackFunc := mes.PubsubCallback(handler)
+	callBackFunc := mes.PubsubCallback(handler, "")
 	ctx := context.Background()
 	pid := peer.ID(mes.ID())
 	msg := &pubsub.Message{

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -277,3 +277,10 @@ type Cacher interface {
 	HasOrAdd(key []byte, value interface{}, sizeInBytes int) (ok, evicted bool)
 	IsInterfaceNil() bool
 }
+
+type Debugger interface {
+	AddIncomingMessage(topic string, size uint64, isRejected bool)
+	AddOutgoingMessage(topic string, size uint64, isRejected bool)
+	Close() error
+	IsInterfaceNil() bool
+}

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -278,6 +278,7 @@ type Cacher interface {
 	IsInterfaceNil() bool
 }
 
+// Debugger represent a p2p debugger able to print p2p statistics (messages received/sent per topic)
 type Debugger interface {
 	AddIncomingMessage(topic string, size uint64, isRejected bool)
 	AddOutgoingMessage(topic string, size uint64, isRejected bool)


### PR DESCRIPTION
- added p2p debugger component that will display bandwidth used by a node split by topic usage.
To enable it, run the node with `*:INFO,debug/p2p:TRACE`