### PR TITLE
Reduced the large amount of p2p/antiflood prints

### DIFF
--- a/debug/antiflood/debugger.go
+++ b/debug/antiflood/debugger.go
@@ -190,7 +190,7 @@ func (d *debugger) getStringEvents() []string {
 }
 
 func (d *debugger) printEvent(data string) {
-	log.Debug(data)
+	log.Trace(data)
 }
 
 // Close will clean up this instance

--- a/p2p/libp2p/connectionMonitorWrapper.go
+++ b/p2p/libp2p/connectionMonitorWrapper.go
@@ -52,7 +52,7 @@ func (cmw *connectionMonitorWrapper) Connected(netw network.Network, conn networ
 
 	pid := conn.RemotePeer()
 	if peerBlackList.IsDenied(core.PeerID(pid)) {
-		log.Debug("dropping connection to black listed peer",
+		log.Trace("dropping connection to blacklisted peer",
 			"pid", pid.Pretty(),
 		)
 		_ = conn.Close()
@@ -87,7 +87,7 @@ func (cmw *connectionMonitorWrapper) CheckConnectionsBlocking() {
 
 	for _, pid := range peers {
 		if peerDenialEvaluator.IsDenied(core.PeerID(pid)) {
-			log.Debug("dropping connection to black listed peer",
+			log.Trace("dropping connection to blacklisted peer",
 				"pid", pid.Pretty(),
 			)
 			_ = cmw.network.ClosePeer(pid)


### PR DESCRIPTION
- reduced the large amount of p2p/antiflood prints. To test this, can connect to an existing network (BoN/mainnet and deliberately change the chain ID from nodesSetup.json)