### PR TITLE
Fix messenger sync clock problem

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -799,6 +799,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		*generalConfig,
 		coreComponents.StatusHandler,
 		coreComponents.InternalMarshalizer,
+		syncer,
 	)
 	if err != nil {
 		return err

--- a/cmd/seednode/main.go
+++ b/cmd/seednode/main.go
@@ -214,6 +214,7 @@ func createNode(p2pConfig config.P2PConfig, marshalizer marshal.Marshalizer) (p2
 		Marshalizer:   marshalizer,
 		ListenAddress: libp2p.ListenAddrWithIp4AndTcp,
 		P2pConfig:     p2pConfig,
+		SyncTimer:     &libp2p.LocalSyncTimer{},
 	}
 
 	return libp2p.NewNetworkMessenger(arg)

--- a/factory/networkComponents.go
+++ b/factory/networkComponents.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/debug/antiflood"
 	"github.com/ElrondNetwork/elrond-go/marshal"
+	"github.com/ElrondNetwork/elrond-go/p2p"
 	"github.com/ElrondNetwork/elrond-go/p2p/libp2p"
 	"github.com/ElrondNetwork/elrond-go/process"
 	antifloodFactory "github.com/ElrondNetwork/elrond-go/process/throttle/antiflood/factory"
@@ -19,6 +20,7 @@ type networkComponentsFactory struct {
 	statusHandler core.AppStatusHandler
 	listenAddress string
 	marshalizer   marshal.Marshalizer
+	syncer        p2p.SyncTimer
 }
 
 // NewNetworkComponentsFactory returns a new instance of a network components factory
@@ -27,6 +29,7 @@ func NewNetworkComponentsFactory(
 	mainConfig config.Config,
 	statusHandler core.AppStatusHandler,
 	marshalizer marshal.Marshalizer,
+	syncer p2p.SyncTimer,
 ) (*networkComponentsFactory, error) {
 	if check.IfNil(statusHandler) {
 		return nil, ErrNilStatusHandler
@@ -41,6 +44,7 @@ func NewNetworkComponentsFactory(
 		mainConfig:    mainConfig,
 		statusHandler: statusHandler,
 		listenAddress: libp2p.ListenAddrWithIp4AndTcp,
+		syncer:        syncer,
 	}, nil
 }
 
@@ -50,6 +54,7 @@ func (ncf *networkComponentsFactory) Create() (*NetworkComponents, error) {
 		Marshalizer:   ncf.marshalizer,
 		ListenAddress: ncf.listenAddress,
 		P2pConfig:     ncf.p2pConfig,
+		SyncTimer:     ncf.syncer,
 	}
 
 	netMessenger, err := libp2p.NewNetworkMessenger(arg)

--- a/factory/networkComponents_test.go
+++ b/factory/networkComponents_test.go
@@ -13,7 +13,13 @@ import (
 func TestNewNetworkComponentsFactory_NilStatusHandlerShouldErr(t *testing.T) {
 	t.Parallel()
 
-	ncf, err := NewNetworkComponentsFactory(config.P2PConfig{}, config.Config{}, nil, &mock.MarshalizerMock{})
+	ncf, err := NewNetworkComponentsFactory(
+		config.P2PConfig{},
+		config.Config{},
+		nil,
+		&mock.MarshalizerMock{},
+		&libp2p.LocalSyncTimer{},
+	)
 	require.Nil(t, ncf)
 	require.Equal(t, ErrNilStatusHandler, err)
 }
@@ -21,7 +27,13 @@ func TestNewNetworkComponentsFactory_NilStatusHandlerShouldErr(t *testing.T) {
 func TestNewNetworkComponentsFactory_NilMarshalizerShouldErr(t *testing.T) {
 	t.Parallel()
 
-	ncf, err := NewNetworkComponentsFactory(config.P2PConfig{}, config.Config{}, &mock.AppStatusHandlerMock{}, nil)
+	ncf, err := NewNetworkComponentsFactory(
+		config.P2PConfig{},
+		config.Config{},
+		&mock.AppStatusHandlerMock{},
+		nil,
+		&libp2p.LocalSyncTimer{},
+	)
 	require.Nil(t, ncf)
 	require.True(t, errors.Is(err, ErrNilMarshalizer))
 }
@@ -29,18 +41,25 @@ func TestNewNetworkComponentsFactory_NilMarshalizerShouldErr(t *testing.T) {
 func TestNewNetworkComponentsFactory_OkValsShouldWork(t *testing.T) {
 	t.Parallel()
 
-	ncf, err := NewNetworkComponentsFactory(config.P2PConfig{}, config.Config{}, &mock.AppStatusHandlerMock{}, &mock.MarshalizerMock{})
+	ncf, err := NewNetworkComponentsFactory(
+		config.P2PConfig{},
+		config.Config{},
+		&mock.AppStatusHandlerMock{},
+		&mock.MarshalizerMock{},
+		&libp2p.LocalSyncTimer{},
+	)
 	require.NoError(t, err)
 	require.NotNil(t, ncf)
 }
 
 func TestNetworkComponentsFactory_Create_ShouldErrDueToBadConfig(t *testing.T) {
-	//TODO remove skip when external library is concurrent safe
-	if testing.Short() {
-		t.Skip("this test fails with race detector on because of the github.com/koron/go-ssdp lib")
-	}
-
-	ncf, _ := NewNetworkComponentsFactory(config.P2PConfig{}, config.Config{}, &mock.AppStatusHandlerMock{}, &mock.MarshalizerMock{})
+	ncf, _ := NewNetworkComponentsFactory(
+		config.P2PConfig{},
+		config.Config{},
+		&mock.AppStatusHandlerMock{},
+		&mock.MarshalizerMock{},
+		&libp2p.LocalSyncTimer{},
+	)
 
 	nc, err := ncf.Create()
 	require.Error(t, err)
@@ -48,11 +67,6 @@ func TestNetworkComponentsFactory_Create_ShouldErrDueToBadConfig(t *testing.T) {
 }
 
 func TestNetworkComponentsFactory_Create_ShouldWork(t *testing.T) {
-	//TODO remove skip when external library is concurrent safe
-	if testing.Short() {
-		t.Skip("this test fails with race detector on because of the github.com/koron/go-ssdp lib")
-	}
-
 	p2pConfig := config.P2PConfig{
 		Node: config.NodeConfig{
 			Port: "0",
@@ -88,6 +102,7 @@ func TestNetworkComponentsFactory_Create_ShouldWork(t *testing.T) {
 		},
 		&mock.AppStatusHandlerMock{},
 		&mock.MarshalizerMock{},
+		&libp2p.LocalSyncTimer{},
 	)
 
 	ncf.SetListenAddress(libp2p.ListenLocalhostAddrWithIp4AndTcp)

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -135,6 +135,7 @@ func CreateMessengerWithKadDht(initialAddr string) p2p.Messenger {
 		Marshalizer:   TestMarshalizer,
 		ListenAddress: libp2p.ListenLocalhostAddrWithIp4AndTcp,
 		P2pConfig:     createP2PConfig(initialAddresses),
+		SyncTimer:     &libp2p.LocalSyncTimer{},
 	}
 
 	libP2PMes, err := libp2p.NewNetworkMessenger(arg)
@@ -157,6 +158,7 @@ func CreateMessengerWithKadDhtAndProtocolID(initialAddr string, protocolID strin
 		Marshalizer:   TestMarshalizer,
 		ListenAddress: libp2p.ListenLocalhostAddrWithIp4AndTcp,
 		P2pConfig:     p2pConfig,
+		SyncTimer:     &libp2p.LocalSyncTimer{},
 	}
 
 	libP2PMes, err := libp2p.NewNetworkMessenger(arg)
@@ -173,6 +175,7 @@ func CreateMessengerFromConfig(p2pConfig config.P2PConfig) p2p.Messenger {
 		Marshalizer:   TestMarshalizer,
 		ListenAddress: libp2p.ListenLocalhostAddrWithIp4AndTcp,
 		P2pConfig:     p2pConfig,
+		SyncTimer:     &libp2p.LocalSyncTimer{},
 	}
 
 	libP2PMes, err := libp2p.NewNetworkMessenger(arg)
@@ -202,6 +205,7 @@ func CreateMessengerWithNoDiscovery() p2p.Messenger {
 		Marshalizer:   TestMarshalizer,
 		ListenAddress: libp2p.ListenLocalhostAddrWithIp4AndTcp,
 		P2pConfig:     p2pConfig,
+		SyncTimer:     &libp2p.LocalSyncTimer{},
 	}
 
 	libP2PMes, err := libp2p.NewNetworkMessenger(arg)

--- a/p2p/errors.go
+++ b/p2p/errors.go
@@ -37,8 +37,11 @@ var ErrEmptyTopicList = errors.New("empty topicIDs")
 // ErrAlreadySeenMessage signals that the message has already been seen
 var ErrAlreadySeenMessage = errors.New("already seen this message")
 
-// ErrOldMessage signals that the message is too old
-var ErrOldMessage = errors.New("message too old")
+// ErrMessageTooNew signals that a message has a timestamp that is in the future relative to self
+var ErrMessageTooNew = errors.New("message is too new")
+
+// ErrMessageTooOld signals that a message has a timestamp that is in the past relative to self
+var ErrMessageTooOld = errors.New("message is too old")
 
 // ErrNilDirectSendMessageHandler signals that the message handler for new message has not been wired
 var ErrNilDirectSendMessageHandler = errors.New("nil direct sender message handler")
@@ -137,3 +140,6 @@ var ErrUnsupportedFields = errors.New("unsupported fields")
 
 // ErrUnsupportedMessageVersion signals that an unsupported message version was detected
 var ErrUnsupportedMessageVersion = errors.New("unsupported message version")
+
+// ErrNilSyncTimer signals that a nil sync timer was provided
+var ErrNilSyncTimer = errors.New("nil sync timer")

--- a/p2p/example/libp2p/autodiscovery/main.go
+++ b/p2p/example/libp2p/autodiscovery/main.go
@@ -33,6 +33,7 @@ func createMockNetworkArgs() libp2p.ArgsNetworkMessenger {
 				Type: p2p.NilListSharder,
 			},
 		},
+		SyncTimer: &libp2p.LocalSyncTimer{},
 	}
 }
 

--- a/p2p/libp2p/export_test.go
+++ b/p2p/libp2p/export_test.go
@@ -35,6 +35,10 @@ func (netMes *networkMessenger) PubsubCallback(handler p2p.MessageProcessor, top
 	return netMes.pubsubCallback(handler, topic)
 }
 
+func (netMes *networkMessenger) ValidMessageByTimestamp(msg p2p.MessageP2P) error {
+	return netMes.validMessageByTimestamp(msg)
+}
+
 func (ds *directSender) ProcessReceivedDirectMessage(message *pubsub_pb.Message, fromConnectedPeer peer.ID) error {
 	return ds.processReceivedDirectMessage(message, fromConnectedPeer)
 }

--- a/p2p/libp2p/issues_test.go
+++ b/p2p/libp2p/issues_test.go
@@ -31,6 +31,7 @@ func createMessenger() p2p.Messenger {
 				Type: p2p.NilListSharder,
 			},
 		},
+		SyncTimer: &libp2p.LocalSyncTimer{},
 	}
 
 	libP2PMes, err := libp2p.NewNetworkMessenger(args)

--- a/p2p/libp2p/localSyncTimer.go
+++ b/p2p/libp2p/localSyncTimer.go
@@ -1,0 +1,17 @@
+package libp2p
+
+import "time"
+
+// LocalSyncTimer uses the local system to provide the current time
+type LocalSyncTimer struct {
+}
+
+// CurrentTime returns the local current time
+func (lst *LocalSyncTimer) CurrentTime() time.Time {
+	return time.Now()
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (lst *LocalSyncTimer) IsInterfaceNil() bool {
+	return lst == nil
+}

--- a/p2p/libp2p/netMessenger.go
+++ b/p2p/libp2p/netMessenger.go
@@ -95,6 +95,7 @@ type networkMessenger struct {
 	connectionsMetric   *metrics.Connections
 	debugger            p2p.Debugger
 	marshalizer         p2p.Marshalizer
+	syncTimer           p2p.SyncTimer
 }
 
 // ArgsNetworkMessenger defines the options used to create a p2p wrapper
@@ -102,12 +103,16 @@ type ArgsNetworkMessenger struct {
 	ListenAddress string
 	Marshalizer   p2p.Marshalizer
 	P2pConfig     config.P2PConfig
+	SyncTimer     p2p.SyncTimer
 }
 
 // NewNetworkMessenger creates a libP2P messenger by opening a port on the current machine
 func NewNetworkMessenger(args ArgsNetworkMessenger) (*networkMessenger, error) {
 	if check.IfNil(args.Marshalizer) {
 		return nil, fmt.Errorf("%w when creating a new network messenger", p2p.ErrNilMarshalizer)
+	}
+	if check.IfNil(args.SyncTimer) {
+		return nil, fmt.Errorf("%w when creating a new network messenger", p2p.ErrNilSyncTimer)
 	}
 
 	p2pPrivKey, err := createP2PPrivKey(args.P2pConfig.Node.Seed)
@@ -189,6 +194,7 @@ func createMessenger(
 		outgoingPLB:       loadBalancer.NewOutgoingChannelLoadBalancer(),
 		peerShardResolver: &unknownPeerShardResolver{},
 		marshalizer:       args.Marshalizer,
+		syncTimer:         args.SyncTimer,
 	}
 	netMes.debugger = p2pDebug.NewP2PDebugger(core.PeerID(p2pHost.ID()))
 
@@ -294,7 +300,7 @@ func (netMes *networkMessenger) createMessageBytes(buff []byte) []byte {
 	message := &data.TopicMessage{
 		Version:   currentTopicMessageVersion,
 		Payload:   buff,
-		Timestamp: time.Now().Unix(),
+		Timestamp: netMes.syncTimer.CurrentTime().Unix(),
 	}
 
 	buffToSend, errMarshal := netMes.marshalizer.Marshal(message)
@@ -770,17 +776,19 @@ func (netMes *networkMessenger) transformAndCheckMessage(pbMsg *pubsub.Message, 
 		return nil, errUnmarshal
 	}
 
-	if !netMes.validMessageByTimestamp(msg) {
+	err := netMes.validMessageByTimestamp(msg)
+	if err != nil {
 		//not reprocessing nor rebrodcasting the same message over and over again
-		log.Trace("received an old message",
+		log.Trace("received an invalid message",
 			"originator pid", p2p.MessageOriginatorPid(msg),
 			"from connected pid", p2p.PeerIdToShortString(pid),
 			"sequence", hex.EncodeToString(msg.SeqNo()),
 			"timestamp", msg.Timestamp(),
+			"error", err,
 		)
 		netMes.processDebugMessage(topic, pid, uint64(len(msg.Data())), true)
 
-		return nil, p2p.ErrOldMessage
+		return nil, err
 	}
 
 	return msg, nil
@@ -810,16 +818,22 @@ func (netMes *networkMessenger) blacklistPid(pid core.PeerID, banDuration time.D
 
 // invalidMessageByTimestamp will check that the message time stamp should be in the interval
 // (now-pubsubTimeCacheDuration+acceptMessagesInAdvanceDuration, now+acceptMessagesInAdvanceDuration)
-func (netMes *networkMessenger) validMessageByTimestamp(msg p2p.MessageP2P) bool {
-	now := time.Now()
+func (netMes *networkMessenger) validMessageByTimestamp(msg p2p.MessageP2P) error {
+	now := netMes.syncTimer.CurrentTime()
 	isInFuture := now.Add(acceptMessagesInAdvanceDuration).Unix() < msg.Timestamp()
 	if isInFuture {
-		return false
+		return fmt.Errorf("%w, self timestamp %d, message timestamp %d",
+			p2p.ErrMessageTooNew, now.Unix(), msg.Timestamp())
 	}
 
 	past := now.Unix() - int64(pubsubTimeCacheDuration.Seconds()) + int64(acceptMessagesInAdvanceDuration.Seconds())
 
-	return msg.Timestamp() > past
+	if msg.Timestamp() < past {
+		return fmt.Errorf("%w, self timestamp %d, message timestamp %d",
+			p2p.ErrMessageTooOld, now.Unix(), msg.Timestamp())
+	}
+
+	return nil
 }
 
 func (netMes *networkMessenger) processDebugMessage(topic string, fromConnectedPeer core.PeerID, size uint64, isRejected bool) {

--- a/p2p/libp2p/netMessenger_test.go
+++ b/p2p/libp2p/netMessenger_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/p2p"
 	"github.com/ElrondNetwork/elrond-go/p2p/data"
 	"github.com/ElrondNetwork/elrond-go/p2p/libp2p"
+	"github.com/ElrondNetwork/elrond-go/p2p/message"
 	"github.com/ElrondNetwork/elrond-go/p2p/mock"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/libp2p/go-libp2p-core/network"
@@ -81,6 +82,7 @@ func createMockNetworkArgs() libp2p.ArgsNetworkMessenger {
 				Type: p2p.NilListSharder,
 			},
 		},
+		SyncTimer: &libp2p.LocalSyncTimer{},
 	}
 }
 
@@ -135,12 +137,25 @@ func TestNewMemoryLibp2pMessenger_OkValsWithoutDiscoveryShouldWork(t *testing.T)
 
 //------- NewNetworkMessenger
 
-func TestNewNetworkMessenger_WithDeactivatedKadDiscovererShouldWork(t *testing.T) {
-	//TODO remove skip when external library is concurrent safe
-	if testing.Short() {
-		t.Skip("this test fails with race detector on because of the github.com/koron/go-ssdp lib")
-	}
+func TestNewNetworkMessenger_NilMessengerShouldErr(t *testing.T) {
+	arg := createMockNetworkArgs()
+	arg.Marshalizer = nil
+	mes, err := libp2p.NewNetworkMessenger(arg)
 
+	assert.True(t, check.IfNil(mes))
+	assert.True(t, errors.Is(err, p2p.ErrNilMarshalizer))
+}
+
+func TestNewNetworkMessenger_NilSyncTimerShouldErr(t *testing.T) {
+	arg := createMockNetworkArgs()
+	arg.SyncTimer = nil
+	mes, err := libp2p.NewNetworkMessenger(arg)
+
+	assert.True(t, check.IfNil(mes))
+	assert.True(t, errors.Is(err, p2p.ErrNilSyncTimer))
+}
+
+func TestNewNetworkMessenger_WithDeactivatedKadDiscovererShouldWork(t *testing.T) {
 	arg := createMockNetworkArgs()
 	mes, err := libp2p.NewNetworkMessenger(arg)
 
@@ -151,11 +166,6 @@ func TestNewNetworkMessenger_WithDeactivatedKadDiscovererShouldWork(t *testing.T
 }
 
 func TestNewNetworkMessenger_WithKadDiscovererListsSharderInvalidTargetConnShouldErr(t *testing.T) {
-	//TODO remove skip when external library is concurrent safe
-	if testing.Short() {
-		t.Skip("this test fails with race detector on because of the github.com/koron/go-ssdp lib")
-	}
-
 	arg := createMockNetworkArgs()
 	arg.P2pConfig.KadDhtPeerDiscovery = config.KadDhtPeerDiscoveryConfig{
 		Enabled:                          true,
@@ -173,11 +183,6 @@ func TestNewNetworkMessenger_WithKadDiscovererListsSharderInvalidTargetConnShoul
 }
 
 func TestNewNetworkMessenger_WithKadDiscovererListSharderShouldWork(t *testing.T) {
-	//TODO remove skip when external library is concurrent safe
-	if testing.Short() {
-		t.Skip("this test fails with race detector on because of the github.com/koron/go-ssdp lib")
-	}
-
 	arg := createMockNetworkArgs()
 	arg.P2pConfig.KadDhtPeerDiscovery = config.KadDhtPeerDiscoveryConfig{
 		Enabled:                          true,
@@ -404,11 +409,6 @@ func TestLibp2pMessenger_UnregisterAllTopicValidatorShouldWork(t *testing.T) {
 }
 
 func TestLibp2pMessenger_BroadcastDataLargeMessageShouldNotCallSend(t *testing.T) {
-	//TODO remove skip when external library is concurrent safe
-	if testing.Short() {
-		t.Skip("this test fails with race detector on because of the github.com/koron/go-ssdp lib")
-	}
-
 	msg := make([]byte, libp2p.MaxSendBuffSize+1)
 	mes, _ := libp2p.NewNetworkMessenger(createMockNetworkArgs())
 	mes.SetLoadBalancer(&mock.ChannelLoadBalancerStub{
@@ -428,11 +428,6 @@ func TestLibp2pMessenger_BroadcastDataLargeMessageShouldNotCallSend(t *testing.T
 }
 
 func TestLibp2pMessenger_BroadcastDataBetween2PeersShouldWork(t *testing.T) {
-	//TODO remove skip when external library is concurrent safe
-	if testing.Short() {
-		t.Skip("this test fails with race detector on because of the github.com/koron/go-ssdp lib")
-	}
-
 	msg := []byte("test message")
 
 	_, mes1, mes2 := createMockNetworkOf2()
@@ -515,11 +510,6 @@ func TestLibp2pMessenger_BroadcastOnChannelBlockingShouldLimitNumberOfGoRoutines
 }
 
 func TestLibp2pMessenger_BroadcastDataBetween2PeersWithLargeMsgShouldWork(t *testing.T) {
-	//TODO remove skip when external library is concurrent safe
-	if testing.Short() {
-		t.Skip("this test fails with race detector on because of the github.com/koron/go-ssdp lib")
-	}
-
 	msg := make([]byte, libp2p.MaxSendBuffSize)
 
 	_, mes1, mes2 := createMockNetworkOf2()
@@ -944,11 +934,6 @@ func generateConnWithRemotePeer(pid core.PeerID) network.Conn {
 }
 
 func TestLibp2pMessenger_SendDirectWithMockNetToConnectedPeerShouldWork(t *testing.T) {
-	//TODO remove skip when github.com/koron/go-ssdp library is concurrent safe
-	if testing.Short() {
-		t.Skip("this test fails with race detector on because of the github.com/koron/go-ssdp lib")
-	}
-
 	msg := []byte("test message")
 
 	_, mes1, mes2 := createMockNetworkOf2()
@@ -986,11 +971,6 @@ func TestLibp2pMessenger_SendDirectWithMockNetToConnectedPeerShouldWork(t *testi
 }
 
 func TestLibp2pMessenger_SendDirectWithRealNetToConnectedPeerShouldWork(t *testing.T) {
-	//TODO remove skip when external library is concurrent safe
-	if testing.Short() {
-		t.Skip("this test fails with race detector on because of the github.com/koron/go-ssdp lib")
-	}
-
 	msg := []byte("test message")
 
 	fmt.Println("Messenger 1:")
@@ -1160,6 +1140,7 @@ func TestNetworkMessenger_PreventReprocessingShouldWork(t *testing.T) {
 				Type: p2p.NilListSharder,
 			},
 		},
+		SyncTimer: &libp2p.LocalSyncTimer{},
 	}
 
 	mes, _ := libp2p.NewNetworkMessenger(args)
@@ -1222,6 +1203,7 @@ func TestNetworkMessenger_PubsubCallbackNotMessageNotValidShouldNotCallHandler(t
 				Type: p2p.NilListSharder,
 			},
 		},
+		SyncTimer: &libp2p.LocalSyncTimer{},
 	}
 
 	mes, _ := libp2p.NewNetworkMessenger(args)
@@ -1291,6 +1273,7 @@ func TestNetworkMessenger_PubsubCallbackReturnsFalseIfHandlerErrors(t *testing.T
 				Type: p2p.NilListSharder,
 			},
 		},
+		SyncTimer: &libp2p.LocalSyncTimer{},
 	}
 
 	mes, _ := libp2p.NewNetworkMessenger(args)
@@ -1350,6 +1333,7 @@ func TestNetworkMessenger_UnjoinAllTopicsShouldWork(t *testing.T) {
 				Type: p2p.NilListSharder,
 			},
 		},
+		SyncTimer: &libp2p.LocalSyncTimer{},
 	}
 
 	mes, _ := libp2p.NewNetworkMessenger(args)
@@ -1362,4 +1346,71 @@ func TestNetworkMessenger_UnjoinAllTopicsShouldWork(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.False(t, mes.HasTopic(topic))
+}
+
+func TestNetworkMessenger_ValidMessageByTimestampMessageTooOld(t *testing.T) {
+	args := createMockNetworkArgs()
+	now := time.Now()
+	args.SyncTimer = &mock.SyncTimerStub{
+		CurrentTimeCalled: func() time.Time {
+			return now
+		},
+	}
+	mes, _ := libp2p.NewNetworkMessenger(args)
+
+	msg := &message.Message{
+		TimestampField: now.Unix() - int64(libp2p.PubsubTimeCacheDuration.Seconds()) +
+			int64(libp2p.AcceptMessagesInAdvanceDuration.Seconds()) - 1,
+	}
+	err := mes.ValidMessageByTimestamp(msg)
+
+	assert.True(t, errors.Is(err, p2p.ErrMessageTooOld))
+}
+
+func TestNetworkMessenger_ValidMessageByTimestampMessageAtLowerLimitShouldWork(t *testing.T) {
+	mes, _ := libp2p.NewNetworkMessenger(createMockNetworkArgs())
+
+	now := time.Now()
+	msg := &message.Message{
+		TimestampField: now.Unix() - int64(libp2p.PubsubTimeCacheDuration.Seconds()) + int64(libp2p.AcceptMessagesInAdvanceDuration.Seconds()),
+	}
+	err := mes.ValidMessageByTimestamp(msg)
+
+	assert.Nil(t, err)
+}
+
+func TestNetworkMessenger_ValidMessageByTimestampMessageTooNew(t *testing.T) {
+	args := createMockNetworkArgs()
+	now := time.Now()
+	args.SyncTimer = &mock.SyncTimerStub{
+		CurrentTimeCalled: func() time.Time {
+			return now
+		},
+	}
+	mes, _ := libp2p.NewNetworkMessenger(args)
+
+	msg := &message.Message{
+		TimestampField: now.Unix() + int64(libp2p.AcceptMessagesInAdvanceDuration.Seconds()) + 1,
+	}
+	err := mes.ValidMessageByTimestamp(msg)
+
+	assert.True(t, errors.Is(err, p2p.ErrMessageTooNew))
+}
+
+func TestNetworkMessenger_ValidMessageByTimestampMessageAtUpperLimitShouldWork(t *testing.T) {
+	args := createMockNetworkArgs()
+	now := time.Now()
+	args.SyncTimer = &mock.SyncTimerStub{
+		CurrentTimeCalled: func() time.Time {
+			return now
+		},
+	}
+	mes, _ := libp2p.NewNetworkMessenger(args)
+
+	msg := &message.Message{
+		TimestampField: now.Unix() + int64(libp2p.AcceptMessagesInAdvanceDuration.Seconds()),
+	}
+	err := mes.ValidMessageByTimestamp(msg)
+
+	assert.Nil(t, err)
 }

--- a/p2p/mock/syncTimerStub.go
+++ b/p2p/mock/syncTimerStub.go
@@ -1,0 +1,22 @@
+package mock
+
+import "time"
+
+// SyncTimerStub -
+type SyncTimerStub struct {
+	CurrentTimeCalled func() time.Time
+}
+
+// CurrentTime -
+func (sts *SyncTimerStub) CurrentTime() time.Time {
+	if sts.CurrentTimeCalled != nil {
+		return sts.CurrentTimeCalled()
+	}
+
+	return time.Time{}
+}
+
+// IsInterfaceNil -
+func (sts *SyncTimerStub) IsInterfaceNil() bool {
+	return sts == nil
+}

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -289,3 +289,9 @@ type Debugger interface {
 	Close() error
 	IsInterfaceNil() bool
 }
+
+// SyncTimer represent an entity able to tell the current time
+type SyncTimer interface {
+	CurrentTime() time.Time
+	IsInterfaceNil() bool
+}


### PR DESCRIPTION
- made the network messenger use an NTP syncer in order to not throw away p2p messages just because the local system clock is out of sync 