### PR TITLE
Fix sync speed problem with attesting finality headers which are not requested in advance

### DIFF
--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -213,6 +213,7 @@ func (bp *baseProcessor) requestHeadersIfMissing(
 	}
 
 	lastNotarizedHdrRound := prevHdr.GetRound()
+	lastNotarizedHdrNonce := prevHdr.GetNonce()
 
 	missingNonces := make([]uint64, 0)
 	isMaxLimitReached := false
@@ -231,7 +232,8 @@ func (bp *baseProcessor) requestHeadersIfMissing(
 		maxNumNoncesToAdd := process.MaxHeaderRequestsAllowed - len(missingNonces)
 		nonces := addMissingNonces(noncesDiff, prevHdr.GetNonce(), maxNumNoncesToAdd)
 		missingNonces = append(missingNonces, nonces...)
-		if len(missingNonces) >= process.MaxHeaderRequestsAllowed {
+		if len(missingNonces) >= process.MaxHeaderRequestsAllowed ||
+			currHdr.GetNonce()-lastNotarizedHdrNonce >= process.MaxHeaderRequestsAllowed {
 			isMaxLimitReached = true
 			break
 		}

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -1059,8 +1059,8 @@ func TestBlocProcessor_RequestHeadersIfMissingShouldWork(t *testing.T) {
 	sortedHeaders := make([]data.HeaderHandler, 0)
 
 	crossNotarizedHeader := &block.MetaBlock{
-		Nonce: 3,
-		Round: 3,
+		Nonce: 5,
+		Round: 5,
 	}
 	arguments.BlockTracker.AddCrossNotarizedHeader(core.MetachainShardId, crossNotarizedHeader, []byte("hash"))
 
@@ -1089,7 +1089,7 @@ func TestBlocProcessor_RequestHeadersIfMissingShouldWork(t *testing.T) {
 	sort.Slice(requestedNonces, func(i, j int) bool {
 		return requestedNonces[i] < requestedNonces[j]
 	})
-	expectedNonces := []uint64{4, 5, 6, 7, 9, 11, 12, 13}
+	expectedNonces := []uint64{6, 7, 9, 11, 12, 13}
 	assert.Equal(t, expectedNonces, requestedNonces)
 
 	requestedNonces = make([]uint64, 0)
@@ -1099,6 +1099,6 @@ func TestBlocProcessor_RequestHeadersIfMissingShouldWork(t *testing.T) {
 	sort.Slice(requestedNonces, func(i, j int) bool {
 		return requestedNonces[i] < requestedNonces[j]
 	})
-	expectedNonces = []uint64{4, 5, 6, 7, 9, 11, 12, 13, 14, 15}
+	expectedNonces = []uint64{6, 7, 9, 11, 12, 13, 14, 15}
 	assert.Equal(t, expectedNonces, requestedNonces)
 }

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -999,15 +999,15 @@ func TestBlocProcessor_RequestHeadersIfMissingShouldWorkWhenSortedHeadersListIsE
 	t.Parallel()
 
 	var requestedNonces []uint64
-	var mutRequetsedNonces sync.Mutex
+	var mutRequestedNonces sync.Mutex
 
 	arguments := CreateMockArguments()
 	rounder := &mock.RounderMock{}
 	requestHandlerStub := &mock.RequestHandlerStub{
 		RequestMetaHeaderByNonceCalled: func(nonce uint64) {
-			mutRequetsedNonces.Lock()
+			mutRequestedNonces.Lock()
 			requestedNonces = append(requestedNonces, nonce)
-			mutRequetsedNonces.Unlock()
+			mutRequestedNonces.Unlock()
 		},
 	}
 	arguments.Rounder = rounder
@@ -1020,9 +1020,11 @@ func TestBlocProcessor_RequestHeadersIfMissingShouldWorkWhenSortedHeadersListIsE
 	rounder.RoundIndex = 15
 	sp.RequestHeadersIfMissing(sortedHeaders, core.MetachainShardId)
 	time.Sleep(100 * time.Millisecond)
+	mutRequestedNonces.Lock()
 	sort.Slice(requestedNonces, func(i, j int) bool {
 		return requestedNonces[i] < requestedNonces[j]
 	})
+	mutRequestedNonces.Unlock()
 	expectedNonces := []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	assert.Equal(t, expectedNonces, requestedNonces)
 
@@ -1030,9 +1032,11 @@ func TestBlocProcessor_RequestHeadersIfMissingShouldWorkWhenSortedHeadersListIsE
 	rounder.RoundIndex = 5
 	sp.RequestHeadersIfMissing(sortedHeaders, core.MetachainShardId)
 	time.Sleep(100 * time.Millisecond)
+	mutRequestedNonces.Lock()
 	sort.Slice(requestedNonces, func(i, j int) bool {
 		return requestedNonces[i] < requestedNonces[j]
 	})
+	mutRequestedNonces.Unlock()
 	expectedNonces = []uint64{1, 2, 3}
 	assert.Equal(t, expectedNonces, requestedNonces)
 }
@@ -1041,15 +1045,15 @@ func TestBlocProcessor_RequestHeadersIfMissingShouldWork(t *testing.T) {
 	t.Parallel()
 
 	var requestedNonces []uint64
-	var mutRequetsedNonces sync.Mutex
+	var mutRequestedNonces sync.Mutex
 
 	arguments := CreateMockArguments()
 	rounder := &mock.RounderMock{}
 	requestHandlerStub := &mock.RequestHandlerStub{
 		RequestMetaHeaderByNonceCalled: func(nonce uint64) {
-			mutRequetsedNonces.Lock()
+			mutRequestedNonces.Lock()
 			requestedNonces = append(requestedNonces, nonce)
-			mutRequetsedNonces.Unlock()
+			mutRequestedNonces.Unlock()
 		},
 	}
 	arguments.Rounder = rounder
@@ -1086,9 +1090,11 @@ func TestBlocProcessor_RequestHeadersIfMissingShouldWork(t *testing.T) {
 	rounder.RoundIndex = 15
 	sp.RequestHeadersIfMissing(sortedHeaders, core.MetachainShardId)
 	time.Sleep(100 * time.Millisecond)
+	mutRequestedNonces.Lock()
 	sort.Slice(requestedNonces, func(i, j int) bool {
 		return requestedNonces[i] < requestedNonces[j]
 	})
+	mutRequestedNonces.Unlock()
 	expectedNonces := []uint64{6, 7, 9, 11, 12, 13}
 	assert.Equal(t, expectedNonces, requestedNonces)
 
@@ -1096,9 +1102,11 @@ func TestBlocProcessor_RequestHeadersIfMissingShouldWork(t *testing.T) {
 	rounder.RoundIndex = 20
 	sp.RequestHeadersIfMissing(sortedHeaders, core.MetachainShardId)
 	time.Sleep(100 * time.Millisecond)
+	mutRequestedNonces.Lock()
 	sort.Slice(requestedNonces, func(i, j int) bool {
 		return requestedNonces[i] < requestedNonces[j]
 	})
+	mutRequestedNonces.Unlock()
 	expectedNonces = []uint64{6, 7, 9, 11, 12, 13, 14, 15}
 	assert.Equal(t, expectedNonces, requestedNonces)
 }

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"math/big"
 	"reflect"
+	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -991,4 +993,112 @@ func TestBlockProcessor_PruneStateOnRollbackPrunesPeerTrieIfSameRootHashButDiffe
 
 	bp.PruneStateOnRollback(currHeader, prevHeader)
 	assert.Equal(t, 2, pruningCalled)
+}
+
+func TestBlocProcessor_RequestHeadersIfMissingShouldWorkWhenSortedHeadersListIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	var requestedNonces []uint64
+	var mutRequetsedNonces sync.Mutex
+
+	arguments := CreateMockArguments()
+	rounder := &mock.RounderMock{}
+	requestHandlerStub := &mock.RequestHandlerStub{
+		RequestMetaHeaderByNonceCalled: func(nonce uint64) {
+			mutRequetsedNonces.Lock()
+			requestedNonces = append(requestedNonces, nonce)
+			mutRequetsedNonces.Unlock()
+		},
+	}
+	arguments.Rounder = rounder
+	arguments.RequestHandler = requestHandlerStub
+	sp, _ := blproc.NewShardProcessor(arguments)
+
+	sortedHeaders := make([]data.HeaderHandler, 0)
+
+	requestedNonces = make([]uint64, 0)
+	rounder.RoundIndex = 15
+	sp.RequestHeadersIfMissing(sortedHeaders, core.MetachainShardId)
+	time.Sleep(100 * time.Millisecond)
+	sort.Slice(requestedNonces, func(i, j int) bool {
+		return requestedNonces[i] < requestedNonces[j]
+	})
+	expectedNonces := []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	assert.Equal(t, expectedNonces, requestedNonces)
+
+	requestedNonces = make([]uint64, 0)
+	rounder.RoundIndex = 5
+	sp.RequestHeadersIfMissing(sortedHeaders, core.MetachainShardId)
+	time.Sleep(100 * time.Millisecond)
+	sort.Slice(requestedNonces, func(i, j int) bool {
+		return requestedNonces[i] < requestedNonces[j]
+	})
+	expectedNonces = []uint64{1, 2, 3}
+	assert.Equal(t, expectedNonces, requestedNonces)
+}
+
+func TestBlocProcessor_RequestHeadersIfMissingShouldWork(t *testing.T) {
+	t.Parallel()
+
+	var requestedNonces []uint64
+	var mutRequetsedNonces sync.Mutex
+
+	arguments := CreateMockArguments()
+	rounder := &mock.RounderMock{}
+	requestHandlerStub := &mock.RequestHandlerStub{
+		RequestMetaHeaderByNonceCalled: func(nonce uint64) {
+			mutRequetsedNonces.Lock()
+			requestedNonces = append(requestedNonces, nonce)
+			mutRequetsedNonces.Unlock()
+		},
+	}
+	arguments.Rounder = rounder
+	arguments.RequestHandler = requestHandlerStub
+	sp, _ := blproc.NewShardProcessor(arguments)
+
+	sortedHeaders := make([]data.HeaderHandler, 0)
+
+	crossNotarizedHeader := &block.MetaBlock{
+		Nonce: 3,
+		Round: 3,
+	}
+	arguments.BlockTracker.AddCrossNotarizedHeader(core.MetachainShardId, crossNotarizedHeader, []byte("hash"))
+
+	hdr1 := &block.MetaBlock{
+		Nonce: 1,
+		Round: 1,
+	}
+	sortedHeaders = append(sortedHeaders, hdr1)
+
+	hdr2 := &block.MetaBlock{
+		Nonce: 8,
+		Round: 8,
+	}
+	sortedHeaders = append(sortedHeaders, hdr2)
+
+	hdr3 := &block.MetaBlock{
+		Nonce: 10,
+		Round: 10,
+	}
+	sortedHeaders = append(sortedHeaders, hdr3)
+
+	requestedNonces = make([]uint64, 0)
+	rounder.RoundIndex = 15
+	sp.RequestHeadersIfMissing(sortedHeaders, core.MetachainShardId)
+	time.Sleep(100 * time.Millisecond)
+	sort.Slice(requestedNonces, func(i, j int) bool {
+		return requestedNonces[i] < requestedNonces[j]
+	})
+	expectedNonces := []uint64{4, 5, 6, 7, 9, 11, 12, 13}
+	assert.Equal(t, expectedNonces, requestedNonces)
+
+	requestedNonces = make([]uint64, 0)
+	rounder.RoundIndex = 20
+	sp.RequestHeadersIfMissing(sortedHeaders, core.MetachainShardId)
+	time.Sleep(100 * time.Millisecond)
+	sort.Slice(requestedNonces, func(i, j int) bool {
+		return requestedNonces[i] < requestedNonces[j]
+	})
+	expectedNonces = []uint64{4, 5, 6, 7, 9, 11, 12, 13, 14, 15}
+	assert.Equal(t, expectedNonces, requestedNonces)
 }

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -241,8 +241,8 @@ func (sp *shardProcessor) CheckHeaderBodyCorrelation(hdr *block.Header, body *bl
 	return sp.checkHeaderBodyCorrelation(hdr.MiniBlockHeaders, body)
 }
 
-func (sp *shardProcessor) CheckAndRequestIfMetaHeadersMissing(round uint64) {
-	sp.checkAndRequestIfMetaHeadersMissing(round)
+func (sp *shardProcessor) CheckAndRequestIfMetaHeadersMissing() {
+	sp.checkAndRequestIfMetaHeadersMissing()
 }
 
 func (sp *shardProcessor) GetHashAndHdrStruct(header data.HeaderHandler, hash []byte) *hashAndHdr {

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -195,6 +195,10 @@ func (bp *baseProcessor) SetHeaderValidator(validator process.HeaderConstruction
 	bp.headerValidator = validator
 }
 
+func (bp *baseProcessor) RequestHeadersIfMissing(sortedHdrs []data.HeaderHandler, shardId uint32) error {
+	return bp.requestHeadersIfMissing(sortedHdrs, shardId)
+}
+
 func (mp *metaProcessor) SetShardBlockFinality(val uint32) {
 	mp.hdrsForCurrBlock.mutHdrsForBlock.Lock()
 	mp.shardBlockFinality = val

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -275,7 +275,7 @@ func (mp *metaProcessor) ProcessBlock(
 	}
 
 	defer func() {
-		go mp.checkAndRequestIfShardHeadersMissing(header.Round)
+		go mp.checkAndRequestIfShardHeadersMissing()
 	}()
 
 	highestNonceHdrs, err := mp.checkShardHeadersValidity(header)
@@ -490,11 +490,11 @@ func (mp *metaProcessor) getAllMiniBlockDstMeFromShards(metaHdr *block.MetaBlock
 	return miniBlockShardsHashes, nil
 }
 
-func (mp *metaProcessor) checkAndRequestIfShardHeadersMissing(round uint64) {
+func (mp *metaProcessor) checkAndRequestIfShardHeadersMissing() {
 	orderedHdrsPerShard := mp.blockTracker.GetTrackedHeadersForAllShards()
 
 	for i := uint32(0); i < mp.shardCoordinator.NumberOfShards(); i++ {
-		err := mp.requestHeadersIfMissing(orderedHdrsPerShard[i], i, round)
+		err := mp.requestHeadersIfMissing(orderedHdrsPerShard[i], i)
 		if err != nil {
 			log.Debug("checkAndRequestIfShardHeadersMissing", "error", err.Error())
 			continue
@@ -1827,7 +1827,7 @@ func (mp *metaProcessor) applyBodyToHeader(metaHdr *block.MetaBlock, bodyHandler
 
 	var err error
 	defer func() {
-		go mp.checkAndRequestIfShardHeadersMissing(metaHdr.GetRound())
+		go mp.checkAndRequestIfShardHeadersMissing()
 	}()
 
 	sw.Start("createShardInfo")

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -215,7 +215,7 @@ func (sp *shardProcessor) ProcessBlock(
 	}
 
 	defer func() {
-		go sp.checkAndRequestIfMetaHeadersMissing(header.Round)
+		go sp.checkAndRequestIfMetaHeadersMissing()
 	}()
 
 	err = sp.checkEpochCorrectnessCrossChain()
@@ -490,10 +490,10 @@ func (sp *shardProcessor) checkMetaHdrFinality(header data.HeaderHandler) error 
 	return nil
 }
 
-func (sp *shardProcessor) checkAndRequestIfMetaHeadersMissing(round uint64) {
+func (sp *shardProcessor) checkAndRequestIfMetaHeadersMissing() {
 	orderedMetaBlocks, _ := sp.blockTracker.GetTrackedHeaders(core.MetachainShardId)
 
-	err := sp.requestHeadersIfMissing(orderedMetaBlocks, core.MetachainShardId, round)
+	err := sp.requestHeadersIfMissing(orderedMetaBlocks, core.MetachainShardId)
 	if err != nil {
 		log.Debug("checkAndRequestIfMetaHeadersMissing", "error", err.Error())
 	}
@@ -1696,7 +1696,7 @@ func (sp *shardProcessor) applyBodyToHeader(shardHeader *block.Header, body *blo
 	shardHeader.RootHash = sp.getRootHash()
 
 	defer func() {
-		go sp.checkAndRequestIfMetaHeadersMissing(shardHeader.GetRound())
+		go sp.checkAndRequestIfMetaHeadersMissing()
 	}()
 
 	if check.IfNil(body) {

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -1343,7 +1343,7 @@ func TestShardProcessor_CheckAndRequestIfMetaHeadersMissingShouldErr(t *testing.
 
 	tdp.Headers().AddHeader(metaHash, meta)
 
-	sp.CheckAndRequestIfMetaHeadersMissing(2)
+	sp.CheckAndRequestIfMetaHeadersMissing()
 	time.Sleep(100 * time.Millisecond)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&hdrNoncesRequestCalled))
 	assert.Equal(t, err, process.ErrTimeIsOut)


### PR DESCRIPTION
* Fixed sync problem when attesting finality header is not requested in advance