### PR TITLE
Add receipts hash storer

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -65,6 +65,19 @@
         MaxBatchSize = 100
         MaxOpenFiles = 10
 
+[ReceiptsStorage]
+    [ReceiptsStorage.Cache]
+        Name = "ReceiptsStorage"
+        Capacity = 1000
+        Type = "SizeLRU"
+        SizeInBytes = 104857600 #100MB
+    [ReceiptsStorage.DB]
+        FilePath = "Receipts"
+        Type = "LvlDBSerial"
+        BatchDelaySeconds = 2
+        MaxBatchSize = 100
+        MaxOpenFiles = 10
+
 [PeerBlockBodyStorage]
     [PeerBlockBodyStorage.Cache]
         Name = "PeerBlockBodyStorage"

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -70,7 +70,7 @@
         Name = "ReceiptsStorage"
         Capacity = 1000
         Type = "SizeLRU"
-        SizeInBytes = 104857600 #100MB
+        SizeInBytes = 10485760 #10MB
     [ReceiptsStorage.DB]
         FilePath = "Receipts"
         Type = "LvlDBSerial"

--- a/config/config.go
+++ b/config/config.go
@@ -106,6 +106,7 @@ type Config struct {
 	ShardHdrNonceHashStorage   StorageConfig
 	MetaHdrNonceHashStorage    StorageConfig
 	StatusMetricsStorage       StorageConfig
+	ReceiptsStorage            StorageConfig
 
 	BootstrapStorage StorageConfig
 	MetaBlockStorage StorageConfig

--- a/config/tomlConfig_test.go
+++ b/config/tomlConfig_test.go
@@ -16,14 +16,19 @@ func TestTomlParser(t *testing.T) {
 	txBlockBodyStorageFile := "path1/file1"
 	txBlockBodyStorageTypeDB := "type2"
 
+	receiptsStorageSize := 171
+	receiptsStorageType := "type3"
+	receiptsStorageFile := "path1/file2"
+	receiptsStorageTypeDB := "type4"
+
 	logsPath := "pathLogger"
 	logsStackDepth := 1010
 
-	accountsStorageSize := 171
-	accountsStorageType := "type3"
-	accountsStorageFile := "path2/file2"
-	accountsStorageTypeDB := "type4"
-	accountsStorageBlomSize := 172
+	accountsStorageSize := 172
+	accountsStorageType := "type5"
+	accountsStorageFile := "path2/file3"
+	accountsStorageTypeDB := "type6"
+	accountsStorageBlomSize := 173
 	accountsStorageBlomHash1 := "hashFunc1"
 	accountsStorageBlomHash2 := "hashFunc2"
 	accountsStorageBlomHash3 := "hashFunc3"
@@ -45,6 +50,16 @@ func TestTomlParser(t *testing.T) {
 				Type:     txBlockBodyStorageTypeDB,
 			},
 		},
+		ReceiptsStorage: StorageConfig{
+			Cache: CacheConfig{
+				Capacity: uint32(receiptsStorageSize),
+				Type:     receiptsStorageType,
+			},
+			DB: DBConfig{
+				FilePath: receiptsStorageFile,
+				Type:     receiptsStorageTypeDB,
+			},
+		},
 		AccountsTrieStorage: StorageConfig{
 			Cache: CacheConfig{
 				Capacity: uint32(accountsStorageSize),
@@ -55,7 +70,7 @@ func TestTomlParser(t *testing.T) {
 				Type:     accountsStorageTypeDB,
 			},
 			Bloom: BloomFilterConfig{
-				Size:     172,
+				Size:     173,
 				HashFunc: []string{accountsStorageBlomHash1, accountsStorageBlomHash2, accountsStorageBlomHash3},
 			},
 		},
@@ -79,6 +94,14 @@ func TestTomlParser(t *testing.T) {
     [MiniBlocksStorage.DB]
         FilePath = "` + txBlockBodyStorageFile + `"
         Type = "` + txBlockBodyStorageTypeDB + `"
+
+[ReceiptsStorage]
+    [ReceiptsStorage.Cache]
+        Capacity = ` + strconv.Itoa(receiptsStorageSize) + `
+        Type = "` + receiptsStorageType + `"
+    [ReceiptsStorage.DB]
+        FilePath = "` + receiptsStorageFile + `"
+        Type = "` + receiptsStorageTypeDB + `"
 
 [Logger]
     Path = "` + logsPath + `"

--- a/dataRetriever/interface.go
+++ b/dataRetriever/interface.go
@@ -39,6 +39,8 @@ func (ut UnitType) String() string {
 		return "BootstrapUnit"
 	case StatusMetricsUnit:
 		return "StatusMetricsUnit"
+	case ReceiptsUnit:
+		return "ReceiptsUnit"
 	}
 
 	if ut < ShardHdrNonceHashDataUnit {
@@ -79,6 +81,8 @@ const (
 	EpochByHashUnit UnitType = 13
 	// MiniblocksHashByTxHashUnit is the miniblocks hash by tx hash storage unit identifier
 	MiniblockHashByTxHashUnit UnitType = 14
+	// ReceiptsUnit is the receipts storage unit identifier
+	ReceiptsUnit UnitType = 15
 
 	// ShardHdrNonceHashDataUnit is the header nonce-hash pair data unit identifier
 	//TODO: Add only unit types lower than 100

--- a/integrationTests/consensus/testInitializer.go
+++ b/integrationTests/consensus/testInitializer.go
@@ -154,6 +154,7 @@ func createTestStore() dataRetriever.StorageService {
 	store.AddStorer(dataRetriever.PeerChangesUnit, createMemUnit())
 	store.AddStorer(dataRetriever.BlockHeaderUnit, createMemUnit())
 	store.AddStorer(dataRetriever.BootstrapUnit, createMemUnit())
+	store.AddStorer(dataRetriever.ReceiptsUnit, createMemUnit())
 	return store
 }
 

--- a/integrationTests/mock/transactionCoordinatorMock.go
+++ b/integrationTests/mock/transactionCoordinatorMock.go
@@ -29,6 +29,7 @@ type TransactionCoordinatorMock struct {
 	GetAllCurrentUsedTxsCalled                  func(blockType block.Type) map[string]data.TransactionHandler
 	VerifyCreatedBlockTransactionsCalled        func(hdr data.HeaderHandler, body *block.Body) error
 	CreatePostProcessMiniBlocksCalled           func() block.MiniBlockSlice
+	CreateMarshalizedReceiptsCalled             func() ([]byte, []byte, error)
 }
 
 // CreatePostProcessMiniBlocks -
@@ -173,6 +174,15 @@ func (tcm *TransactionCoordinatorMock) VerifyCreatedBlockTransactions(hdr data.H
 	}
 
 	return tcm.VerifyCreatedBlockTransactionsCalled(hdr, body)
+}
+
+// CreateMarshalizedReceipts -
+func (tcm *TransactionCoordinatorMock) CreateMarshalizedReceipts() ([]byte, []byte, error) {
+	if tcm.CreateMarshalizedReceiptsCalled == nil {
+		return nil, nil, nil
+	}
+
+	return tcm.CreateMarshalizedReceiptsCalled()
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/integrationTests/mock/transactionCoordinatorMock.go
+++ b/integrationTests/mock/transactionCoordinatorMock.go
@@ -29,7 +29,7 @@ type TransactionCoordinatorMock struct {
 	GetAllCurrentUsedTxsCalled                  func(blockType block.Type) map[string]data.TransactionHandler
 	VerifyCreatedBlockTransactionsCalled        func(hdr data.HeaderHandler, body *block.Body) error
 	CreatePostProcessMiniBlocksCalled           func() block.MiniBlockSlice
-	CreateMarshalizedReceiptsCalled             func() ([]byte, []byte, error)
+	CreateMarshalizedReceiptsCalled             func() ([]byte, error)
 }
 
 // CreatePostProcessMiniBlocks -
@@ -177,9 +177,9 @@ func (tcm *TransactionCoordinatorMock) VerifyCreatedBlockTransactions(hdr data.H
 }
 
 // CreateMarshalizedReceipts -
-func (tcm *TransactionCoordinatorMock) CreateMarshalizedReceipts() ([]byte, []byte, error) {
+func (tcm *TransactionCoordinatorMock) CreateMarshalizedReceipts() ([]byte, error) {
 	if tcm.CreateMarshalizedReceiptsCalled == nil {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	return tcm.CreateMarshalizedReceiptsCalled()

--- a/integrationTests/multiShard/endOfEpoch/startInEpoch/startInEpoch_test.go
+++ b/integrationTests/multiShard/endOfEpoch/startInEpoch/startInEpoch_test.go
@@ -297,6 +297,7 @@ func getGeneralConfig() config.Config {
 	generalConfig.MetaHdrNonceHashStorage.DB.Type = string(storageUnit.LvlDBSerial)
 	generalConfig.BlockHeaderStorage.DB.Type = string(storageUnit.LvlDBSerial)
 	generalConfig.BootstrapStorage.DB.Type = string(storageUnit.LvlDBSerial)
+	generalConfig.ReceiptsStorage.DB.Type = string(storageUnit.LvlDBSerial)
 
 	return generalConfig
 }

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -339,6 +339,7 @@ func CreateStore(numOfShards uint32) dataRetriever.StorageService {
 	store.AddStorer(dataRetriever.BootstrapUnit, CreateMemUnit())
 	store.AddStorer(dataRetriever.StatusMetricsUnit, CreateMemUnit())
 	store.AddStorer(dataRetriever.MetaHdrNonceHashDataUnit, CreateMemUnit())
+	store.AddStorer(dataRetriever.ReceiptsUnit, CreateMemUnit())
 
 	for i := uint32(0); i < numOfShards; i++ {
 		hdrNonceHashDataUnit := dataRetriever.ShardHdrNonceHashDataUnit + dataRetriever.UnitType(i)

--- a/node/nodeMemoryConfig_test.go
+++ b/node/nodeMemoryConfig_test.go
@@ -34,6 +34,7 @@ func TestMemoryConfig(t *testing.T) {
 	plannedMemory += nodeConfig.MetaHdrNonceHashStorage.Cache.SizeInBytes
 	plannedMemory += nodeConfig.AccountsTrieStorage.Cache.SizeInBytes
 	plannedMemory += nodeConfig.PeerAccountsTrieStorage.Cache.SizeInBytes
+	plannedMemory += nodeConfig.ReceiptsStorage.Cache.SizeInBytes
 	plannedMemory += nodeConfig.BadBlocksCache.SizeInBytes
 	plannedMemory += nodeConfig.PeerBlockBodyDataPool.SizeInBytes
 	plannedMemory += nodeConfig.TxDataPool.SizeInBytes

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -988,14 +988,16 @@ func (bp *baseProcessor) saveBody(body *block.Body, header data.HeaderHandler) {
 		log.Trace("saveBody.Put -> MiniBlockUnit", "time", time.Since(startTime))
 	}
 
-	marshalizedReceiptsHashes, errNotCritical := bp.txCoordinator.CreateMarshalizedReceipts()
-	if errNotCritical != nil {
-		log.Warn("saveBody.CreateMarshalizedReceipts", "error", errNotCritical.Error())
-	}
-
-	errNotCritical = bp.store.Put(dataRetriever.ReceiptsUnit, header.GetReceiptsHash(), marshalizedReceiptsHashes)
-	if errNotCritical != nil {
-		log.Warn("saveBody.Put -> ReceiptsUnit", "error", errNotCritical.Error())
+	if len(header.GetReceiptsHash()) > 0 {
+		marshalizedReceiptsHashes, errNotCritical := bp.txCoordinator.CreateMarshalizedReceipts()
+		if errNotCritical != nil {
+			log.Warn("saveBody.CreateMarshalizedReceipts", "error", errNotCritical.Error())
+		} else {
+			errNotCritical = bp.store.Put(dataRetriever.ReceiptsUnit, header.GetReceiptsHash(), marshalizedReceiptsHashes)
+			if errNotCritical != nil {
+				log.Warn("saveBody.Put -> ReceiptsUnit", "error", errNotCritical.Error())
+			}
+		}
 	}
 
 	elapsedTime := time.Since(startTime)

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -988,6 +988,16 @@ func (bp *baseProcessor) saveBody(body *block.Body) {
 		log.Trace("saveBody.Put -> MiniBlockUnit", "time", time.Since(startTime))
 	}
 
+	finalReceiptHash, marshalizedReceiptsHashes, errNotCritical := bp.txCoordinator.CreateMarshalizedReceipts()
+	if errNotCritical != nil {
+		log.Warn("saveBody.CreateMarshalizedReceipts", "error", errNotCritical.Error())
+	}
+
+	errNotCritical = bp.store.Put(dataRetriever.ReceiptsUnit, finalReceiptHash, marshalizedReceiptsHashes)
+	if errNotCritical != nil {
+		log.Warn("saveBody.Put -> ReceiptsUnit", "error", errNotCritical.Error())
+	}
+
 	elapsedTime := time.Since(startTime)
 	if elapsedTime >= core.PutInStorerMaxTime {
 		log.Warn("saveBody", "elapsed time", elapsedTime)

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -963,7 +963,7 @@ func (bp *baseProcessor) DecodeBlockHeader(dta []byte) data.HeaderHandler {
 	return header
 }
 
-func (bp *baseProcessor) saveBody(body *block.Body) {
+func (bp *baseProcessor) saveBody(body *block.Body, header data.HeaderHandler) {
 	startTime := time.Now()
 
 	errNotCritical := bp.txCoordinator.SaveBlockDataToStorage(body)
@@ -988,12 +988,12 @@ func (bp *baseProcessor) saveBody(body *block.Body) {
 		log.Trace("saveBody.Put -> MiniBlockUnit", "time", time.Since(startTime))
 	}
 
-	finalReceiptHash, marshalizedReceiptsHashes, errNotCritical := bp.txCoordinator.CreateMarshalizedReceipts()
+	marshalizedReceiptsHashes, errNotCritical := bp.txCoordinator.CreateMarshalizedReceipts()
 	if errNotCritical != nil {
 		log.Warn("saveBody.CreateMarshalizedReceipts", "error", errNotCritical.Error())
 	}
 
-	errNotCritical = bp.store.Put(dataRetriever.ReceiptsUnit, finalReceiptHash, marshalizedReceiptsHashes)
+	errNotCritical = bp.store.Put(dataRetriever.ReceiptsUnit, header.GetReceiptsHash(), marshalizedReceiptsHashes)
 	if errNotCritical != nil {
 		log.Warn("saveBody.Put -> ReceiptsUnit", "error", errNotCritical.Error())
 	}

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -201,6 +201,7 @@ func initStore() *dataRetriever.ChainStorer {
 	store.AddStorer(dataRetriever.BlockHeaderUnit, generateTestUnit())
 	store.AddStorer(dataRetriever.ShardHdrNonceHashDataUnit, generateTestUnit())
 	store.AddStorer(dataRetriever.MetaHdrNonceHashDataUnit, generateTestUnit())
+	store.AddStorer(dataRetriever.ReceiptsUnit, generateTestUnit())
 	return store
 }
 

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -1037,7 +1037,7 @@ func (mp *metaProcessor) CommitBlock(
 	mp.commitEpochStart(header, body)
 	headerHash := mp.hasher.Compute(string(marshalizedHeader))
 	mp.saveMetaHeader(header, headerHash, marshalizedHeader)
-	mp.saveBody(body)
+	mp.saveBody(body, header)
 
 	err = mp.commitAll()
 	if err != nil {

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -788,7 +788,7 @@ func (sp *shardProcessor) CommitBlock(
 		return err
 	}
 
-	sp.saveBody(body)
+	sp.saveBody(body, header)
 
 	processedMetaHdrs, err := sp.getOrderedProcessedMetaBlocksFromHeader(header)
 	if err != nil {

--- a/process/coordinator/process.go
+++ b/process/coordinator/process.go
@@ -952,8 +952,8 @@ func (tc *transactionCoordinator) CreateReceiptsHash() ([]byte, error) {
 	return finalReceiptHash, err
 }
 
-// CreateMarshalizedReceipts will return the final receipt hash and all the receipts hashes list in one marshalized object
-func (tc *transactionCoordinator) CreateMarshalizedReceipts() ([]byte, []byte, error) {
+// CreateMarshalizedReceipts will return all the receipts hashes list in one marshalized object
+func (tc *transactionCoordinator) CreateMarshalizedReceipts() ([]byte, error) {
 	receiptsHashes := make([][]byte, 0)
 	for _, blockType := range tc.keysInterimProcs {
 		interProc, ok := tc.interimProcessors[blockType]
@@ -968,24 +968,19 @@ func (tc *transactionCoordinator) CreateMarshalizedReceipts() ([]byte, []byte, e
 
 		mbHash, err := core.CalculateHash(tc.marshalizer, tc.hasher, mb)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
 		receiptsHashes = append(receiptsHashes, mbHash)
 	}
 
 	receiptsBatch := &batch.Batch{Data: receiptsHashes}
-	finalReceiptHash, err := core.CalculateHash(tc.marshalizer, tc.hasher, receiptsBatch)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	marshalizedReceiptsHashes, err := tc.marshalizer.Marshal(receiptsBatch)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return finalReceiptHash, marshalizedReceiptsHashes, nil
+	return marshalizedReceiptsHashes, nil
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/process/coordinator/process_test.go
+++ b/process/coordinator/process_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data"
+	"github.com/ElrondNetwork/elrond-go/data/batch"
 	"github.com/ElrondNetwork/elrond-go/data/block"
 	"github.com/ElrondNetwork/elrond-go/data/rewardTx"
 	"github.com/ElrondNetwork/elrond-go/data/smartContractResult"
@@ -166,6 +167,7 @@ func initStore() *dataRetriever.ChainStorer {
 	store.AddStorer(dataRetriever.BlockHeaderUnit, generateTestUnit())
 	store.AddStorer(dataRetriever.ShardHdrNonceHashDataUnit, generateTestUnit())
 	store.AddStorer(dataRetriever.MetaHdrNonceHashDataUnit, generateTestUnit())
+	store.AddStorer(dataRetriever.ReceiptsUnit, generateTestUnit())
 	return store
 }
 
@@ -2536,4 +2538,56 @@ func TestTransactionCoordinator_PreprocessorsHasToBeOrderedRewardsAreLast(t *tes
 	lastKey := tc.keysTxPreProcs[preProcLen-1]
 
 	assert.Equal(t, block.RewardsBlock, lastKey)
+}
+
+func TestTransactionCoordinator_CreateMarshalizedReceiptsShouldWork(t *testing.T) {
+	t.Parallel()
+
+	tc, _ := NewTransactionCoordinator(
+		&mock.HasherMock{},
+		&mock.MarshalizerMock{},
+		mock.NewMultiShardsCoordinatorMock(5),
+		&mock.AccountsStub{},
+		testscommon.NewPoolsHolderMock().MiniBlocks(),
+		&mock.RequestHandlerStub{},
+		&mock.PreProcessorContainerMock{},
+		&mock.InterimProcessorContainerMock{},
+		&mock.GasHandlerMock{},
+		&mock.FeeAccumulatorStub{},
+		&mock.BlockSizeComputationStub{},
+		&mock.BalanceComputationStub{},
+	)
+
+	mb1 := &block.MiniBlock{
+		Type: block.SmartContractResultBlock,
+	}
+	mb2 := &block.MiniBlock{
+		Type: block.ReceiptBlock,
+	}
+	mbHash1, _ := core.CalculateHash(tc.marshalizer, tc.hasher, mb1)
+	mbHash2, _ := core.CalculateHash(tc.marshalizer, tc.hasher, mb2)
+	mbHashes := [][]byte{mbHash1, mbHash2}
+	mbsBatch := &batch.Batch{Data: mbHashes}
+	expextedFinalReceiptHash, _ := core.CalculateHash(tc.marshalizer, tc.hasher, mbsBatch)
+	expectedMarshalizedReceiptsHashes, _ := tc.marshalizer.Marshal(mbsBatch)
+
+	tc.keysInterimProcs = append(tc.keysInterimProcs, block.SmartContractResultBlock)
+	tc.keysInterimProcs = append(tc.keysInterimProcs, block.ReceiptBlock)
+
+	tc.interimProcessors[block.SmartContractResultBlock] = &mock.IntermediateTransactionHandlerMock{
+		GetCreatedInShardMiniBlockCalled: func() *block.MiniBlock {
+			return mb1
+		},
+	}
+	tc.interimProcessors[block.ReceiptBlock] = &mock.IntermediateTransactionHandlerMock{
+		GetCreatedInShardMiniBlockCalled: func() *block.MiniBlock {
+			return mb2
+		},
+	}
+
+	finalReceiptHash, marshalizedReceiptsHashes, err := tc.CreateMarshalizedReceipts()
+
+	assert.Nil(t, err)
+	assert.Equal(t, expextedFinalReceiptHash, finalReceiptHash)
+	assert.Equal(t, expectedMarshalizedReceiptsHashes, marshalizedReceiptsHashes)
 }

--- a/process/coordinator/process_test.go
+++ b/process/coordinator/process_test.go
@@ -2568,7 +2568,6 @@ func TestTransactionCoordinator_CreateMarshalizedReceiptsShouldWork(t *testing.T
 	mbHash2, _ := core.CalculateHash(tc.marshalizer, tc.hasher, mb2)
 	mbHashes := [][]byte{mbHash1, mbHash2}
 	mbsBatch := &batch.Batch{Data: mbHashes}
-	expextedFinalReceiptHash, _ := core.CalculateHash(tc.marshalizer, tc.hasher, mbsBatch)
 	expectedMarshalizedReceiptsHashes, _ := tc.marshalizer.Marshal(mbsBatch)
 
 	tc.keysInterimProcs = append(tc.keysInterimProcs, block.SmartContractResultBlock)
@@ -2585,9 +2584,8 @@ func TestTransactionCoordinator_CreateMarshalizedReceiptsShouldWork(t *testing.T
 		},
 	}
 
-	finalReceiptHash, marshalizedReceiptsHashes, err := tc.CreateMarshalizedReceipts()
+	marshalizedReceiptsHashes, err := tc.CreateMarshalizedReceipts()
 
 	assert.Nil(t, err)
-	assert.Equal(t, expextedFinalReceiptHash, finalReceiptHash)
 	assert.Equal(t, expectedMarshalizedReceiptsHashes, marshalizedReceiptsHashes)
 }

--- a/process/interface.go
+++ b/process/interface.go
@@ -138,6 +138,7 @@ type TransactionCoordinator interface {
 
 	CreateReceiptsHash() ([]byte, error)
 	VerifyCreatedBlockTransactions(hdr data.HeaderHandler, body *block.Body) error
+	CreateMarshalizedReceipts() ([]byte, []byte, error)
 	IsInterfaceNil() bool
 }
 

--- a/process/interface.go
+++ b/process/interface.go
@@ -138,7 +138,7 @@ type TransactionCoordinator interface {
 
 	CreateReceiptsHash() ([]byte, error)
 	VerifyCreatedBlockTransactions(hdr data.HeaderHandler, body *block.Body) error
-	CreateMarshalizedReceipts() ([]byte, []byte, error)
+	CreateMarshalizedReceipts() ([]byte, error)
 	IsInterfaceNil() bool
 }
 

--- a/process/mock/intermediateTransactionHandlerMock.go
+++ b/process/mock/intermediateTransactionHandlerMock.go
@@ -15,6 +15,7 @@ type IntermediateTransactionHandlerMock struct {
 	CreateMarshalizedDataCalled              func(txHashes [][]byte) ([][]byte, error)
 	GetAllCurrentFinishedTxsCalled           func() map[string]data.TransactionHandler
 	RemoveProcessedResultsForCalled          func(txHashes [][]byte)
+	GetCreatedInShardMiniBlockCalled         func() *block.MiniBlock
 	intermediateTransactions                 []data.TransactionHandler
 }
 
@@ -88,6 +89,9 @@ func (ith *IntermediateTransactionHandlerMock) GetAllCurrentFinishedTxs() map[st
 
 // GetCreatedInShardMiniBlock -
 func (ith *IntermediateTransactionHandlerMock) GetCreatedInShardMiniBlock() *block.MiniBlock {
+	if ith.GetCreatedInShardMiniBlockCalled != nil {
+		return ith.GetCreatedInShardMiniBlockCalled()
+	}
 	return &block.MiniBlock{}
 }
 

--- a/process/mock/transactionCoordinatorMock.go
+++ b/process/mock/transactionCoordinatorMock.go
@@ -29,6 +29,7 @@ type TransactionCoordinatorMock struct {
 	GetAllCurrentUsedTxsCalled                  func(blockType block.Type) map[string]data.TransactionHandler
 	VerifyCreatedBlockTransactionsCalled        func(hdr data.HeaderHandler, body *block.Body) error
 	CreatePostProcessMiniBlocksCalled           func() block.MiniBlockSlice
+	CreateMarshalizedReceiptsCalled             func() ([]byte, []byte, error)
 }
 
 // CreatePostProcessMiniBlocks -
@@ -173,6 +174,15 @@ func (tcm *TransactionCoordinatorMock) VerifyCreatedBlockTransactions(hdr data.H
 	}
 
 	return tcm.VerifyCreatedBlockTransactionsCalled(hdr, body)
+}
+
+// CreateMarshalizedReceipts -
+func (tcm *TransactionCoordinatorMock) CreateMarshalizedReceipts() ([]byte, []byte, error) {
+	if tcm.CreateMarshalizedReceiptsCalled == nil {
+		return nil, nil, nil
+	}
+
+	return tcm.CreateMarshalizedReceiptsCalled()
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/process/mock/transactionCoordinatorMock.go
+++ b/process/mock/transactionCoordinatorMock.go
@@ -29,7 +29,7 @@ type TransactionCoordinatorMock struct {
 	GetAllCurrentUsedTxsCalled                  func(blockType block.Type) map[string]data.TransactionHandler
 	VerifyCreatedBlockTransactionsCalled        func(hdr data.HeaderHandler, body *block.Body) error
 	CreatePostProcessMiniBlocksCalled           func() block.MiniBlockSlice
-	CreateMarshalizedReceiptsCalled             func() ([]byte, []byte, error)
+	CreateMarshalizedReceiptsCalled             func() ([]byte, error)
 }
 
 // CreatePostProcessMiniBlocks -
@@ -177,9 +177,9 @@ func (tcm *TransactionCoordinatorMock) VerifyCreatedBlockTransactions(hdr data.H
 }
 
 // CreateMarshalizedReceipts -
-func (tcm *TransactionCoordinatorMock) CreateMarshalizedReceipts() ([]byte, []byte, error) {
+func (tcm *TransactionCoordinatorMock) CreateMarshalizedReceipts() ([]byte, error) {
 	if tcm.CreateMarshalizedReceiptsCalled == nil {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	return tcm.CreateMarshalizedReceiptsCalled()

--- a/process/sync/shardblock_test.go
+++ b/process/sync/shardblock_test.go
@@ -91,6 +91,7 @@ func createFullStore() dataRetriever.StorageService {
 	store.AddStorer(dataRetriever.PeerChangesUnit, generateTestUnit())
 	store.AddStorer(dataRetriever.BlockHeaderUnit, generateTestUnit())
 	store.AddStorer(dataRetriever.ShardHdrNonceHashDataUnit, generateTestUnit())
+	store.AddStorer(dataRetriever.ReceiptsUnit, generateTestUnit())
 	return store
 }
 

--- a/process/track/baseBlockTrack_test.go
+++ b/process/track/baseBlockTrack_test.go
@@ -74,6 +74,7 @@ func initStore() *dataRetriever.ChainStorer {
 	store.AddStorer(dataRetriever.BlockHeaderUnit, generateStorageUnit())
 	store.AddStorer(dataRetriever.ShardHdrNonceHashDataUnit, generateStorageUnit())
 	store.AddStorer(dataRetriever.MetaHdrNonceHashDataUnit, generateStorageUnit())
+	store.AddStorer(dataRetriever.ReceiptsUnit, generateStorageUnit())
 	return store
 }
 

--- a/storage/factory/pruningStorerFactory.go
+++ b/storage/factory/pruningStorerFactory.go
@@ -77,6 +77,7 @@ func (psf *StorageServiceFactory) CreateForShard() (dataRetriever.StorageService
 	var rewardTxUnit *pruning.PruningStorer
 	var bootstrapUnit *pruning.PruningStorer
 	var txLogsUnit *pruning.PruningStorer
+	var receiptsUnit *pruning.PruningStorer
 	var err error
 
 	successfullyCreatedStorers := make([]storage.Storer, 0)
@@ -206,6 +207,13 @@ func (psf *StorageServiceFactory) CreateForShard() (dataRetriever.StorageService
 	}
 	successfullyCreatedStorers = append(successfullyCreatedStorers, txLogsUnit)
 
+	receiptsUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.ReceiptsStorage)
+	receiptsUnit, err = pruning.NewPruningStorer(receiptsUnitArgs)
+	if err != nil {
+		return nil, err
+	}
+	successfullyCreatedStorers = append(successfullyCreatedStorers, receiptsUnit)
+
 	store := dataRetriever.NewChainStorer()
 	store.AddStorer(dataRetriever.TransactionUnit, txUnit)
 	store.AddStorer(dataRetriever.MiniBlockUnit, miniBlockUnit)
@@ -221,6 +229,7 @@ func (psf *StorageServiceFactory) CreateForShard() (dataRetriever.StorageService
 	store.AddStorer(dataRetriever.BootstrapUnit, bootstrapUnit)
 	store.AddStorer(dataRetriever.StatusMetricsUnit, statusMetricsStorageUnit)
 	store.AddStorer(dataRetriever.TxLogsUnit, txLogsUnit)
+	store.AddStorer(dataRetriever.ReceiptsUnit, receiptsUnit)
 
 	err = psf.setupFullHistory(store, &successfullyCreatedStorers)
 	if err != nil {
@@ -240,6 +249,7 @@ func (psf *StorageServiceFactory) CreateForMeta() (dataRetriever.StorageService,
 	var rewardTxUnit *pruning.PruningStorer
 	var bootstrapUnit *pruning.PruningStorer
 	var txLogsUnit *pruning.PruningStorer
+	var receiptsUnit *pruning.PruningStorer
 	var err error
 
 	successfullyCreatedStorers := make([]storage.Storer, 0)
@@ -367,6 +377,13 @@ func (psf *StorageServiceFactory) CreateForMeta() (dataRetriever.StorageService,
 	}
 	successfullyCreatedStorers = append(successfullyCreatedStorers, txLogsUnit)
 
+	receiptsUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.ReceiptsStorage)
+	receiptsUnit, err = pruning.NewPruningStorer(receiptsUnitArgs)
+	if err != nil {
+		return nil, err
+	}
+	successfullyCreatedStorers = append(successfullyCreatedStorers, receiptsUnit)
+
 	store := dataRetriever.NewChainStorer()
 	store.AddStorer(dataRetriever.MetaBlockUnit, metaBlockUnit)
 	store.AddStorer(dataRetriever.BlockHeaderUnit, headerUnit)
@@ -383,6 +400,7 @@ func (psf *StorageServiceFactory) CreateForMeta() (dataRetriever.StorageService,
 	store.AddStorer(dataRetriever.BootstrapUnit, bootstrapUnit)
 	store.AddStorer(dataRetriever.StatusMetricsUnit, statusMetricsStorageUnit)
 	store.AddStorer(dataRetriever.TxLogsUnit, txLogsUnit)
+	store.AddStorer(dataRetriever.ReceiptsUnit, receiptsUnit)
 
 	err = psf.setupFullHistory(store, &successfullyCreatedStorers)
 	if err != nil {

--- a/testscommon/generalConfig.go
+++ b/testscommon/generalConfig.go
@@ -229,6 +229,16 @@ func GetGeneralConfig() config.Config {
 				MaxOpenFiles:      10,
 			},
 		},
+		ReceiptsStorage: config.StorageConfig{
+			Cache: getLRUCacheConfig(),
+			DB: config.DBConfig{
+				FilePath:          AddTimestampSuffix("Receipts"),
+				Type:              string(storageUnit.MemoryDB),
+				BatchDelaySeconds: 30,
+				MaxBatchSize:      6,
+				MaxOpenFiles:      10,
+			},
+		},
 		Versions: config.VersionsConfig{
 			DefaultVersion: "default",
 			VersionsByEpochs: []config.VersionByEpochs{

--- a/update/mock/transactionCoordinatorMock.go
+++ b/update/mock/transactionCoordinatorMock.go
@@ -28,6 +28,7 @@ type TransactionCoordinatorMock struct {
 	GetAllCurrentUsedTxsCalled                  func(blockType block.Type) map[string]data.TransactionHandler
 	VerifyCreatedBlockTransactionsCalled        func(hdr data.HeaderHandler, body *block.Body) error
 	CreatePostProcessMiniBlocksCalled           func() block.MiniBlockSlice
+	CreateMarshalizedReceiptsCalled             func() ([]byte, []byte, error)
 }
 
 // CreatePostProcessMiniBlocks -
@@ -172,6 +173,15 @@ func (tcm *TransactionCoordinatorMock) VerifyCreatedBlockTransactions(hdr data.H
 	}
 
 	return tcm.VerifyCreatedBlockTransactionsCalled(hdr, body)
+}
+
+// CreateMarshalizedReceipts -
+func (tcm *TransactionCoordinatorMock) CreateMarshalizedReceipts() ([]byte, []byte, error) {
+	if tcm.CreateMarshalizedReceiptsCalled == nil {
+		return nil, nil, nil
+	}
+
+	return tcm.CreateMarshalizedReceiptsCalled()
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/update/mock/transactionCoordinatorMock.go
+++ b/update/mock/transactionCoordinatorMock.go
@@ -28,7 +28,7 @@ type TransactionCoordinatorMock struct {
 	GetAllCurrentUsedTxsCalled                  func(blockType block.Type) map[string]data.TransactionHandler
 	VerifyCreatedBlockTransactionsCalled        func(hdr data.HeaderHandler, body *block.Body) error
 	CreatePostProcessMiniBlocksCalled           func() block.MiniBlockSlice
-	CreateMarshalizedReceiptsCalled             func() ([]byte, []byte, error)
+	CreateMarshalizedReceiptsCalled             func() ([]byte, error)
 }
 
 // CreatePostProcessMiniBlocks -
@@ -176,9 +176,9 @@ func (tcm *TransactionCoordinatorMock) VerifyCreatedBlockTransactions(hdr data.H
 }
 
 // CreateMarshalizedReceipts -
-func (tcm *TransactionCoordinatorMock) CreateMarshalizedReceipts() ([]byte, []byte, error) {
+func (tcm *TransactionCoordinatorMock) CreateMarshalizedReceipts() ([]byte, error) {
 	if tcm.CreateMarshalizedReceiptsCalled == nil {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	return tcm.CreateMarshalizedReceiptsCalled()

--- a/update/process/shardBlock.go
+++ b/update/process/shardBlock.go
@@ -217,14 +217,16 @@ func (s *shardBlockCreator) saveAllTransactionsToStorageIfSelfShard(
 		}
 	}
 
-	marshalizedReceiptsHashes, errNotCritical := s.txCoordinator.CreateMarshalizedReceipts()
-	if errNotCritical != nil {
-		log.Warn("saveAllTransactionsToStorageIfSelfShard.CreateMarshalizedReceipts", "error", errNotCritical.Error())
-	}
-
-	errNotCritical = s.storage.Put(dataRetriever.ReceiptsUnit, shardHdr.GetReceiptsHash(), marshalizedReceiptsHashes)
-	if errNotCritical != nil {
-		log.Warn("saveAllTransactionsToStorageIfSelfShard.Put -> ReceiptsUnit", "error", errNotCritical.Error())
+	if len(shardHdr.GetReceiptsHash()) > 0 {
+		marshalizedReceiptsHashes, errNotCritical := s.txCoordinator.CreateMarshalizedReceipts()
+		if errNotCritical != nil {
+			log.Warn("saveAllTransactionsToStorageIfSelfShard.CreateMarshalizedReceipts", "error", errNotCritical.Error())
+		} else {
+			errNotCritical = s.storage.Put(dataRetriever.ReceiptsUnit, shardHdr.GetReceiptsHash(), marshalizedReceiptsHashes)
+			if errNotCritical != nil {
+				log.Warn("saveAllTransactionsToStorageIfSelfShard.Put -> ReceiptsUnit", "error", errNotCritical.Error())
+			}
+		}
 	}
 
 	mapTxs := s.importHandler.GetTransactions()

--- a/update/process/shardBlock.go
+++ b/update/process/shardBlock.go
@@ -217,6 +217,16 @@ func (s *shardBlockCreator) saveAllTransactionsToStorageIfSelfShard(
 		}
 	}
 
+	finalReceiptHash, marshalizedReceiptsHashes, errNotCritical := s.txCoordinator.CreateMarshalizedReceipts()
+	if errNotCritical != nil {
+		log.Warn("saveAllTransactionsToStorageIfSelfShard.CreateMarshalizedReceipts", "error", errNotCritical.Error())
+	}
+
+	errNotCritical = s.storage.Put(dataRetriever.ReceiptsUnit, finalReceiptHash, marshalizedReceiptsHashes)
+	if errNotCritical != nil {
+		log.Warn("saveAllTransactionsToStorageIfSelfShard.Put -> ReceiptsUnit", "error", errNotCritical.Error())
+	}
+
 	mapTxs := s.importHandler.GetTransactions()
 	// save transactions from imported map
 	for _, miniBlock := range body.MiniBlocks {

--- a/update/process/shardBlock.go
+++ b/update/process/shardBlock.go
@@ -217,12 +217,12 @@ func (s *shardBlockCreator) saveAllTransactionsToStorageIfSelfShard(
 		}
 	}
 
-	finalReceiptHash, marshalizedReceiptsHashes, errNotCritical := s.txCoordinator.CreateMarshalizedReceipts()
+	marshalizedReceiptsHashes, errNotCritical := s.txCoordinator.CreateMarshalizedReceipts()
 	if errNotCritical != nil {
 		log.Warn("saveAllTransactionsToStorageIfSelfShard.CreateMarshalizedReceipts", "error", errNotCritical.Error())
 	}
 
-	errNotCritical = s.storage.Put(dataRetriever.ReceiptsUnit, finalReceiptHash, marshalizedReceiptsHashes)
+	errNotCritical = s.storage.Put(dataRetriever.ReceiptsUnit, shardHdr.GetReceiptsHash(), marshalizedReceiptsHashes)
 	if errNotCritical != nil {
 		log.Warn("saveAllTransactionsToStorageIfSelfShard.Put -> ReceiptsUnit", "error", errNotCritical.Error())
 	}

--- a/update/process/shardBlock_test.go
+++ b/update/process/shardBlock_test.go
@@ -41,6 +41,7 @@ func initStore() dataRetriever.StorageService {
 	store.AddStorer(dataRetriever.BlockHeaderUnit, generateTestUnit())
 	store.AddStorer(dataRetriever.ShardHdrNonceHashDataUnit, generateTestUnit())
 	store.AddStorer(dataRetriever.MetaHdrNonceHashDataUnit, generateTestUnit())
+	store.AddStorer(dataRetriever.ReceiptsUnit, generateTestUnit())
 	return store
 }
 

--- a/update/sync/syncHeaders_test.go
+++ b/update/sync/syncHeaders_test.go
@@ -55,6 +55,7 @@ func initStore() *dataRetriever.ChainStorer {
 	store.AddStorer(dataRetriever.BlockHeaderUnit, generateTestUnit())
 	store.AddStorer(dataRetriever.ShardHdrNonceHashDataUnit, generateTestUnit())
 	store.AddStorer(dataRetriever.MetaHdrNonceHashDataUnit, generateTestUnit())
+	store.AddStorer(dataRetriever.ReceiptsUnit, generateTestUnit())
 	return store
 }
 


### PR DESCRIPTION
* Added receipts hash storer which holds cumulative receipt hash as a key and all the receipts hashes list marshalized as a value, for each committed block

Testing steps:

a) Prerequisites

b) Test steps

Start a normal testnet

c) Expected results

We should have another storage/folder/db created in: .../Epoch_X/Shard_Y/**Receipts** which holds cumulative receipt hash as a key and all the receipts hashes list marshalized as a value, for each committed block

d) Actual results

Test process is in pending