### PR TITLE
GetAllLeaves On Channel 

### DIFF
--- a/core/interface.go
+++ b/core/interface.go
@@ -44,3 +44,9 @@ type WatchdogTimer interface {
 	Reset(alarmID string)
 	IsInterfaceNil() bool
 }
+
+// KeyValueHolder is used to hold a key and an associated value
+type KeyValueHolder interface {
+	GetKey() []byte
+	GetValue() []byte
+}

--- a/core/keyValStorage/keyValStorage.go
+++ b/core/keyValStorage/keyValStorage.go
@@ -1,0 +1,25 @@
+package keyValStorage
+
+// KeyValStorage holds a key and an associated value
+type keyValStorage struct {
+	key   []byte
+	value []byte
+}
+
+// NewKeyValStorage creates a new key-value storage
+func NewKeyValStorage(key []byte, val []byte) *keyValStorage {
+	return &keyValStorage{
+		key:   key,
+		value: val,
+	}
+}
+
+// GetKey returns the key in the key-value storage
+func (k *keyValStorage) GetKey() []byte {
+	return k.key
+}
+
+// GetValue returns the value in the key-value storage
+func (k *keyValStorage) GetValue() []byte {
+	return k.value
+}

--- a/core/keyValStorage/keyValStorage_test.go
+++ b/core/keyValStorage/keyValStorage_test.go
@@ -1,0 +1,20 @@
+package keyValStorage_test
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/core/keyValStorage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewKeyValStorage_GetKeyAndVal(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("key")
+	value := []byte("value")
+
+	keyVal := keyValStorage.NewKeyValStorage(key, value)
+	assert.NotNil(t, keyVal)
+	assert.Equal(t, key, keyVal.GetKey())
+	assert.Equal(t, value, keyVal.GetValue())
+}

--- a/data/interface.go
+++ b/data/interface.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/core"
 )
 
 // TriePruningIdentifier is the type for trie pruning identifiers
