### PR TITLE
Fix whitelisting of nonce/epoch requests

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -766,7 +766,6 @@ func newShardInterceptorContainerFactory(
 		WhiteListHandler:        whiteListHandler,
 		WhiteListerVerifiedTxs:  whiteListerVerifiedTxs,
 		AntifloodHandler:        network.InputAntifloodHandler,
-		NonceConverter:          dataCore.Uint64ByteSliceConverter,
 	}
 	interceptorContainerFactory, err := interceptorscontainer.NewShardInterceptorsContainerFactory(shardInterceptorsContainerFactoryArgs)
 	if err != nil {
@@ -821,7 +820,6 @@ func newMetaInterceptorContainerFactory(
 		WhiteListHandler:        whiteListHandler,
 		WhiteListerVerifiedTxs:  whiteListerVerifiedTxs,
 		AntifloodHandler:        network.InputAntifloodHandler,
-		NonceConverter:          dataCore.Uint64ByteSliceConverter,
 	}
 	interceptorContainerFactory, err := interceptorscontainer.NewMetaInterceptorsContainerFactory(metaInterceptorsContainerFactoryArgs)
 	if err != nil {

--- a/dataRetriever/requestHandlers/requestHandler.go
+++ b/dataRetriever/requestHandlers/requestHandler.go
@@ -21,6 +21,8 @@ var log = logger.GetOrCreate("dataretriever/requesthandlers")
 const minHashesToRequest = 10
 const timeToAccumulateTrieHashes = 100 * time.Millisecond
 
+//TODO move the keys definitions that are whitelisted in core and use them in InterceptedData implementations, Identifiers() function
+
 type resolverRequestHandler struct {
 	epoch                 uint32
 	shardID               uint32

--- a/epochStart/bootstrap/factory/epochStartInterceptorsContainerFactory.go
+++ b/epochStart/bootstrap/factory/epochStartInterceptorsContainerFactory.go
@@ -93,7 +93,6 @@ func NewEpochStartInterceptorsContainer(args ArgsEpochStartInterceptorContainer)
 		WhiteListHandler:        args.WhiteListHandler,
 		WhiteListerVerifiedTxs:  args.WhiteListerVerifiedTxs,
 		AntifloodHandler:        antiFloodHandler,
-		NonceConverter:          args.NonceConverter,
 	}
 
 	interceptorsContainerFactory, err := interceptorscontainer.NewMetaInterceptorsContainerFactory(containerFactoryArgs)

--- a/epochStart/bootstrap/syncEpochStartMeta.go
+++ b/epochStart/bootstrap/syncEpochStartMeta.go
@@ -106,7 +106,6 @@ func NewEpochStartMetaSyncer(args ArgsNewEpochStartMetaSyncer) (*epochStartMetaS
 		HeaderIntegrityVerifier: headerIntegrityVerifier,
 		ValidityAttester:        disabled.NewValidityAttester(),
 		EpochStartTrigger:       disabled.NewEpochStartTrigger(),
-		NonceConverter:          args.NonceConverter,
 	}
 
 	interceptedMetaHdrDataFactory, err := interceptorsFactory.NewInterceptedMetaHeaderDataFactory(&argsInterceptedDataFactory)

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -688,7 +688,6 @@ func (tpn *TestProcessorNode) initInterceptors() {
 			WhiteListHandler:        tpn.WhiteListHandler,
 			WhiteListerVerifiedTxs:  tpn.WhiteListerVerifiedTxs,
 			AntifloodHandler:        &mock.NilAntifloodHandler{},
-			NonceConverter:          TestUint64Converter,
 		}
 		interceptorContainerFactory, _ := interceptorscontainer.NewMetaInterceptorsContainerFactory(metaIntercContFactArgs)
 
@@ -747,7 +746,6 @@ func (tpn *TestProcessorNode) initInterceptors() {
 			WhiteListHandler:        tpn.WhiteListHandler,
 			WhiteListerVerifiedTxs:  tpn.WhiteListerVerifiedTxs,
 			AntifloodHandler:        &mock.NilAntifloodHandler{},
-			NonceConverter:          TestUint64Converter,
 		}
 		interceptorContainerFactory, _ := interceptorscontainer.NewShardInterceptorsContainerFactory(shardInterContFactArgs)
 

--- a/process/block/interceptedBlocks/argInterceptedBlockHeader.go
+++ b/process/block/interceptedBlocks/argInterceptedBlockHeader.go
@@ -1,7 +1,6 @@
 package interceptedBlocks
 
 import (
-	"github.com/ElrondNetwork/elrond-go/data/typeConverters"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -18,5 +17,4 @@ type ArgInterceptedBlockHeader struct {
 	HeaderIntegrityVerifier process.InterceptedHeaderIntegrityVerifier
 	ValidityAttester        process.ValidityAttester
 	EpochStartTrigger       process.EpochStartTriggerHandler
-	NonceConverter          typeConverters.Uint64ByteSliceConverter
 }

--- a/process/block/interceptedBlocks/common.go
+++ b/process/block/interceptedBlocks/common.go
@@ -37,9 +37,6 @@ func checkBlockHeaderArgument(arg *ArgInterceptedBlockHeader) error {
 	if check.IfNil(arg.ValidityAttester) {
 		return process.ErrNilValidityAttester
 	}
-	if check.IfNil(arg.NonceConverter) {
-		return process.ErrNilUint64Converter
-	}
 
 	return nil
 }

--- a/process/block/interceptedBlocks/common_test.go
+++ b/process/block/interceptedBlocks/common_test.go
@@ -19,7 +19,6 @@ func createDefaultBlockHeaderArgument() *ArgInterceptedBlockHeader {
 		HeaderIntegrityVerifier: &mock.HeaderIntegrityVerifierStub{},
 		ValidityAttester:        &mock.ValidityAttesterStub{},
 		EpochStartTrigger:       &mock.EpochStartTriggerStub{},
-		NonceConverter:          mock.NewNonceHashConverterMock(),
 	}
 
 	return arg
@@ -133,17 +132,6 @@ func TestCheckBlockHeaderArgument_NilValidityAttesterShouldErr(t *testing.T) {
 	err := checkBlockHeaderArgument(arg)
 
 	assert.Equal(t, process.ErrNilValidityAttester, err)
-}
-
-func TestCheckBlockHeaderArgument_NilNonceConverterShouldErr(t *testing.T) {
-	t.Parallel()
-
-	arg := createDefaultBlockHeaderArgument()
-	arg.NonceConverter = nil
-
-	err := checkBlockHeaderArgument(arg)
-
-	assert.Equal(t, process.ErrNilUint64Converter, err)
 }
 
 func TestCheckBlockHeaderArgument_ShouldWork(t *testing.T) {

--- a/process/block/interceptedBlocks/interceptedBlockHeader.go
+++ b/process/block/interceptedBlocks/interceptedBlockHeader.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/block"
-	"github.com/ElrondNetwork/elrond-go/data/typeConverters"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -29,7 +28,6 @@ type InterceptedHeader struct {
 	isForCurrentShard bool
 	validityAttester  process.ValidityAttester
 	epochStartTrigger process.EpochStartTriggerHandler
-	nonceConverter    typeConverters.Uint64ByteSliceConverter
 }
 
 // NewInterceptedHeader creates a new instance of InterceptedHeader struct
@@ -52,7 +50,6 @@ func NewInterceptedHeader(arg *ArgInterceptedBlockHeader) (*InterceptedHeader, e
 		shardCoordinator:  arg.ShardCoordinator,
 		validityAttester:  arg.ValidityAttester,
 		epochStartTrigger: arg.EpochStartTrigger,
-		nonceConverter:    arg.NonceConverter,
 	}
 	inHdr.processFields(arg.HdrBuff)
 
@@ -192,9 +189,10 @@ func (inHdr *InterceptedHeader) String() string {
 
 // Identifiers returns the identifiers used in requests
 func (inHdr *InterceptedHeader) Identifiers() [][]byte {
-	nonceBytes := inHdr.nonceConverter.ToByteSlice(inHdr.hdr.Nonce)
+	keyNonce := []byte(fmt.Sprintf("%d-%d", inHdr.hdr.ShardID, inHdr.hdr.Nonce))
+	keyEpoch := []byte(core.EpochStartIdentifier(inHdr.hdr.Epoch))
 
-	return [][]byte{inHdr.hash, nonceBytes}
+	return [][]byte{inHdr.hash, keyNonce, keyEpoch}
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/process/block/interceptedBlocks/interceptedBlockHeader_test.go
+++ b/process/block/interceptedBlocks/interceptedBlockHeader_test.go
@@ -30,7 +30,6 @@ func createDefaultShardArgument() *interceptedBlocks.ArgInterceptedBlockHeader {
 		HeaderIntegrityVerifier: &mock.HeaderIntegrityVerifierStub{},
 		ValidityAttester:        &mock.ValidityAttesterStub{},
 		EpochStartTrigger:       &mock.EpochStartTriggerStub{},
-		NonceConverter:          mock.NewNonceHashConverterMock(),
 	}
 
 	hdr := createMockShardHeader()

--- a/process/block/interceptedBlocks/interceptedMetaBlockHeader.go
+++ b/process/block/interceptedBlocks/interceptedMetaBlockHeader.go
@@ -3,9 +3,9 @@ package interceptedBlocks
 import (
 	"fmt"
 
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/block"
-	"github.com/ElrondNetwork/elrond-go/data/typeConverters"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -25,7 +25,6 @@ type InterceptedMetaHeader struct {
 	hash              []byte
 	validityAttester  process.ValidityAttester
 	epochStartTrigger process.EpochStartTriggerHandler
-	nonceConverter    typeConverters.Uint64ByteSliceConverter
 }
 
 // NewInterceptedMetaHeader creates a new instance of InterceptedMetaHeader struct
@@ -48,7 +47,6 @@ func NewInterceptedMetaHeader(arg *ArgInterceptedBlockHeader) (*InterceptedMetaH
 		shardCoordinator:  arg.ShardCoordinator,
 		validityAttester:  arg.ValidityAttester,
 		epochStartTrigger: arg.EpochStartTrigger,
-		nonceConverter:    arg.NonceConverter,
 	}
 	inHdr.processFields(arg.HdrBuff)
 
@@ -147,9 +145,10 @@ func (imh *InterceptedMetaHeader) String() string {
 
 // Identifiers returns the identifiers used in requests
 func (imh *InterceptedMetaHeader) Identifiers() [][]byte {
-	nonceBytes := imh.nonceConverter.ToByteSlice(imh.hdr.Nonce)
+	keyNonce := []byte(fmt.Sprintf("%d-%d", core.MetachainShardId, imh.hdr.Nonce))
+	keyEpoch := []byte(core.EpochStartIdentifier(imh.hdr.Epoch))
 
-	return [][]byte{imh.hash, nonceBytes}
+	return [][]byte{imh.hash, keyNonce, keyEpoch}
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/process/block/interceptedBlocks/interceptedMetaBlockHeader_test.go
+++ b/process/block/interceptedBlocks/interceptedMetaBlockHeader_test.go
@@ -22,7 +22,6 @@ func createDefaultMetaArgument() *interceptedBlocks.ArgInterceptedBlockHeader {
 		HeaderIntegrityVerifier: &mock.HeaderIntegrityVerifierStub{},
 		ValidityAttester:        &mock.ValidityAttesterStub{},
 		EpochStartTrigger:       &mock.EpochStartTriggerStub{},
-		NonceConverter:          mock.NewNonceHashConverterMock(),
 	}
 
 	hdr := createMockMetaHeader()

--- a/process/factory/interceptorscontainer/args.go
+++ b/process/factory/interceptorscontainer/args.go
@@ -4,7 +4,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/crypto"
 	"github.com/ElrondNetwork/elrond-go/data/state"
-	"github.com/ElrondNetwork/elrond-go/data/typeConverters"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
@@ -40,7 +39,6 @@ type ShardInterceptorsContainerFactoryArgs struct {
 	WhiteListHandler        process.WhiteListHandler
 	WhiteListerVerifiedTxs  process.WhiteListHandler
 	AntifloodHandler        process.P2PAntifloodHandler
-	NonceConverter          typeConverters.Uint64ByteSliceConverter
 }
 
 // MetaInterceptorsContainerFactoryArgs holds the arguments needed for MetaInterceptorsContainerFactory
@@ -71,5 +69,4 @@ type MetaInterceptorsContainerFactoryArgs struct {
 	WhiteListHandler        process.WhiteListHandler
 	WhiteListerVerifiedTxs  process.WhiteListHandler
 	AntifloodHandler        process.P2PAntifloodHandler
-	NonceConverter          typeConverters.Uint64ByteSliceConverter
 }

--- a/process/factory/interceptorscontainer/metaInterceptorsContainerFactory.go
+++ b/process/factory/interceptorscontainer/metaInterceptorsContainerFactory.go
@@ -94,7 +94,6 @@ func NewMetaInterceptorsContainerFactory(
 		HeaderIntegrityVerifier: args.HeaderIntegrityVerifier,
 		ValidityAttester:        args.ValidityAttester,
 		EpochStartTrigger:       args.EpochStartTrigger,
-		NonceConverter:          args.NonceConverter,
 		WhiteListerVerifiedTxs:  args.WhiteListerVerifiedTxs,
 	}
 

--- a/process/factory/interceptorscontainer/metaInterceptorsContainerFactory_test.go
+++ b/process/factory/interceptorscontainer/metaInterceptorsContainerFactory_test.go
@@ -480,7 +480,6 @@ func getArgumentsMeta() interceptorscontainer.MetaInterceptorsContainerFactoryAr
 		EpochStartTrigger:       &mock.EpochStartTriggerStub{},
 		AntifloodHandler:        &mock.P2PAntifloodHandlerStub{},
 		WhiteListHandler:        &mock.WhiteListHandlerStub{},
-		NonceConverter:          mock.NewNonceHashConverterMock(),
 		WhiteListerVerifiedTxs:  &mock.WhiteListHandlerStub{},
 	}
 }

--- a/process/factory/interceptorscontainer/shardInterceptorsContainerFactory.go
+++ b/process/factory/interceptorscontainer/shardInterceptorsContainerFactory.go
@@ -94,7 +94,6 @@ func NewShardInterceptorsContainerFactory(
 		HeaderIntegrityVerifier: args.HeaderIntegrityVerifier,
 		ValidityAttester:        args.ValidityAttester,
 		EpochStartTrigger:       args.EpochStartTrigger,
-		NonceConverter:          args.NonceConverter,
 		WhiteListerVerifiedTxs:  args.WhiteListerVerifiedTxs,
 	}
 

--- a/process/factory/interceptorscontainer/shardInterceptorsContainerFactory_test.go
+++ b/process/factory/interceptorscontainer/shardInterceptorsContainerFactory_test.go
@@ -530,7 +530,6 @@ func getArgumentsShard() interceptorscontainer.ShardInterceptorsContainerFactory
 		EpochStartTrigger:       &mock.EpochStartTriggerStub{},
 		AntifloodHandler:        &mock.P2PAntifloodHandlerStub{},
 		WhiteListHandler:        &mock.WhiteListHandlerStub{},
-		NonceConverter:          mock.NewNonceHashConverterMock(),
 		WhiteListerVerifiedTxs:  &mock.WhiteListHandlerStub{},
 	}
 }

--- a/process/interceptors/factory/argInterceptedDataFactory.go
+++ b/process/interceptors/factory/argInterceptedDataFactory.go
@@ -3,7 +3,6 @@ package factory
 import (
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/crypto"
-	"github.com/ElrondNetwork/elrond-go/data/typeConverters"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -30,5 +29,4 @@ type ArgInterceptedDataFactory struct {
 	HeaderIntegrityVerifier process.InterceptedHeaderIntegrityVerifier
 	ValidityAttester        process.ValidityAttester
 	EpochStartTrigger       process.EpochStartTriggerHandler
-	NonceConverter          typeConverters.Uint64ByteSliceConverter
 }

--- a/process/interceptors/factory/interceptedMetaHeaderDataFactory.go
+++ b/process/interceptors/factory/interceptedMetaHeaderDataFactory.go
@@ -2,7 +2,6 @@ package factory
 
 import (
 	"github.com/ElrondNetwork/elrond-go/core/check"
-	"github.com/ElrondNetwork/elrond-go/data/typeConverters"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -21,7 +20,6 @@ type interceptedMetaHeaderDataFactory struct {
 	chainID                 []byte
 	validityAttester        process.ValidityAttester
 	epochStartTrigger       process.EpochStartTriggerHandler
-	nonceConverter          typeConverters.Uint64ByteSliceConverter
 }
 
 // NewInterceptedMetaHeaderDataFactory creates an instance of interceptedMetaHeaderDataFactory
@@ -53,9 +51,6 @@ func NewInterceptedMetaHeaderDataFactory(argument *ArgInterceptedDataFactory) (*
 	if check.IfNil(argument.ValidityAttester) {
 		return nil, process.ErrNilValidityAttester
 	}
-	if check.IfNil(argument.NonceConverter) {
-		return nil, process.ErrNilUint64Converter
-	}
 
 	return &interceptedMetaHeaderDataFactory{
 		marshalizer:             argument.ProtoMarshalizer,
@@ -65,7 +60,6 @@ func NewInterceptedMetaHeaderDataFactory(argument *ArgInterceptedDataFactory) (*
 		headerIntegrityVerifier: argument.HeaderIntegrityVerifier,
 		validityAttester:        argument.ValidityAttester,
 		epochStartTrigger:       argument.EpochStartTrigger,
-		nonceConverter:          argument.NonceConverter,
 	}, nil
 }
 
@@ -80,7 +74,6 @@ func (imhdf *interceptedMetaHeaderDataFactory) Create(buff []byte) (process.Inte
 		HeaderIntegrityVerifier: imhdf.headerIntegrityVerifier,
 		ValidityAttester:        imhdf.validityAttester,
 		EpochStartTrigger:       imhdf.epochStartTrigger,
-		NonceConverter:          imhdf.nonceConverter,
 	}
 
 	return interceptedBlocks.NewInterceptedMetaHeader(arg)

--- a/process/interceptors/factory/interceptedMetaHeaderDataFactory_test.go
+++ b/process/interceptors/factory/interceptedMetaHeaderDataFactory_test.go
@@ -68,7 +68,6 @@ func createMockArgument() *ArgInterceptedDataFactory {
 		HeaderIntegrityVerifier: &mock.HeaderIntegrityVerifierStub{},
 		ValidityAttester:        &mock.ValidityAttesterStub{},
 		EpochStartTrigger:       &mock.EpochStartTriggerStub{},
-		NonceConverter:          mock.NewNonceHashConverterMock(),
 		WhiteListerVerifiedTxs:  &mock.WhiteListHandlerStub{},
 	}
 }
@@ -157,17 +156,6 @@ func TestNewInterceptedMetaHeaderDataFactory_NilValidityAttesterShouldErr(t *tes
 	imh, err := NewInterceptedMetaHeaderDataFactory(arg)
 	assert.True(t, check.IfNil(imh))
 	assert.Equal(t, process.ErrNilValidityAttester, err)
-}
-
-func TestNewInterceptedMetaHeaderDataFactory_NilNonceConverterShouldErr(t *testing.T) {
-	t.Parallel()
-
-	arg := createMockArgument()
-	arg.NonceConverter = nil
-
-	imh, err := NewInterceptedMetaHeaderDataFactory(arg)
-	assert.True(t, check.IfNil(imh))
-	assert.Equal(t, process.ErrNilUint64Converter, err)
 }
 
 func TestNewInterceptedMetaHeaderDataFactory_ShouldWorkAndCreate(t *testing.T) {

--- a/process/interceptors/factory/interceptedShardHeaderDataFactory.go
+++ b/process/interceptors/factory/interceptedShardHeaderDataFactory.go
@@ -2,7 +2,6 @@ package factory
 
 import (
 	"github.com/ElrondNetwork/elrond-go/core/check"
-	"github.com/ElrondNetwork/elrond-go/data/typeConverters"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -21,7 +20,6 @@ type interceptedShardHeaderDataFactory struct {
 	chainID                 []byte
 	validityAttester        process.ValidityAttester
 	epochStartTrigger       process.EpochStartTriggerHandler
-	nonceConverter          typeConverters.Uint64ByteSliceConverter
 }
 
 // NewInterceptedShardHeaderDataFactory creates an instance of interceptedShardHeaderDataFactory
@@ -53,9 +51,6 @@ func NewInterceptedShardHeaderDataFactory(argument *ArgInterceptedDataFactory) (
 	if check.IfNil(argument.ValidityAttester) {
 		return nil, process.ErrNilValidityAttester
 	}
-	if check.IfNil(argument.NonceConverter) {
-		return nil, process.ErrNilUint64Converter
-	}
 
 	return &interceptedShardHeaderDataFactory{
 		marshalizer:             argument.ProtoMarshalizer,
@@ -65,7 +60,6 @@ func NewInterceptedShardHeaderDataFactory(argument *ArgInterceptedDataFactory) (
 		headerIntegrityVerifier: argument.HeaderIntegrityVerifier,
 		validityAttester:        argument.ValidityAttester,
 		epochStartTrigger:       argument.EpochStartTrigger,
-		nonceConverter:          argument.NonceConverter,
 	}, nil
 }
 
@@ -80,7 +74,6 @@ func (ishdf *interceptedShardHeaderDataFactory) Create(buff []byte) (process.Int
 		HeaderIntegrityVerifier: ishdf.headerIntegrityVerifier,
 		ValidityAttester:        ishdf.validityAttester,
 		EpochStartTrigger:       ishdf.epochStartTrigger,
-		NonceConverter:          ishdf.nonceConverter,
 	}
 
 	return interceptedBlocks.NewInterceptedHeader(arg)

--- a/process/interceptors/factory/interceptedShardHeaderDataFactory_test.go
+++ b/process/interceptors/factory/interceptedShardHeaderDataFactory_test.go
@@ -86,17 +86,6 @@ func TestNewInterceptedShardHeaderDataFactory_NilValidityAttesterShouldErr(t *te
 	assert.Equal(t, process.ErrNilValidityAttester, err)
 }
 
-func TestNewInterceptedShardHeaderDataFactory_NilNonceConverterShouldErr(t *testing.T) {
-	t.Parallel()
-
-	arg := createMockArgument()
-	arg.NonceConverter = nil
-
-	imh, err := NewInterceptedShardHeaderDataFactory(arg)
-	assert.True(t, check.IfNil(imh))
-	assert.Equal(t, process.ErrNilUint64Converter, err)
-}
-
 func TestInterceptedShardHeaderDataFactory_ShouldWorkAndCreate(t *testing.T) {
 	t.Parallel()
 

--- a/process/interceptors/whiteListDataVerifier.go
+++ b/process/interceptors/whiteListDataVerifier.go
@@ -31,7 +31,13 @@ func (w *whiteListDataVerifier) IsWhiteListed(interceptedData process.Intercepte
 		return false
 	}
 
-	return w.cache.Has(interceptedData.Hash())
+	for _, identifier := range interceptedData.Identifiers() {
+		if w.cache.Has(identifier) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Add adds all the list to the cache

--- a/process/interceptors/whiteListDataVerifier_test.go
+++ b/process/interceptors/whiteListDataVerifier_test.go
@@ -113,8 +113,8 @@ func TestWhiteListDataVerifier_IsWhiteListedFoundShouldRetTrue(t *testing.T) {
 	)
 
 	ids := &mock.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return keyCheck
+		IdentifiersCalled: func() [][]byte {
+			return [][]byte{keyCheck}
 		},
 	}
 

--- a/update/factory/fullSyncInterceptors.go
+++ b/update/factory/fullSyncInterceptors.go
@@ -163,7 +163,6 @@ func NewFullSyncInterceptorsContainerFactory(
 		HeaderIntegrityVerifier: args.HeaderIntegrityVerifier,
 		ValidityAttester:        args.ValidityAttester,
 		EpochStartTrigger:       args.EpochStartTrigger,
-		NonceConverter:          args.NonceConverter,
 		WhiteListerVerifiedTxs:  args.WhiteListerVerifiedTxs,
 	}
 


### PR DESCRIPTION
- fixed the checking of whitelisting intercepted data that will include the checking of nonce or epoch start in the case of shard/meta headers. This will prevent dropping the messages from observers because they were not whitelisted.