### PR TITLE
check if node exists in genesis config before setting destination shard

### DIFF
--- a/epochStart/bootstrap/process_test.go
+++ b/epochStart/bootstrap/process_test.go
@@ -38,7 +38,11 @@ func createPkBytes(numShards uint32) map[uint32][]byte {
 
 func createMockEpochStartBootstrapArgs() ArgsEpochStartBootstrap {
 	return ArgsEpochStartBootstrap{
-		PublicKey:         &mock.PublicKeyStub{},
+		PublicKey: &mock.PublicKeyStub{
+			ToByteArrayStub: func() ([]byte, error) {
+				return []byte("pubKey"), nil
+			},
+		},
 		Marshalizer:       &mock.MarshalizerMock{},
 		TxSignMarshalizer: &mock.MarshalizerMock{},
 		Hasher:            &mock.HasherMock{},

--- a/epochStart/bootstrap/process_test.go
+++ b/epochStart/bootstrap/process_test.go
@@ -224,6 +224,68 @@ func TestPrepareForEpochZero(t *testing.T) {
 	assert.Equal(t, uint32(0), params.Epoch)
 }
 
+func TestPrepareForEpochZero_NodeInGenesisShouldNotAlterShardID(t *testing.T) {
+	shardIDAsValidator := uint32(1)
+
+	args := createMockEpochStartBootstrapArgs()
+	args.GenesisShardCoordinator = &mock.ShardCoordinatorStub{
+		SelfIdCalled: func() uint32 {
+			return shardIDAsValidator
+		},
+	}
+	args.DestinationShardAsObserver = uint32(7)
+	args.PublicKey = &mock.PublicKeyStub{
+		ToByteArrayStub: func() ([]byte, error) {
+			return []byte("pubKey11"), nil
+		},
+	}
+	args.GenesisNodesConfig = &mock.NodesSetupStub{
+		InitialNodesInfoCalled: func() (map[uint32][]sharding.GenesisNodeInfoHandler, map[uint32][]sharding.GenesisNodeInfoHandler) {
+			eligibleMap := map[uint32][]sharding.GenesisNodeInfoHandler{
+				1: {mock.NewNodeInfo([]byte("addr"), []byte("pubKey11"), 1)},
+			}
+			return eligibleMap, nil
+		},
+	}
+
+	epochStartProvider, _ := NewEpochStartBootstrap(args)
+
+	params, err := epochStartProvider.prepareEpochZero()
+	assert.NoError(t, err)
+	assert.Equal(t, shardIDAsValidator, params.SelfShardId)
+}
+
+func TestPrepareForEpochZero_NodeNotInGenesisShouldAlterShardID(t *testing.T) {
+	desiredShardAsObserver := uint32(7)
+
+	args := createMockEpochStartBootstrapArgs()
+	args.GenesisShardCoordinator = &mock.ShardCoordinatorStub{
+		SelfIdCalled: func() uint32 {
+			return uint32(1)
+		},
+	}
+	args.DestinationShardAsObserver = desiredShardAsObserver
+	args.PublicKey = &mock.PublicKeyStub{
+		ToByteArrayStub: func() ([]byte, error) {
+			return []byte("pubKeyNotInGenesis"), nil
+		},
+	}
+	args.GenesisNodesConfig = &mock.NodesSetupStub{
+		InitialNodesInfoCalled: func() (map[uint32][]sharding.GenesisNodeInfoHandler, map[uint32][]sharding.GenesisNodeInfoHandler) {
+			eligibleMap := map[uint32][]sharding.GenesisNodeInfoHandler{
+				1: {mock.NewNodeInfo([]byte("addr"), []byte("pubKey11"), 1)},
+			}
+			return eligibleMap, nil
+		},
+	}
+
+	epochStartProvider, _ := NewEpochStartBootstrap(args)
+
+	params, err := epochStartProvider.prepareEpochZero()
+	assert.NoError(t, err)
+	assert.Equal(t, desiredShardAsObserver, params.SelfShardId)
+}
+
 func TestCreateSyncers(t *testing.T) {
 	args := createMockEpochStartBootstrapArgs()
 


### PR DESCRIPTION
fixed the situation where if an entire testnet started with the same `prefs.toml` file and it's value of `DestinationShardAsObserver` would have not been set to `disabled` then all the nodes joined as observers in that shard.