### PR TITLE
changed the message displayed when a key is not available in termui

### DIFF
--- a/statusHandler/presenter/blockInfoGetters_test.go
+++ b/statusHandler/presenter/blockInfoGetters_test.go
@@ -80,7 +80,7 @@ func TestPresenterStatusHandler_GetConsensusStateShouldReturnErrorMessageInvalid
 	presenterStatusHandler.SetUInt64Value(core.MetricConsensusState, consensusState)
 	result := presenterStatusHandler.GetConsensusState()
 
-	assert.Equal(t, invalidType, result)
+	assert.Equal(t, metricNotAvailable, result)
 }
 
 func TestPresenterStatusHandler_GetConsensusStateShouldReturnErrorMessageInvalidKey(t *testing.T) {
@@ -89,7 +89,7 @@ func TestPresenterStatusHandler_GetConsensusStateShouldReturnErrorMessageInvalid
 	presenterStatusHandler := NewPresenterStatusHandler()
 	result := presenterStatusHandler.GetConsensusState()
 
-	assert.Equal(t, invalidKey, result)
+	assert.Equal(t, metricNotAvailable, result)
 }
 
 func TestPresenterStatusHandler_GetConsensusRoundStateState(t *testing.T) {

--- a/statusHandler/presenter/common.go
+++ b/statusHandler/presenter/common.go
@@ -6,8 +6,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/core"
 )
 
-const invalidKey = "N/A"
-const invalidType = "[not a string]"
+const metricNotAvailable = "N/A"
 
 func (psh *PresenterStatusHandler) getFromCacheAsUint64(metric string) uint64 {
 	val, ok := psh.presenterMetrics.Load(metric)
@@ -26,12 +25,12 @@ func (psh *PresenterStatusHandler) getFromCacheAsUint64(metric string) uint64 {
 func (psh *PresenterStatusHandler) getFromCacheAsString(metric string) string {
 	val, ok := psh.presenterMetrics.Load(metric)
 	if !ok {
-		return invalidKey
+		return metricNotAvailable
 	}
 
 	valStr, ok := val.(string)
 	if !ok {
-		return invalidType
+		return metricNotAvailable
 	}
 
 	return valStr

--- a/statusHandler/presenter/common.go
+++ b/statusHandler/presenter/common.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/core"
 )
 
-const invalidKey = "[invalid key]"
+const invalidKey = "N/A"
 const invalidType = "[not a string]"
 
 func (psh *PresenterStatusHandler) getFromCacheAsUint64(metric string) uint64 {


### PR DESCRIPTION
changed the message displayed when a key is missing in TermUI from `[key not found]` to `N/A`. Before, that message wasn't displayed correctly and could lead to references to the validator key. 