### PR TITLE
fix validator keys indexing watchdog expiry

### DIFF
--- a/core/indexer/elasticsearch.go
+++ b/core/indexer/elasticsearch.go
@@ -132,7 +132,7 @@ func (ei *elasticIndexer) epochStartEventHandler() epochStart.ActionHandler {
 				"error", err.Error())
 		}
 
-		ei.SaveValidatorsPubKeys(validatorsPubKeys, currentEpoch)
+		go ei.SaveValidatorsPubKeys(validatorsPubKeys, currentEpoch)
 
 	}, func(_ data.HeaderHandler) {}, core.IndexerOrder)
 


### PR DESCRIPTION
Indexing validator public keys moved on separate goroutine to not block consensus, otherwise, in some cases consensus is blocked for more than the expiry time of the consensus watchdog and causes a node reset