@@ -19,12 +20,6 @@ const (
 
 // ModifiedHashes is used to memorize all old hashes and new hashes from when a trie is committed
 type ModifiedHashes map[string]struct{}
-
-// TrieLeaf holds the key to a leaf and the value associated with that leaf
-type TrieLeaf struct {
-	Key   []byte
-	Value []byte
-}
 
 // HeaderHandler defines getters and setters for header data holder
 type HeaderHandler interface {
@@ -167,7 +162,7 @@ type Trie interface {
 	Database() DBWriteCacher
 	GetSerializedNodes([]byte, uint64) ([][]byte, uint64, error)
 	GetAllLeaves() (map[string][]byte, error)
-	GetAllLeavesOnChannel(leavesChannel chan *TrieLeaf) error
+	GetAllLeavesOnChannel() chan core.KeyValueHolder
 	GetAllHashes() ([][]byte, error)
 	IsPruningEnabled() bool
 	EnterSnapshotMode()

--- a/data/interface.go
+++ b/data/interface.go
@@ -20,6 +20,12 @@ const (
 // ModifiedHashes is used to memorize all old hashes and new hashes from when a trie is committed
 type ModifiedHashes map[string]struct{}
 
+// TrieLeaf holds the key to a leaf and the value associated with that leaf
+type TrieLeaf struct {
+	Key   []byte
+	Value []byte
+}
+
 // HeaderHandler defines getters and setters for header data holder
 type HeaderHandler interface {
 	GetShardID() uint32
@@ -161,6 +167,7 @@ type Trie interface {
 	Database() DBWriteCacher
 	GetSerializedNodes([]byte, uint64) ([][]byte, uint64, error)
 	GetAllLeaves() (map[string][]byte, error)
+	GetAllLeavesOnChannel(leavesChannel chan *TrieLeaf) error
 	GetAllHashes() ([][]byte, error)
 	IsPruningEnabled() bool
 	EnterSnapshotMode()

--- a/data/mock/trieStub.go
+++ b/data/mock/trieStub.go
@@ -10,24 +10,25 @@ var errNotImplemented = errors.New("not implemented")
 
 // TrieStub -
 type TrieStub struct {
-	GetCalled                func(key []byte) ([]byte, error)
-	UpdateCalled             func(key, value []byte) error
-	DeleteCalled             func(key []byte) error
-	RootCalled               func() ([]byte, error)
-	CommitCalled             func() error
-	RecreateCalled           func(root []byte) (data.Trie, error)
-	CancelPruneCalled        func(rootHash []byte, identifier data.TriePruningIdentifier)
-	PruneCalled              func(rootHash []byte, identifier data.TriePruningIdentifier)
-	ResetOldHashesCalled     func() [][]byte
-	AppendToOldHashesCalled  func([][]byte)
-	TakeSnapshotCalled       func(rootHash []byte)
-	SetCheckpointCalled      func(rootHash []byte)
-	GetSerializedNodesCalled func([]byte, uint64) ([][]byte, uint64, error)
-	DatabaseCalled           func() data.DBWriteCacher
-	GetAllLeavesCalled       func() (map[string][]byte, error)
-	GetAllHashesCalled       func() ([][]byte, error)
-	IsPruningEnabledCalled   func() bool
-	ClosePersisterCalled     func() error
+	GetCalled                   func(key []byte) ([]byte, error)
+	UpdateCalled                func(key, value []byte) error
+	DeleteCalled                func(key []byte) error
+	RootCalled                  func() ([]byte, error)
+	CommitCalled                func() error
+	RecreateCalled              func(root []byte) (data.Trie, error)
+	CancelPruneCalled           func(rootHash []byte, identifier data.TriePruningIdentifier)
+	PruneCalled                 func(rootHash []byte, identifier data.TriePruningIdentifier)
+	ResetOldHashesCalled        func() [][]byte
+	AppendToOldHashesCalled     func([][]byte)
+	TakeSnapshotCalled          func(rootHash []byte)
+	SetCheckpointCalled         func(rootHash []byte)
+	GetSerializedNodesCalled    func([]byte, uint64) ([][]byte, uint64, error)
+	DatabaseCalled              func() data.DBWriteCacher
+	GetAllLeavesCalled          func() (map[string][]byte, error)
+	GetAllLeavesOnChannelCalled func(chan *data.TrieLeaf) error
+	GetAllHashesCalled          func() ([][]byte, error)
+	IsPruningEnabledCalled      func() bool
+	ClosePersisterCalled        func() error
 }
 
 // EnterSnapshotMode -
@@ -113,6 +114,15 @@ func (ts *TrieStub) GetAllLeaves() (map[string][]byte, error) {
 	}
 
 	return nil, errNotImplemented
+}
+
+// GetAllLeavesOnChannel -
+func (ts *TrieStub) GetAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf) error {
+	if ts.GetAllLeavesOnChannelCalled != nil {
+		return ts.GetAllLeavesOnChannelCalled(leavesChannel)
+	}
+
+	return errNotImplemented
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/data/mock/trieStub.go
+++ b/data/mock/trieStub.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"errors"
 
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data"
 )
 
@@ -25,7 +26,7 @@ type TrieStub struct {
 	GetSerializedNodesCalled    func([]byte, uint64) ([][]byte, uint64, error)
 	DatabaseCalled              func() data.DBWriteCacher
 	GetAllLeavesCalled          func() (map[string][]byte, error)
-	GetAllLeavesOnChannelCalled func(chan *data.TrieLeaf) error
+	GetAllLeavesOnChannelCalled func() chan core.KeyValueHolder
 	GetAllHashesCalled          func() ([][]byte, error)
 	IsPruningEnabledCalled      func() bool
 	ClosePersisterCalled        func() error
@@ -117,12 +118,12 @@ func (ts *TrieStub) GetAllLeaves() (map[string][]byte, error) {
 }
 
 // GetAllLeavesOnChannel -
-func (ts *TrieStub) GetAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf) error {
+func (ts *TrieStub) GetAllLeavesOnChannel() chan core.KeyValueHolder {
 	if ts.GetAllLeavesOnChannelCalled != nil {
-		return ts.GetAllLeavesOnChannelCalled(leavesChannel)
+		return ts.GetAllLeavesOnChannelCalled()
 	}
 
-	return errNotImplemented
+	return nil
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/data/trie/branchNode.go
+++ b/data/trie/branchNode.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"sync"
 
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/hashing"
@@ -730,7 +731,7 @@ func (bn *branchNode) getAllLeaves(leaves map[string][]byte, key []byte, db data
 	return nil
 }
 
-func (bn *branchNode) getAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf, key []byte, db data.DBWriteCacher, marshalizer marshal.Marshalizer) error {
+func (bn *branchNode) getAllLeavesOnChannel(leavesChannel chan core.KeyValueHolder, key []byte, db data.DBWriteCacher, marshalizer marshal.Marshalizer) error {
 	err := bn.isEmptyOrNil()
 	if err != nil {
 		return fmt.Errorf("getAllLeavesOnChannel error: %w", err)

--- a/data/trie/extensionNode.go
+++ b/data/trie/extensionNode.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"sync"
 
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/hashing"
@@ -593,7 +594,7 @@ func (en *extensionNode) getAllLeaves(leaves map[string][]byte, key []byte, db d
 	return nil
 }
 
-func (en *extensionNode) getAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf, key []byte, db data.DBWriteCacher, marshalizer marshal.Marshalizer) error {
+func (en *extensionNode) getAllLeavesOnChannel(leavesChannel chan core.KeyValueHolder, key []byte, db data.DBWriteCacher, marshalizer marshal.Marshalizer) error {
 	err := en.isEmptyOrNil()
 	if err != nil {
 		return fmt.Errorf("getAllLeavesOnChannel error: %w", err)

--- a/data/trie/extensionNode.go
+++ b/data/trie/extensionNode.go
@@ -593,6 +593,26 @@ func (en *extensionNode) getAllLeaves(leaves map[string][]byte, key []byte, db d
 	return nil
 }
 
+func (en *extensionNode) getAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf, key []byte, db data.DBWriteCacher, marshalizer marshal.Marshalizer) error {
+	err := en.isEmptyOrNil()
+	if err != nil {
+		return fmt.Errorf("getAllLeavesOnChannel error: %w", err)
+	}
+
+	err = resolveIfCollapsed(en, 0, db)
+	if err != nil {
+		return err
+	}
+
+	childKey := append(key, en.Key...)
+	err = en.child.getAllLeavesOnChannel(leavesChannel, childKey, db, marshalizer)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (en *extensionNode) getAllHashes(db data.DBWriteCacher) ([][]byte, error) {
 	err := en.isEmptyOrNil()
 	if err != nil {

--- a/data/trie/interface.go
+++ b/data/trie/interface.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
@@ -39,7 +40,7 @@ type node interface {
 	setDirty(bool)
 	loadChildren(func([]byte) (node, error)) ([][]byte, []node, error)
 	getAllLeaves(map[string][]byte, []byte, data.DBWriteCacher, marshal.Marshalizer) error
-	getAllLeavesOnChannel(chan *data.TrieLeaf, []byte, data.DBWriteCacher, marshal.Marshalizer) error
+	getAllLeavesOnChannel(chan core.KeyValueHolder, []byte, data.DBWriteCacher, marshal.Marshalizer) error
 	getAllHashes(db data.DBWriteCacher) ([][]byte, error)
 
 	getMarshalizer() marshal.Marshalizer

--- a/data/trie/interface.go
+++ b/data/trie/interface.go
@@ -39,6 +39,7 @@ type node interface {
 	setDirty(bool)
 	loadChildren(func([]byte) (node, error)) ([][]byte, []node, error)
 	getAllLeaves(map[string][]byte, []byte, data.DBWriteCacher, marshal.Marshalizer) error
+	getAllLeavesOnChannel(chan *data.TrieLeaf, []byte, data.DBWriteCacher, marshal.Marshalizer) error
 	getAllHashes(db data.DBWriteCacher) ([][]byte, error)
 
 	getMarshalizer() marshal.Marshalizer

--- a/data/trie/leafNode.go
+++ b/data/trie/leafNode.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"sync"
 
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
+	"github.com/ElrondNetwork/elrond-go/core/keyValStorage"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
@@ -355,7 +357,7 @@ func (ln *leafNode) getAllLeaves(leaves map[string][]byte, key []byte, _ data.DB
 	return nil
 }
 
-func (ln *leafNode) getAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf, key []byte, _ data.DBWriteCacher, _ marshal.Marshalizer) error {
+func (ln *leafNode) getAllLeavesOnChannel(leavesChannel chan core.KeyValueHolder, key []byte, _ data.DBWriteCacher, _ marshal.Marshalizer) error {
 	err := ln.isEmptyOrNil()
 	if err != nil {
 		return fmt.Errorf("getAllLeavesOnChannel error: %w", err)
@@ -367,10 +369,7 @@ func (ln *leafNode) getAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf, key
 		return err
 	}
 
-	trieLeaf := &data.TrieLeaf{
-		Key:   nodeKey,
-		Value: ln.Value,
-	}
+	trieLeaf := keyValStorage.NewKeyValStorage(nodeKey, ln.Value)
 	leavesChannel <- trieLeaf
 
 	return nil

--- a/data/trie/leafNode.go
+++ b/data/trie/leafNode.go
@@ -355,6 +355,27 @@ func (ln *leafNode) getAllLeaves(leaves map[string][]byte, key []byte, _ data.DB
 	return nil
 }
 
+func (ln *leafNode) getAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf, key []byte, _ data.DBWriteCacher, _ marshal.Marshalizer) error {
+	err := ln.isEmptyOrNil()
+	if err != nil {
+		return fmt.Errorf("getAllLeavesOnChannel error: %w", err)
+	}
+
+	nodeKey := append(key, ln.Key...)
+	nodeKey, err = hexToKeyBytes(nodeKey)
+	if err != nil {
+		return err
+	}
+
+	trieLeaf := &data.TrieLeaf{
+		Key:   nodeKey,
+		Value: ln.Value,
+	}
+	leavesChannel <- trieLeaf
+
+	return nil
+}
+
 func (ln *leafNode) getAllHashes(_ data.DBWriteCacher) ([][]byte, error) {
 	err := ln.isEmptyOrNil()
 	if err != nil {

--- a/data/trie/patriciaMerkleTrie.go
+++ b/data/trie/patriciaMerkleTrie.go
@@ -605,6 +605,7 @@ func (tr *patriciaMerkleTrie) GetAllLeaves() (map[string][]byte, error) {
 
 // GetAllLeavesOnChannel adds all the trie leaves to the given channel
 func (tr *patriciaMerkleTrie) GetAllLeavesOnChannel() chan core.KeyValueHolder {
+	//TODO pass a context for cancellation purposes when needed
 	leavesChannel := make(chan core.KeyValueHolder)
 
 	tr.mutOperation.RLock()

--- a/data/trie/patriciaMerkleTrie.go
+++ b/data/trie/patriciaMerkleTrie.go
@@ -613,7 +613,7 @@ func (tr *patriciaMerkleTrie) GetAllLeavesOnChannel() chan core.KeyValueHolder {
 		tr.mutOperation.RUnlock()
 		close(leavesChannel)
 
-		return nil
+		return leavesChannel
 	}
 	tr.mutOperation.RUnlock()
 

--- a/data/trie/patriciaMerkleTrie.go
+++ b/data/trie/patriciaMerkleTrie.go
@@ -602,6 +602,25 @@ func (tr *patriciaMerkleTrie) GetAllLeaves() (map[string][]byte, error) {
 	return leaves, nil
 }
 
+// GetAllLeavesOnChannel adds all the trie leaves to the given channel
+func (tr *patriciaMerkleTrie) GetAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf) error {
+	tr.mutOperation.RLock()
+	defer tr.mutOperation.RUnlock()
+
+	if tr.root == nil {
+		close(leavesChannel)
+		return nil
+	}
+
+	err := tr.root.getAllLeavesOnChannel(leavesChannel, []byte{}, tr.Database(), tr.marshalizer)
+	if err != nil {
+		return err
+	}
+	close(leavesChannel)
+
+	return nil
+}
+
 // GetAllHashes returns all the hashes from the trie
 func (tr *patriciaMerkleTrie) GetAllHashes() ([][]byte, error) {
 	tr.mutOperation.Lock()

--- a/data/trie/patriciaMerkleTrie.go
+++ b/data/trie/patriciaMerkleTrie.go
@@ -605,10 +605,12 @@ func (tr *patriciaMerkleTrie) GetAllLeaves() (map[string][]byte, error) {
 // GetAllLeavesOnChannel adds all the trie leaves to the given channel
 func (tr *patriciaMerkleTrie) GetAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf) error {
 	tr.mutOperation.RLock()
-	defer tr.mutOperation.RUnlock()
+	defer func() {
+		close(leavesChannel)
+		tr.mutOperation.RUnlock()
+	}()
 
 	if tr.root == nil {
-		close(leavesChannel)
 		return nil
 	}
 
@@ -616,7 +618,6 @@ func (tr *patriciaMerkleTrie) GetAllLeavesOnChannel(leavesChannel chan *data.Tri
 	if err != nil {
 		return err
 	}
-	close(leavesChannel)
 
 	return nil
 }

--- a/data/trie/patriciaMerkleTrie_test.go
+++ b/data/trie/patriciaMerkleTrie_test.go
@@ -641,7 +641,10 @@ func TestPatriciaMerkleTrie_GetAllLeavesOnChannelNilTrie(t *testing.T) {
 	tr := emptyTrie()
 
 	leavesChannel := tr.GetAllLeavesOnChannel()
-	assert.Nil(t, leavesChannel)
+	assert.NotNil(t, leavesChannel)
+
+	_, ok := <-leavesChannel
+	assert.False(t, ok)
 }
 
 func TestPatriciaMerkleTrie_GetAllLeavesOnChannel(t *testing.T) {

--- a/data/trie/patriciaMerkleTrie_test.go
+++ b/data/trie/patriciaMerkleTrie_test.go
@@ -635,6 +635,31 @@ func TestPatriciaMerkleTrie_GetAllHashesEmtyTrie(t *testing.T) {
 	assert.Equal(t, 0, len(hashes))
 }
 
+func TestPatriciaMerkleTrie_GetAllLeavesOnChannel(t *testing.T) {
+	t.Parallel()
+
+	tr := initTrie()
+	leafChannel := make(chan *data.TrieLeaf, 10)
+	leaves := map[string][]byte{
+		"doe":  []byte("reindeer"),
+		"dog":  []byte("puppy"),
+		"ddog": []byte("cat"),
+	}
+
+	expectedLeaves := 3
+	err := tr.GetAllLeavesOnChannel(leafChannel)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedLeaves, len(leafChannel))
+
+	for i := 0; i < expectedLeaves; i++ {
+		leaf := <-leafChannel
+		assert.Equal(t, leaves[string(leaf.Key)], leaf.Value)
+	}
+
+	_, ok := <-leafChannel
+	assert.False(t, ok)
+}
+
 func BenchmarkPatriciaMerkleTree_Insert(b *testing.B) {
 	tr := emptyTrie()
 	hsh := keccak.Keccak{}

--- a/dataRetriever/mock/trieStub.go
+++ b/dataRetriever/mock/trieStub.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data"
 )
 
@@ -19,7 +20,7 @@ type TrieStub struct {
 	GetSerializedNodesCalled    func([]byte, uint64) ([][]byte, uint64, error)
 	GetAllHashesCalled          func() ([][]byte, error)
 	DatabaseCalled              func() data.DBWriteCacher
-	GetAllLeavesOnChannelCalled func(chan *data.TrieLeaf) error
+	GetAllLeavesOnChannelCalled func() chan core.KeyValueHolder
 }
 
 // EnterSnapshotMode -
@@ -49,12 +50,12 @@ func (ts *TrieStub) GetAllLeaves() (map[string][]byte, error) {
 }
 
 // GetAllLeavesOnChannel -
-func (ts *TrieStub) GetAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf) error {
+func (ts *TrieStub) GetAllLeavesOnChannel() chan core.KeyValueHolder {
 	if ts.GetAllLeavesOnChannelCalled != nil {
-		return ts.GetAllLeavesOnChannelCalled(leavesChannel)
+		return ts.GetAllLeavesOnChannelCalled()
 	}
 
-	return errNotImplemented
+	return nil
 }
 
 // IsPruningEnabled -

--- a/dataRetriever/mock/trieStub.go
+++ b/dataRetriever/mock/trieStub.go
@@ -6,19 +6,20 @@ import (
 
 // TrieStub -
 type TrieStub struct {
-	GetCalled                func(key []byte) ([]byte, error)
-	UpdateCalled             func(key, value []byte) error
-	DeleteCalled             func(key []byte) error
-	RootCalled               func() ([]byte, error)
-	CommitCalled             func() error
-	RecreateCalled           func(root []byte) (data.Trie, error)
-	CancelPruneCalled        func(rootHash []byte, identifier data.TriePruningIdentifier)
-	PruneCalled              func(rootHash []byte, identifier data.TriePruningIdentifier)
-	ResetOldHashesCalled     func() [][]byte
-	AppendToOldHashesCalled  func([][]byte)
-	GetSerializedNodesCalled func([]byte, uint64) ([][]byte, uint64, error)
-	GetAllHashesCalled       func() ([][]byte, error)
-	DatabaseCalled           func() data.DBWriteCacher
+	GetCalled                   func(key []byte) ([]byte, error)
+	UpdateCalled                func(key, value []byte) error
+	DeleteCalled                func(key []byte) error
+	RootCalled                  func() ([]byte, error)
+	CommitCalled                func() error
+	RecreateCalled              func(root []byte) (data.Trie, error)
+	CancelPruneCalled           func(rootHash []byte, identifier data.TriePruningIdentifier)
+	PruneCalled                 func(rootHash []byte, identifier data.TriePruningIdentifier)
+	ResetOldHashesCalled        func() [][]byte
+	AppendToOldHashesCalled     func([][]byte)
+	GetSerializedNodesCalled    func([]byte, uint64) ([][]byte, uint64, error)
+	GetAllHashesCalled          func() ([][]byte, error)
+	DatabaseCalled              func() data.DBWriteCacher
+	GetAllLeavesOnChannelCalled func(chan *data.TrieLeaf) error
 }
 
 // EnterSnapshotMode -
@@ -45,6 +46,15 @@ func (ts *TrieStub) SetCheckpoint(_ []byte) {
 // GetAllLeaves -
 func (ts *TrieStub) GetAllLeaves() (map[string][]byte, error) {
 	return make(map[string][]byte), nil
+}
+
+// GetAllLeavesOnChannel -
+func (ts *TrieStub) GetAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf) error {
+	if ts.GetAllLeavesOnChannelCalled != nil {
+		return ts.GetAllLeavesOnChannelCalled(leavesChannel)
+	}
+
+	return errNotImplemented
 }
 
 // IsPruningEnabled -

--- a/dataRetriever/mock/trieStub.go
+++ b/dataRetriever/mock/trieStub.go
@@ -55,7 +55,10 @@ func (ts *TrieStub) GetAllLeavesOnChannel() chan core.KeyValueHolder {
 		return ts.GetAllLeavesOnChannelCalled()
 	}
 
-	return nil
+	ch := make(chan core.KeyValueHolder)
+	close(ch)
+
+	return ch
 }
 
 // IsPruningEnabled -

--- a/epochStart/mock/trieStub.go
+++ b/epochStart/mock/trieStub.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"errors"
 
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data"
 )
 
@@ -28,7 +29,7 @@ type TrieStub struct {
 	GetAllHashesCalled          func() ([][]byte, error)
 	IsPruningEnabledCalled      func() bool
 	ClosePersisterCalled        func() error
-	GetAllLeavesOnChannelCalled func(chan *data.TrieLeaf) error
+	GetAllLeavesOnChannelCalled func() chan core.KeyValueHolder
 }
 
 // EnterSnapshotMode -
@@ -117,12 +118,12 @@ func (ts *TrieStub) GetAllLeaves() (map[string][]byte, error) {
 }
 
 // GetAllLeavesOnChannel -
-func (ts *TrieStub) GetAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf) error {
+func (ts *TrieStub) GetAllLeavesOnChannel() chan core.KeyValueHolder {
 	if ts.GetAllLeavesOnChannelCalled != nil {
-		return ts.GetAllLeavesOnChannelCalled(leavesChannel)
+		return ts.GetAllLeavesOnChannelCalled()
 	}
 
-	return errNotImplemented
+	return nil
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/epochStart/mock/trieStub.go
+++ b/epochStart/mock/trieStub.go
@@ -123,7 +123,10 @@ func (ts *TrieStub) GetAllLeavesOnChannel() chan core.KeyValueHolder {
 		return ts.GetAllLeavesOnChannelCalled()
 	}
 
-	return nil
+	ch := make(chan core.KeyValueHolder)
+	close(ch)
+
+	return ch
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/epochStart/mock/trieStub.go
+++ b/epochStart/mock/trieStub.go
@@ -10,24 +10,25 @@ var errNotImplemented = errors.New("not implemented")
 
 // TrieStub -
 type TrieStub struct {
-	GetCalled                func(key []byte) ([]byte, error)
-	UpdateCalled             func(key, value []byte) error
-	DeleteCalled             func(key []byte) error
-	RootCalled               func() ([]byte, error)
-	CommitCalled             func() error
-	RecreateCalled           func(root []byte) (data.Trie, error)
-	CancelPruneCalled        func(rootHash []byte, identifier data.TriePruningIdentifier)
-	PruneCalled              func(rootHash []byte, identifier data.TriePruningIdentifier)
-	ResetOldHashesCalled     func() [][]byte
-	AppendToOldHashesCalled  func([][]byte)
-	TakeSnapshotCalled       func(rootHash []byte)
-	SetCheckpointCalled      func(rootHash []byte)
-	GetSerializedNodesCalled func([]byte, uint64) ([][]byte, uint64, error)
-	DatabaseCalled           func() data.DBWriteCacher
-	GetAllLeavesCalled       func() (map[string][]byte, error)
-	GetAllHashesCalled       func() ([][]byte, error)
-	IsPruningEnabledCalled   func() bool
-	ClosePersisterCalled     func() error
+	GetCalled                   func(key []byte) ([]byte, error)
+	UpdateCalled                func(key, value []byte) error
+	DeleteCalled                func(key []byte) error
+	RootCalled                  func() ([]byte, error)
+	CommitCalled                func() error
+	RecreateCalled              func(root []byte) (data.Trie, error)
+	CancelPruneCalled           func(rootHash []byte, identifier data.TriePruningIdentifier)
+	PruneCalled                 func(rootHash []byte, identifier data.TriePruningIdentifier)
+	ResetOldHashesCalled        func() [][]byte
+	AppendToOldHashesCalled     func([][]byte)
+	TakeSnapshotCalled          func(rootHash []byte)
+	SetCheckpointCalled         func(rootHash []byte)
+	GetSerializedNodesCalled    func([]byte, uint64) ([][]byte, uint64, error)
+	DatabaseCalled              func() data.DBWriteCacher
+	GetAllLeavesCalled          func() (map[string][]byte, error)
+	GetAllHashesCalled          func() ([][]byte, error)
+	IsPruningEnabledCalled      func() bool
+	ClosePersisterCalled        func() error
+	GetAllLeavesOnChannelCalled func(chan *data.TrieLeaf) error
 }
 
 // EnterSnapshotMode -
@@ -113,6 +114,15 @@ func (ts *TrieStub) GetAllLeaves() (map[string][]byte, error) {
 	}
 
 	return nil, errNotImplemented
+}
+
+// GetAllLeavesOnChannel -
+func (ts *TrieStub) GetAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf) error {
+	if ts.GetAllLeavesOnChannelCalled != nil {
+		return ts.GetAllLeavesOnChannelCalled(leavesChannel)
+	}
+
+	return errNotImplemented
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/node/mock/trieStub.go
+++ b/node/mock/trieStub.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data"
 )
 
@@ -19,7 +20,7 @@ type TrieStub struct {
 	GetSerializedNodesCalled    func([]byte, uint64) ([][]byte, uint64, error)
 	GetAllHashesCalled          func() ([][]byte, error)
 	DatabaseCalled              func() data.DBWriteCacher
-	GetAllLeavesOnChannelCalled func(chan *data.TrieLeaf) error
+	GetAllLeavesOnChannelCalled func() chan core.KeyValueHolder
 }
 
 // EnterSnapshotMode -
@@ -49,12 +50,12 @@ func (ts *TrieStub) GetAllLeaves() (map[string][]byte, error) {
 }
 
 // GetAllLeavesOnChannel -
-func (ts *TrieStub) GetAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf) error {
+func (ts *TrieStub) GetAllLeavesOnChannel() chan core.KeyValueHolder {
 	if ts.GetAllLeavesOnChannelCalled != nil {
-		return ts.GetAllLeavesOnChannelCalled(leavesChannel)
+		return ts.GetAllLeavesOnChannelCalled()
 	}
 
-	return errNotImplemented
+	return nil
 }
 
 // IsPruningEnabled -

--- a/node/mock/trieStub.go
+++ b/node/mock/trieStub.go
@@ -6,19 +6,20 @@ import (
 
 // TrieStub -
 type TrieStub struct {
-	GetCalled                func(key []byte) ([]byte, error)
-	UpdateCalled             func(key, value []byte) error
-	DeleteCalled             func(key []byte) error
-	RootCalled               func() ([]byte, error)
-	CommitCalled             func() error
-	RecreateCalled           func(root []byte) (data.Trie, error)
-	CancelPruneCalled        func(rootHash []byte, identifier data.TriePruningIdentifier)
-	PruneCalled              func(rootHash []byte, identifier data.TriePruningIdentifier)
-	ResetOldHashesCalled     func() [][]byte
-	AppendToOldHashesCalled  func([][]byte)
-	GetSerializedNodesCalled func([]byte, uint64) ([][]byte, uint64, error)
-	GetAllHashesCalled       func() ([][]byte, error)
-	DatabaseCalled           func() data.DBWriteCacher
+	GetCalled                   func(key []byte) ([]byte, error)
+	UpdateCalled                func(key, value []byte) error
+	DeleteCalled                func(key []byte) error
+	RootCalled                  func() ([]byte, error)
+	CommitCalled                func() error
+	RecreateCalled              func(root []byte) (data.Trie, error)
+	CancelPruneCalled           func(rootHash []byte, identifier data.TriePruningIdentifier)
+	PruneCalled                 func(rootHash []byte, identifier data.TriePruningIdentifier)
+	ResetOldHashesCalled        func() [][]byte
+	AppendToOldHashesCalled     func([][]byte)
+	GetSerializedNodesCalled    func([]byte, uint64) ([][]byte, uint64, error)
+	GetAllHashesCalled          func() ([][]byte, error)
+	DatabaseCalled              func() data.DBWriteCacher
+	GetAllLeavesOnChannelCalled func(chan *data.TrieLeaf) error
 }
 
 // EnterSnapshotMode -
@@ -45,6 +46,15 @@ func (ts *TrieStub) SetCheckpoint(_ []byte) {
 // GetAllLeaves -
 func (ts *TrieStub) GetAllLeaves() (map[string][]byte, error) {
 	return make(map[string][]byte), nil
+}
+
+// GetAllLeavesOnChannel -
+func (ts *TrieStub) GetAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf) error {
+	if ts.GetAllLeavesOnChannelCalled != nil {
+		return ts.GetAllLeavesOnChannelCalled(leavesChannel)
+	}
+
+	return errNotImplemented
 }
 
 // IsPruningEnabled -

--- a/node/mock/trieStub.go
+++ b/node/mock/trieStub.go
@@ -55,7 +55,10 @@ func (ts *TrieStub) GetAllLeavesOnChannel() chan core.KeyValueHolder {
 		return ts.GetAllLeavesOnChannelCalled()
 	}
 
-	return nil
+	ch := make(chan core.KeyValueHolder)
+	close(ch)
+
+	return ch
 }
 
 // IsPruningEnabled -

--- a/process/mock/trieStub.go
+++ b/process/mock/trieStub.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data"
 )
 
@@ -20,7 +21,7 @@ type TrieStub struct {
 	GetSerializedNodesCalled    func([]byte, uint64) ([][]byte, uint64, error)
 	GetAllHashesCalled          func() ([][]byte, error)
 	DatabaseCalled              func() data.DBWriteCacher
-	GetAllLeavesOnChannelCalled func(chan *data.TrieLeaf) error
+	GetAllLeavesOnChannelCalled func() chan core.KeyValueHolder
 }
 
 // EnterSnapshotMode -
@@ -45,12 +46,12 @@ func (ts *TrieStub) GetAllLeaves() (map[string][]byte, error) {
 }
 
 // GetAllLeavesOnChannel -
-func (ts *TrieStub) GetAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf) error {
+func (ts *TrieStub) GetAllLeavesOnChannel() chan core.KeyValueHolder {
 	if ts.GetAllLeavesOnChannelCalled != nil {
-		return ts.GetAllLeavesOnChannelCalled(leavesChannel)
+		return ts.GetAllLeavesOnChannelCalled()
 	}
 
-	return errNotImplemented
+	return nil
 }
 
 // IsPruningEnabled -

--- a/process/mock/trieStub.go
+++ b/process/mock/trieStub.go
@@ -51,7 +51,10 @@ func (ts *TrieStub) GetAllLeavesOnChannel() chan core.KeyValueHolder {
 		return ts.GetAllLeavesOnChannelCalled()
 	}
 
-	return nil
+	ch := make(chan core.KeyValueHolder)
+	close(ch)
+
+	return ch
 }
 
 // IsPruningEnabled -

--- a/process/mock/trieStub.go
+++ b/process/mock/trieStub.go
@@ -6,20 +6,21 @@ import (
 
 // TrieStub -
 type TrieStub struct {
-	GetCalled                func(key []byte) ([]byte, error)
-	UpdateCalled             func(key, value []byte) error
-	DeleteCalled             func(key []byte) error
-	RootCalled               func() ([]byte, error)
-	CommitCalled             func() error
-	RecreateCalled           func(root []byte) (data.Trie, error)
-	CancelPruneCalled        func(rootHash []byte, identifier data.TriePruningIdentifier)
-	PruneCalled              func(rootHash []byte, identifier data.TriePruningIdentifier)
-	ResetOldHashesCalled     func() [][]byte
-	AppendToOldHashesCalled  func([][]byte)
-	SnapshotCalled           func() error
-	GetSerializedNodesCalled func([]byte, uint64) ([][]byte, uint64, error)
-	GetAllHashesCalled       func() ([][]byte, error)
-	DatabaseCalled           func() data.DBWriteCacher
+	GetCalled                   func(key []byte) ([]byte, error)
+	UpdateCalled                func(key, value []byte) error
+	DeleteCalled                func(key []byte) error
+	RootCalled                  func() ([]byte, error)
+	CommitCalled                func() error
+	RecreateCalled              func(root []byte) (data.Trie, error)
+	CancelPruneCalled           func(rootHash []byte, identifier data.TriePruningIdentifier)
+	PruneCalled                 func(rootHash []byte, identifier data.TriePruningIdentifier)
+	ResetOldHashesCalled        func() [][]byte
+	AppendToOldHashesCalled     func([][]byte)
+	SnapshotCalled              func() error
+	GetSerializedNodesCalled    func([]byte, uint64) ([][]byte, uint64, error)
+	GetAllHashesCalled          func() ([][]byte, error)
+	DatabaseCalled              func() data.DBWriteCacher
+	GetAllLeavesOnChannelCalled func(chan *data.TrieLeaf) error
 }
 
 // EnterSnapshotMode -
@@ -41,6 +42,15 @@ func (ts *TrieStub) SetCheckpoint(_ []byte) {
 // GetAllLeaves -
 func (ts *TrieStub) GetAllLeaves() (map[string][]byte, error) {
 	return nil, nil
+}
+
+// GetAllLeavesOnChannel -
+func (ts *TrieStub) GetAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf) error {
+	if ts.GetAllLeavesOnChannelCalled != nil {
+		return ts.GetAllLeavesOnChannelCalled(leavesChannel)
+	}
+
+	return errNotImplemented
 }
 
 // IsPruningEnabled -

--- a/update/mock/trieStub.go
+++ b/update/mock/trieStub.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data"
 )
 
@@ -20,7 +21,7 @@ type TrieStub struct {
 	GetSerializedNodesCalled    func([]byte, uint64) ([][]byte, uint64, error)
 	GetAllHashesCalled          func() ([][]byte, error)
 	DatabaseCalled              func() data.DBWriteCacher
-	GetAllLeavesOnChannelCalled func(chan *data.TrieLeaf) error
+	GetAllLeavesOnChannelCalled func() chan core.KeyValueHolder
 }
 
 // EnterSnapshotMode -
@@ -45,12 +46,12 @@ func (ts *TrieStub) GetAllLeaves() (map[string][]byte, error) {
 }
 
 // GetAllLeavesOnChannel -
-func (ts *TrieStub) GetAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf) error {
+func (ts *TrieStub) GetAllLeavesOnChannel() chan core.KeyValueHolder {
 	if ts.GetAllLeavesOnChannelCalled != nil {
-		return ts.GetAllLeavesOnChannelCalled(leavesChannel)
+		return ts.GetAllLeavesOnChannelCalled()
 	}
 
-	return errNotImplemented
+	return nil
 }
 
 // IsPruningEnabled -

--- a/update/mock/trieStub.go
+++ b/update/mock/trieStub.go
@@ -51,7 +51,10 @@ func (ts *TrieStub) GetAllLeavesOnChannel() chan core.KeyValueHolder {
 		return ts.GetAllLeavesOnChannelCalled()
 	}
 
-	return nil
+	ch := make(chan core.KeyValueHolder)
+	close(ch)
+
+	return ch
 }
 
 // IsPruningEnabled -

--- a/update/mock/trieStub.go
+++ b/update/mock/trieStub.go
@@ -6,20 +6,21 @@ import (
 
 // TrieStub -
 type TrieStub struct {
-	GetCalled                func(key []byte) ([]byte, error)
-	UpdateCalled             func(key, value []byte) error
-	DeleteCalled             func(key []byte) error
-	RootCalled               func() ([]byte, error)
-	CommitCalled             func() error
-	RecreateCalled           func(root []byte) (data.Trie, error)
-	CancelPruneCalled        func(rootHash []byte, identifier data.TriePruningIdentifier)
-	PruneCalled              func(rootHash []byte, identifier data.TriePruningIdentifier)
-	ResetOldHashesCalled     func() [][]byte
-	AppendToOldHashesCalled  func([][]byte)
-	SnapshotCalled           func() error
-	GetSerializedNodesCalled func([]byte, uint64) ([][]byte, uint64, error)
-	GetAllHashesCalled       func() ([][]byte, error)
-	DatabaseCalled           func() data.DBWriteCacher
+	GetCalled                   func(key []byte) ([]byte, error)
+	UpdateCalled                func(key, value []byte) error
+	DeleteCalled                func(key []byte) error
+	RootCalled                  func() ([]byte, error)
+	CommitCalled                func() error
+	RecreateCalled              func(root []byte) (data.Trie, error)
+	CancelPruneCalled           func(rootHash []byte, identifier data.TriePruningIdentifier)
+	PruneCalled                 func(rootHash []byte, identifier data.TriePruningIdentifier)
+	ResetOldHashesCalled        func() [][]byte
+	AppendToOldHashesCalled     func([][]byte)
+	SnapshotCalled              func() error
+	GetSerializedNodesCalled    func([]byte, uint64) ([][]byte, uint64, error)
+	GetAllHashesCalled          func() ([][]byte, error)
+	DatabaseCalled              func() data.DBWriteCacher
+	GetAllLeavesOnChannelCalled func(chan *data.TrieLeaf) error
 }
 
 // EnterSnapshotMode -
@@ -41,6 +42,15 @@ func (ts *TrieStub) SetCheckpoint(_ []byte) {
 // GetAllLeaves -
 func (ts *TrieStub) GetAllLeaves() (map[string][]byte, error) {
 	return nil, nil
+}
+
+// GetAllLeavesOnChannel -
+func (ts *TrieStub) GetAllLeavesOnChannel(leavesChannel chan *data.TrieLeaf) error {
+	if ts.GetAllLeavesOnChannelCalled != nil {
+		return ts.GetAllLeavesOnChannelCalled(leavesChannel)
+	}
+
+	return errNotImplemented
 }
 
 // IsPruningEnabled -


### PR DESCRIPTION
Add a new trie functionality, getAllLeavesOnChannel, which returns all the trie leaves on a channel. When all the leaves have been sent, the channel closes.