### PR TITLE
Fix pools cleaner lock-unlock and start from storage edge case

### DIFF
--- a/consensus/broadcast/metaChainMessenger.go
+++ b/consensus/broadcast/metaChainMessenger.go
@@ -169,8 +169,7 @@ func (mcm *metaChainMessenger) PrepareBroadcastBlockDataValidator(
 	_ map[uint32][]byte,
 	_ map[string][][]byte,
 	_ int,
-) error {
-	return nil
+) {
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/consensus/broadcast/shardChainMessenger.go
+++ b/consensus/broadcast/shardChainMessenger.go
@@ -205,17 +205,19 @@ func (scm *shardChainMessenger) PrepareBroadcastBlockDataValidator(
 	miniBlocks map[uint32][]byte,
 	transactions map[string][][]byte,
 	idx int,
-) error {
+) {
 	if check.IfNil(header) {
-		return spos.ErrNilHeader
+		log.Error("shardChainMessenger.PrepareBroadcastBlockDataValidator", "error", spos.ErrNilHeader)
+		return
 	}
 	if len(miniBlocks) == 0 {
-		return nil
+		return
 	}
 
 	headerHash, err := core.CalculateHash(scm.marshalizer, scm.hasher, header)
 	if err != nil {
-		return err
+		log.Error("shardChainMessenger.PrepareBroadcastBlockDataValidator", "error", err)
+		return
 	}
 
 	broadcastData := &delayedBroadcastData{
@@ -226,7 +228,10 @@ func (scm *shardChainMessenger) PrepareBroadcastBlockDataValidator(
 		order:          uint32(idx),
 	}
 
-	return scm.delayedBlockBroadcaster.SetValidatorData(broadcastData)
+	err = scm.delayedBlockBroadcaster.SetValidatorData(broadcastData)
+	if err != nil {
+		log.Error("shardChainMessenger.PrepareBroadcastBlockDataValidator", "error", err)
+	}
 }
 
 // Close closes all the started infinite looping goroutines and subcomponents

--- a/consensus/broadcast/shardChainMessenger_test.go
+++ b/consensus/broadcast/shardChainMessenger_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/factory"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func createDelayData(prefix string) ([]byte, *block.Header, map[uint32][]byte, map[string][][]byte) {
@@ -366,52 +365,4 @@ func TestShardChainMessenger_BroadcastBlockDataLeaderShouldTriggerWaitingDelayed
 	time.Sleep(10 * time.Millisecond)
 	assert.Nil(t, err)
 	assert.True(t, wasCalled.IsSet())
-}
-
-func TestShardChainMessenger_PrepareBroadcastBlockDataValidatorNilHeaderShouldErr(t *testing.T) {
-	args := createDefaultShardChainArgs()
-	scm, _ := broadcast.NewShardChainMessenger(args)
-	vArgs := createValidatorDelayArgs(0)
-	vArgs.header = nil
-
-	err := scm.PrepareBroadcastBlockDataValidator(
-		vArgs.header,
-		vArgs.miniBlocks,
-		vArgs.transactions,
-		int(vArgs.order),
-	)
-
-	require.Equal(t, spos.ErrNilHeader, err)
-}
-
-func TestShardChainMessenger_PrepareBroadcastBlockDataValidatorNoMiniBlocksShouldReturn(t *testing.T) {
-	args := createDefaultShardChainArgs()
-	scm, _ := broadcast.NewShardChainMessenger(args)
-	vArgs := createValidatorDelayArgs(0)
-	vArgs.miniBlocks = nil
-	vArgs.transactions = nil
-
-	err := scm.PrepareBroadcastBlockDataValidator(
-		vArgs.header,
-		vArgs.miniBlocks,
-		vArgs.transactions,
-		int(vArgs.order),
-	)
-
-	require.Nil(t, err)
-}
-
-func TestShardChainMessenger_PrepareBroadcastBlockDataValidatorOK(t *testing.T) {
-	args := createDefaultShardChainArgs()
-	scm, _ := broadcast.NewShardChainMessenger(args)
-	vArgs := createValidatorDelayArgs(0)
-
-	err := scm.PrepareBroadcastBlockDataValidator(
-		vArgs.header,
-		vArgs.miniBlocks,
-		vArgs.transactions,
-		int(vArgs.order),
-	)
-
-	require.Nil(t, err)
 }

--- a/consensus/interface.go
+++ b/consensus/interface.go
@@ -64,7 +64,7 @@ type BroadcastMessenger interface {
 	BroadcastConsensusMessage(*Message) error
 	BroadcastBlockDataLeader(header data.HeaderHandler, miniBlocks map[uint32][]byte, transactions map[string][][]byte) error
 	PrepareBroadcastHeaderValidator(header data.HeaderHandler, miniBlocks map[uint32][]byte, transactions map[string][][]byte, order int)
-	PrepareBroadcastBlockDataValidator(header data.HeaderHandler, miniBlocks map[uint32][]byte, transactions map[string][][]byte, idx int) error
+	PrepareBroadcastBlockDataValidator(header data.HeaderHandler, miniBlocks map[uint32][]byte, transactions map[string][][]byte, idx int)
 	IsInterfaceNil() bool
 }
 

--- a/consensus/mock/broadcastMessangerMock.go
+++ b/consensus/mock/broadcastMessangerMock.go
@@ -57,16 +57,15 @@ func (bmm *BroadcastMessengerMock) PrepareBroadcastBlockDataValidator(
 	miniBlocks map[uint32][]byte,
 	transactions map[string][][]byte,
 	idx int,
-) error {
+) {
 	if bmm.PrepareBroadcastBlockDataValidatorCalled != nil {
-		return bmm.PrepareBroadcastBlockDataValidatorCalled(
+		bmm.PrepareBroadcastBlockDataValidatorCalled(
 			header,
 			miniBlocks,
 			transactions,
 			idx,
 		)
 	}
-	return nil
 }
 
 // PrepareBroadcastHeaderValidator -

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -342,3 +342,10 @@ func (sp *shardProcessor) CreateBlockBody(shardHdr *block.Header, haveTime func(
 func (sp *shardProcessor) CheckEpochCorrectnessCrossChain() error {
 	return sp.checkEpochCorrectnessCrossChain()
 }
+
+func (sp *shardProcessor) GetBootstrapHeadersInfo(
+	selfNotarizedHeaders []data.HeaderHandler,
+	selfNotarizedHeadersHashes [][]byte,
+) []bootstrapStorage.BootstrapHeaderInfo {
+	return sp.getBootstrapHeadersInfo(selfNotarizedHeaders, selfNotarizedHeadersHashes)
+}

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -4377,3 +4377,96 @@ func TestShardProcessor_checkEpochCorrectnessCrossChainInCorrectEpochRollback2Bl
 	assert.Equal(t, process.ErrEpochDoesNotMatch, err)
 	assert.Equal(t, nonceCalled, prevHeader.Nonce)
 }
+
+func TestShardProcessor_GetBootstrapHeadersInfoShouldReturnNilWhenNoSelfNotarizedHeadersExists(t *testing.T) {
+	t.Parallel()
+
+	arguments := CreateMockArgumentsMultiShard()
+	sp, _ := blproc.NewShardProcessor(arguments)
+
+	bootstrapHeaderInfos := sp.GetBootstrapHeadersInfo(nil, nil)
+
+	assert.Nil(t, bootstrapHeaderInfos)
+}
+
+func TestShardProcessor_GetBootstrapHeadersInfoShouldReturnOneItemWhenFinalNonceIsHigherThanGenesis(t *testing.T) {
+	t.Parallel()
+
+	finalNonce := uint64(1)
+	finalHash := []byte("final hash")
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.ForkDetector = &mock.ForkDetectorMock{
+		GetHighestFinalBlockNonceCalled: func() uint64 {
+			return finalNonce
+		},
+		GetHighestFinalBlockHashCalled: func() []byte {
+			return finalHash
+		},
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
+
+	bootstrapHeaderInfos := sp.GetBootstrapHeadersInfo(nil, nil)
+
+	require.Equal(t, 1, len(bootstrapHeaderInfos))
+	assert.Equal(t, finalHash, bootstrapHeaderInfos[0].Hash)
+}
+
+func TestShardProcessor_GetBootstrapHeadersInfoShouldReturnOneItemWhenFinalNonceIsNotHigherThanSelfNotarizedNonce(t *testing.T) {
+	t.Parallel()
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.ForkDetector = &mock.ForkDetectorMock{
+		GetHighestFinalBlockNonceCalled: func() uint64 {
+			return 0
+		},
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
+
+	hash := []byte("hash")
+	header := &block.Header{}
+
+	selfNotarizedHeaders := make([]data.HeaderHandler, 0)
+	selfNotarizedHeadersHashes := make([][]byte, 0)
+
+	selfNotarizedHeaders = append(selfNotarizedHeaders, header)
+	selfNotarizedHeadersHashes = append(selfNotarizedHeadersHashes, hash)
+
+	bootstrapHeaderInfos := sp.GetBootstrapHeadersInfo(selfNotarizedHeaders, selfNotarizedHeadersHashes)
+
+	require.Equal(t, 1, len(bootstrapHeaderInfos))
+	assert.Equal(t, hash, bootstrapHeaderInfos[0].Hash)
+}
+
+func TestShardProcessor_GetBootstrapHeadersInfoShouldReturnTwoItemsWhenFinalNonceIsHigherThanSelfNotarizedNonce(t *testing.T) {
+	t.Parallel()
+
+	finalNonce := uint64(2)
+	finalHash := []byte("final hash")
+
+	arguments := CreateMockArgumentsMultiShard()
+	arguments.ForkDetector = &mock.ForkDetectorMock{
+		GetHighestFinalBlockNonceCalled: func() uint64 {
+			return finalNonce
+		},
+		GetHighestFinalBlockHashCalled: func() []byte {
+			return finalHash
+		},
+	}
+	sp, _ := blproc.NewShardProcessor(arguments)
+
+	hash := []byte("hash")
+	header := &block.Header{Nonce: 1}
+
+	selfNotarizedHeaders := make([]data.HeaderHandler, 0)
+	selfNotarizedHeadersHashes := make([][]byte, 0)
+
+	selfNotarizedHeaders = append(selfNotarizedHeaders, header)
+	selfNotarizedHeadersHashes = append(selfNotarizedHeadersHashes, hash)
+
+	bootstrapHeaderInfos := sp.GetBootstrapHeadersInfo(selfNotarizedHeaders, selfNotarizedHeadersHashes)
+
+	require.Equal(t, 2, len(bootstrapHeaderInfos))
+	assert.Equal(t, hash, bootstrapHeaderInfos[0].Hash)
+	assert.Equal(t, finalHash, bootstrapHeaderInfos[1].Hash)
+}


### PR DESCRIPTION
* Fixed edge case on bootstrap from storage when the highest final nonce was higher than highest self notarized nonce committed in the last block (this situation could happen when a node is in sync mode and each committed block become final because the node has in advance info from metachain, which confirms the finality of the committed block, and also that the node is on right chain)
* Fixed/optimized lock/unlock situation in txPoolsCleaner and miniBlockPoolsCleaner
* Optimized computation for PrepareBroadcastBlockDataValidator in subround EndRound