### PR TITLE
Fixed panic in alarm

### DIFF
--- a/core/alarm/alarm.go
+++ b/core/alarm/alarm.go
@@ -177,13 +177,14 @@ func (as *alarmScheduler) Close() {
 func (as *alarmScheduler) Reset(alarmID string) {
 	as.mutScheduledAlarms.RLock()
 	alarm, ok := as.scheduledAlarms[alarmID]
+	if !ok {
+		as.mutScheduledAlarms.RUnlock()
+		return
+	}
+
 	callback := alarm.callback
 	duration := alarm.initialDuration
 	as.mutScheduledAlarms.RUnlock()
-
-	if !ok {
-		return
-	}
 
 	evt := alarmEvent{
 		alarmID: alarmID,


### PR DESCRIPTION
- fixed panic in alarm.go by correctly treating the ok flag after fetching the alarm struct from the internal map