### PR TITLE
bugFix/restart-without-db

### DIFF
--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -618,6 +618,10 @@ func (e *epochStartBootstrap) saveSelfShardId() {
 
 func (e *epochStartBootstrap) processNodesConfig(pubKey []byte) error {
 	var err error
+	shardId := e.destinationShardAsObserver
+	if shardId > e.baseData.numberOfShards && shardId != core.MetachainShardId {
+		shardId = e.genesisShardCoordinator.SelfId()
+	}
 	argsNewValidatorStatusSyncers := ArgsNewSyncValidatorStatus{
 		DataPool:           e.dataPool,
 		Marshalizer:        e.marshalizer,
@@ -627,7 +631,7 @@ func (e *epochStartBootstrap) processNodesConfig(pubKey []byte) error {
 		NodeShuffler:       e.nodeShuffler,
 		Hasher:             e.hasher,
 		PubKey:             pubKey,
-		ShardIdAsObserver:  e.destinationShardAsObserver,
+		ShardIdAsObserver:  shardId,
 	}
 	e.nodesConfigHandler, err = NewSyncValidatorStatus(argsNewValidatorStatusSyncers)
 	if err != nil {

--- a/epochStart/bootstrap/process_test.go
+++ b/epochStart/bootstrap/process_test.go
@@ -482,3 +482,40 @@ func TestRequestAndProcessing(t *testing.T) {
 	assert.Equal(t, Parameters{}, params)
 	assert.Equal(t, storage.ErrInvalidNumberOfEpochsToSave, err)
 }
+
+func TestEpochStartBootstrap_WithDisabledShardIDAsOBserver(t *testing.T) {
+	t.Parallel()
+
+	args := createMockEpochStartBootstrapArgs()
+	args.DestinationShardAsObserver = core.DisabledShardIDAsObserver
+	args.GenesisNodesConfig = getNodesConfigMock(2)
+
+	epochStartProvider, err := NewEpochStartBootstrap(args)
+	assert.Nil(t, err)
+	assert.False(t, check.IfNil(epochStartProvider))
+
+	epochStartProvider.dataPool = &testscommon.PoolsHolderStub{
+		HeadersCalled: func() dataRetriever.HeadersPool {
+			return &mock.HeadersCacherStub{}
+		},
+		TransactionsCalled: func() dataRetriever.ShardedDataCacherNotifier {
+			return testscommon.NewShardedDataStub()
+		},
+		UnsignedTransactionsCalled: func() dataRetriever.ShardedDataCacherNotifier {
+			return testscommon.NewShardedDataStub()
+		},
+		RewardTransactionsCalled: func() dataRetriever.ShardedDataCacherNotifier {
+			return testscommon.NewShardedDataStub()
+		},
+		MiniBlocksCalled: func() storage.Cacher {
+			return testscommon.NewCacherStub()
+		},
+		TrieNodesCalled: func() storage.Cacher {
+			return testscommon.NewCacherStub()
+		},
+	}
+	epochStartProvider.requestHandler = &mock.RequestHandlerStub{}
+	epochStartProvider.epochStartMeta = &block.MetaBlock{Epoch: 0}
+	err = epochStartProvider.processNodesConfig([]byte("something"))
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
When destination as shard ID was set to disabled restart without DB stopped working.