### PR TITLE
consensus: memory leak debug data

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -453,8 +453,8 @@
    Type = "json"
 
 [EpochStartConfig]
-    MinRoundsBetweenEpochs = 200
-    RoundsPerEpoch         = 200
+    MinRoundsBetweenEpochs = 14400 #revert after test
+    RoundsPerEpoch         = 14400 #revert after test
     # Min and Max ShuffledOutRestartThreshold represents the minimum and maximum duration of an epoch (in percentage) after a node which
     # has been shuffled out has to restart its process in order to start in a new shard
     MinShuffledOutRestartThreshold = 0.05

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -453,8 +453,8 @@
    Type = "json"
 
 [EpochStartConfig]
-    MinRoundsBetweenEpochs = 14400 #revert after test
-    RoundsPerEpoch         = 14400 #revert after test
+    MinRoundsBetweenEpochs = 200
+    RoundsPerEpoch         = 200
     # Min and Max ShuffledOutRestartThreshold represents the minimum and maximum duration of an epoch (in percentage) after a node which
     # has been shuffled out has to restart its process in order to start in a new shard
     MinShuffledOutRestartThreshold = 0.05

--- a/consensus/broadcast/delayedBroadcast.go
+++ b/consensus/broadcast/delayedBroadcast.go
@@ -163,6 +163,12 @@ func (dbb *delayedBlockBroadcaster) SetHeaderForValidator(vData *validatorHeader
 		return spos.ErrNilHeaderHash
 	}
 
+	log.Debug("memory leak debug data",
+		"nbDelayedBroadcastData", len(dbb.delayedBroadcastData),
+		"nbValBroadcastData", len(dbb.valBroadcastData),
+		"nbValHeaderBroadcastData", len(dbb.valHeaderBroadcastData),
+	)
+
 	// set alarm only for validators that are aware that the block was finalized
 	if len(vData.header.GetSignature()) != 0 {
 		_, alreadyReceived := dbb.cacheHeaders.Get(vData.headerHash)


### PR DESCRIPTION
memory leak is caused by accumulation of metablocks.
the references to metablocks are stored in an array in the delayed broadcast implementation, where they should get removed also when alarms  are canceled, not only when alarms expire. 
fix is to remove the reference as well on canceling the alarms.