### PR TITLE
[RC] fix destination shard as observer

### DIFF
--- a/cmd/node/config/prefs.toml
+++ b/cmd/node/config/prefs.toml
@@ -1,7 +1,8 @@
 [Preferences]
-   # DestinationShardAsObserver represents the desired shard when running as observer
+   # DestinationShardAsObserver represents the desired shard when running as observer.
    # value will be given as string. For example: "0", "1", "15", "metachain"
-   DestinationShardAsObserver = "0"
+   # if "disabled" is provided then the node will start in the corresponding shard for its public key or 0 otherwise
+   DestinationShardAsObserver = "disabled"
 
    # NodeDisplayName represents the friendly name a user can pick for his node in the status monitor
    NodeDisplayName = ""

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -87,6 +87,7 @@ const (
 	defaultStaticDbString        = "Static"
 	defaultShardString           = "Shard"
 	metachainShardName           = "metachain"
+	notSetDestinationShardID     = "disabled"
 	secondsToWaitForP2PBootstrap = 20
 	maxNumGoRoutinesTxsByHashApi = 10
 	maxTimeToClose               = 10 * time.Second
@@ -1653,6 +1654,9 @@ func createShardCoordinator(
 		log.Info("starting as observer node")
 
 		selfShardId, err = processDestinationShardAsObserver(prefsConfig)
+		if selfShardId == core.DefaultShardIDAsObserver {
+			selfShardId = uint32(0)
+		}
 	}
 	if err != nil {
 		return nil, "", err
@@ -1692,6 +1696,9 @@ func createNodesCoordinator(
 	shardIDAsObserver, err := processDestinationShardAsObserver(prefsConfig)
 	if err != nil {
 		return nil, err
+	}
+	if shardIDAsObserver == core.DefaultShardIDAsObserver {
+		shardIDAsObserver = uint32(0)
 	}
 
 	nbShards := nodesConfig.NumberOfShards()
@@ -1792,6 +1799,9 @@ func processDestinationShardAsObserver(prefsConfig config.PreferencesConfig) (ui
 	destShard := strings.ToLower(prefsConfig.DestinationShardAsObserver)
 	if len(destShard) == 0 {
 		return 0, errors.New("option DestinationShardAsObserver is not set in prefs.toml")
+	}
+	if destShard == notSetDestinationShardID {
+		return core.DefaultShardIDAsObserver, nil
 	}
 	if destShard == metachainShardName {
 		return core.MetachainShardId, nil

--- a/core/constants.go
+++ b/core/constants.go
@@ -36,6 +36,10 @@ const CombinedPeerType = "%s (%s)"
 // the appVersion flag
 const UnVersionedAppString = "undefined"
 
+// DefaultShardIDAsObserver defines the uint32 identifier which tells that the node hasn't configured any preferred
+// shard to start in
+const DefaultShardIDAsObserver = uint32(0xFFFFFFFF) - 7
+
 // NodeType represents the node's role in the network
 type NodeType string
 

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -250,9 +250,13 @@ func (e *epochStartBootstrap) prepareEpochZero() (Parameters, error) {
 		return Parameters{}, err
 	}
 
+	shardIDToReturn := e.genesisShardCoordinator.SelfId()
+	if shardIDToReturn != e.destinationShardAsObserver && e.destinationShardAsObserver != core.DefaultShardIDAsObserver {
+		shardIDToReturn = e.destinationShardAsObserver
+	}
 	parameters := Parameters{
 		Epoch:       0,
-		SelfShardId: e.genesisShardCoordinator.SelfId(),
+		SelfShardId: shardIDToReturn,
 		NumOfShards: e.genesisShardCoordinator.NumberOfShards(),
 	}
 	return parameters, nil
@@ -593,6 +597,9 @@ func (e *epochStartBootstrap) processNodesConfig(pubKey []byte) error {
 	}
 
 	e.nodesConfig, e.baseData.shardId, err = e.nodesConfigHandler.NodesConfigFromMetaBlock(e.epochStartMeta, e.prevEpochStartMeta)
+	if e.destinationShardAsObserver != core.DefaultShardIDAsObserver {
+		e.baseData.shardId = e.destinationShardAsObserver
+	}
 	return err
 }
 


### PR DESCRIPTION
refactored the way `DestinationShardAsObserver` works inside `epochBootstrapper` so if a shard is set it will "force" the node to start in the specified shard. Before this, the specified information could have been ignored. Now if a value different than `disabled` is set, the node will start in the shard specified in the `prefs.toml` file or using the `--destination-shard-as-observer` flag.