### PR TITLE
En 6993 prune code on remove account

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -213,7 +213,7 @@
 [TrieStorageManagerConfig]
     PruningBufferLen = 100000
     SnapshotsBufferLen = 1000000
-    MaxSnapshots = 2
+    MaxSnapshots = 3
 
 [PeerAccountsTrieStorage]
     [PeerAccountsTrieStorage.Cache]

--- a/data/state/accountsDB_test.go
+++ b/data/state/accountsDB_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/ElrondNetwork/elrond-go/config"
-
 	"github.com/ElrondNetwork/elrond-go/core/atomic"
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/data"

--- a/data/state/errors.go
+++ b/data/state/errors.go
@@ -109,9 +109,3 @@ var ErrInvalidErdAddress = errors.New("invalid ERD address")
 
 // ErrInvalidPubkeyConverterType signals that the provided pubkey converter type is invalid
 var ErrInvalidPubkeyConverterType = errors.New("invalid pubkey converter type")
-
-// ErrNilNewCodeMap signals that the provided map is nil
-var ErrNilNewCodeMap = errors.New("nil newCode map")
-
-// ErrNilCodeForEvictionMap signals that the provided map is nil
-var ErrNilCodeForEvictionMap = errors.New("nil codeForEviction map")

--- a/data/state/export_test.go
+++ b/data/state/export_test.go
@@ -19,14 +19,6 @@ func (adb *AccountsDB) GetAccount(address []byte) (AccountHandler, error) {
 	return adb.getAccount(address)
 }
 
-func (adb *AccountsDB) GetNewCodeMap() map[string]struct{} {
-	return adb.newCode
-}
-
-func (adb *AccountsDB) GetCodeForEvictionMap() map[string]struct{} {
-	return adb.codeForEviction
-}
-
 func (tdaw *TrackableDataTrie) OriginalData() map[string][]byte {
 	return tdaw.originalData
 }

--- a/data/state/journalEntries.go
+++ b/data/state/journalEntries.go
@@ -9,13 +9,11 @@ import (
 )
 
 type journalEntryCode struct {
-	oldCodeEntry    *CodeEntry
-	oldCodeHash     []byte
-	newCodeHash     []byte
-	codeForEviction map[string]struct{}
-	newCode         map[string]struct{}
-	trie            Updater
-	marshalizer     marshal.Marshalizer
+	oldCodeEntry *CodeEntry
+	oldCodeHash  []byte
+	newCodeHash  []byte
+	trie         Updater
+	marshalizer  marshal.Marshalizer
 }
 
 // NewJournalEntryCode creates a new instance of JournalEntryCode
