### PR TITLE
consensus: fix: TrimPrefix instead of TrimLeft for trimming prefixes

### DIFF
--- a/consensus/broadcast/delayedBroadcast.go
+++ b/consensus/broadcast/delayedBroadcast.go
@@ -377,7 +377,7 @@ func (dbb *delayedBlockBroadcaster) scheduleValidatorBroadcast(dataForValidators
 }
 
 func (dbb *delayedBlockBroadcaster) alarmExpired(alarmID string) {
-	headerHash, err := hex.DecodeString(strings.TrimLeft(alarmID, prefixDelayDataAlarm))
+	headerHash, err := hex.DecodeString(strings.TrimPrefix(alarmID, prefixDelayDataAlarm))
 	if err != nil {
 		log.Error("delayedBroadcast.alarmExpired", "error", err.Error(), "alarmID", alarmID)
 		return


### PR DESCRIPTION
Fix: TrimLeft removes characters left not prefixes, use TrimPrefix instead.