### PR TITLE
ratings increases and decreases for metachain are 20% more than in the shards

### DIFF
--- a/cmd/node/config/ratings.toml
+++ b/cmd/node/config/ratings.toml
@@ -13,7 +13,6 @@
     StartRating = 5000001
     MaxRating = 10000000
     MinRating = 1
-    HoursToMaxRatingFromStartRating = 72
     SignedBlocksThreshold = 0.01
     SelectionChances = [
         { MaxThreshold = 0, ChancePercent = 5},
@@ -30,12 +29,14 @@
     ]
 
 [ShardChain.RatingSteps]
+    HoursToMaxRatingFromStartRating = 72
     ProposerValidatorImportance = 1.0
     ProposerDecreaseFactor = -4.0
     ValidatorDecreaseFactor = -4.0
     ConsecutiveMissedBlocksPenalty = 1.10
 
 [MetaChain.RatingSteps]
+    HoursToMaxRatingFromStartRating = 60
     ProposerValidatorImportance = 1.0
     ProposerDecreaseFactor = -4.0
     ValidatorDecreaseFactor = -4.0

--- a/config/ratingsConfig.go
+++ b/config/ratingsConfig.go
@@ -10,12 +10,11 @@ type RatingsConfig struct {
 
 // General will hold ratings settings both for metachain and shardChain
 type General struct {
-	StartRating                     uint32
-	MaxRating                       uint32
-	MinRating                       uint32
-	SignedBlocksThreshold           float32
-	HoursToMaxRatingFromStartRating uint32
-	SelectionChances                []*SelectionChance
+	StartRating           uint32
+	MaxRating             uint32
+	MinRating             uint32
+	SignedBlocksThreshold float32
+	SelectionChances      []*SelectionChance
 }
 
 // ShardChain will hold RatingSteps for the Shard
@@ -42,10 +41,11 @@ type SelectionChance struct {
 
 // RatingSteps holds the necessary increases and decreases of the rating steps
 type RatingSteps struct {
-	ProposerValidatorImportance    float32
-	ProposerDecreaseFactor         float32
-	ValidatorDecreaseFactor        float32
-	ConsecutiveMissedBlocksPenalty float32
+	HoursToMaxRatingFromStartRating uint32
+	ProposerValidatorImportance     float32
+	ProposerDecreaseFactor          float32
+	ValidatorDecreaseFactor         float32
+	ConsecutiveMissedBlocksPenalty  float32
 }
 
 // PeerHonestyConfig holds the parameters for the peer honesty handler

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -628,26 +628,27 @@ func CreateRatingsData() *rating.RatingsData {
 	ratingsConfig := config.RatingsConfig{
 		ShardChain: config.ShardChain{
 			RatingSteps: config.RatingSteps{
-				ProposerValidatorImportance:    1,
-				ProposerDecreaseFactor:         -4,
-				ValidatorDecreaseFactor:        -4,
-				ConsecutiveMissedBlocksPenalty: 1.1,
+				HoursToMaxRatingFromStartRating: 50,
+				ProposerValidatorImportance:     1,
+				ProposerDecreaseFactor:          -4,
+				ValidatorDecreaseFactor:         -4,
+				ConsecutiveMissedBlocksPenalty:  1.1,
 			},
 		},
 		MetaChain: config.MetaChain{
 			RatingSteps: config.RatingSteps{
-				ProposerValidatorImportance:    1,
-				ProposerDecreaseFactor:         -4,
-				ValidatorDecreaseFactor:        -4,
-				ConsecutiveMissedBlocksPenalty: 1.1,
+				HoursToMaxRatingFromStartRating: 50,
+				ProposerValidatorImportance:     1,
+				ProposerDecreaseFactor:          -4,
+				ValidatorDecreaseFactor:         -4,
+				ConsecutiveMissedBlocksPenalty:  1.1,
 			},
 		},
 		General: config.General{
-			StartRating:                     500000,
-			MaxRating:                       1000000,
-			MinRating:                       1,
-			HoursToMaxRatingFromStartRating: 50,
-			SignedBlocksThreshold:           0.025,
+			StartRating:           500000,
+			MaxRating:             1000000,
+			MinRating:             1,
+			SignedBlocksThreshold: 0.025,
 			SelectionChances: []*config.SelectionChance{
 				{
 					MaxThreshold:  0,

--- a/process/rating/ratingsData.go
+++ b/process/rating/ratingsData.go
@@ -68,7 +68,7 @@ func NewRatingsData(args RatingsDataArg) (*RatingsData, error) {
 		roundTimeMilis:                  args.RoundDurationMiliseconds,
 		startRating:                     ratingsConfig.General.StartRating,
 		maxRating:                       ratingsConfig.General.MaxRating,
-		hoursToMaxRatingFromStartRating: ratingsConfig.General.HoursToMaxRatingFromStartRating,
+		hoursToMaxRatingFromStartRating: ratingsConfig.ShardChain.HoursToMaxRatingFromStartRating,
 		proposerDecreaseFactor:          ratingsConfig.ShardChain.ProposerDecreaseFactor,
 		validatorDecreaseFactor:         ratingsConfig.ShardChain.ValidatorDecreaseFactor,
 		consecutiveMissedBlocksPenalty:  ratingsConfig.ShardChain.ConsecutiveMissedBlocksPenalty,
@@ -85,7 +85,7 @@ func NewRatingsData(args RatingsDataArg) (*RatingsData, error) {
 		roundTimeMilis:                  args.RoundDurationMiliseconds,
 		startRating:                     ratingsConfig.General.StartRating,
 		maxRating:                       ratingsConfig.General.MaxRating,
-		hoursToMaxRatingFromStartRating: ratingsConfig.General.HoursToMaxRatingFromStartRating,
+		hoursToMaxRatingFromStartRating: ratingsConfig.MetaChain.HoursToMaxRatingFromStartRating,
 		proposerDecreaseFactor:          ratingsConfig.MetaChain.ProposerDecreaseFactor,
 		validatorDecreaseFactor:         ratingsConfig.MetaChain.ValidatorDecreaseFactor,
 		consecutiveMissedBlocksPenalty:  ratingsConfig.MetaChain.ConsecutiveMissedBlocksPenalty,
@@ -129,8 +129,13 @@ func verifyRatingsConfig(settings config.RatingsConfig) error {
 			process.ErrSignedBlocksThresholdNotBetweenZeroAndOne,
 			settings.General.SignedBlocksThreshold)
 	}
-	if settings.General.HoursToMaxRatingFromStartRating == 0 {
-		return process.ErrHoursToMaxRatingFromStartRatingZero
+	if settings.ShardChain.HoursToMaxRatingFromStartRating == 0 {
+		return fmt.Errorf("%w hoursToMaxRatingFromStartRating: shardChain",
+			process.ErrHoursToMaxRatingFromStartRatingZero)
+	}
+	if settings.MetaChain.HoursToMaxRatingFromStartRating == 0 {
+		return fmt.Errorf("%w hoursToMaxRatingFromStartRating: metachain",
+			process.ErrHoursToMaxRatingFromStartRatingZero)
 	}
 	if settings.MetaChain.ConsecutiveMissedBlocksPenalty < 1 {
 		return fmt.Errorf("%w: metaChain consecutiveMissedBlocksPenalty: %v",

--- a/process/rating/ratingsData_test.go
+++ b/process/rating/ratingsData_test.go
@@ -47,11 +47,10 @@ func createDymmyRatingsData() RatingsDataArg {
 func createDummyRatingsConfig() config.RatingsConfig {
 	return config.RatingsConfig{
 		General: config.General{
-			StartRating:                     4000,
-			MaxRating:                       10000,
-			MinRating:                       1,
-			SignedBlocksThreshold:           signedBlocksThreshold,
-			HoursToMaxRatingFromStartRating: 2,
+			StartRating:           4000,
+			MaxRating:             10000,
+			MinRating:             1,
+			SignedBlocksThreshold: signedBlocksThreshold,
 			SelectionChances: []*config.SelectionChance{
 				{MaxThreshold: 0, ChancePercent: 5},
 				{MaxThreshold: 25, ChancePercent: 19},
@@ -61,18 +60,20 @@ func createDummyRatingsConfig() config.RatingsConfig {
 		},
 		ShardChain: config.ShardChain{
 			RatingSteps: config.RatingSteps{
-				ProposerValidatorImportance:    1,
-				ProposerDecreaseFactor:         -4,
-				ValidatorDecreaseFactor:        -4,
-				ConsecutiveMissedBlocksPenalty: consecutiveMissedBlocksPenalty,
+				HoursToMaxRatingFromStartRating: 2,
+				ProposerValidatorImportance:     1,
+				ProposerDecreaseFactor:          -4,
+				ValidatorDecreaseFactor:         -4,
+				ConsecutiveMissedBlocksPenalty:  consecutiveMissedBlocksPenalty,
 			},
 		},
 		MetaChain: config.MetaChain{
 			RatingSteps: config.RatingSteps{
-				ProposerValidatorImportance:    1,
-				ProposerDecreaseFactor:         -4,
-				ValidatorDecreaseFactor:        -4,
-				ConsecutiveMissedBlocksPenalty: consecutiveMissedBlocksPenalty,
+				HoursToMaxRatingFromStartRating: 2,
+				ProposerValidatorImportance:     1,
+				ProposerDecreaseFactor:          -4,
+				ValidatorDecreaseFactor:         -4,
+				ConsecutiveMissedBlocksPenalty:  consecutiveMissedBlocksPenalty,
 			},
 		},
 	}
@@ -185,12 +186,12 @@ func TestRatingsData_HoursToMaxRatingFromStartRatingZeroErr(t *testing.T) {
 
 	ratingsDataArg := createDymmyRatingsData()
 	ratingsConfig := createDummyRatingsConfig()
-	ratingsConfig.General.HoursToMaxRatingFromStartRating = 0
+	ratingsConfig.MetaChain.HoursToMaxRatingFromStartRating = 0
 	ratingsDataArg.Config = ratingsConfig
 	ratingsData, err := NewRatingsData(ratingsDataArg)
 
 	require.Nil(t, ratingsData)
-	require.Equal(t, process.ErrHoursToMaxRatingFromStartRatingZero, err)
+	require.True(t, errors.Is(err, process.ErrHoursToMaxRatingFromStartRatingZero))
 }
 
 func TestRatingsData_PositiveDecreaseRatingsStepsShouldErr(t *testing.T) {
@@ -336,7 +337,7 @@ func TestRatingsData_IncreaseLowerThanZeroErr(t *testing.T) {
 	ratingsDataArg := createDymmyRatingsData()
 	ratingsConfig := createDummyRatingsConfig()
 	ratingsDataArg.Config = ratingsConfig
-	ratingsDataArg.Config.General.HoursToMaxRatingFromStartRating = math.MaxUint32
+	ratingsDataArg.Config.MetaChain.HoursToMaxRatingFromStartRating = math.MaxUint32
 	ratingsData, err := NewRatingsData(ratingsDataArg)
 
 	require.Nil(t, ratingsData)
@@ -346,7 +347,7 @@ func TestRatingsData_IncreaseLowerThanZeroErr(t *testing.T) {
 	ratingsDataArg = createDymmyRatingsData()
 	ratingsConfig = createDummyRatingsConfig()
 	ratingsDataArg.Config = ratingsConfig
-	ratingsDataArg.Config.General.HoursToMaxRatingFromStartRating = 2
+	ratingsDataArg.Config.MetaChain.HoursToMaxRatingFromStartRating = 2
 	ratingsDataArg.Config.MetaChain.ProposerValidatorImportance = math.MaxUint32
 	ratingsData, err = NewRatingsData(ratingsDataArg)
 
@@ -372,7 +373,8 @@ func TestRatingsData_RatingsCorrectValues(t *testing.T) {
 	ratingsConfig.General.MinRating = minRating
 	ratingsConfig.General.MaxRating = maxRating
 	ratingsConfig.General.StartRating = startRating
-	ratingsConfig.General.HoursToMaxRatingFromStartRating = hoursToMaxRatingFromStartRating
+	ratingsConfig.MetaChain.HoursToMaxRatingFromStartRating = hoursToMaxRatingFromStartRating
+	ratingsConfig.ShardChain.HoursToMaxRatingFromStartRating = hoursToMaxRatingFromStartRating
 	ratingsConfig.General.SignedBlocksThreshold = signedBlocksThreshold
 	ratingsConfig.ShardChain.ConsecutiveMissedBlocksPenalty = shardConsecutivePenalty
 	ratingsConfig.ShardChain.ProposerDecreaseFactor = decreaseFactor

--- a/sharding/indexHashedNodesCoordinator.go
+++ b/sharding/indexHashedNodesCoordinator.go
@@ -310,7 +310,9 @@ func (ihgs *indexHashedNodesCoordinator) ComputeConsensusGroup(
 		"randomness", randomness,
 		"consensus size", consensusSize,
 		"eligible list length", len(eligibleList),
-		"epoch", epoch)
+		"epoch", epoch,
+		"round", round,
+		"shardID", shardID)
 
 	tempList, err := selectValidators(selector, randomness, uint32(consensusSize), eligibleList)
 	if err != nil {


### PR DESCRIPTION
- differentiate rating increases and decreases to have a higher value in the metachain of ~10% for each shard => 20% increase  in a setup with 2 shards and metachain
- added round and shardId to nodescoordinator.ComputeConsensusGroup for log.Debug