### PR TITLE
bugFix/economics-based-on-genesis-supply-only

### DIFF
--- a/epochStart/metachain/economics.go
+++ b/epochStart/metachain/economics.go
@@ -70,14 +70,15 @@ func NewEndOfEpochEconomicsDataCreator(args ArgsNewEpochEconomics) (*economics, 
 	}
 
 	e := &economics{
-		marshalizer:      args.Marshalizer,
-		hasher:           args.Hasher,
-		store:            args.Store,
-		shardCoordinator: args.ShardCoordinator,
-		rewardsHandler:   args.RewardsHandler,
-		roundTime:        args.RoundTime,
-		genesisEpoch:     args.GenesisEpoch,
-		genesisNonce:     args.GenesisNonce,
+		marshalizer:        args.Marshalizer,
+		hasher:             args.Hasher,
+		store:              args.Store,
+		shardCoordinator:   args.ShardCoordinator,
+		rewardsHandler:     args.RewardsHandler,
+		roundTime:          args.RoundTime,
+		genesisEpoch:       args.GenesisEpoch,
+		genesisNonce:       args.GenesisNonce,
+		genesisTotalSupply: big.NewInt(0).Set(args.GenesisTotalSupply),
 	}
 
 	return e, nil
@@ -116,7 +117,7 @@ func (e *economics) ComputeEndOfEpochEconomics(
 	totalNumBlocksInEpoch := e.computeNumOfTotalCreatedBlocks(noncesPerShardPrevEpoch, noncesPerShardCurrEpoch)
 
 	inflationRate := e.computeInflationRate(metaBlock.GetRound())
-	rwdPerBlock := e.computeRewardsPerBlock(prevEpochEconomics.TotalSupply, maxBlocksInEpoch, inflationRate)
+	rwdPerBlock := e.computeRewardsPerBlock(e.genesisTotalSupply, maxBlocksInEpoch, inflationRate)
 	totalRewardsToBeDistributed := big.NewInt(0).Mul(rwdPerBlock, big.NewInt(0).SetUint64(totalNumBlocksInEpoch))
 
 	newTokens := big.NewInt(0).Sub(totalRewardsToBeDistributed, metaBlock.AccumulatedFeesInEpoch)

--- a/epochStart/metachain/economics_test.go
+++ b/epochStart/metachain/economics_test.go
@@ -390,13 +390,14 @@ func TestEconomics_VerifyRewardsPerBlock_DifferentHitRates(t *testing.T) {
 			return time.Duration(roundDur) * time.Second
 		},
 	}
+	newTotalSupply := big.NewInt(0).Add(totalSupply, totalSupply)
 	hdrPrevEpochStart := block.MetaBlock{
 		Round: 0,
 		Nonce: 0,
 		Epoch: 0,
 		EpochStart: block.EpochStart{
 			Economics: block.Economics{
-				TotalSupply:         totalSupply,
+				TotalSupply:         newTotalSupply,
 				TotalToDistribute:   big.NewInt(10),
 				TotalNewlyMinted:    big.NewInt(10),
 				RewardsPerBlock:     big.NewInt(10),
@@ -418,6 +419,7 @@ func TestEconomics_VerifyRewardsPerBlock_DifferentHitRates(t *testing.T) {
 			}}
 		},
 	}
+	args.GenesisTotalSupply = totalSupply
 	ec, _ := NewEndOfEpochEconomicsDataCreator(args)
 
 	expRwdPerBlock := 84 // based on 0.1 inflation
@@ -436,7 +438,7 @@ func TestEconomics_VerifyRewardsPerBlock_DifferentHitRates(t *testing.T) {
 	for _, numBlocksInEpoch := range numBlocksInEpochSlice {
 		expectedTotalToDistribute := big.NewInt(int64(expRwdPerBlock * numBlocksInEpoch * 3)) // 2 shards + meta
 		expectedTotalNewlyMinted := big.NewInt(0).Sub(expectedTotalToDistribute, accFeesInEpoch)
-		expectedTotalSupply := big.NewInt(0).Add(totalSupply, expectedTotalNewlyMinted)
+		expectedTotalSupply := big.NewInt(0).Add(newTotalSupply, expectedTotalNewlyMinted)
 		expectedCommunityRewards := big.NewInt(0).Div(expectedTotalToDistribute, big.NewInt(10))
 		commRewardPerBlock := big.NewInt(0).Div(expectedCommunityRewards, big.NewInt(int64(numBlocksInEpoch*3)))
 		adjustedRwdPerBlock := big.NewInt(0).Sub(big.NewInt(int64(expRwdPerBlock)), commRewardPerBlock)
@@ -578,6 +580,7 @@ func createArgsForComputeEndOfEpochEconomics(
 			}}
 		},
 	}
+	args.GenesisTotalSupply = totalSupply
 
 	return args
 }


### PR DESCRIPTION
fixed economics computation where the previous total supply was taken in consideration for the total to distribute, instead the genesis total supply has to be taken according to new documents.