### PR TITLE
Fix number of shard headers included in one meta block

### DIFF
--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -860,7 +860,11 @@ func (mp *metaProcessor) createAndProcessCrossMiniBlocksDstMe(
 		return nil, 0, 0, err
 	}
 
-	maxShardHeadersFromSameShard := process.MaxShardHeadersAllowedInOneMetaBlock / mp.shardCoordinator.NumberOfShards()
+	maxShardHeadersFromSameShard := core.MaxUint32(
+		process.MinShardHeadersInOneMetaBlock,
+		process.MaxShardHeadersAllowedInOneMetaBlock/mp.shardCoordinator.NumberOfShards(),
+	)
+	maxShardHeadersAllowedInOneMetaBlock := maxShardHeadersFromSameShard * mp.shardCoordinator.NumberOfShards()
 	hdrsAddedForShard := make(map[uint32]uint32)
 
 	mp.hdrsForCurrBlock.mutHdrsForBlock.Lock()
@@ -872,7 +876,7 @@ func (mp *metaProcessor) createAndProcessCrossMiniBlocksDstMe(
 			break
 		}
 
-		if hdrsAdded >= process.MaxShardHeadersAllowedInOneMetaBlock {
+		if hdrsAdded >= maxShardHeadersAllowedInOneMetaBlock {
 			log.Debug("maximum shard headers allowed to be included in one meta block has been reached",
 				"shard headers added", hdrsAdded,
 			)

--- a/process/constants.go
+++ b/process/constants.go
@@ -91,15 +91,19 @@ const MaxMetaNoncesBehind = 15
 // shard block nonce by meta, before meta is considered stuck
 const MaxShardNoncesBehind = 15
 
-// MaxRoundsWithoutNewBlockReceived defines the maximum rounds to wait for a new block to be received,
+// MaxRoundsWithoutNewBlockReceived defines the maximum number of rounds to wait for a new block to be received,
 // before a special action to be applied
 const MaxRoundsWithoutNewBlockReceived = 10
 
-// MaxMetaHeadersAllowedInOneShardBlock defines the maximum meta headers allowed to be included in one shard block
+// MaxMetaHeadersAllowedInOneShardBlock defines the maximum number of meta headers allowed to be included in one shard block
 const MaxMetaHeadersAllowedInOneShardBlock = 50
 
-// MaxShardHeadersAllowedInOneMetaBlock defines the maximum shard headers allowed to be included in one meta block
+// MaxShardHeadersAllowedInOneMetaBlock defines the maximum number of shard headers allowed to be included in one meta block
 const MaxShardHeadersAllowedInOneMetaBlock = 50
+
+// MinShardHeadersInOneMetaBlock defines the minimum number of shard headers which would be included in one meta block
+// if they are available
+const MinShardHeadersInOneMetaBlock = 5
 
 // MaxNumOfTxsToSelect defines the maximum number of transactions that should be selected from the cache
 const MaxNumOfTxsToSelect = 30000


### PR DESCRIPTION
* Fixed computation of number of shard headers which could be included in one meta block