### PR TITLE
Adapt prerequisites.sh for Arch based distributions.

### DIFF
--- a/scripts/testnet/prerequisites.sh
+++ b/scripts/testnet/prerequisites.sh
@@ -26,7 +26,15 @@ elif [[ "$DISTRIBUTION" =~ ^(arch)$ ]]; then
   echo "Using PACMAN to install required packages: $REQUIRED_PACKAGES"
 fi
 
-$INSTALL_PACKAGES_COMMAND
+if [ -z "$INSTALL_PACKAGES_COMMAND" ]; then
+  echo "Your operating system was not identified. The required packages were not installed, however they could still be part of your system."
+  read -r -p "Would you like to try to continue anyway? [Y/n] " response
+  if [[ "$response" =~ ^[Nn][Oo]?$ ]]; then
+    exit
+  fi
+else
+  $INSTALL_PACKAGES_COMMAND
+fi
 
 if [[ "$DISTRIBUTION" =~ ^(ubuntu|debian)$ ]]; then
 

--- a/scripts/testnet/prerequisites.sh
+++ b/scripts/testnet/prerequisites.sh
@@ -9,17 +9,24 @@ export DISTRIBUTION=$(cat /etc/os-release | grep "^ID=" | sed 's/ID=//')
 if [[ "$DISTRIBUTION" =~ ^(fedora|centos|rhel)$ ]]; then
   export PACKAGE_MANAGER="dnf"
   export REQUIRED_PACKAGES="git golang gcc lsof jq curl"
-  echo "Using DNF to install required packages: $REQUIRED_PACKAGES"
-fi
+  export INSTALL_PACKAGES_COMMAND="sudo $PACKAGE_MANAGER install -y $REQUIRED_PACKAGES"
 
-if [[ "$DISTRIBUTION" =~ ^(ubuntu|debian)$ ]]; then
+  echo "Using DNF to install required packages: $REQUIRED_PACKAGES"
+elif [[ "$DISTRIBUTION" =~ ^(ubuntu|debian)$ ]]; then
   export PACKAGE_MANAGER="apt-get"
   export REQUIRED_PACKAGES="git gcc lsof jq curl"
+  export INSTALL_PACKAGES_COMMAND="sudo $PACKAGE_MANAGER install -y $REQUIRED_PACKAGES"
 
   echo "Using APT to install required packages: $REQUIRED_PACKAGES"
+elif [[ "$DISTRIBUTION" =~ ^(arch)$ ]]; then
+  export PACKAGE_MANAGER="pacman"
+  export REQUIRED_PACKAGES="git gcc lsof jq curl"
+  export INSTALL_PACKAGES_COMMAND="sudo $PACKAGE_MANAGER -S $REQUIRED_PACKAGES"
+
+  echo "Using PACMAN to install required packages: $REQUIRED_PACKAGES"
 fi
 
-sudo $PACKAGE_MANAGER install -y $REQUIRED_PACKAGES
+$INSTALL_PACKAGES_COMMAND
 
 if [[ "$DISTRIBUTION" =~ ^(ubuntu|debian)$ ]]; then
 


### PR DESCRIPTION
- Changes how to install command is composed. 
- Adds syntax for pacman (Arch Linux) to install required packages.
- Asks the user if they want to continue, even if the operating system was not identified.