### PR TITLE
Avoid whitelisting out of range block data

### DIFF
--- a/process/track/baseBlockTrack_test.go
+++ b/process/track/baseBlockTrack_test.go
@@ -2434,6 +2434,68 @@ func TestBaseBlockTrack_DoWhitelistWithShardHeaderIfNeededNilShardShouldReturnAn
 	assert.Equal(t, 0, len(cache))
 }
 
+func TestBaseBlockTrack_DoWhitelistWithMetaBlockIfNeededIsHeaderOutOfRangeShouldReturn(t *testing.T) {
+	t.Parallel()
+
+	cache := make(map[string]struct{})
+	mutCache := sync.Mutex{}
+	shardArguments := CreateShardTrackerMockArguments()
+	shardArguments.WhitelistHandler = &mock.WhiteListHandlerStub{
+		AddCalled: func(keys [][]byte) {
+			mutCache.Lock()
+			for _, key := range keys {
+				cache[string(key)] = struct{}{}
+			}
+			mutCache.Unlock()
+		},
+	}
+	sbt, _ := track.NewShardBlockTrack(shardArguments)
+
+	metaHdr := &block.MetaBlock{
+		Round: process.MaxHeadersToRequestInAdvance + 1,
+		Nonce: process.MaxHeadersToRequestInAdvance + 1,
+		MiniBlockHeaders: []block.MiniBlockHeader{
+			{Hash: []byte("shardHash0"), SenderShardID: 1, ReceiverShardID: 0},
+		},
+	}
+
+	sbt.DoWhitelistWithMetaBlockIfNeeded(metaHdr)
+	_, ok := cache[string(metaHdr.MiniBlockHeaders[0].Hash)]
+
+	assert.False(t, ok)
+}
+
+func TestBaseBlockTrack_DoWhitelistWithShardHeaderIfNeededIsHeaderOutOfRangeShouldReturn(t *testing.T) {
+	t.Parallel()
+
+	cache := make(map[string]struct{})
+	mutCache := sync.Mutex{}
+	metaArguments := CreateMetaTrackerMockArguments()
+	metaArguments.WhitelistHandler = &mock.WhiteListHandlerStub{
+		AddCalled: func(keys [][]byte) {
+			mutCache.Lock()
+			for _, key := range keys {
+				cache[string(key)] = struct{}{}
+			}
+			mutCache.Unlock()
+		},
+	}
+	mbt, _ := track.NewMetaBlockTrack(metaArguments)
+
+	shardHdr := &block.Header{
+		Round: process.MaxHeadersToRequestInAdvance + 1,
+		Nonce: process.MaxHeadersToRequestInAdvance + 1,
+		MiniBlockHeaders: []block.MiniBlockHeader{
+			{Hash: []byte("shardHash0"), SenderShardID: 0, ReceiverShardID: core.MetachainShardId},
+		},
+	}
+
+	mbt.DoWhitelistWithShardHeaderIfNeeded(shardHdr)
+	_, ok := cache[string(shardHdr.MiniBlockHeaders[0].Hash)]
+
+	assert.False(t, ok)
+}
+
 func TestBaseBlockTrack_DoWhitelistWithMetaBlockIfNeededShardShouldWhitelistCrossMiniblocks(t *testing.T) {
 	t.Parallel()
 
@@ -2494,4 +2556,35 @@ func TestBaseBlockTrack_DoWhitelistWithShardHeaderIfNeededMetaShouldWhitelistCro
 	_, ok := cache[string(shardHdr.MiniBlockHeaders[0].Hash)]
 
 	assert.True(t, ok)
+}
+
+func TestBaseBlockTrack_IsHeaderOutOfRangeShouldWork(t *testing.T) {
+	t.Parallel()
+
+	shardArguments := CreateShardTrackerMockArguments()
+	sbt, _ := track.NewShardBlockTrack(shardArguments)
+
+	metaHdr := &block.MetaBlock{
+		Round: 1,
+		Nonce: 0,
+	}
+	assert.True(t, sbt.IsHeaderOutOfRange(metaHdr))
+
+	metaHdr = &block.MetaBlock{
+		Round: 0,
+		Nonce: 1,
+	}
+	assert.True(t, sbt.IsHeaderOutOfRange(metaHdr))
+
+	metaHdr = &block.MetaBlock{
+		Round: process.MaxHeadersToRequestInAdvance + 1,
+		Nonce: process.MaxHeadersToRequestInAdvance + 1,
+	}
+	assert.True(t, sbt.IsHeaderOutOfRange(metaHdr))
+
+	metaHdr = &block.MetaBlock{
+		Round: process.MaxHeadersToRequestInAdvance,
+		Nonce: process.MaxHeadersToRequestInAdvance,
+	}
+	assert.False(t, sbt.IsHeaderOutOfRange(metaHdr))
 }

