### PR TITLE
Fixed intercepted txs test

### DIFF
--- a/integrationTests/multiShard/transaction/interceptedResolvedBulkTx/interceptedResolvedBulkTx_test.go
+++ b/integrationTests/multiShard/transaction/interceptedResolvedBulkTx/interceptedResolvedBulkTx_test.go
@@ -213,7 +213,7 @@ func TestNode_InterceptorBulkTxsSentFromOtherShardShouldBeRoutedInSenderShardAnd
 		}
 	}()
 
-	txToSend := 10
+	txToSend := 2
 
 	shardRequester := uint32(5)
 	randomShard := uint32(2)


### PR DESCRIPTION
- reduced the number of transactions generated and sent in TestNode_InterceptorBulkTxsSentFromOtherShardShouldBeRoutedInSenderShardAndRequestShouldWork