### PR TITLE
Use round instead of nonce for synchronization estimation

### DIFF
--- a/statusHandler/presenter/chainInfoGetters.go
+++ b/statusHandler/presenter/chainInfoGetters.go
@@ -59,7 +59,7 @@ func (psh *PresenterStatusHandler) GetCurrentRound() uint64 {
 // CalculateTimeToSynchronize will calculate and return an estimation of
 // the time required for synchronization in a human friendly format
 func (psh *PresenterStatusHandler) CalculateTimeToSynchronize() string {
-	currentBlock := psh.GetNonce()
+	currentSynchronizedRound := psh.GetSynchronizedRound()
 
 	numsynchronizationSpeedHistory := len(psh.synchronizationSpeedHistory)
 
@@ -73,13 +73,13 @@ func (psh *PresenterStatusHandler) CalculateTimeToSynchronize() string {
 		speed = float64(sum) / float64(numsynchronizationSpeedHistory)
 	}
 
-	probableHighestNonce := psh.GetProbableHighestNonce()
-	if probableHighestNonce < currentBlock || speed == 0 {
+	currentRound := psh.GetCurrentRound()
+	if currentRound < currentSynchronizedRound || speed == 0 {
 		return ""
 	}
 
-	remainingBlocksToSynchronize := probableHighestNonce - currentBlock
-	timeEstimationSeconds := float64(remainingBlocksToSynchronize) / speed
+	remainingRoundsToSynchronize := currentRound - currentSynchronizedRound
+	timeEstimationSeconds := float64(remainingRoundsToSynchronize) / speed
 	remainingTime := core.SecondsToHourMinSec(int(timeEstimationSeconds))
 
 	return remainingTime
@@ -88,25 +88,25 @@ func (psh *PresenterStatusHandler) CalculateTimeToSynchronize() string {
 // CalculateSynchronizationSpeed will calculate and return speed of synchronization
 // how many block per second are synchronized
 func (psh *PresenterStatusHandler) CalculateSynchronizationSpeed() uint64 {
-	currentBlock := psh.GetNonce()
-	if psh.oldNonce == 0 {
-		psh.oldNonce = currentBlock
+	currentSynchronizedRound := psh.GetSynchronizedRound()
+	if psh.oldRound == 0 {
+		psh.oldRound = currentSynchronizedRound
 		return 0
 	}
 
-	blocksPerSecond := int64(currentBlock - psh.oldNonce)
-	if blocksPerSecond < 0 {
-		blocksPerSecond = 0
+	roundsPerSecond := int64(currentSynchronizedRound - psh.oldRound)
+	if roundsPerSecond < 0 {
+		roundsPerSecond = 0
 	}
 
 	if len(psh.synchronizationSpeedHistory) >= maxSpeedHistorySaved {
 		psh.synchronizationSpeedHistory = psh.synchronizationSpeedHistory[1:len(psh.synchronizationSpeedHistory)]
 	}
-	psh.synchronizationSpeedHistory = append(psh.synchronizationSpeedHistory, uint64(blocksPerSecond))
+	psh.synchronizationSpeedHistory = append(psh.synchronizationSpeedHistory, uint64(roundsPerSecond))
 
-	psh.oldNonce = currentBlock
+	psh.oldRound = currentSynchronizedRound
 
-	return uint64(blocksPerSecond)
+	return uint64(roundsPerSecond)
 }
 
 // GetNumTxProcessed will return number of processed transactions since node starts

--- a/statusHandler/presenter/chainInfoGetters.go
+++ b/statusHandler/presenter/chainInfoGetters.go
@@ -86,7 +86,7 @@ func (psh *PresenterStatusHandler) CalculateTimeToSynchronize() string {
 }
 
 // CalculateSynchronizationSpeed will calculate and return speed of synchronization
-// how many block per second are synchronized
+// how many blocks per second are synchronized
 func (psh *PresenterStatusHandler) CalculateSynchronizationSpeed() uint64 {
 	currentSynchronizedRound := psh.GetSynchronizedRound()
 	if psh.oldRound == 0 {

--- a/statusHandler/presenter/chainInfoGetters_test.go
+++ b/statusHandler/presenter/chainInfoGetters_test.go
@@ -127,8 +127,8 @@ func TestPresenterStatusHandler_CalculateTimeToSynchronize(t *testing.T) {
 	presenterStatusHandler := NewPresenterStatusHandler()
 
 	time.Sleep(time.Second)
-	presenterStatusHandler.SetUInt64Value(core.MetricNonce, currentBlockNonce)
-	presenterStatusHandler.SetUInt64Value(core.MetricProbableHighestNonce, probableHighestNonce)
+	presenterStatusHandler.SetUInt64Value(core.MetricSynchronizedRound, currentBlockNonce)
+	presenterStatusHandler.SetUInt64Value(core.MetricCurrentRound, probableHighestNonce)
 	presenterStatusHandler.synchronizationSpeedHistory = append(presenterStatusHandler.synchronizationSpeedHistory, synchronizationSpeed)
 	synchronizationEstimation := presenterStatusHandler.CalculateTimeToSynchronize()
 
@@ -146,9 +146,9 @@ func TestPresenterStatusHandler_CalculateSynchronizationSpeed(t *testing.T) {
 	initialNonce := uint64(10)
 	currentNonce := uint64(20)
 	presenterStatusHandler := NewPresenterStatusHandler()
-	presenterStatusHandler.SetUInt64Value(core.MetricNonce, initialNonce)
+	presenterStatusHandler.SetUInt64Value(core.MetricSynchronizedRound, initialNonce)
 	_ = presenterStatusHandler.CalculateSynchronizationSpeed()
-	presenterStatusHandler.SetUInt64Value(core.MetricNonce, currentNonce)
+	presenterStatusHandler.SetUInt64Value(core.MetricSynchronizedRound, currentNonce)
 	syncSpeed := presenterStatusHandler.CalculateSynchronizationSpeed()
 
 	expectedSpeed := currentNonce - initialNonce

--- a/statusHandler/presenter/presenterStatusHandler.go
+++ b/statusHandler/presenter/presenterStatusHandler.go
@@ -14,7 +14,7 @@ type PresenterStatusHandler struct {
 	presenterMetrics            *sync.Map
 	logLines                    []string
 	mutLogLineWrite             sync.RWMutex
-	oldNonce                    uint64
+	oldRound                    uint64
 	synchronizationSpeedHistory []uint64
 	totalRewardsOld             *big.Float
 }


### PR DESCRIPTION
Change input data for formula that is used to calculate synchronization time (estimation). 
Instead of using current synchronized nonce now is used current synchronized round because if we are using nonce we will have an estimation for current epoch not for  all the epochs that are needed to be synchronized.