### PR TITLE
Add VM return message into the REST response

### DIFF
--- a/process/smartContract/scQueryService.go
+++ b/process/smartContract/scQueryService.go
@@ -96,7 +96,10 @@ func (service *SCQueryService) createVMCallInput(query *process.SCQuery, gasPric
 
 func (service *SCQueryService) checkVMOutput(vmOutput *vmcommon.VMOutput) error {
 	if vmOutput.ReturnCode != vmcommon.Ok {
-		return errors.New(fmt.Sprintf("error running vm func: code: %d, %s", vmOutput.ReturnCode, vmOutput.ReturnCode))
+		return errors.New(fmt.Sprintf("error running vm func: code: %d, %s (%s)",
+			vmOutput.ReturnCode,
+			vmOutput.ReturnCode,
+			vmOutput.ReturnMessage))
 	}
 
 	return nil

--- a/process/smartContract/scQueryService_test.go
+++ b/process/smartContract/scQueryService_test.go
@@ -175,7 +175,8 @@ func TestExecuteQuery_WhenNotOkCodeShouldErr(t *testing.T) {
 	mockVM := &mock.VMExecutionHandlerStub{
 		RunSmartContractCallCalled: func(input *vmcommon.ContractCallInput) (output *vmcommon.VMOutput, e error) {
 			return &vmcommon.VMOutput{
-				ReturnCode: vmcommon.OutOfGas,
+				ReturnCode:    vmcommon.OutOfGas,
+				ReturnMessage: "add more gas",
 			}, nil
 		},
 	}
@@ -202,6 +203,7 @@ func TestExecuteQuery_WhenNotOkCodeShouldErr(t *testing.T) {
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "error running vm func")
+	assert.Contains(t, err.Error(), "add more gas")
 	assert.Nil(t, returnedData)
 }
 


### PR DESCRIPTION
Currently, the REST response produced by a call to the `SCQueryService` does not contain `vmOutput.ReturnMessage` in case of failure. This error message is very useful for developing apps that interface with a custom SC.

The PR adds `vmOutput.ReturnMessage` to the error produced by `SCQueryService.ExecuteQuery()`, in case the execution fails.