### PR TITLE
bugFix/go-routine-control-on-interceptors

### DIFF
--- a/integrationTests/multiShard/block/executingMiniblocks/executingMiniblocks_test.go
+++ b/integrationTests/multiShard/block/executingMiniblocks/executingMiniblocks_test.go
@@ -205,7 +205,14 @@ func TestSimpleTransactionsWithMoreGasWhichYieldInReceiptsInMultiShardedEnvironm
 		nonce++
 
 		for _, node := range nodes {
-			integrationTests.CreateAndSendTransactionWithGasLimit(node, sendValue, gasLimit, receiverAddress, []byte(""))
+			integrationTests.PlayerSendsTransaction(
+				nodes,
+				node.OwnAccount,
+				receiverAddress,
+				sendValue,
+				"",
+				gasLimit,
+			)
 		}
 
 		time.Sleep(2 * time.Second)
@@ -285,7 +292,14 @@ func TestSimpleTransactionsWithMoreValueThanBalanceYieldReceiptsInMultiShardedEn
 
 	for _, node := range nodes {
 		for j := uint64(0); j < nrTxsToSend; j++ {
-			integrationTests.CreateAndSendTransactionWithGasLimit(node, halfInitVal, minGasLimit, receiverAddress, []byte(""))
+			integrationTests.PlayerSendsTransaction(
+				nodes,
+				node.OwnAccount,
+				receiverAddress,
+				halfInitVal,
+				"",
+				minGasLimit,
+			)
 		}
 	}
 

