### PR TITLE
Fix block size throttle

### DIFF
--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -880,7 +880,7 @@ func (mp *metaProcessor) createAndProcessCrossMiniBlocksDstMe(
 			break
 		}
 
-		if hdrsAdded > process.MaxShardHeadersAllowedInOneMetaBlock {
+		if hdrsAdded >= process.MaxShardHeadersAllowedInOneMetaBlock {
 			log.Debug("maximum shard headers allowed to be included in one meta block has been reached",
 				"shard headers added", hdrsAdded,
 			)
@@ -896,7 +896,7 @@ func (mp *metaProcessor) createAndProcessCrossMiniBlocksDstMe(
 			continue
 		}
 
-		if hdrsAddedForShard[currShardHdr.GetShardID()] > maxShardHeadersFromSameShard {
+		if hdrsAddedForShard[currShardHdr.GetShardID()] >= maxShardHeadersFromSameShard {
 			log.Trace("maximum shard headers from same shard allowed to be included in one meta block has been reached",
 				"shard", currShardHdr.GetShardID(),
 				"shard headers added", hdrsAddedForShard[currShardHdr.GetShardID()],

--- a/process/block/poolsCleaner/txsPoolsCleaner.go
+++ b/process/block/poolsCleaner/txsPoolsCleaner.go
@@ -178,10 +178,11 @@ func (tpc *txsPoolsCleaner) processReceivedTx(
 	receiverShardID uint32,
 	txType int8,
 ) {
-	tpc.mutMapTxsRounds.Lock()
-	defer tpc.mutMapTxsRounds.Unlock()
+	tpc.mutMapTxsRounds.RLock()
+	_, ok := tpc.mapTxsRounds[string(key)]
+	tpc.mutMapTxsRounds.RUnlock()
 
-	if _, ok := tpc.mapTxsRounds[string(key)]; !ok {
+	if !ok {
 		transactionPool := tpc.getTransactionPool(txType)
 		if transactionPool == nil {
 			return
@@ -201,7 +202,9 @@ func (tpc *txsPoolsCleaner) processReceivedTx(
 			txStore:         txStore,
 		}
 
+		tpc.mutMapTxsRounds.Lock()
 		tpc.mapTxsRounds[string(key)] = currTxInfo
+		tpc.mutMapTxsRounds.Unlock()
 
 		log.Trace("transaction has been added",
 			"hash", key,

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -1524,7 +1524,7 @@ func (sp *shardProcessor) createAndProcessMiniBlocksDstMe(
 			break
 		}
 
-		if hdrsAdded > process.MaxMetaHeadersAllowedInOneShardBlock {
+		if hdrsAdded >= process.MaxMetaHeadersAllowedInOneShardBlock {
 			log.Debug("maximum meta headers allowed to be included in one shard block has been reached",
 				"meta headers added", hdrsAdded,
 			)

--- a/process/constants.go
+++ b/process/constants.go
@@ -94,10 +94,10 @@ const MaxShardNoncesBehind = 15
 const MaxRoundsWithoutNewBlockReceived = 10
 
 // MaxMetaHeadersAllowedInOneShardBlock defines the maximum meta headers allowed to be included in one shard block
-const MaxMetaHeadersAllowedInOneShardBlock = 100
+const MaxMetaHeadersAllowedInOneShardBlock = 50
 
 // MaxShardHeadersAllowedInOneMetaBlock defines the maximum shard headers allowed to be included in one meta block
-const MaxShardHeadersAllowedInOneMetaBlock = 100
+const MaxShardHeadersAllowedInOneMetaBlock = 50
 
 // MaxNumOfTxsToSelect defines the maximum number of transactions that should be selected from the cache
 const MaxNumOfTxsToSelect = 30000

--- a/process/factory/interceptorscontainer/baseInterceptorsContainerFactory.go
+++ b/process/factory/interceptorscontainer/baseInterceptorsContainerFactory.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/sharding"
 )
 
-const numGoRoutines = 2000
+const numGoRoutines = 100
 
 type baseInterceptorsContainerFactory struct {
 	container              process.InterceptorsContainer

--- a/process/throttle/block.go
+++ b/process/throttle/block.go
@@ -13,8 +13,8 @@ var _ process.BlockSizeThrottler = (*blockSizeThrottle)(nil)
 var log = logger.GetOrCreate("process/throttle")
 
 const (
-	jumpAbovePercent        = 90
-	jumpBelowPercent        = 90
+	jumpAbovePercent        = 75
+	jumpBelowPercent        = 75
 	jumpAboveFactor         = 0.5
 	jumpBelowFactor         = 0.5
 	maxNumOfStatistics      = 600
@@ -59,9 +59,6 @@ func (bst *blockSizeThrottle) GetCurrentMaxSize() uint32 {
 
 // Add adds the new size for last block which has been sent in the given round
 func (bst *blockSizeThrottle) Add(round uint64, size uint32) {
-	if size < bst.minSize || size > bst.maxSize {
-		return
-	}
 	bst.mutThrottler.Lock()
 	bst.statistics = append(
 		bst.statistics,

--- a/process/throttle/block_test.go
+++ b/process/throttle/block_test.go
@@ -11,7 +11,7 @@ import (
 const minSizeInBytes = uint32(core.MegabyteSize * 10 / 100)
 const maxSizeInBytes = uint32(core.MegabyteSize * 90 / 100)
 const testMaxSizeInBytes = maxSizeInBytes / 1000 * 900
-const testMediumSizeInBytes = maxSizeInBytes / 1000 * 800
+const testMediumSizeInBytes = maxSizeInBytes / 1000 * 650
 const testHalfSizeInBytes = maxSizeInBytes / 1000 * 450
 
 func TestNewBlockSizeThrottle_ShouldWork(t *testing.T) {


### PR DESCRIPTION
* Optimized mutex Lock/Unlock in txsPoolsCleaner component
* Tweaked some parameters in createAndProcessCrossMiniBlocksDstMe (how many shard/meta headers should be included in one block)
* Reduced number of go routines from 2000 to 100
* Tweaked some parameters in blockSizeThrottle component to speed up adaptivity to the network conditions
* Fixed a situation when block max size, from blockSizeThrottle component,  is increased to slow after a network problem