### PR TITLE
EN-7054: Rest API endpoints throttlers

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -37,11 +37,11 @@ var ErrValidationEmptyTxHash = errors.New("TxHash is empty")
 // ErrGetTransaction signals an error happened trying to fetch a transaction
 var ErrGetTransaction = errors.New("transaction getting failed")
 
-// ErrTxNotFound signals an error happened trying to fetch a transaction
-var ErrTxNotFound = errors.New("transaction was not found")
-
 // ErrQueryError signals a general query error
 var ErrQueryError = errors.New("query error")
 
 // ErrGetPidInfo signals that an error occurred while getting peer ID info
 var ErrGetPidInfo = errors.New("error getting peer id info")
+
+// ErrTooManyRequests signals that too many requests were simultaneously received
+var ErrTooManyRequests = errors.New("too many request")

--- a/api/middleware/globalThrottler.go
+++ b/api/middleware/globalThrottler.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net/http"
 
+	"github.com/ElrondNetwork/elrond-go/api/shared"
 	"github.com/gin-gonic/gin"
 )
 
@@ -28,7 +29,14 @@ func (gt *globalThrottler) MiddlewareHandlerFunc() gin.HandlerFunc {
 		select {
 		case gt.queue <- struct{}{}:
 		default:
-			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "too many requests to observer"})
+			c.AbortWithStatusJSON(
+				http.StatusTooManyRequests,
+				shared.GenericAPIResponse{
+					Data:  nil,
+					Error: "too many requests to observer",
+					Code:  shared.ReturnCodeSystemBusy,
+				},
+			)
 			return
 		}
 

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -37,6 +37,16 @@ type Facade struct {
 	GetQueryHandlerCalled             func(name string) (debug.QueryHandler, error)
 	GetValueForKeyCalled              func(address string, key string) (string, error)
 	GetPeerInfoCalled                 func(pid string) ([]core.QueryP2PPeerInfo, error)
+	GetThrottlerForEndpointCalled     func(endpoint string) (core.Throttler, bool)
+}
+
+// GetThrottlerForEndpoint -
+func (f *Facade) GetThrottlerForEndpoint(endpoint string) (core.Throttler, bool) {
+	if f.GetThrottlerForEndpointCalled != nil {
+		return f.GetThrottlerForEndpointCalled(endpoint)
+	}
+
+	return nil, false
 }
 
 // RestApiInterface -

--- a/api/mock/throttlerStub.go
+++ b/api/mock/throttlerStub.go
@@ -1,0 +1,40 @@
+package mock
+
+// ThrottlerStub -
+type ThrottlerStub struct {
+	CanProcessCalled      func() bool
+	StartProcessingCalled func()
+	EndProcessingCalled   func()
+	StartWasCalled        bool
+	EndWasCalled          bool
+}
+
+// CanProcess -
+func (ts *ThrottlerStub) CanProcess() bool {
+	if ts.CanProcessCalled != nil {
+		return ts.CanProcessCalled()
+	}
+
+	return true
+}
+
+// StartProcessing -
+func (ts *ThrottlerStub) StartProcessing() {
+	ts.StartWasCalled = true
+	if ts.StartProcessingCalled != nil {
+		ts.StartProcessingCalled()
+	}
+}
+
+// EndProcessing -
+func (ts *ThrottlerStub) EndProcessing() {
+	ts.EndWasCalled = true
+	if ts.EndProcessingCalled != nil {
+		ts.EndProcessingCalled()
+	}
+}
+
+// IsInterfaceNil -
+func (ts *ThrottlerStub) IsInterfaceNil() bool {
+	return ts == nil
+}

--- a/api/shared/shared.go
+++ b/api/shared/shared.go
@@ -18,3 +18,6 @@ const ReturnCodeInternalError ReturnCode = "internal_issue"
 
 // ReturnCodeRequestError defines a request which hasn't been executed successfully due to a bad request received
 const ReturnCodeRequestError ReturnCode = "bad_request"
+
+// ReturnCodeRequestError defines a request which hasn't been executed successfully due to too many requests
+const ReturnCodeSystemBusy ReturnCode = "system_busy"

