### PR TITLE
Fix whitelisting in advance for miniblocks

### DIFF
--- a/epochStart/bootstrap/disabled/disabledValidityAttester.go
+++ b/epochStart/bootstrap/disabled/disabledValidityAttester.go
@@ -25,6 +25,11 @@ func (v *validityAttester) CheckBlockAgainstRounder(_ data.HeaderHandler) error 
 	return nil
 }
 
+// CheckBlockAgainstWhitelist -
+func (v *validityAttester) CheckBlockAgainstWhitelist(_ process.InterceptedData) bool {
+	return false
+}
+
 // IsInterfaceNil -
 func (v *validityAttester) IsInterfaceNil() bool {
 	return v == nil

--- a/epochStart/metachain/epochStartData.go
+++ b/epochStart/metachain/epochStartData.go
@@ -162,7 +162,7 @@ func (e *epochStartData) createShardStartDataAndLastProcessedHeaders() (*block.E
 
 	allShardHdrList := make([][]*block.Header, e.shardCoordinator.NumberOfShards())
 	for shardID := uint32(0); shardID < e.shardCoordinator.NumberOfShards(); shardID++ {
-		lastCrossNotarizedHeaderForShard, _, err := e.blockTracker.GetLastCrossNotarizedHeader(shardID)
+		lastCrossNotarizedHeaderForShard, hdrHash, err := e.blockTracker.GetLastCrossNotarizedHeader(shardID)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -170,11 +170,6 @@ func (e *epochStartData) createShardStartDataAndLastProcessedHeaders() (*block.E
 		shardHeader, ok := lastCrossNotarizedHeaderForShard.(*block.Header)
 		if !ok {
 			return nil, nil, process.ErrWrongTypeAssertion
-		}
-
-		hdrHash, err := core.CalculateHash(e.marshalizer, e.hasher, lastCrossNotarizedHeaderForShard)
-		if err != nil {
-			return nil, nil, err
 		}
 
 		firstPendingMetaHash, lastFinalizedMetaHash, currShardHdrList, err := e.lastFinalizedFirstPendingListHeadersForShard(shardHeader)

--- a/epochStart/metachain/epochStartData_test.go
+++ b/epochStart/metachain/epochStartData_test.go
@@ -3,7 +3,6 @@ package metachain
 import (
 	"bytes"
 	"crypto/rand"
-	"errors"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go/core"
@@ -274,31 +273,6 @@ func TestEpochStartCreator_CreateEpochStartFromMetaBlockEpochIsNotStarted(t *tes
 
 	emptyEpochStart := block.EpochStart{}
 	assert.Equal(t, emptyEpochStart, *epStart)
-}
-
-func TestEpochStartCreator_CreateEpochStartFromMetaBlockHashComputeIssueShouldErr(t *testing.T) {
-	t.Parallel()
-
-	expectedErr := errors.New("err computing hash")
-
-	arguments := createMockEpochStartCreatorArguments()
-	arguments.Marshalizer = &mock.MarshalizerStub{
-		// trigger an error on the Marshal method called from core's ComputeHash
-		MarshalCalled: func(obj interface{}) (i []byte, e error) {
-			return nil, expectedErr
-		},
-	}
-	arguments.EpochStartTrigger = &mock.EpochStartTriggerStub{
-		IsEpochStartCalled: func() bool {
-			return true
-		},
-	}
-
-	epoch, _ := NewEpochStartData(arguments)
-
-	epStart, err := epoch.CreateEpochStartData()
-	assert.Nil(t, epStart)
-	assert.Equal(t, expectedErr, err)
 }
 
 func TestMetaProcessor_CreateEpochStartFromMetaBlockShouldWork(t *testing.T) {

--- a/integrationTests/mock/blockTrackerStub.go
+++ b/integrationTests/mock/blockTrackerStub.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/block"
+	"github.com/ElrondNetwork/elrond-go/process"
 )
 
 // BlockTrackerStub -
@@ -12,6 +13,7 @@ type BlockTrackerStub struct {
 	AddSelfNotarizedHeaderCalled                      func(shardID uint32, selfNotarizedHeader data.HeaderHandler, selfNotarizedHeaderHash []byte)
 	CheckBlockAgainstFinalCalled                      func(headerHandler data.HeaderHandler) error
 	CheckBlockAgainstRounderCalled                    func(headerHandler data.HeaderHandler) error
+	CheckBlockAgainstWhitelistCalled                  func(interceptedData process.InterceptedData) bool
 	CleanupHeadersBehindNonceCalled                   func(shardID uint32, selfNotarizedNonce uint64, crossNotarizedNonce uint64)
 	ComputeLongestChainCalled                         func(shardID uint32, header data.HeaderHandler) ([]data.HeaderHandler, [][]byte)
 	ComputeLongestMetaChainFromLastNotarizedCalled    func() ([]data.HeaderHandler, [][]byte, error)
@@ -70,6 +72,15 @@ func (bts *BlockTrackerStub) CheckBlockAgainstFinal(headerHandler data.HeaderHan
 	}
 
 	return nil
+}
+
+// CheckBlockAgainstWhitelist -
+func (bts *BlockTrackerStub) CheckBlockAgainstWhitelist(interceptedData process.InterceptedData) bool {
+	if bts.CheckBlockAgainstWhitelistCalled != nil {
+		return bts.CheckBlockAgainstWhitelistCalled(interceptedData)
+	}
+
+	return false
 }
 
 // CleanupHeadersBehindNonce -

--- a/node/mock/blockTrackerStub.go
+++ b/node/mock/blockTrackerStub.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"github.com/ElrondNetwork/elrond-go/data"
+	"github.com/ElrondNetwork/elrond-go/process"
 )
 
 // BlockTrackerStub -
@@ -11,6 +12,7 @@ type BlockTrackerStub struct {
 	AddSelfNotarizedHeaderCalled                      func(shardID uint32, selfNotarizedHeader data.HeaderHandler, selfNotarizedHeaderHash []byte)
 	CheckBlockAgainstRounderCalled                    func(headerHandler data.HeaderHandler) error
 	CheckBlockAgainstFinalCalled                      func(headerHandler data.HeaderHandler) error
+	CheckBlockAgainstWhitelistCalled                  func(interceptedData process.InterceptedData) bool
 	CleanupHeadersBehindNonceCalled                   func(shardID uint32, selfNotarizedNonce uint64, crossNotarizedNonce uint64)
 	ComputeLongestChainCalled                         func(shardID uint32, header data.HeaderHandler) ([]data.HeaderHandler, [][]byte)
 	ComputeLongestMetaChainFromLastNotarizedCalled    func() ([]data.HeaderHandler, [][]byte, error)
@@ -69,6 +71,15 @@ func (bts *BlockTrackerStub) CheckBlockAgainstFinal(headerHandler data.HeaderHan
 	}
 
 	return nil
+}
+
+// CheckBlockAgainstWhitelist -
+func (bts *BlockTrackerStub) CheckBlockAgainstWhitelist(interceptedData process.InterceptedData) bool {
+	if bts.CheckBlockAgainstWhitelistCalled != nil {
+		return bts.CheckBlockAgainstWhitelistCalled(interceptedData)
+	}
+
+	return false
 }
 
 // CleanupHeadersBehindNonce -

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -1164,13 +1164,6 @@ func (bp *baseProcessor) requestMiniBlocksIfNeeded(headerHandler data.HeaderHand
 		return
 	}
 
-	if headerHandler.GetNonce() <= lastCrossNotarizedHeader.GetNonce() {
-		return
-	}
-	if headerHandler.GetRound() <= lastCrossNotarizedHeader.GetRound() {
-		return
-	}
-
 	isHeaderOutOfRequestRange := headerHandler.GetNonce() > lastCrossNotarizedHeader.GetNonce()+process.MaxHeadersToRequestInAdvance
 	if isHeaderOutOfRequestRange {
 		return

--- a/process/block/interceptedBlocks/interceptedBlockHeader.go
+++ b/process/block/interceptedBlocks/interceptedBlockHeader.go
@@ -138,9 +138,11 @@ func (inHdr *InterceptedHeader) integrity() error {
 		return err
 	}
 
-	err = inHdr.validityAttester.CheckBlockAgainstFinal(inHdr.HeaderHandler())
-	if err != nil {
-		return err
+	if !inHdr.validityAttester.CheckBlockAgainstWhitelist(inHdr) {
+		err = inHdr.validityAttester.CheckBlockAgainstFinal(inHdr.HeaderHandler())
+		if err != nil {
+			return err
+		}
 	}
 
 	err = inHdr.validityAttester.CheckBlockAgainstRounder(inHdr.HeaderHandler())

--- a/process/block/interceptedBlocks/interceptedMetaBlockHeader.go
+++ b/process/block/interceptedBlocks/interceptedMetaBlockHeader.go
@@ -86,9 +86,11 @@ func (imh *InterceptedMetaHeader) CheckValidity() error {
 		return err
 	}
 
-	err = imh.validityAttester.CheckBlockAgainstFinal(imh.HeaderHandler())
-	if err != nil {
-		return err
+	if !imh.validityAttester.CheckBlockAgainstWhitelist(imh) {
+		err = imh.validityAttester.CheckBlockAgainstFinal(imh.HeaderHandler())
+		if err != nil {
+			return err
+		}
 	}
 
 	err = imh.validityAttester.CheckBlockAgainstRounder(imh.HeaderHandler())

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -1221,7 +1221,12 @@ func (mp *metaProcessor) updateState(lastMetaBlock data.HeaderHandler) {
 
 	mp.validatorStatisticsProcessor.SetLastFinalizedRootHash(lastMetaBlock.GetValidatorStatsRootHash())
 
-	prevHeader, errNotCritical := process.GetMetaHeaderFromStorage(lastMetaBlock.GetPrevHash(), mp.marshalizer, mp.store)
+	prevHeader, errNotCritical := process.GetMetaHeader(
+		lastMetaBlock.GetPrevHash(),
+		mp.dataPool.Headers(),
+		mp.marshalizer,
+		mp.store,
+	)
 	if errNotCritical != nil {
 		log.Debug("could not get meta header from storage")
 		return
@@ -1286,7 +1291,12 @@ func (mp *metaProcessor) getLastSelfNotarizedHeaderByShard(
 		}
 
 		for _, metaHash := range shardHeader.MetaBlockHashes {
-			metaHeader, errGet := process.GetMetaHeader(metaHash, mp.dataPool.Headers(), mp.marshalizer, mp.store)
+			metaHeader, errGet := process.GetMetaHeader(
+				metaHash,
+				mp.dataPool.Headers(),
+				mp.marshalizer,
+				mp.store,
+			)
 			if errGet != nil {
 				log.Trace("getLastSelfNotarizedHeaderByShard.GetMetaHeader", "error", errGet.Error())
 				continue

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -949,7 +949,12 @@ func (sp *shardProcessor) updateState(headers []data.HeaderHandler, currentHeade
 			break
 		}
 
-		prevHeader, errNotCritical := process.GetShardHeaderFromStorage(hdr.GetPrevHash(), sp.marshalizer, sp.store)
+		prevHeader, errNotCritical := process.GetShardHeader(
+			hdr.GetPrevHash(),
+			sp.dataPool.Headers(),
+			sp.marshalizer,
+			sp.store,
+		)
 		if errNotCritical != nil {
 			log.Debug("could not get shard header from storage")
 			return
@@ -1040,8 +1045,9 @@ func (sp *shardProcessor) checkEpochCorrectnessCrossChain() error {
 		}
 
 		shouldRevertChain = true
-		prevHeader, err := process.GetShardHeaderFromStorage(
+		prevHeader, err := process.GetShardHeader(
 			currentHeader.GetPrevHash(),
+			sp.dataPool.Headers(),
 			sp.marshalizer,
 			sp.store,
 		)

--- a/process/constants.go
+++ b/process/constants.go
@@ -109,3 +109,6 @@ const MaxRoundsToKeepUnprocessedMiniBlocks = 100
 
 // MaxRoundsToKeepUnprocessedTransactions defines the maximum number of rounds for which unprocessed transactions are kept in pool
 const MaxRoundsToKeepUnprocessedTransactions = 100
+
+// MaxHeadersToWhitelistInAdvance defines the maximum number of headers whose miniblocks will be whitelisted in advance
+const MaxHeadersToWhitelistInAdvance = 20

--- a/process/interface.go
+++ b/process/interface.go
@@ -685,6 +685,7 @@ type BlockTracker interface {
 	AddTrackedHeader(header data.HeaderHandler, hash []byte)
 	CheckBlockAgainstFinal(headerHandler data.HeaderHandler) error
 	CheckBlockAgainstRounder(headerHandler data.HeaderHandler) error
+	CheckBlockAgainstWhitelist(interceptedData InterceptedData) bool
 	CleanupHeadersBehindNonce(shardID uint32, selfNotarizedNonce uint64, crossNotarizedNonce uint64)
 	CleanupInvalidCrossHeaders(metaNewEpoch uint32, metaRoundAttestingEpoch uint64)
 	ComputeLongestChain(shardID uint32, header data.HeaderHandler) ([]data.HeaderHandler, [][]byte)
@@ -784,6 +785,7 @@ type EpochStartValidatorInfoCreator interface {
 type ValidityAttester interface {
 	CheckBlockAgainstFinal(headerHandler data.HeaderHandler) error
 	CheckBlockAgainstRounder(headerHandler data.HeaderHandler) error
+	CheckBlockAgainstWhitelist(interceptedData InterceptedData) bool
 	IsInterfaceNil() bool
 }
 

--- a/process/mock/blockTrackerMock.go
+++ b/process/mock/blockTrackerMock.go
@@ -26,6 +26,7 @@ type BlockTrackerMock struct {
 	AddSelfNotarizedHeaderCalled                      func(shardID uint32, selfNotarizedHeader data.HeaderHandler, selfNotarizedHeaderHash []byte)
 	CheckBlockAgainstFinalCalled                      func(headerHandler data.HeaderHandler) error
 	CheckBlockAgainstRounderCalled                    func(headerHandler data.HeaderHandler) error
+	CheckBlockAgainstWhitelistCalled                  func(interceptedData process.InterceptedData) bool
 	CleanupHeadersBehindNonceCalled                   func(shardID uint32, selfNotarizedNonce uint64, crossNotarizedNonce uint64)
 	ComputeLongestChainCalled                         func(shardID uint32, header data.HeaderHandler) ([]data.HeaderHandler, [][]byte)
 	ComputeLongestMetaChainFromLastNotarizedCalled    func() ([]data.HeaderHandler, [][]byte, error)
@@ -174,6 +175,15 @@ func (btm *BlockTrackerMock) CheckBlockAgainstFinal(headerHandler data.HeaderHan
 	}
 
 	return nil
+}
+
+// CheckBlockAgainstWhitelist -
+func (btm *BlockTrackerMock) CheckBlockAgainstWhitelist(interceptedData process.InterceptedData) bool {
+	if btm.CheckBlockAgainstWhitelistCalled != nil {
+		return btm.CheckBlockAgainstWhitelistCalled(interceptedData)
+	}
+
+	return false
 }
 
 // CleanupHeadersBehindNonce -

--- a/process/mock/finalityAttesterStub.go
+++ b/process/mock/finalityAttesterStub.go
@@ -2,12 +2,14 @@ package mock
 
 import (
 	"github.com/ElrondNetwork/elrond-go/data"
+	"github.com/ElrondNetwork/elrond-go/process"
 )
 
 // ValidityAttesterStub -
 type ValidityAttesterStub struct {
-	CheckBlockAgainstRounderCalled func(headerHandler data.HeaderHandler) error
-	CheckBlockAgainstFinalCalled   func(headerHandler data.HeaderHandler) error
+	CheckBlockAgainstRounderCalled   func(headerHandler data.HeaderHandler) error
+	CheckBlockAgainstFinalCalled     func(headerHandler data.HeaderHandler) error
+	CheckBlockAgainstWhitelistCalled func(interceptedData process.InterceptedData) bool
 }
 
 // CheckBlockAgainstRounder -
@@ -26,6 +28,15 @@ func (vas *ValidityAttesterStub) CheckBlockAgainstFinal(headerHandler data.Heade
 	}
 
 	return nil
+}
+
+// CheckBlockAgainstWhitelist -
+func (vas *ValidityAttesterStub) CheckBlockAgainstWhitelist(interceptedData process.InterceptedData) bool {
+	if vas.CheckBlockAgainstWhitelistCalled != nil {
+		return vas.CheckBlockAgainstWhitelistCalled(interceptedData)
+	}
+
+	return false
 }
 
 // IsInterfaceNil -

--- a/process/track/baseBlockTrack.go
+++ b/process/track/baseBlockTrack.go
@@ -799,13 +799,6 @@ func (bbt *baseBlockTrack) isHeaderOutOfRange(headerHandler data.HeaderHandler) 
 		return true
 	}
 
-	if headerHandler.GetNonce() <= lastCrossNotarizedHeader.GetNonce() {
-		return true
-	}
-	if headerHandler.GetRound() <= lastCrossNotarizedHeader.GetRound() {
-		return true
-	}
-
-	isHeaderOutOfRange := headerHandler.GetNonce() > lastCrossNotarizedHeader.GetNonce()+process.MaxHeadersToRequestInAdvance
+	isHeaderOutOfRange := headerHandler.GetNonce() > lastCrossNotarizedHeader.GetNonce()+process.MaxHeadersToWhitelistInAdvance
 	return isHeaderOutOfRange
 }

--- a/process/track/baseBlockTrack.go
+++ b/process/track/baseBlockTrack.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"sync"
 
-	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/data"
@@ -179,16 +179,6 @@ func (bbt *baseBlockTrack) shouldAddHeaderForShard(
 	blockNotarizer blockNotarizerHandler,
 	shardForFirstNotarizedHeader uint32,
 ) bool {
-	firstNotarizedHeader, _, err := blockNotarizer.GetFirstNotarizedHeader(shardForFirstNotarizedHeader)
-	if err != nil {
-		log.Debug("shouldAddHeaderForShard.GetFirstNotarizedHeader",
-			"shard", shardForFirstNotarizedHeader,
-			"error", err.Error())
-		return false
-	}
-
-	firstNotarizedHeaderNonce := firstNotarizedHeader.GetNonce()
-
 	lastNotarizedHeader, _, err := blockNotarizer.GetLastNotarizedHeader(headerHandler.GetShardID())
 	if err != nil {
 		log.Debug("shouldAddHeaderForShard.GetLastNotarizedHeader",
@@ -199,9 +189,7 @@ func (bbt *baseBlockTrack) shouldAddHeaderForShard(
 
 	lastNotarizedHeaderNonce := lastNotarizedHeader.GetNonce()
 
-	isHeaderOutOfRange := headerHandler.GetNonce() < firstNotarizedHeaderNonce ||
-		headerHandler.GetNonce() > lastNotarizedHeaderNonce+uint64(bbt.maxNumHeadersToKeepPerShard)
-
+	isHeaderOutOfRange := headerHandler.GetNonce() > lastNotarizedHeaderNonce+uint64(bbt.maxNumHeadersToKeepPerShard)
 	return !isHeaderOutOfRange
 }
 
@@ -460,6 +448,11 @@ func (bbt *baseBlockTrack) getFinalHeader(shardID uint32) (data.HeaderHandler, [
 	}
 
 	return bbt.selfNotarizer.GetFirstNotarizedHeader(shardID)
+}
+
+// CheckBlockAgainstWhiteList returns if the provided intercepted data (blocks) is whitelisted or not
+func (bbt *baseBlockTrack) CheckBlockAgainstWhitelist(interceptedData process.InterceptedData) bool {
+	return bbt.whitelistHandler.IsWhiteListed(interceptedData)
 }
 
 // GetLastCrossNotarizedHeader returns last cross notarized header for a given shard

--- a/process/track/baseBlockTrack_test.go
+++ b/process/track/baseBlockTrack_test.go
@@ -2452,8 +2452,8 @@ func TestBaseBlockTrack_DoWhitelistWithMetaBlockIfNeededIsHeaderOutOfRangeShould
 	sbt, _ := track.NewShardBlockTrack(shardArguments)
 
 	metaHdr := &block.MetaBlock{
-		Round: process.MaxHeadersToRequestInAdvance + 1,
-		Nonce: process.MaxHeadersToRequestInAdvance + 1,
+		Round: process.MaxHeadersToWhitelistInAdvance + 1,
+		Nonce: process.MaxHeadersToWhitelistInAdvance + 1,
 		MiniBlockHeaders: []block.MiniBlockHeader{
 			{Hash: []byte("shardHash0"), SenderShardID: 1, ReceiverShardID: 0},
 		},
@@ -2483,8 +2483,8 @@ func TestBaseBlockTrack_DoWhitelistWithShardHeaderIfNeededIsHeaderOutOfRangeShou
 	mbt, _ := track.NewMetaBlockTrack(metaArguments)
 
 	shardHdr := &block.Header{
-		Round: process.MaxHeadersToRequestInAdvance + 1,
-		Nonce: process.MaxHeadersToRequestInAdvance + 1,
+		Round: process.MaxHeadersToWhitelistInAdvance + 1,
+		Nonce: process.MaxHeadersToWhitelistInAdvance + 1,
 		MiniBlockHeaders: []block.MiniBlockHeader{
 			{Hash: []byte("shardHash0"), SenderShardID: 0, ReceiverShardID: core.MetachainShardId},
 		},
@@ -2574,26 +2574,14 @@ func TestBaseBlockTrack_IsHeaderOutOfRangeShouldWork(t *testing.T) {
 	sbt.AddCrossNotarizedHeader(core.MetachainShardId, crossNotarizedHeader, []byte("hash"))
 
 	metaHdr := &block.MetaBlock{
-		Round: round + 1,
-		Nonce: nonce,
+		Round: round + process.MaxHeadersToWhitelistInAdvance + 1,
+		Nonce: nonce + process.MaxHeadersToWhitelistInAdvance + 1,
 	}
 	assert.True(t, sbt.IsHeaderOutOfRange(metaHdr))
 
 	metaHdr = &block.MetaBlock{
-		Round: round,
-		Nonce: nonce + 1,
-	}
-	assert.True(t, sbt.IsHeaderOutOfRange(metaHdr))
-
-	metaHdr = &block.MetaBlock{
-		Round: round + process.MaxHeadersToRequestInAdvance + 1,
-		Nonce: nonce + process.MaxHeadersToRequestInAdvance + 1,
-	}
-	assert.True(t, sbt.IsHeaderOutOfRange(metaHdr))
-
-	metaHdr = &block.MetaBlock{
-		Round: round + process.MaxHeadersToRequestInAdvance,
-		Nonce: nonce + process.MaxHeadersToRequestInAdvance,
+		Round: round + process.MaxHeadersToWhitelistInAdvance,
+		Nonce: nonce + process.MaxHeadersToWhitelistInAdvance,
 	}
 	assert.False(t, sbt.IsHeaderOutOfRange(metaHdr))
 }

--- a/process/track/baseBlockTrack_test.go
+++ b/process/track/baseBlockTrack_test.go
@@ -682,17 +682,7 @@ func TestShouldAddHeader_ShouldWork(t *testing.T) {
 	assert.False(t, sbt.ShouldAddHeader(&block.MetaBlock{Nonce: maxNumHeadersToKeepPerShard + 1}))
 }
 
-func TestShouldAddHeaderForShard_ShouldReturnFalseWhenGetFirstNotarizedHeaderErr(t *testing.T) {
-	t.Parallel()
-
-	shardArguments := CreateShardTrackerMockArguments()
-	sbt, _ := track.NewShardBlockTrack(shardArguments)
-
-	result := sbt.ShouldAddHeaderForCrossShard(&block.Header{Nonce: uint64(sbt.GetMaxNumHeadersToKeepPerShard()), ShardID: 2})
-	assert.False(t, result)
-}
-
-func TestShouldAddHeaderForShard_ShouldReturnFalseWhenGeLastNotarizedHeaderErr(t *testing.T) {
+func TestShouldAddHeaderForShard_ShouldReturnFalseWhenGetLastNotarizedHeaderErr(t *testing.T) {
 	t.Parallel()
 
 	shardArguments := CreateShardTrackerMockArguments()


### PR DESCRIPTION
* Fixed a possible problem which could avoid whitelisting miniblocks

* Fixed situation when on headers interceptor and also in block tracker component, some old headers are dropped because they have nonces behind final, but the node still needs them (especially in epoch start headers could exist some old references to headers behind final and they should be accepted, as they are requested and whitelisted)

* Changed some behavior of getting headers from storage with getting headers from pool and afterward from storage