--- a/integrationTests/multiShard/smartContract/scCallingSC_test.go
+++ b/integrationTests/multiShard/smartContract/scCallingSC_test.go
@@ -400,7 +400,14 @@ func TestSCCallingInCrossShard(t *testing.T) {
 	// make smart contract call to shard 1 which will do in shard 0
 	for _, node := range nodes {
 		txData := "doSomething"
-		integrationTests.CreateAndSendTransaction(node, big.NewInt(50), secondSCAddress, txData)
+		integrationTests.PlayerSendsTransaction(
+			nodes,
+			node.OwnAccount,
+			secondSCAddress,
+			big.NewInt(50),
+			txData,
+			500000,
+		)
 	}
 
 	time.Sleep(time.Second)

--- a/integrationTests/multiShard/transaction/interceptedResolvedBulkTx/interceptedResolvedBulkTx_test.go
+++ b/integrationTests/multiShard/transaction/interceptedResolvedBulkTx/interceptedResolvedBulkTx_test.go
@@ -149,7 +149,16 @@ func TestNode_InterceptorBulkTxsSentFromOtherShardShouldBeRoutedInSenderShard(t 
 	senderPrivateKeys := []crypto.PrivateKey{nodes[idxSender].OwnAccount.SkTxSign}
 	integrationTests.CreateMintingForSenders(nodes, shardId, senderPrivateKeys, mintingValue)
 
-	_ = nodes[idxSender].Node.GenerateAndSendBulkTransactions(
+	dispatcherNodeID := nodes[0].ShardCoordinator.ComputeId(nodes[idxSender].OwnAccount.Address)
+	dispatcherNode := nodes[0]
+	for _, node := range nodes {
+		if node.ShardCoordinator.SelfId() == dispatcherNodeID {
+			dispatcherNode = node
+			break
+		}
+	}
+
+	_ = dispatcherNode.Node.GenerateAndSendBulkTransactions(
 		addrInShardFive,
 		txValue,
 		uint64(txToSend),
@@ -261,7 +270,15 @@ func TestNode_InterceptorBulkTxsSentFromOtherShardShouldBeRoutedInSenderShardAnd
 		integrationTests.WhiteListTxs(nodes, txs)
 	}
 
-	_ = nodes[0].Node.GenerateAndSendBulkTransactions(
+	dispatcherNodeID := nodes[0].ShardCoordinator.ComputeId(nodes[idxSender].OwnAccount.Address)
+	dispatcherNode := nodes[0]
+	for _, node := range nodes {
+		if node.ShardCoordinator.SelfId() == dispatcherNodeID {
+			dispatcherNode = node
+			break
+		}
+	}
+	_ = dispatcherNode.Node.GenerateAndSendBulkTransactions(
 		addrInShardFive,
 		txValue,
 		uint64(txToSend),

--- a/process/errors.go
+++ b/process/errors.go
@@ -847,3 +847,6 @@ var ErrOnlyValidatorsCanUseThisTopic = errors.New("only validators can use this 
 
 // ErrTransactionIsNotWhitelisted signals that a transaction is not whitelisted
 var ErrTransactionIsNotWhitelisted = errors.New("transaction is not whitelisted")
+
+// ErrInterceptedDataNotForCurrentShard signals that intercepted data is not for current shard
+var ErrInterceptedDataNotForCurrentShard = errors.New("intercepted data not for current shard")

--- a/process/interceptors/common.go
+++ b/process/interceptors/common.go
@@ -1,8 +1,6 @@
 package interceptors
 
 import (
-	"sync"
-
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -44,14 +42,9 @@ func processInterceptedData(
 	handler process.InterceptedDebugger,
 	data process.InterceptedData,
 	topic string,
-	wgProcess *sync.WaitGroup,
 	msg p2p.MessageP2P,
 ) {
 	err := processor.Validate(data, msg.Peer())
-
-	defer func() {
-		wgProcess.Done()
-	}()
 	if err != nil {
 		log.Trace("intercepted data is not valid",
 			"hash", data.Hash(),

--- a/process/interceptors/common_test.go
+++ b/process/interceptors/common_test.go
@@ -2,9 +2,7 @@ package interceptors
 
 import (
 	"errors"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/p2p"
@@ -132,29 +130,15 @@ func TestProcessInterceptedData_NotValidShouldCallDoneAndNotCallProcessed(t *tes
 		},
 	}
 
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	chDone := make(chan struct{})
-	go func() {
-		wg.Wait()
-		chDone <- struct{}{}
-	}()
-
 	processInterceptedData(
 		processor,
 		&mock.InterceptedDebugHandlerStub{},
 		&mock.InterceptedDataStub{},
 		"topic",
-		wg,
 		&mock.P2PMessageMock{},
 	)
 
-	select {
-	case <-chDone:
-		assert.False(t, processCalled)
-	case <-time.After(time.Second):
-		assert.Fail(t, "timeout while waiting for wait group object to be finished")
-	}
+	assert.False(t, processCalled)
 }
 
 func TestProcessInterceptedData_ValidShouldCallDoneAndCallProcessed(t *testing.T) {
@@ -171,29 +155,15 @@ func TestProcessInterceptedData_ValidShouldCallDoneAndCallProcessed(t *testing.T
 		},
 	}
 
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	chDone := make(chan struct{})
-	go func() {
-		wg.Wait()
-		chDone <- struct{}{}
-	}()
-
 	processInterceptedData(
 		processor,
 		&mock.InterceptedDebugHandlerStub{},
 		&mock.InterceptedDataStub{},
 		"topic",
-		wg,
 		&mock.P2PMessageMock{},
 	)
 
-	select {
-	case <-chDone:
-		assert.True(t, processCalled)
-	case <-time.After(time.Second):
-		assert.Fail(t, "timeout while waiting for wait group object to be finished")
-	}
+	assert.True(t, processCalled)
 }
 
 func TestProcessInterceptedData_ProcessErrorShouldCallDone(t *testing.T) {
@@ -210,29 +180,15 @@ func TestProcessInterceptedData_ProcessErrorShouldCallDone(t *testing.T) {
 		},
 	}
 
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	chDone := make(chan struct{})
-	go func() {
-		wg.Wait()
-		chDone <- struct{}{}
-	}()
-
 	processInterceptedData(
 		processor,
 		&mock.InterceptedDebugHandlerStub{},
 		&mock.InterceptedDataStub{},
 		"topic",
-		wg,
 		&mock.P2PMessageMock{},
 	)
 
-	select {
-	case <-chDone:
-		assert.True(t, processCalled)
-	case <-time.After(time.Second):
-		assert.Fail(t, "timeout while waiting for wait group object to be finished")
-	}
+	assert.True(t, processCalled)
 }
 
 //------- debug

--- a/process/interceptors/multiDataInterceptor.go
+++ b/process/interceptors/multiDataInterceptor.go
@@ -113,32 +113,26 @@ func (mdi *MultiDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, 
 		return err
 	}
 
-	lastErrEncountered := error(nil)
-	wgProcess := &sync.WaitGroup{}
-	wgProcess.Add(len(multiDataBuff))
-
-	go func() {
-		wgProcess.Wait()
-		mdi.throttler.EndProcessing()
-	}()
-
+	listInterceptedData := make([]process.InterceptedData, len(multiDataBuff))
 	errOriginator := mdi.antifloodHandler.IsOriginatorEligibleForTopic(message.Peer(), mdi.topic)
-	allWhiteListed := true
-	for _, dataBuff := range multiDataBuff {
+
+	for index, dataBuff := range multiDataBuff {
 		var interceptedData process.InterceptedData
 		interceptedData, err = mdi.interceptedData(dataBuff, message.Peer(), fromConnectedPeer)
+		listInterceptedData[index] = interceptedData
 		if err != nil {
-			lastErrEncountered = err
-			wgProcess.Done()
-			continue
+			mdi.throttler.EndProcessing()
+			return err
 		}
 
 		isWhiteListed := mdi.whiteListRequest.IsWhiteListed(interceptedData)
 		if !isWhiteListed && errOriginator != nil {
-			lastErrEncountered = errOriginator
-			allWhiteListed = false
-			wgProcess.Done()
-			continue
+			mdi.throttler.EndProcessing()
+			log.Debug("got message from peer on topic only for validators", "originator",
+				p2p.PeerIdToShortString(message.Peer()),
+				"topic", mdi.topic,
+				"err", errOriginator)
+			return errOriginator
 		}
 
 		isForCurrentShard := interceptedData.IsForCurrentShard()
@@ -152,28 +146,25 @@ func (mdi *MultiDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, 
 				"is for this shard", isForCurrentShard,
 				"is white listed", isWhiteListed,
 			)
-			wgProcess.Done()
-			continue
+			mdi.throttler.EndProcessing()
+			return nil
 		}
-
-		go processInterceptedData(
-			mdi.processor,
-			mdi.interceptedDebugHandler,
-			interceptedData,
-			mdi.topic,
-			wgProcess,
-			message,
-		)
 	}
 
-	if !allWhiteListed && errOriginator != nil {
-		log.Debug("got message from peer on topic only for validators", "originator",
-			p2p.PeerIdToShortString(message.Peer()),
-			"topic", mdi.topic,
-			"err", errOriginator)
-	}
+	go func() {
+		for _, interceptedData := range listInterceptedData {
+			processInterceptedData(
+				mdi.processor,
+				mdi.interceptedDebugHandler,
+				interceptedData,
+				mdi.topic,
+				message,
+			)
+		}
+		mdi.throttler.EndProcessing()
+	}()
 
-	return lastErrEncountered
+	return nil
 }
 
 func (mdi *MultiDataInterceptor) interceptedData(dataBuff []byte, originator core.PeerID, fromConnectedPeer core.PeerID) (process.InterceptedData, error) {

--- a/process/interceptors/multiDataInterceptor.go
+++ b/process/interceptors/multiDataInterceptor.go
@@ -128,7 +128,7 @@ func (mdi *MultiDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, 
 		isWhiteListed := mdi.whiteListRequest.IsWhiteListed(interceptedData)
 		if !isWhiteListed && errOriginator != nil {
 			mdi.throttler.EndProcessing()
-			log.Debug("got message from peer on topic only for validators", "originator",
+			log.Trace("got message from peer on topic only for validators", "originator",
 				p2p.PeerIdToShortString(message.Peer()),
 				"topic", mdi.topic,
 				"err", errOriginator)
@@ -147,7 +147,7 @@ func (mdi *MultiDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, 
 				"is white listed", isWhiteListed,
 			)
 			mdi.throttler.EndProcessing()
-			return nil
+			return process.ErrInterceptedDataNotForCurrentShard
 		}
 	}
 

--- a/process/interceptors/multiDataInterceptor_test.go
+++ b/process/interceptors/multiDataInterceptor_test.go
@@ -345,8 +345,8 @@ func TestMultiDataInterceptor_ProcessReceivedPartiallyCorrectDataShouldErr(t *te
 	time.Sleep(time.Second)
 
 	assert.Equal(t, errExpected, err)
-	assert.Equal(t, int32(1), atomic.LoadInt32(&checkCalledNum))
-	assert.Equal(t, int32(1), atomic.LoadInt32(&processCalledNum))
+	assert.Equal(t, int32(0), atomic.LoadInt32(&checkCalledNum))
+	assert.Equal(t, int32(0), atomic.LoadInt32(&processCalledNum))
 	assert.Equal(t, int32(1), throttler.StartProcessingCount())
 	assert.Equal(t, int32(1), throttler.EndProcessingCount())
 }

--- a/process/interceptors/multiDataInterceptor_test.go
+++ b/process/interceptors/multiDataInterceptor_test.go
@@ -361,7 +361,7 @@ func TestMultiDataInterceptor_ProcessReceivedMessageNotValidShouldErrAndNotProce
 func TestMultiDataInterceptor_ProcessReceivedMessageIsAddressedToOtherShardShouldRetNilAndNotProcess(t *testing.T) {
 	t.Parallel()
 
-	testProcessReceiveMessageMultiData(t, false, nil, 0)
+	testProcessReceiveMessageMultiData(t, false, process.ErrInterceptedDataNotForCurrentShard, 0)
 }
 
 func TestMultiDataInterceptor_ProcessReceivedMessageOkMessageShouldRetNil(t *testing.T) {

--- a/process/interceptors/singleDataInterceptor.go
+++ b/process/interceptors/singleDataInterceptor.go
@@ -122,21 +122,16 @@ func (sdi *SingleDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P,
 		return nil
 	}
 
-	wgProcess := &sync.WaitGroup{}
-	wgProcess.Add(1)
 	go func() {
-		wgProcess.Wait()
+		processInterceptedData(
+			sdi.processor,
+			sdi.interceptedDebugHandler,
+			interceptedData,
+			sdi.topic,
+			message,
+		)
 		sdi.throttler.EndProcessing()
 	}()
-
-	go processInterceptedData(
-		sdi.processor,
-		sdi.interceptedDebugHandler,
-		interceptedData,
-		sdi.topic,
-		wgProcess,
-		message,
-	)
 
 	return nil
 }


### PR DESCRIPTION
added go routine control for multi data interceptors. made them launch only one routine per received message.