### PR TITLE
Fix stop offline syncer

### DIFF
--- a/dataRetriever/factory/storageResolversContainer/baseResolversContainerFactory.go
+++ b/dataRetriever/factory/storageResolversContainer/baseResolversContainerFactory.go
@@ -95,11 +95,13 @@ func (brcf *baseResolversContainerFactory) createTxResolver(
 	txStorer := brcf.store.GetStorer(unit)
 
 	arg := storageResolvers.ArgSliceResolver{
-		Messenger:         brcf.messenger,
-		ResponseTopicName: responseTopic,
-		Storage:           txStorer,
-		DataPacker:        brcf.dataPacker,
-		Marshalizer:       brcf.marshalizer,
+		Messenger:                brcf.messenger,
+		ResponseTopicName:        responseTopic,
+		Storage:                  txStorer,
+		DataPacker:               brcf.dataPacker,
+		Marshalizer:              brcf.marshalizer,
+		ManualEpochStartNotifier: brcf.manualEpochStartNotifier,
+		ChanGracefullyClose:      brcf.chanGracefullyClose,
 	}
 	resolver, err := storageResolvers.NewSliceResolver(arg)
 	if err != nil {
@@ -151,11 +153,13 @@ func (brcf *baseResolversContainerFactory) createMiniBlocksResolver(responseTopi
 	miniBlocksStorer := brcf.store.GetStorer(dataRetriever.MiniBlockUnit)
 
 	arg := storageResolvers.ArgSliceResolver{
-		Messenger:         brcf.messenger,
-		ResponseTopicName: responseTopic,
-		Storage:           miniBlocksStorer,
-		DataPacker:        brcf.dataPacker,
-		Marshalizer:       brcf.marshalizer,
+		Messenger:                brcf.messenger,
+		ResponseTopicName:        responseTopic,
+		Storage:                  miniBlocksStorer,
+		DataPacker:               brcf.dataPacker,
+		Marshalizer:              brcf.marshalizer,
+		ManualEpochStartNotifier: brcf.manualEpochStartNotifier,
+		ChanGracefullyClose:      brcf.chanGracefullyClose,
 	}
 	mbResolver, err := storageResolvers.NewSliceResolver(arg)
 	if err != nil {

--- a/dataRetriever/storageResolvers/storageResolver.go
+++ b/dataRetriever/storageResolvers/storageResolver.go
@@ -1,14 +1,19 @@
 package storageResolvers
 
 import (
+	"fmt"
+
 	"github.com/ElrondNetwork/elrond-go/core"
+	"github.com/ElrondNetwork/elrond-go/data/endProcess"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 )
 
 type storageResolver struct {
-	messenger         dataRetriever.MessageHandler
-	responseTopicName string
+	messenger                dataRetriever.MessageHandler
+	responseTopicName        string
+	manualEpochStartNotifier dataRetriever.ManualEpochStartNotifier
+	chanGracefullyClose      chan endProcess.ArgEndProcess
 }
 
 // ProcessReceivedMessage does nothing, won't be able to process network requests
@@ -32,4 +37,20 @@ func (sr *storageResolver) NumPeersToQuery() (int, int) {
 
 func (sr *storageResolver) sendToSelf(buffToSend []byte) error {
 	return sr.messenger.SendToConnectedPeer(sr.responseTopicName, buffToSend, sr.messenger.ID())
+}
+
+func (sr *storageResolver) signalGracefullyClose() {
+	crtEpoch := sr.manualEpochStartNotifier.CurrentEpoch()
+
+	argEndProcess := endProcess.ArgEndProcess{
+		Reason: core.ImportComplete,
+		Description: fmt.Sprintf("import ended because data from epochs %d or %d does not exist",
+			crtEpoch-1, crtEpoch),
+	}
+
+	select {
+	case sr.chanGracefullyClose <- argEndProcess:
+	default:
+		log.Debug("storageResolver.RequestDataFromHash: could not wrote on the end chan")
+	}
 }


### PR DESCRIPTION
- fixed the stopping process when importing data with the offline syncer

Testing procesures:
- as in PR #2248, the import process should run as expected until a missing data error happens. This time can be any data (tx, miniblock, nonce-hash, receipt, etc.), not just the hash-header info.