### PR TITLE
disable-sc-deploy

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -12,7 +12,7 @@
    StartInEpochEnabled = true
 
    # DisableDeploy represents the flag to enable/disable deployment of smart contracts
-   DisableDeploy = true
+   DisableDeploy = false
 
 [StoragePruning]
    # If the Enabled flag is set to false, then the storers won't divide epochs into separate dbs

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -12,7 +12,7 @@
    StartInEpochEnabled = true
 
    # DisableDeploy represents the flag to enable/disable deployment of smart contracts
-   DisableDeploy = false
+   DisableDeploy = true
 
 [StoragePruning]
    # If the Enabled flag is set to false, then the storers won't divide epochs into separate dbs

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -11,6 +11,9 @@
    # available in local disk
    StartInEpochEnabled = true
 
+   # DisableDeploy represents the flag to enable/disable deployment of smart contracts
+   DisableDeploy = true
+
 [StoragePruning]
    # If the Enabled flag is set to false, then the storers won't divide epochs into separate dbs
    Enabled = false

--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -1222,6 +1222,7 @@ func newShardBlockProcessor(
 		BuiltInFunctions: vmFactory.BlockChainHookImpl().GetBuiltInFunctions(),
 		TxLogsProcessor:  txLogsProcessor,
 		TxTypeHandler:    txTypeHandler,
+		DisableDeploy:    config.GeneralSettings.DisableDeploy,
 	}
 	scProcessor, err := smartContract.NewSmartContractProcessor(argsNewScProcessor)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -196,6 +196,7 @@ type GeneralSettingsConfig struct {
 	StatusPollingIntervalSec int
 	MaxComputableRounds      uint64
 	StartInEpochEnabled      bool
+	DisableDeploy            bool
 }
 
 // FacadeConfig will hold different configuration option that will be passed to the main ElrondFacade

--- a/process/errors.go
+++ b/process/errors.go
@@ -856,3 +856,6 @@ var ErrTransactionIsNotWhitelisted = errors.New("transaction is not whitelisted"
 
 // ErrInterceptedDataNotForCurrentShard signals that intercepted data is not for current shard
 var ErrInterceptedDataNotForCurrentShard = errors.New("intercepted data not for current shard")
+
+// ErrSmartContractDeploymentIsDisabled signals that smart contract deployment was disabled
+var ErrSmartContractDeploymentIsDisabled = errors.New("smart Contract deployment is disabled")


### PR DESCRIPTION
disable deployment of contracts through config. deployment and execution of any contract calls are safe.