### PR TITLE
Fix date in log file name

### DIFF
--- a/core/file.go
+++ b/core/file.go
@@ -114,7 +114,8 @@ func CreateFile(prefix string, subfolder string, fileExtension string) (*os.File
 		return nil, err
 	}
 
-	fileName := time.Now().Format("2006-02-01-15-04-05")
+	fileName := time.Now().Format("2006-01-02T15-04-05")
+	fileName = strings.Replace(fileName, "T", "-", 1)
 	if prefix != "" {
 		fileName = prefix + "-" + fileName
 	}


### PR DESCRIPTION
Previously, the node used to generate log files of the form `elrond-go-YYYY-DD-MM-HH-MM-SS.log` (note the order year-day-month). This PR fixes the order in the date format, changing it to the more readable `YYYY-MM-DD` (year-month-date).