--- a/process/track/baseBlockTrack_test.go
+++ b/process/track/baseBlockTrack_test.go
@@ -2564,27 +2564,36 @@ func TestBaseBlockTrack_IsHeaderOutOfRangeShouldWork(t *testing.T) {
 	shardArguments := CreateShardTrackerMockArguments()
 	sbt, _ := track.NewShardBlockTrack(shardArguments)
 
+	round := uint64(10)
+	nonce := uint64(8)
+	crossNotarizedHeader := &block.MetaBlock{
+		Round: round,
+		Nonce: nonce,
+	}
+
+	sbt.AddCrossNotarizedHeader(core.MetachainShardId, crossNotarizedHeader, []byte("hash"))
+
 	metaHdr := &block.MetaBlock{
-		Round: 1,
-		Nonce: 0,
+		Round: round + 1,
+		Nonce: nonce,
 	}
 	assert.True(t, sbt.IsHeaderOutOfRange(metaHdr))
 
 	metaHdr = &block.MetaBlock{
-		Round: 0,
-		Nonce: 1,
+		Round: round,
+		Nonce: nonce + 1,
 	}
 	assert.True(t, sbt.IsHeaderOutOfRange(metaHdr))
 
 	metaHdr = &block.MetaBlock{
-		Round: process.MaxHeadersToRequestInAdvance + 1,
-		Nonce: process.MaxHeadersToRequestInAdvance + 1,
+		Round: round + process.MaxHeadersToRequestInAdvance + 1,
+		Nonce: nonce + process.MaxHeadersToRequestInAdvance + 1,
 	}
 	assert.True(t, sbt.IsHeaderOutOfRange(metaHdr))
 
 	metaHdr = &block.MetaBlock{
-		Round: process.MaxHeadersToRequestInAdvance,
-		Nonce: process.MaxHeadersToRequestInAdvance,
+		Round: round + process.MaxHeadersToRequestInAdvance,
+		Nonce: nonce + process.MaxHeadersToRequestInAdvance,
 	}
 	assert.False(t, sbt.IsHeaderOutOfRange(metaHdr))
 }

--- a/process/track/export_test.go
+++ b/process/track/export_test.go
@@ -113,6 +113,10 @@ func (bbt *baseBlockTrack) DoWhitelistWithShardHeaderIfNeeded(shardHeader *block
 	bbt.doWhitelistWithShardHeaderIfNeeded(shardHeader)
 }
 
+func (bbt *baseBlockTrack) IsHeaderOutOfRange(headerHandler data.HeaderHandler) bool {
+	return bbt.isHeaderOutOfRange(headerHandler)
+}
+
 // blockNotifier
 
 func (bn *blockNotifier) GetNotarizedHeadersHandlers() []func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte) {


### PR DESCRIPTION
* Rejected whitelisting miniblocks included in headers which are out of range (this will fix the situation when a node is syncing and it will receive headers with higher nonces compared with the last one processed. Because of these headers which are received, it will whitelist its miniblocks and afterwards its transactions. More than this it will also add these transactions into immunized cache. This will fill up these caches (whitelist cache, immunized cache) with a lot of information which is not needed right now and which will also be evicted until its time will come)