--- a/api/transaction/routes.go
+++ b/api/transaction/routes.go
@@ -14,6 +14,12 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const (
+	sendTransactionEndpoint          = "/transaction/send"
+	sendMultipleTransactionsEndpoint = "/transaction/send-multiple"
+	getTransactionEndpoint           = "/transaction/:hash"
+)
+
 // TxService interface defines methods that can be used from `elrondFacade` context variable
 type TxService interface {
 	CreateTransaction(nonce uint64, value string, receiver string, sender string, gasPrice uint64,
@@ -89,7 +95,7 @@ func SendTransaction(c *gin.Context) {
 		return
 	}
 
-	endpointThrottler, ok := ef.GetThrottlerForEndpoint("/transaction/send")
+	endpointThrottler, ok := ef.GetThrottlerForEndpoint(sendTransactionEndpoint)
 	if ok {
 		if !endpointThrottler.CanProcess() {
 			c.JSON(
@@ -197,7 +203,7 @@ func SendMultipleTransactions(c *gin.Context) {
 		return
 	}
 
-	endpointThrottler, ok := ef.GetThrottlerForEndpoint("/transaction/send-multiple")
+	endpointThrottler, ok := ef.GetThrottlerForEndpoint(sendMultipleTransactionsEndpoint)
 	if ok {
 		if !endpointThrottler.CanProcess() {
 			c.JSON(
@@ -303,7 +309,7 @@ func GetTransaction(c *gin.Context) {
 		return
 	}
 
-	endpointThrottler, ok := ef.GetThrottlerForEndpoint("/transaction/get")
+	endpointThrottler, ok := ef.GetThrottlerForEndpoint(getTransactionEndpoint)
 	if ok {
 		if !endpointThrottler.CanProcess() {
 			c.JSON(

--- a/api/transaction/routes_test.go
+++ b/api/transaction/routes_test.go
@@ -12,7 +12,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	errors2 "github.com/ElrondNetwork/elrond-go/api/errors"
+	apiErrors "github.com/ElrondNetwork/elrond-go/api/errors"
 	"github.com/ElrondNetwork/elrond-go/api/middleware"
 	"github.com/ElrondNetwork/elrond-go/api/mock"
 	"github.com/ElrondNetwork/elrond-go/api/shared"
@@ -147,7 +147,7 @@ func TestGetTransaction_FailsWithWrongFacadeTypeConversion(t *testing.T) {
 	transactionResponse := transactionResponse{}
 	loadResponse(resp.Body, &transactionResponse)
 	assert.Equal(t, resp.Code, http.StatusInternalServerError)
-	assert.Equal(t, transactionResponse.Error, errors2.ErrInvalidAppContext.Error())
+	assert.Equal(t, transactionResponse.Error, apiErrors.ErrInvalidAppContext.Error())
 }
 
 func TestGetTransaction_ErrorWithExceededNumGoRoutines(t *testing.T) {
@@ -171,7 +171,7 @@ func TestGetTransaction_ErrorWithExceededNumGoRoutines(t *testing.T) {
 	loadResponse(resp.Body, &transactionResponse)
 
 	assert.Equal(t, http.StatusTooManyRequests, resp.Code)
-	assert.Equal(t, errors2.ErrTooManyRequests.Error(), transactionResponse.Error)
+	assert.Equal(t, apiErrors.ErrTooManyRequests.Error(), transactionResponse.Error)
 	assert.Equal(t, string(shared.ReturnCodeSystemBusy), transactionResponse.Code)
 	assert.Empty(t, transactionResponse.Data)
 }
@@ -187,7 +187,7 @@ func TestSendTransaction_ErrorWithWrongFacade(t *testing.T) {
 	transactionResponse := sendSingleTxResponse{}
 	loadResponse(resp.Body, &transactionResponse)
 	assert.Equal(t, resp.Code, http.StatusInternalServerError)
-	assert.Equal(t, errors2.ErrInvalidAppContext.Error(), transactionResponse.Error)
+	assert.Equal(t, apiErrors.ErrInvalidAppContext.Error(), transactionResponse.Error)
 }
 
 func TestSendTransaction_ErrorWithExceededNumGoRoutines(t *testing.T) {
@@ -214,7 +214,7 @@ func TestSendTransaction_ErrorWithExceededNumGoRoutines(t *testing.T) {
 	loadResponse(resp.Body, &transactionResponse)
 
 	assert.Equal(t, http.StatusTooManyRequests, resp.Code)
-	assert.Equal(t, errors2.ErrTooManyRequests.Error(), transactionResponse.Error)
+	assert.Equal(t, apiErrors.ErrTooManyRequests.Error(), transactionResponse.Error)
 	assert.Equal(t, string(shared.ReturnCodeSystemBusy), transactionResponse.Code)
 	assert.Empty(t, transactionResponse.Data)
 }
@@ -245,7 +245,7 @@ func TestSendTransaction_WrongParametersShouldErrorOnValidation(t *testing.T) {
 	loadResponse(resp.Body, &transactionResponse)
 
 	assert.Equal(t, http.StatusBadRequest, resp.Code)
-	assert.Contains(t, transactionResponse.Error, errors2.ErrValidation.Error())
+	assert.Contains(t, transactionResponse.Error, apiErrors.ErrValidation.Error())
 	assert.Empty(t, transactionResponse.Data)
 }
 
@@ -352,7 +352,7 @@ func TestSendMultipleTransactions_ErrorWithWrongFacade(t *testing.T) {
 	transactionResponse := sendMultipleTxsResponse{}
 	loadResponse(resp.Body, &transactionResponse)
 	assert.Equal(t, http.StatusInternalServerError, resp.Code)
-	assert.Equal(t, errors2.ErrInvalidAppContext.Error(), transactionResponse.Error)
+	assert.Equal(t, apiErrors.ErrInvalidAppContext.Error(), transactionResponse.Error)
 }
 
 func TestSendMultipleTransactions_ErrorWithExceededNumGoRoutines(t *testing.T) {
@@ -380,7 +380,7 @@ func TestSendMultipleTransactions_ErrorWithExceededNumGoRoutines(t *testing.T) {
 	loadResponse(resp.Body, &transactionResponse)
 
 	assert.Equal(t, http.StatusTooManyRequests, resp.Code)
-	assert.Equal(t, errors2.ErrTooManyRequests.Error(), transactionResponse.Error)
+	assert.Equal(t, apiErrors.ErrTooManyRequests.Error(), transactionResponse.Error)
 	assert.Equal(t, string(shared.ReturnCodeSystemBusy), transactionResponse.Code)
 	assert.Empty(t, transactionResponse.Data)
 }
@@ -402,7 +402,7 @@ func TestSendMultipleTransactions_WrongPayloadShouldErrorOnValidation(t *testing
 	loadResponse(resp.Body, &transactionResponse)
 
 	assert.Equal(t, http.StatusBadRequest, resp.Code)
-	assert.Contains(t, transactionResponse.Error, errors2.ErrValidation.Error())
+	assert.Contains(t, transactionResponse.Error, apiErrors.ErrValidation.Error())
 	assert.Empty(t, transactionResponse.Data)
 }
 

--- a/api/transaction/routes_test.go
+++ b/api/transaction/routes_test.go
@@ -19,32 +19,49 @@ import (
 	"github.com/ElrondNetwork/elrond-go/api/transaction"
 	"github.com/ElrondNetwork/elrond-go/api/wrapper"
 	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/core"
 	tr "github.com/ElrondNetwork/elrond-go/data/transaction"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
 
-type GeneralResponse struct {
-	Message string `json:"message"`
-	Error   string `json:"error"`
-}
-
-type TransactionResponse struct {
-	GeneralResponse
+type transactionResponseData struct {
 	TxResp *transaction.TxResponse `json:"transaction,omitempty"`
 }
 
-type TransactionHashResponse struct {
-	GeneralResponse
-	TxHash string `json:"txHash,omitempty"`
+type transactionResponse struct {
+	Data  transactionResponseData `json:"data"`
+	Error string                  `json:"error"`
+	Code  string                  `json:"code"`
+}
+
+type sendMultipleTxsResponseData struct {
+	TxsSent   int      `json:"txsSent"`
+	TxsHashes []string `json:"txsHashes"`
+}
+
+type sendMultipleTxsResponse struct {
+	Data  sendMultipleTxsResponseData `json:"data"`
+	Error string                      `json:"error"`
+	Code  string                      `json:"code"`
+}
+
+type sendSingleTxResponseData struct {
+	TxHash string `json:"txHash"`
+}
+
+type sendSingleTxResponse struct {
+	Data  sendSingleTxResponseData `json:"data"`
+	Error string                   `json:"error"`
+	Code  string                   `json:"code"`
 }
 
 type transactionCostResponseData struct {
 	Cost uint64 `json:"txGasUnits"`
 }
 
-type TransactionCostResponse struct {
+type transactionCostResponse struct {
 	Data  transactionCostResponseData `json:"data"`
 	Error string                      `json:"error"`
 	Code  string                      `json:"code"`
@@ -76,15 +93,10 @@ func TestGetTransaction_WithCorrectHashShouldReturnTransaction(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	response := shared.GenericAPIResponse{}
+	response := transactionResponse{}
 	loadResponse(resp.Body, &response)
 
-	transactionResponse := TransactionResponse{}
-	mapResponseData := response.Data.(map[string]interface{})
-	mapResponseDataBytes, _ := json.Marshal(mapResponseData)
-	_ = json.Unmarshal(mapResponseDataBytes, &transactionResponse)
-
-	txResp := transactionResponse.TxResp
+	txResp := response.Data.TxResp
 	assert.Equal(t, http.StatusOK, resp.Code)
 	assert.Equal(t, sender, txResp.Sender)
 	assert.Equal(t, receiver, txResp.Receiver)
@@ -117,11 +129,11 @@ func TestGetTransaction_WithUnknownHashShouldReturnNil(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	transactionResponse := TransactionResponse{}
+	transactionResponse := transactionResponse{}
 	loadResponse(resp.Body, &transactionResponse)
 
 	assert.Equal(t, http.StatusInternalServerError, resp.Code)
-	assert.Nil(t, transactionResponse.TxResp)
+	assert.Empty(t, transactionResponse.Data)
 }
 
 func TestGetTransaction_FailsWithWrongFacadeTypeConversion(t *testing.T) {
@@ -132,10 +144,36 @@ func TestGetTransaction_FailsWithWrongFacadeTypeConversion(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	transactionResponse := TransactionResponse{}
+	transactionResponse := transactionResponse{}
 	loadResponse(resp.Body, &transactionResponse)
 	assert.Equal(t, resp.Code, http.StatusInternalServerError)
 	assert.Equal(t, transactionResponse.Error, errors2.ErrInvalidAppContext.Error())
+}
+
+func TestGetTransaction_ErrorWithExceededNumGoRoutines(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{
+		GetThrottlerForEndpointCalled: func(_ string) (core.Throttler, bool) {
+			return &mock.ThrottlerStub{
+				CanProcessCalled: func() bool { return false },
+			}, true
+		},
+	}
+	ws := startNodeServer(&facade)
+
+	req, _ := http.NewRequest("GET", "/transaction/eeee", nil)
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	transactionResponse := transactionResponse{}
+	loadResponse(resp.Body, &transactionResponse)
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.Code)
+	assert.Equal(t, errors2.ErrTooManyRequests.Error(), transactionResponse.Error)
+	assert.Equal(t, string(shared.ReturnCodeSystemBusy), transactionResponse.Code)
+	assert.Empty(t, transactionResponse.Data)
 }
 
 func TestSendTransaction_ErrorWithWrongFacade(t *testing.T) {
@@ -146,10 +184,39 @@ func TestSendTransaction_ErrorWithWrongFacade(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	transactionResponse := TransactionResponse{}
+	transactionResponse := sendSingleTxResponse{}
 	loadResponse(resp.Body, &transactionResponse)
 	assert.Equal(t, resp.Code, http.StatusInternalServerError)
-	assert.Equal(t, transactionResponse.Error, errors2.ErrInvalidAppContext.Error())
+	assert.Equal(t, errors2.ErrInvalidAppContext.Error(), transactionResponse.Error)
+}
+
+func TestSendTransaction_ErrorWithExceededNumGoRoutines(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{
+		GetThrottlerForEndpointCalled: func(_ string) (core.Throttler, bool) {
+			return &mock.ThrottlerStub{
+				CanProcessCalled: func() bool { return false },
+			}, true
+		},
+	}
+	ws := startNodeServer(&facade)
+
+	tx := transaction.SendTxRequest{}
+
+	jsonBytes, _ := json.Marshal(tx)
+	req, _ := http.NewRequest("POST", "/transaction/send", bytes.NewBuffer(jsonBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	transactionResponse := sendSingleTxResponse{}
+	loadResponse(resp.Body, &transactionResponse)
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.Code)
+	assert.Equal(t, errors2.ErrTooManyRequests.Error(), transactionResponse.Error)
+	assert.Equal(t, string(shared.ReturnCodeSystemBusy), transactionResponse.Code)
+	assert.Empty(t, transactionResponse.Data)
 }
 
 func TestSendTransaction_WrongParametersShouldErrorOnValidation(t *testing.T) {
@@ -174,12 +241,12 @@ func TestSendTransaction_WrongParametersShouldErrorOnValidation(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	transactionResponse := TransactionResponse{}
+	transactionResponse := sendSingleTxResponse{}
 	loadResponse(resp.Body, &transactionResponse)
 
 	assert.Equal(t, http.StatusBadRequest, resp.Code)
 	assert.Contains(t, transactionResponse.Error, errors2.ErrValidation.Error())
-	assert.Empty(t, transactionResponse.TxResp)
+	assert.Empty(t, transactionResponse.Data)
 }
 
 func TestSendTransaction_ErrorWhenFacadeSendTransactionError(t *testing.T) {
@@ -218,12 +285,12 @@ func TestSendTransaction_ErrorWhenFacadeSendTransactionError(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	transactionResponse := TransactionResponse{}
+	transactionResponse := sendSingleTxResponse{}
 	loadResponse(resp.Body, &transactionResponse)
 
 	assert.Equal(t, http.StatusInternalServerError, resp.Code)
 	assert.Contains(t, transactionResponse.Error, errorString)
-	assert.Empty(t, transactionResponse.TxResp)
+	assert.Empty(t, transactionResponse.Data)
 }
 
 func TestSendTransaction_ReturnsSuccessfully(t *testing.T) {
@@ -266,17 +333,12 @@ func TestSendTransaction_ReturnsSuccessfully(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	response := shared.GenericAPIResponse{}
+	response := sendSingleTxResponse{}
 	loadResponse(resp.Body, &response)
 
-	txHashResponse := TransactionHashResponse{}
-	mapResponseData := response.Data.(map[string]interface{})
-	mapResponseDataBytes, _ := json.Marshal(mapResponseData)
-	_ = json.Unmarshal(mapResponseDataBytes, &txHashResponse)
-
 	assert.Equal(t, http.StatusOK, resp.Code)
-	assert.Empty(t, txHashResponse.Error)
-	assert.Equal(t, hexTxHash, txHashResponse.TxHash)
+	assert.Empty(t, response.Error)
+	assert.Equal(t, hexTxHash, response.Data.TxHash)
 }
 
 func TestSendMultipleTransactions_ErrorWithWrongFacade(t *testing.T) {
@@ -287,10 +349,40 @@ func TestSendMultipleTransactions_ErrorWithWrongFacade(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	transactionResponse := TransactionResponse{}
+	transactionResponse := sendMultipleTxsResponse{}
 	loadResponse(resp.Body, &transactionResponse)
 	assert.Equal(t, http.StatusInternalServerError, resp.Code)
-	assert.Equal(t, transactionResponse.Error, errors2.ErrInvalidAppContext.Error())
+	assert.Equal(t, errors2.ErrInvalidAppContext.Error(), transactionResponse.Error)
+}
+
+func TestSendMultipleTransactions_ErrorWithExceededNumGoRoutines(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{
+		GetThrottlerForEndpointCalled: func(_ string) (core.Throttler, bool) {
+			return &mock.ThrottlerStub{
+				CanProcessCalled: func() bool { return false },
+			}, true
+		},
+	}
+	ws := startNodeServer(&facade)
+
+	tx0 := transaction.SendTxRequest{}
+	txs := []*transaction.SendTxRequest{&tx0}
+
+	jsonBytes, _ := json.Marshal(txs)
+	req, _ := http.NewRequest("POST", "/transaction/send-multiple", bytes.NewBuffer(jsonBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	transactionResponse := sendMultipleTxsResponse{}
+	loadResponse(resp.Body, &transactionResponse)
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.Code)
+	assert.Equal(t, errors2.ErrTooManyRequests.Error(), transactionResponse.Error)
+	assert.Equal(t, string(shared.ReturnCodeSystemBusy), transactionResponse.Code)
+	assert.Empty(t, transactionResponse.Data)
 }
 
 func TestSendMultipleTransactions_WrongPayloadShouldErrorOnValidation(t *testing.T) {
@@ -306,12 +398,12 @@ func TestSendMultipleTransactions_WrongPayloadShouldErrorOnValidation(t *testing
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	transactionResponse := TransactionResponse{}
+	transactionResponse := sendMultipleTxsResponse{}
 	loadResponse(resp.Body, &transactionResponse)
 
 	assert.Equal(t, http.StatusBadRequest, resp.Code)
 	assert.Contains(t, transactionResponse.Error, errors2.ErrValidation.Error())
-	assert.Empty(t, transactionResponse.TxResp)
+	assert.Empty(t, transactionResponse.Data)
 }
 
 func TestSendMultipleTransactions_OkPayloadShouldWork(t *testing.T) {
@@ -357,7 +449,7 @@ func TestSendMultipleTransactions_OkPayloadShouldWork(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	transactionResponse := TransactionResponse{}
+	transactionResponse := sendMultipleTxsResponse{}
 	loadResponse(resp.Body, &transactionResponse)
 
 	assert.Equal(t, http.StatusOK, resp.Code)
@@ -399,7 +491,7 @@ func TestComputeTransactionGasLimit(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	transactionCostResponse := TransactionCostResponse{}
+	transactionCostResponse := transactionCostResponse{}
 	loadResponse(resp.Body, &transactionCostResponse)
 
 	assert.Equal(t, http.StatusOK, resp.Code)

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -384,9 +384,9 @@
         # SameSourceResetIntervalInSec time frame between counter reset, in seconds
         SameSourceResetIntervalInSec = 1
         # EndpointsThrottlers represents a map for maximum simultaneous go routines for an endpoint
-        EndpointsThrottlers = [{ Endpoint = "/transaction/get", MaxNumGoRoutines = 10 },
-                               { Endpoint = "/transaction/send", MaxNumGoRoutines = 10 },
-                               { Endpoint = "/transaction/send-multiple", MaxNumGoRoutines = 10 }]
+        EndpointsThrottlers = [{ Endpoint = "/transaction/:hash", MaxNumGoRoutines = 10 },
+                               { Endpoint = "/transaction/send", MaxNumGoRoutines = 2 },
+                               { Endpoint = "/transaction/send-multiple", MaxNumGoRoutines = 2 }]
     [Antiflood.TxAccumulator]
         # MaxAllowedTimeInMilliseconds is used as a time frame in which the node gathers transactions.
         # After this period, collected transactions will be sent on the p2p topics

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -383,6 +383,10 @@
         SameSourceRequests = 10000
         # SameSourceResetIntervalInSec time frame between counter reset, in seconds
         SameSourceResetIntervalInSec = 1
+        # EndpointsThrottlers represents a map for maximum simultaneous go routines for an endpoint
+        EndpointsThrottlers = [{ Endpoint = "/transaction/get", MaxNumGoRoutines = 10 },
+                               { Endpoint = "/transaction/send", MaxNumGoRoutines = 10 },
+                               { Endpoint = "/transaction/send-multiple", MaxNumGoRoutines = 10 }]
     [Antiflood.TxAccumulator]
         # MaxAllowedTimeInMilliseconds is used as a time frame in which the node gathers transactions.
         # After this period, collected transactions will be sent on the p2p topics

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/core/random"
 	"github.com/ElrondNetwork/elrond-go/core/serviceContainer"
 	"github.com/ElrondNetwork/elrond-go/core/statistics"
-	"github.com/ElrondNetwork/elrond-go/core/throttler"
 	"github.com/ElrondNetwork/elrond-go/core/watchdog"
 	"github.com/ElrondNetwork/elrond-go/crypto"
 	"github.com/ElrondNetwork/elrond-go/crypto/signing/mcl"
@@ -94,7 +93,6 @@ const (
 	notSetDestinationShardID     = "disabled"
 	metachainShardName           = "metachain"
 	secondsToWaitForP2PBootstrap = 20
-	maxNumGoRoutinesTxsByHashApi = 10
 	maxTimeToClose               = 10 * time.Second
 	maxMachineIDLen              = 10
 )
@@ -2066,11 +2064,6 @@ func createNode(
 
 	factory.PrepareOpenTopics(network.InputAntifloodHandler, shardCoordinator)
 
-	apiTxsByHashThrottler, err := throttler.NewNumGoRoutinesThrottler(maxNumGoRoutinesTxsByHashApi)
-	if err != nil {
-		return nil, err
-	}
-
 	alarmScheduler := alarm.NewAlarmScheduler()
 	watchdogTimer, err := watchdog.NewWatchdog(alarmScheduler, chanStopNodeProcess)
 	if err != nil {
@@ -2156,7 +2149,6 @@ func createNode(
 		node.WithSignatureSize(config.ValidatorPubkeyConverter.SignatureLength),
 		node.WithPublicKeySize(config.ValidatorPubkeyConverter.Length),
 		node.WithNodeStopChannel(chanStopNodeProcess),
-		node.WithApiTransactionByHashThrottler(apiTxsByHashThrottler),
 		node.WithPeerHonestyHandler(peerHonestyHandler),
 		node.WithWatchdogTimer(watchdogTimer),
 	)

--- a/config/config.go
+++ b/config/config.go
@@ -219,11 +219,18 @@ type TrieStorageManagerConfig struct {
 	MaxSnapshots       uint8
 }
 
-// WebServerAntifloodConfig will hold the anti-lflooding parameters for the web server
+// EndpointsThrottlersConfig holds a pair of an endpoint and its maximum number of simultaneous go routines
+type EndpointsThrottlersConfig struct {
+	Endpoint         string
+	MaxNumGoRoutines int32
+}
+
+// WebServerAntifloodConfig will hold the anti-flooding parameters for the web server
 type WebServerAntifloodConfig struct {
 	SimultaneousRequests         uint32
 	SameSourceRequests           uint32
 	SameSourceResetIntervalInSec uint32
+	EndpointsThrottlers          []EndpointsThrottlersConfig
 }
 
 // BlackListConfig will hold the p2p peer black list threshold values

--- a/core/interface.go
+++ b/core/interface.go
@@ -44,3 +44,11 @@ type WatchdogTimer interface {
 	Reset(alarmID string)
 	IsInterfaceNil() bool
 }
+
+// Throttler can monitor the number of the currently running go routines
+type Throttler interface {
+	CanProcess() bool
+	StartProcessing()
+	EndProcessing()
+	IsInterfaceNil() bool
+}

--- a/debug/antiflood/debugger.go
+++ b/debug/antiflood/debugger.go
@@ -55,7 +55,7 @@ func (ev *event) String() string {
 		sequences = append([]string{moreSequencesPresent}, sequences[len(sequences)-maxSequencesToPrint:]...)
 	}
 
-	return fmt.Sprintf("pid: %s; topic: %s; num rejected: %d; size rejected: %d; seqences: %s; is blacklisted: %v",
+	return fmt.Sprintf("pid: %s; topic: %s; num rejected: %d; size rejected: %d; sequences: %s; is blacklisted: %v",
 		ev.pid.Pretty(), ev.topic, ev.numRejected, ev.sizeRejected, strings.Join(sequences, ", "), ev.isBlackListed)
 }
 

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -107,9 +107,9 @@ func NewNodeFacade(arg ArgNodeFacade) (*nodeFacade, error) {
 	}, nil
 }
 
-func computeEndpointsNumGoRoutinesThrottlers(endpointSpecificAntiFlood config.WebServerAntifloodConfig) map[string]core.Throttler {
+func computeEndpointsNumGoRoutinesThrottlers(webServerAntiFloodConfig config.WebServerAntifloodConfig) map[string]core.Throttler {
 	throttlersMap := make(map[string]core.Throttler)
-	for _, endpointSetting := range endpointSpecificAntiFlood.EndpointsThrottlers {
+	for _, endpointSetting := range webServerAntiFloodConfig.EndpointsThrottlers {
 		newThrottler, err := throttler.NewNumGoRoutinesThrottler(endpointSetting.MaxNumGoRoutines)
 		if err != nil {
 			log.Warn("error when setting the maximum go routines throttler for endpoint",

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/core/statistics"
+	"github.com/ElrondNetwork/elrond-go/core/throttler"
 	"github.com/ElrondNetwork/elrond-go/data/state"
 	"github.com/ElrondNetwork/elrond-go/data/transaction"
 	"github.com/ElrondNetwork/elrond-go/debug"
@@ -68,6 +69,7 @@ type nodeFacade struct {
 	config                 config.FacadeConfig
 	wsAntifloodConfig      config.WebServerAntifloodConfig
 	apiRoutesConfig        config.ApiRoutesConfig
+	endpointsThrottlers    map[string]core.Throttler
 	restAPIServerDebugMode bool
 }
 
@@ -92,6 +94,8 @@ func NewNodeFacade(arg ArgNodeFacade) (*nodeFacade, error) {
 		return nil, fmt.Errorf("%w, SameSourceResetIntervalInSec should not be 0", ErrInvalidValue)
 	}
 
+	throtlersMap := computeEndpointsNumGoRoutinesThrottlers(arg.WsAntifloodConfig)
+
 	return &nodeFacade{
 		node:                   arg.Node,
 		apiResolver:            arg.ApiResolver,
@@ -99,7 +103,26 @@ func NewNodeFacade(arg ArgNodeFacade) (*nodeFacade, error) {
 		wsAntifloodConfig:      arg.WsAntifloodConfig,
 		config:                 arg.FacadeConfig,
 		apiRoutesConfig:        arg.ApiRoutesConfig,
+		endpointsThrottlers:    throtlersMap,
 	}, nil
+}
+
+func computeEndpointsNumGoRoutinesThrottlers(endpointSpecificAntiFlood config.WebServerAntifloodConfig) map[string]core.Throttler {
+	throttlersMap := make(map[string]core.Throttler)
+	for _, endpointSetting := range endpointSpecificAntiFlood.EndpointsThrottlers {
+		newThrottler, err := throttler.NewNumGoRoutinesThrottler(endpointSetting.MaxNumGoRoutines)
+		if err != nil {
+			log.Warn("error when setting the maximum go routines throttler for endpoint",
+				"endpoint", endpointSetting.Endpoint,
+				"max go routines", endpointSetting.MaxNumGoRoutines,
+				"error", err,
+			)
+			continue
+		}
+		throttlersMap[endpointSetting.Endpoint] = newThrottler
+	}
+
+	return throttlersMap
 }
 
 // SetSyncer sets the current syncer
@@ -310,6 +333,14 @@ func (nf *nodeFacade) GetQueryHandler(name string) (debug.QueryHandler, error) {
 // GetPeerInfo returns the peer info of a provided pid
 func (nf *nodeFacade) GetPeerInfo(pid string) ([]core.QueryP2PPeerInfo, error) {
 	return nf.node.GetPeerInfo(pid)
+}
+
+// GetThrottlerForEndpoint returns the throttler for a given endpoint if found
+func (nf *nodeFacade) GetThrottlerForEndpoint(endpoint string) (core.Throttler, bool) {
+	throttlerForEndpoint, ok := nf.endpointsThrottlers[endpoint]
+	isThrottlerOk := ok && throttlerForEndpoint != nil
+
+	return throttlerForEndpoint, isThrottlerOk
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -94,7 +94,7 @@ func NewNodeFacade(arg ArgNodeFacade) (*nodeFacade, error) {
 		return nil, fmt.Errorf("%w, SameSourceResetIntervalInSec should not be 0", ErrInvalidValue)
 	}
 
-	throtlersMap := computeEndpointsNumGoRoutinesThrottlers(arg.WsAntifloodConfig)
+	throttlersMap := computeEndpointsNumGoRoutinesThrottlers(arg.WsAntifloodConfig)
 
 	return &nodeFacade{
 		node:                   arg.Node,
@@ -103,7 +103,7 @@ func NewNodeFacade(arg ArgNodeFacade) (*nodeFacade, error) {
 		wsAntifloodConfig:      arg.WsAntifloodConfig,
 		config:                 arg.FacadeConfig,
 		apiRoutesConfig:        arg.ApiRoutesConfig,
-		endpointsThrottlers:    throtlersMap,
+		endpointsThrottlers:    throttlersMap,
 	}, nil
 }
 

--- a/facade/nodeFacade_test.go
+++ b/facade/nodeFacade_test.go
@@ -578,3 +578,52 @@ func TestNodeFacade_GetPeerInfo(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, []core.QueryP2PPeerInfo{pinfo}, val)
 }
+
+func TestNodeFacade_GetThrottlerForEndpointNoConfigShouldReturnNilAndFalse(t *testing.T) {
+	t.Parallel()
+
+	arg := createMockArguments()
+	arg.WsAntifloodConfig.EndpointsThrottlers = []config.EndpointsThrottlersConfig{} //ensure it is empty
+	nf, _ := NewNodeFacade(arg)
+
+	thr, ok := nf.GetThrottlerForEndpoint("any-endpoint")
+
+	assert.Nil(t, thr)
+	assert.False(t, ok)
+}
+
+func TestNodeFacade_GetThrottlerForEndpointNotFoundShouldReturnNilAndFalse(t *testing.T) {
+	t.Parallel()
+
+	arg := createMockArguments()
+	arg.WsAntifloodConfig.EndpointsThrottlers = []config.EndpointsThrottlersConfig{
+		{
+			Endpoint:         "endpoint",
+			MaxNumGoRoutines: 10,
+		},
+	}
+	nf, _ := NewNodeFacade(arg)
+
+	thr, ok := nf.GetThrottlerForEndpoint("different-endpoint")
+
+	assert.Nil(t, thr)
+	assert.False(t, ok)
+}
+
+func TestNodeFacade_GetThrottlerForEndpointShouldFindAndReturn(t *testing.T) {
+	t.Parallel()
+
+	arg := createMockArguments()
+	arg.WsAntifloodConfig.EndpointsThrottlers = []config.EndpointsThrottlersConfig{
+		{
+			Endpoint:         "endpoint",
+			MaxNumGoRoutines: 10,
+		},
+	}
+	nf, _ := NewNodeFacade(arg)
+
+	thr, ok := nf.GetThrottlerForEndpoint("endpoint")
+
+	assert.NotNil(t, thr)
+	assert.True(t, ok)
+}

--- a/node/node.go
+++ b/node/node.go
@@ -96,7 +96,6 @@ type Node struct {
 	validatorsProvider            process.ValidatorsProvider
 	whiteListRequest              process.WhiteListHandler
 	whiteListerVerifiedTxs        process.WhiteListHandler
-	apiTransactionByHashThrottler Throttler
 
 	pubKey            crypto.PublicKey
 	privKey           crypto.PrivateKey

--- a/node/nodeTransactions.go
+++ b/node/nodeTransactions.go
@@ -24,13 +24,6 @@ const (
 // GetTransaction gets the transaction based on the given hash. It will search in the cache and the storage and
 // will return the transaction in a format which can be respected by all types of transactions (normal, reward or unsigned)
 func (n *Node) GetTransaction(txHash string) (*transaction.ApiTransactionResult, error) {
-	if !n.apiTransactionByHashThrottler.CanProcess() {
-		return nil, ErrSystemBusyTxHash
-	}
-
-	n.apiTransactionByHashThrottler.StartProcessing()
-	defer n.apiTransactionByHashThrottler.EndProcessing()
-
 	hash, err := hex.DecodeString(txHash)
 	if err != nil {
 		return nil, err

--- a/node/nodeTransactions_test.go
+++ b/node/nodeTransactions_test.go
@@ -18,32 +18,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNode_GetTransaction_ThrottlerCannotProcessShouldErr(t *testing.T) {
-	t.Parallel()
-
-	throttler := &mock.ThrottlerStub{
-		CanProcessCalled: func() bool {
-			return false
-		},
-	}
-	n, _ := node.NewNode(
-		node.WithApiTransactionByHashThrottler(throttler),
-	)
-	_, err := n.GetTransaction("aaa")
-	assert.Equal(t, node.ErrSystemBusyTxHash, err)
-}
-
 func TestNode_GetTransaction_InvalidHashShouldErr(t *testing.T) {
 	t.Parallel()
 
-	throttler := &mock.ThrottlerStub{
-		CanProcessCalled: func() bool {
-			return true
-		},
-	}
-	n, _ := node.NewNode(
-		node.WithApiTransactionByHashThrottler(throttler),
-	)
+	n, _ := node.NewNode()
 	_, err := n.GetTransaction("zzz")
 	assert.Error(t, err)
 }
@@ -51,16 +29,10 @@ func TestNode_GetTransaction_InvalidHashShouldErr(t *testing.T) {
 func TestNode_GetTransaction_ShouldFindInTxCacheAndReturn(t *testing.T) {
 	t.Parallel()
 
-	throttler := &mock.ThrottlerStub{
-		CanProcessCalled: func() bool {
-			return true
-		},
-	}
 	dataPool := &testscommon.PoolsHolderStub{
 		TransactionsCalled: getCacherHandler(true, ""),
 	}
 	n, _ := node.NewNode(
-		node.WithApiTransactionByHashThrottler(throttler),
 		node.WithDataPool(dataPool),
 		node.WithInternalMarshalizer(&mock.MarshalizerFake{}, 0),
 		node.WithAddressPubkeyConverter(&mock.PubkeyConverterMock{}),
@@ -75,17 +47,11 @@ func TestNode_GetTransaction_ShouldFindInTxCacheAndReturn(t *testing.T) {
 func TestNode_GetTransaction_ShouldFindInRwdTxCacheAndReturn(t *testing.T) {
 	t.Parallel()
 
-	throttler := &mock.ThrottlerStub{
-		CanProcessCalled: func() bool {
-			return true
-		},
-	}
 	dataPool := &testscommon.PoolsHolderStub{
 		TransactionsCalled:       getCacherHandler(false, ""),
 		RewardTransactionsCalled: getCacherHandler(true, "reward"),
 	}
 	n, _ := node.NewNode(
-		node.WithApiTransactionByHashThrottler(throttler),
 		node.WithDataPool(dataPool),
 		node.WithInternalMarshalizer(&mock.MarshalizerFake{}, 0),
 		node.WithAddressPubkeyConverter(&mock.PubkeyConverterMock{}),
@@ -100,18 +66,12 @@ func TestNode_GetTransaction_ShouldFindInRwdTxCacheAndReturn(t *testing.T) {
 func TestNode_GetTransaction_ShouldFindInUnsignedTxCacheAndReturn(t *testing.T) {
 	t.Parallel()
 
-	throttler := &mock.ThrottlerStub{
-		CanProcessCalled: func() bool {
-			return true
-		},
-	}
 	dataPool := &testscommon.PoolsHolderStub{
 		TransactionsCalled:         getCacherHandler(false, ""),
 		RewardTransactionsCalled:   getCacherHandler(false, ""),
 		UnsignedTransactionsCalled: getCacherHandler(true, "unsigned"),
 	}
 	n, _ := node.NewNode(
-		node.WithApiTransactionByHashThrottler(throttler),
 		node.WithDataPool(dataPool),
 		node.WithInternalMarshalizer(&mock.MarshalizerFake{}, 0),
 		node.WithAddressPubkeyConverter(&mock.PubkeyConverterMock{}),
@@ -126,11 +86,6 @@ func TestNode_GetTransaction_ShouldFindInUnsignedTxCacheAndReturn(t *testing.T) 
 func TestNode_GetTransaction_ShouldFindInTxStorageAndReturn(t *testing.T) {
 	t.Parallel()
 
-	throttler := &mock.ThrottlerStub{
-		CanProcessCalled: func() bool {
-			return true
-		},
-	}
 	dataPool := &testscommon.PoolsHolderStub{
 		TransactionsCalled:         getCacherHandler(false, ""),
 		RewardTransactionsCalled:   getCacherHandler(false, ""),
@@ -142,7 +97,6 @@ func TestNode_GetTransaction_ShouldFindInTxStorageAndReturn(t *testing.T) {
 		},
 	}
 	n, _ := node.NewNode(
-		node.WithApiTransactionByHashThrottler(throttler),
 		node.WithDataPool(dataPool),
 		node.WithDataStore(storer),
 		node.WithInternalMarshalizer(&mock.MarshalizerFake{}, 0),
@@ -158,11 +112,6 @@ func TestNode_GetTransaction_ShouldFindInTxStorageAndReturn(t *testing.T) {
 func TestNode_GetTransaction_ShouldFindInRwdTxStorageAndReturn(t *testing.T) {
 	t.Parallel()
 
-	throttler := &mock.ThrottlerStub{
-		CanProcessCalled: func() bool {
-			return true
-		},
-	}
 	dataPool := &testscommon.PoolsHolderStub{
 		TransactionsCalled:         getCacherHandler(false, ""),
 		RewardTransactionsCalled:   getCacherHandler(false, ""),
@@ -178,7 +127,6 @@ func TestNode_GetTransaction_ShouldFindInRwdTxStorageAndReturn(t *testing.T) {
 		},
 	}
 	n, _ := node.NewNode(
-		node.WithApiTransactionByHashThrottler(throttler),
 		node.WithDataPool(dataPool),
 		node.WithDataStore(storer),
 		node.WithInternalMarshalizer(&mock.MarshalizerFake{}, 0),
@@ -194,11 +142,6 @@ func TestNode_GetTransaction_ShouldFindInRwdTxStorageAndReturn(t *testing.T) {
 func TestNode_GetTransaction_ShouldFindInUnsignedTxStorageAndReturn(t *testing.T) {
 	t.Parallel()
 
-	throttler := &mock.ThrottlerStub{
-		CanProcessCalled: func() bool {
-			return true
-		},
-	}
 	dataPool := &testscommon.PoolsHolderStub{
 		TransactionsCalled:         getCacherHandler(false, ""),
 		RewardTransactionsCalled:   getCacherHandler(false, ""),
@@ -215,7 +158,6 @@ func TestNode_GetTransaction_ShouldFindInUnsignedTxStorageAndReturn(t *testing.T
 		},
 	}
 	n, _ := node.NewNode(
-		node.WithApiTransactionByHashThrottler(throttler),
 		node.WithDataPool(dataPool),
 		node.WithDataStore(storer),
 		node.WithInternalMarshalizer(&mock.MarshalizerFake{}, 0),
@@ -233,11 +175,6 @@ func TestNode_GetTransaction_ShouldFindInStorageButErrorUnmarshaling(t *testing.
 
 	expectedErr := errors.New("error unmarshalling")
 
-	throttler := &mock.ThrottlerStub{
-		CanProcessCalled: func() bool {
-			return true
-		},
-	}
 	dataPool := &testscommon.PoolsHolderStub{
 		TransactionsCalled:         getCacherHandler(false, ""),
 		RewardTransactionsCalled:   getCacherHandler(false, ""),
@@ -254,7 +191,6 @@ func TestNode_GetTransaction_ShouldFindInStorageButErrorUnmarshaling(t *testing.
 		},
 	}
 	n, _ := node.NewNode(
-		node.WithApiTransactionByHashThrottler(throttler),
 		node.WithDataPool(dataPool),
 		node.WithDataStore(storer),
 		node.WithInternalMarshalizer(&mock.MarshalizerMock{
@@ -272,11 +208,6 @@ func TestNode_GetTransaction_ShouldFindInStorageButErrorUnmarshaling(t *testing.
 func TestNode_GetTransaction_ShouldNotFindAndReturnUnknown(t *testing.T) {
 	t.Parallel()
 
-	throttler := &mock.ThrottlerStub{
-		CanProcessCalled: func() bool {
-			return true
-		},
-	}
 	dataPool := &testscommon.PoolsHolderStub{
 		TransactionsCalled:         getCacherHandler(false, ""),
 		RewardTransactionsCalled:   getCacherHandler(false, ""),
@@ -288,7 +219,6 @@ func TestNode_GetTransaction_ShouldNotFindAndReturnUnknown(t *testing.T) {
 		},
 	}
 	n, _ := node.NewNode(
-		node.WithApiTransactionByHashThrottler(throttler),
 		node.WithDataPool(dataPool),
 		node.WithDataStore(storer),
 	)
@@ -300,11 +230,6 @@ func TestNode_GetTransaction_ShouldNotFindAndReturnUnknown(t *testing.T) {
 func TestNode_ComputeTransactionStatus(t *testing.T) {
 	t.Parallel()
 
-	throttler := &mock.ThrottlerStub{
-		CanProcessCalled: func() bool {
-			return true
-		},
-	}
 	storer := &mock.ChainStorerMock{
 		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
 			return getStorerStub(false)
@@ -323,7 +248,6 @@ func TestNode_ComputeTransactionStatus(t *testing.T) {
 	}
 
 	n, _ := node.NewNode(
-		node.WithApiTransactionByHashThrottler(throttler),
 		node.WithDataStore(storer),
 		node.WithShardCoordinator(shardCoordinator),
 	)

--- a/node/options.go
+++ b/node/options.go
@@ -678,17 +678,6 @@ func WithNodeStopChannel(channel chan endProcess.ArgEndProcess) Option {
 	}
 }
 
-// WithApiTransactionByHashThrottler sets up the api transaction by hash throttler
-func WithApiTransactionByHashThrottler(throttler Throttler) Option {
-	return func(n *Node) error {
-		if throttler == nil {
-			return ErrNilApiTransactionByHashThrottler
-		}
-		n.apiTransactionByHashThrottler = throttler
-		return nil
-	}
-}
-
 // WithPeerHonestyHandler sets up a peer honesty handler for the Node
 func WithPeerHonestyHandler(peerHonestyHandler consensus.PeerHonestyHandler) Option {
 	return func(n *Node) error {


### PR DESCRIPTION
- implemented custom endpoints throttlers in order to be able to limit the maximum number of simultaneous requests (or goroutines) at once.
- removed old implementation for `/transaction/:hash`'s throttler and switched to this approach
- corrected a typo
