### PR TITLE
bugFix/shuffle-out-epoch-1-restart

### DIFF
--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -340,9 +340,9 @@ func (e *epochStartBootstrap) Bootstrap() (Parameters, error) {
 	}
 
 	isStartInEpochZero := e.isStartInEpochZero()
-	isCurrentEpochIsSaved := e.computeIfCurrentEpochIsSaved()
+	isCurrentEpochSaved := e.computeIfCurrentEpochIsSaved()
 
-	if isStartInEpochZero || isCurrentEpochIsSaved {
+	if isStartInEpochZero || isCurrentEpochSaved {
 		if e.baseData.lastEpoch == e.startEpoch {
 			return e.prepareEpochZero()
 		}

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -339,7 +339,10 @@ func (e *epochStartBootstrap) Bootstrap() (Parameters, error) {
 		return Parameters{}, err
 	}
 
-	if e.isStartInEpochZero() || e.computeIfCurrentEpochIsSaved() {
+	isStartInEpochZero := e.isStartInEpochZero()
+	isCurrentEpochIsSaved := e.computeIfCurrentEpochIsSaved()
+
+	if isStartInEpochZero || isCurrentEpochIsSaved {
 		if e.baseData.lastEpoch == e.startEpoch {
 			return e.prepareEpochZero()
 		}


### PR DESCRIPTION
edge case fix when reshuffling in early epoch 1, the node currently thinks it should start in epoch 0.