### PR TITLE
fixed the situation when empty receipts would have been saved

### DIFF
--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -988,11 +988,11 @@ func (bp *baseProcessor) saveBody(body *block.Body, header data.HeaderHandler) {
 		log.Trace("saveBody.Put -> MiniBlockUnit", "time", time.Since(startTime))
 	}
 
-	if len(header.GetReceiptsHash()) > 0 {
-		marshalizedReceiptsHashes, errNotCritical := bp.txCoordinator.CreateMarshalizedReceipts()
-		if errNotCritical != nil {
-			log.Warn("saveBody.CreateMarshalizedReceipts", "error", errNotCritical.Error())
-		} else {
+	marshalizedReceiptsHashes, errNotCritical := bp.txCoordinator.CreateMarshalizedReceipts()
+	if errNotCritical != nil {
+		log.Warn("saveBody.CreateMarshalizedReceipts", "error", errNotCritical.Error())
+	} else {
+		if len(marshalizedReceiptsHashes) > 0 {
 			errNotCritical = bp.store.Put(dataRetriever.ReceiptsUnit, header.GetReceiptsHash(), marshalizedReceiptsHashes)
 			if errNotCritical != nil {
 				log.Warn("saveBody.Put -> ReceiptsUnit", "error", errNotCritical.Error())

--- a/process/coordinator/process.go
+++ b/process/coordinator/process.go
@@ -974,6 +974,10 @@ func (tc *transactionCoordinator) CreateMarshalizedReceipts() ([]byte, error) {
 		receiptsHashes = append(receiptsHashes, mbHash)
 	}
 
+	if len(receiptsHashes) == 0 {
+		return nil, nil
+	}
+
 	receiptsBatch := &batch.Batch{Data: receiptsHashes}
 	marshalizedReceiptsHashes, err := tc.marshalizer.Marshal(receiptsBatch)
 	if err != nil {

--- a/update/process/shardBlock.go
+++ b/update/process/shardBlock.go
@@ -217,11 +217,11 @@ func (s *shardBlockCreator) saveAllTransactionsToStorageIfSelfShard(
 		}
 	}
 
-	if len(shardHdr.GetReceiptsHash()) > 0 {
-		marshalizedReceiptsHashes, errNotCritical := s.txCoordinator.CreateMarshalizedReceipts()
-		if errNotCritical != nil {
-			log.Warn("saveAllTransactionsToStorageIfSelfShard.CreateMarshalizedReceipts", "error", errNotCritical.Error())
-		} else {
+	marshalizedReceiptsHashes, errNotCritical := s.txCoordinator.CreateMarshalizedReceipts()
+	if errNotCritical != nil {
+		log.Warn("saveAllTransactionsToStorageIfSelfShard.CreateMarshalizedReceipts", "error", errNotCritical.Error())
+	} else {
+		if len(marshalizedReceiptsHashes) > 0 {
 			errNotCritical = s.storage.Put(dataRetriever.ReceiptsUnit, shardHdr.GetReceiptsHash(), marshalizedReceiptsHashes)
 			if errNotCritical != nil {
 				log.Warn("saveAllTransactionsToStorageIfSelfShard.Put -> ReceiptsUnit", "error", errNotCritical.Error())


### PR DESCRIPTION
Previously, the function which computed the receipts hash would have returned a hash even if no receipts was present. Added an extra check