@@ -23,8 +21,6 @@ func NewJournalEntryCode(
 	oldCodeEntry *CodeEntry,
 	oldCodeHash []byte,
 	newCodeHash []byte,
-	codeForEviction map[string]struct{},
-	newCode map[string]struct{},
 	trie Updater,
 	marshalizer marshal.Marshalizer,
 ) (*journalEntryCode, error) {
@@ -34,21 +30,13 @@ func NewJournalEntryCode(
 	if check.IfNil(marshalizer) {
 		return nil, ErrNilMarshalizer
 	}
-	if codeForEviction == nil {
-		return nil, ErrNilCodeForEvictionMap
-	}
-	if newCode == nil {
-		return nil, ErrNilNewCodeMap
-	}
 
 	return &journalEntryCode{
-		oldCodeEntry:    oldCodeEntry,
-		oldCodeHash:     oldCodeHash,
-		newCodeHash:     newCodeHash,
-		trie:            trie,
-		marshalizer:     marshalizer,
-		codeForEviction: codeForEviction,
-		newCode:         newCode,
+		oldCodeEntry: oldCodeEntry,
+		oldCodeHash:  oldCodeHash,
+		newCodeHash:  newCodeHash,
+		trie:         trie,
+		marshalizer:  marshalizer,
 	}, nil
 }
 
@@ -76,10 +64,6 @@ func (jea *journalEntryCode) revertOldCodeEntry() error {
 		return nil
 	}
 
-	if jea.oldCodeEntry.NumReferences <= 1 {
-		delete(jea.codeForEviction, string(jea.oldCodeHash))
-	}
-
 	err := saveCodeEntry(jea.oldCodeHash, jea.oldCodeEntry, jea.trie, jea.marshalizer)
 	if err != nil {
 		return err
@@ -104,7 +88,6 @@ func (jea *journalEntryCode) revertNewCodeEntry() error {
 			return err
 		}
 
-		delete(jea.newCode, string(jea.newCodeHash))
 		return nil
 	}
 

--- a/data/state/journalEntries_test.go
+++ b/data/state/journalEntries_test.go
@@ -13,7 +13,7 @@ import (
 func TestNewJournalEntryCode_NilUpdaterShouldErr(t *testing.T) {
 	t.Parallel()
 
-	entry, err := state.NewJournalEntryCode(&state.CodeEntry{}, []byte("code hash"), []byte("code hash"), map[string]struct{}{}, map[string]struct{}{}, nil, &mock.MarshalizerMock{})
+	entry, err := state.NewJournalEntryCode(&state.CodeEntry{}, []byte("code hash"), []byte("code hash"), nil, &mock.MarshalizerMock{})
 	assert.True(t, check.IfNil(entry))
 	assert.Equal(t, state.ErrNilUpdater, err)
 }
@@ -21,31 +21,15 @@ func TestNewJournalEntryCode_NilUpdaterShouldErr(t *testing.T) {
 func TestNewJournalEntryCode_NilMarshalizerShouldErr(t *testing.T) {
 	t.Parallel()
 
-	entry, err := state.NewJournalEntryCode(&state.CodeEntry{}, []byte("code hash"), []byte("code hash"), map[string]struct{}{}, map[string]struct{}{}, &mock.TrieStub{}, nil)
+	entry, err := state.NewJournalEntryCode(&state.CodeEntry{}, []byte("code hash"), []byte("code hash"), &mock.TrieStub{}, nil)
 	assert.True(t, check.IfNil(entry))
 	assert.Equal(t, state.ErrNilMarshalizer, err)
-}
-
-func TestNewJournalEntryCode_NilCodeForEvictionMapShouldErr(t *testing.T) {
-	t.Parallel()
-
-	entry, err := state.NewJournalEntryCode(&state.CodeEntry{}, []byte("code hash"), []byte("code hash"), nil, map[string]struct{}{}, &mock.TrieStub{}, &mock.MarshalizerMock{})
-	assert.True(t, check.IfNil(entry))
-	assert.Equal(t, state.ErrNilCodeForEvictionMap, err)
-}
-
-func TestNewJournalEntryCode_NilNewCodeMapShouldErr(t *testing.T) {
-	t.Parallel()
-
-	entry, err := state.NewJournalEntryCode(&state.CodeEntry{}, []byte("code hash"), []byte("code hash"), map[string]struct{}{}, nil, &mock.TrieStub{}, &mock.MarshalizerMock{})
-	assert.True(t, check.IfNil(entry))
-	assert.Equal(t, state.ErrNilNewCodeMap, err)
 }
 
 func TestNewJournalEntryCode_OkParams(t *testing.T) {
 	t.Parallel()
 
-	entry, err := state.NewJournalEntryCode(&state.CodeEntry{}, []byte("code hash"), []byte("code hash"), map[string]struct{}{}, map[string]struct{}{}, &mock.TrieStub{}, &mock.MarshalizerMock{})
+	entry, err := state.NewJournalEntryCode(&state.CodeEntry{}, []byte("code hash"), []byte("code hash"), &mock.TrieStub{}, &mock.MarshalizerMock{})
 	assert.Nil(t, err)
 	assert.False(t, check.IfNil(entry))
 }
@@ -54,7 +38,7 @@ func TestJournalEntryCode_OldHashAndNewHashAreNil(t *testing.T) {
 	t.Parallel()
 
 	trieStub := &mock.TrieStub{}
-	entry, _ := state.NewJournalEntryCode(&state.CodeEntry{}, nil, nil, map[string]struct{}{}, map[string]struct{}{}, trieStub, &mock.MarshalizerMock{})
+	entry, _ := state.NewJournalEntryCode(&state.CodeEntry{}, nil, nil, trieStub, &mock.MarshalizerMock{})
 
 	acc, err := entry.Revert()
 	assert.Nil(t, err)
@@ -84,8 +68,6 @@ func TestJournalEntryCode_OldHashIsNilAndNewHashIsNotNil(t *testing.T) {
 		&state.CodeEntry{},
 		nil,
 		[]byte("newHash"),
-		map[string]struct{}{},
-		map[string]struct{}{},
 		trieStub,
 		marshalizer,
 	)

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -63,6 +63,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process/smartContract"
 	"github.com/ElrondNetwork/elrond-go/process/smartContract/builtInFunctions"
 	"github.com/ElrondNetwork/elrond-go/process/smartContract/hooks"
+	sync2 "github.com/ElrondNetwork/elrond-go/process/sync"
 	"github.com/ElrondNetwork/elrond-go/process/track"
 	"github.com/ElrondNetwork/elrond-go/process/transaction"
 	"github.com/ElrondNetwork/elrond-go/sharding"
@@ -1185,19 +1186,10 @@ func (tpn *TestProcessorNode) addMockVm(blockchainHook vmcommon.BlockchainHook) 
 func (tpn *TestProcessorNode) initBlockProcessor(stateCheckpointModulus uint) {
 	var err error
 
-	tpn.ForkDetector = &mock.ForkDetectorStub{
-		AddHeaderCalled: func(header data.HeaderHandler, hash []byte, state process.BlockHeaderState, selfNotarizedHeaders []data.HeaderHandler, selfNotarizedHeadersHashes [][]byte) error {
-			return nil
-		},
-		GetHighestFinalBlockNonceCalled: func() uint64 {
-			return 100
-		},
-		ProbableHighestNonceCalled: func() uint64 {
-			return 0
-		},
-		GetHighestFinalBlockHashCalled: func() []byte {
-			return nil
-		},
+	if tpn.ShardCoordinator.SelfId() != core.MetachainShardId {
+		tpn.ForkDetector, _ = sync2.NewShardForkDetector(tpn.Rounder, tpn.BlockBlackListHandler, tpn.BlockTracker, tpn.NodesSetup.GetStartTime())
+	} else {
+		tpn.ForkDetector, _ = sync2.NewMetaForkDetector(tpn.Rounder, tpn.BlockBlackListHandler, tpn.BlockTracker, tpn.NodesSetup.GetStartTime())
 	}
 
 	accountsDb := make(map[state.AccountsDbIdentifier]state.AccountsAdapter)


### PR DESCRIPTION
When an account is removed, also remove  the code (or decrease numReferences).
Removed unneeded code.
Change max trie snapshots to remember from config.
Use a real fork detector in integration tests.