### PR TITLE
Handle transactions towards metachain in DbLookupExtensions

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -645,7 +645,7 @@
     PollingIntervalInMinutes = 65
 
 [DbLookupExtensions]
-    Enabled = true  # TODO: Disable after tests
+    Enabled = false
     [DbLookupExtensions.MiniblocksMetadataStorageConfig.Cache]
         Name = "DbLookupExtensions.MiniblocksMetadataStorage"
         Capacity = 20000

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -645,7 +645,7 @@
     PollingIntervalInMinutes = 65
 
 [DbLookupExtensions]
-    Enabled = false
+    Enabled = true  # TODO: Disable after tests
     [DbLookupExtensions.MiniblocksMetadataStorageConfig.Cache]
         Name = "DbLookupExtensions.MiniblocksMetadataStorage"
         Capacity = 20000

--- a/core/dblookupext/historyRepository.go
+++ b/core/dblookupext/historyRepository.go
@@ -244,13 +244,13 @@ func (hr *historyRepository) onNotarizedBlocks(shardID uint32, headers []data.He
 			for _, shardData := range metaBlock.ShardInfo {
 				hr.onNotarizedInMetaBlock(metaBlock.GetNonce(), headerHash, &shardData)
 			}
-			return
+			continue
 		}
 
 		header, isHeader := headerHandler.(*block.Header)
 		if isHeader {
 			hr.onNotarizedInRegularBlockOfMeta(header.GetNonce(), headerHash, header)
-			return
+			continue
 		}
 
 		log.Error("onNotarizedBlocks(): unexpected type of header", "type", fmt.Sprintf("%T", headerHandler))

--- a/core/dblookupext/historyRepository_test.go
+++ b/core/dblookupext/historyRepository_test.go
@@ -500,3 +500,79 @@ func TestHistoryRepository_OnNotarizedBlocksCrossEpoch(t *testing.T) {
 	require.Equal(t, 4001, int(metadata.NotarizedAtDestinationInMetaNonce))
 	require.Equal(t, []byte("metablockFoo"), metadata.NotarizedAtDestinationInMetaHash)
 }
+
+func TestHistoryRepository_OnNotarizedBlocksWithMetachainTransactions(t *testing.T) {
+	t.Parallel()
+
+	args := createMockHistoryRepoArgs(42)
+	args.SelfShardID = 14
+	repoAtShard, err := NewHistoryRepository(args)
+	require.Nil(t, err)
+	require.NotNil(t, repoAtShard)
+
+	args = createMockHistoryRepoArgs(42)
+	args.SelfShardID = core.MetachainShardId
+	repoAtMeta, err := NewHistoryRepository(args)
+	require.Nil(t, err)
+	require.NotNil(t, repoAtMeta)
+
+	// Assumming one miniblock of system smart contract transactions,
+	miniblock := &block.MiniBlock{
+		SenderShardID:   14,
+		ReceiverShardID: core.MetachainShardId,
+		TxHashes:        [][]byte{[]byte("txStaking")},
+	}
+	miniblockHash, _ := repoAtShard.computeMiniblockHash(miniblock)
+
+	// Let's commit the block at source
+	repoAtShard.RecordBlock([]byte("fooBlock"),
+		&block.Header{Epoch: 42, Round: 4321},
+		&block.Body{
+			MiniBlocks: []*block.MiniBlock{
+				miniblock,
+			},
+		},
+	)
+
+	// Let's commit the block at metachain as well
+	repoAtMeta.RecordBlock([]byte("barBlock"),
+		&block.Header{Epoch: 42, Round: 4321, Nonce: 3999},
+		&block.Body{
+			MiniBlocks: []*block.MiniBlock{
+				miniblock,
+			},
+		},
+	)
+
+	// At metachain, the hyperblock coordinates should be already set at commit time
+	metadata, err := repoAtMeta.getMiniblockMetadataByMiniblockHash(miniblockHash)
+	require.Nil(t, err)
+	require.Equal(t, 42, int(metadata.Epoch))
+	require.Equal(t, 3999, int(metadata.NotarizedAtSourceInMetaNonce))
+	require.Equal(t, []byte("barBlock"), metadata.NotarizedAtSourceInMetaHash)
+	require.Equal(t, 3999, int(metadata.NotarizedAtDestinationInMetaNonce))
+	require.Equal(t, []byte("barBlock"), metadata.NotarizedAtDestinationInMetaHash)
+
+	// Now, we should receive a the notification at source shard
+	blockOfMeta := &block.Header{
+		Nonce: 3999,
+		MiniBlockHeaders: []block.MiniBlockHeader{
+			{
+				SenderShardID:   12,
+				ReceiverShardID: core.MetachainShardId,
+				Hash:            miniblockHash,
+			},
+		},
+	}
+
+	repoAtShard.onNotarizedBlocks(core.MetachainShardId, []data.HeaderHandler{blockOfMeta}, [][]byte{[]byte("barBlock")})
+
+	// The hyperblock coordinates should now be set at source as well
+	metadata, err = repoAtMeta.getMiniblockMetadataByMiniblockHash(miniblockHash)
+	require.Nil(t, err)
+	require.Equal(t, 42, int(metadata.Epoch))
+	require.Equal(t, 3999, int(metadata.NotarizedAtSourceInMetaNonce))
+	require.Equal(t, []byte("barBlock"), metadata.NotarizedAtSourceInMetaHash)
+	require.Equal(t, 3999, int(metadata.NotarizedAtDestinationInMetaNonce))
+	require.Equal(t, []byte("barBlock"), metadata.NotarizedAtDestinationInMetaHash)
+}

--- a/core/dblookupext/historyRepository_test.go
+++ b/core/dblookupext/historyRepository_test.go
@@ -558,7 +558,7 @@ func TestHistoryRepository_OnNotarizedBlocksWithMetachainTransactions(t *testing
 		Nonce: 3999,
 		MiniBlockHeaders: []block.MiniBlockHeader{
 			{
-				SenderShardID:   12,
+				SenderShardID:   14,
 				ReceiverShardID: core.MetachainShardId,
 				Hash:            miniblockHash,
 			},
@@ -568,7 +568,7 @@ func TestHistoryRepository_OnNotarizedBlocksWithMetachainTransactions(t *testing
 	repoAtShard.onNotarizedBlocks(core.MetachainShardId, []data.HeaderHandler{blockOfMeta}, [][]byte{[]byte("barBlock")})
 
 	// The hyperblock coordinates should now be set at source as well
-	metadata, err = repoAtMeta.getMiniblockMetadataByMiniblockHash(miniblockHash)
+	metadata, err = repoAtShard.getMiniblockMetadataByMiniblockHash(miniblockHash)
 	require.Nil(t, err)
 	require.Equal(t, 42, int(metadata.Epoch))
 	require.Equal(t, 3999, int(metadata.NotarizedAtSourceInMetaNonce))

--- a/data/transaction/apiTransactionResult.go
+++ b/data/transaction/apiTransactionResult.go
@@ -21,7 +21,12 @@ type ApiTransactionResult struct {
 	GasPrice                          uint64                  `json:"gasPrice,omitempty"`
 	GasLimit                          uint64                  `json:"gasLimit,omitempty"`
 	Data                              []byte                  `json:"data,omitempty"`
+	CodeMetadata                      []byte                  `json:"codeMetadata,omitempty"`
 	Code                              string                  `json:"code,omitempty"`
+	PreviousTransactionHash           string                  `json:"previousTransactionHash,omitempty"`
+	OriginalTransactionHash           string                  `json:"originalTransactionHash,omitempty"`
+	ReturnMessage                     string                  `json:"returnMessage,omitempty"`
+	OriginalSender                    string                  `json:"originalSender,omitempty"`
 	Signature                         string                  `json:"signature,omitempty"`
 	SourceShard                       uint32                  `json:"sourceShard"`
 	DestinationShard                  uint32                  `json:"destinationShard"`

--- a/data/transaction/status.go
+++ b/data/transaction/status.go
@@ -23,12 +23,13 @@ const (
 
 // StatusComputer computes a transaction status
 type StatusComputer struct {
-	MiniblockType    block.Type
-	SourceShard      uint32
-	DestinationShard uint32
-	Receiver         []byte
-	TransactionData  []byte
-	SelfShard        uint32
+	MiniblockType           block.Type
+	MiniblockFullyNotarized bool
+	SourceShard             uint32
+	DestinationShard        uint32
+	Receiver                []byte
+	TransactionData         []byte
+	SelfShard               uint32
 }
 
 // ComputeStatusWhenInPool computes the transaction status when transaction is in pool
@@ -48,7 +49,7 @@ func (params *StatusComputer) ComputeStatusWhenInStorageKnowingMiniblock() TxSta
 	if params.isMiniblockInvalid() {
 		return TxStatusInvalid
 	}
-	if params.isDestinationMe() || params.isContractDeploy() {
+	if params.MiniblockFullyNotarized || params.isDestinationMe() || params.isContractDeploy() {
 		return TxStatusExecuted
 	}
 

--- a/data/transaction/status.go
+++ b/data/transaction/status.go
@@ -23,13 +23,13 @@ const (
 
 // StatusComputer computes a transaction status
 type StatusComputer struct {
-	MiniblockType             block.Type
-	IsMiniblockFullyNotarized bool
-	SourceShard               uint32
-	DestinationShard          uint32
-	Receiver                  []byte
-	TransactionData           []byte
-	SelfShard                 uint32
+	MiniblockType        block.Type
+	IsMiniblockFinalized bool
+	SourceShard          uint32
+	DestinationShard     uint32
+	Receiver             []byte
+	TransactionData      []byte
+	SelfShard            uint32
 }
 
 // ComputeStatusWhenInPool computes the transaction status when transaction is in pool
@@ -49,7 +49,7 @@ func (params *StatusComputer) ComputeStatusWhenInStorageKnowingMiniblock() TxSta
 	if params.isMiniblockInvalid() {
 		return TxStatusInvalid
 	}
-	if params.IsMiniblockFullyNotarized || params.isDestinationMe() || params.isContractDeploy() {
+	if params.IsMiniblockFinalized || params.isDestinationMe() || params.isContractDeploy() {
 		return TxStatusExecuted
 	}
 

--- a/data/transaction/status.go
+++ b/data/transaction/status.go
@@ -23,13 +23,13 @@ const (
 
 // StatusComputer computes a transaction status
 type StatusComputer struct {
-	MiniblockType           block.Type
-	MiniblockFullyNotarized bool
-	SourceShard             uint32
-	DestinationShard        uint32
-	Receiver                []byte
-	TransactionData         []byte
-	SelfShard               uint32
+	MiniblockType             block.Type
+	IsMiniblockFullyNotarized bool
+	SourceShard               uint32
+	DestinationShard          uint32
+	Receiver                  []byte
+	TransactionData           []byte
+	SelfShard                 uint32
 }
 
 // ComputeStatusWhenInPool computes the transaction status when transaction is in pool
@@ -49,7 +49,7 @@ func (params *StatusComputer) ComputeStatusWhenInStorageKnowingMiniblock() TxSta
 	if params.isMiniblockInvalid() {
 		return TxStatusInvalid
 	}
-	if params.MiniblockFullyNotarized || params.isDestinationMe() || params.isContractDeploy() {
+	if params.IsMiniblockFullyNotarized || params.isDestinationMe() || params.isContractDeploy() {
 		return TxStatusExecuted
 	}
 

--- a/data/transaction/status_test.go
+++ b/data/transaction/status_test.go
@@ -65,11 +65,11 @@ func TestStatusComputer_ComputeStatusWhenInStorageKnowingMiniblock(t *testing.T)
 
 	// Cross, at source, but knowing that it has been fully notarized (through DatabaseLookupExtensions)
 	computer = &StatusComputer{
-		MiniblockType:             block.TxBlock,
-		IsMiniblockFullyNotarized: true,
-		SourceShard:               12,
-		DestinationShard:          13,
-		SelfShard:                 12,
+		MiniblockType:        block.TxBlock,
+		IsMiniblockFinalized: true,
+		SourceShard:          12,
+		DestinationShard:     13,
+		SelfShard:            12,
 	}
 	require.Equal(t, TxStatusExecuted, computer.ComputeStatusWhenInStorageKnowingMiniblock())
 

--- a/data/transaction/status_test.go
+++ b/data/transaction/status_test.go
@@ -65,11 +65,11 @@ func TestStatusComputer_ComputeStatusWhenInStorageKnowingMiniblock(t *testing.T)
 
 	// Cross, at source, but knowing that it has been fully notarized (through DatabaseLookupExtensions)
 	computer = &StatusComputer{
-		MiniblockType:           block.TxBlock,
-		MiniblockFullyNotarized: true,
-		SourceShard:             12,
-		DestinationShard:        13,
-		SelfShard:               12,
+		MiniblockType:             block.TxBlock,
+		IsMiniblockFullyNotarized: true,
+		SourceShard:               12,
+		DestinationShard:          13,
+		SelfShard:                 12,
 	}
 	require.Equal(t, TxStatusExecuted, computer.ComputeStatusWhenInStorageKnowingMiniblock())
 

--- a/data/transaction/status_test.go
+++ b/data/transaction/status_test.go
@@ -63,6 +63,16 @@ func TestStatusComputer_ComputeStatusWhenInStorageKnowingMiniblock(t *testing.T)
 	}
 	require.Equal(t, TxStatusPartiallyExecuted, computer.ComputeStatusWhenInStorageKnowingMiniblock())
 
+	// Cross, at source, but knowing that it has been fully notarized (through DatabaseLookupExtensions)
+	computer = &StatusComputer{
+		MiniblockType:           block.TxBlock,
+		MiniblockFullyNotarized: true,
+		SourceShard:             12,
+		DestinationShard:        13,
+		SelfShard:               12,
+	}
+	require.Equal(t, TxStatusExecuted, computer.ComputeStatusWhenInStorageKnowingMiniblock())
+
 	// Cross, destination me
 	computer = &StatusComputer{
 		MiniblockType:    block.TxBlock,

--- a/node/nodeTransactions.go
+++ b/node/nodeTransactions.go
@@ -70,6 +70,13 @@ func (n *Node) lookupHistoricalTransaction(hash []byte) (*transaction.ApiTransac
 		return nil, fmt.Errorf("%s: %w", ErrCannotRetrieveTransaction.Error(), err)
 	}
 
+	// After looking up a transaction from storage, it's impossible to say whether it was successful or invalid
+	// (since both successful and invalid transactions are kept in the same storage unit),
+	// so we have to use our extra information from the "miniblockMetadata" to correct the txType if appropriate
+	if block.Type(miniblockMetadata.Type) == block.InvalidBlock {
+		txType = transaction.TxTypeInvalid
+	}
+
 	tx, err := n.unmarshalTransaction(txBytes, txType)
 	if err != nil {
 		log.Warn("lookupHistoricalTransaction(): unexpected condition, cannot unmarshal transaction")

--- a/node/nodeTransactions.go
+++ b/node/nodeTransactions.go
@@ -86,12 +86,12 @@ func (n *Node) lookupHistoricalTransaction(hash []byte) (*transaction.ApiTransac
 	putMiniblockFieldsInTransaction(tx, miniblockMetadata)
 
 	tx.Status = (&transaction.StatusComputer{
-		MiniblockType:           block.Type(miniblockMetadata.Type),
-		MiniblockFullyNotarized: tx.NotarizedAtDestinationInMetaNonce > 0,
-		DestinationShard:        tx.DestinationShard,
-		Receiver:                tx.Tx.GetRcvAddr(),
-		TransactionData:         tx.Data,
-		SelfShard:               n.shardCoordinator.SelfId(),
+		MiniblockType:             block.Type(miniblockMetadata.Type),
+		IsMiniblockFullyNotarized: tx.NotarizedAtDestinationInMetaNonce > 0,
+		DestinationShard:          tx.DestinationShard,
+		Receiver:                  tx.Tx.GetRcvAddr(),
+		TransactionData:           tx.Data,
+		SelfShard:                 n.shardCoordinator.SelfId(),
 	}).ComputeStatusWhenInStorageKnowingMiniblock()
 
 	return tx, nil

--- a/node/nodeTransactions.go
+++ b/node/nodeTransactions.go
@@ -79,11 +79,12 @@ func (n *Node) lookupHistoricalTransaction(hash []byte) (*transaction.ApiTransac
 	putMiniblockFieldsInTransaction(tx, miniblockMetadata)
 
 	tx.Status = (&transaction.StatusComputer{
-		MiniblockType:    block.Type(miniblockMetadata.Type),
-		DestinationShard: tx.DestinationShard,
-		Receiver:         tx.Tx.GetRcvAddr(),
-		TransactionData:  tx.Data,
-		SelfShard:        n.shardCoordinator.SelfId(),
+		MiniblockType:           block.Type(miniblockMetadata.Type),
+		MiniblockFullyNotarized: tx.NotarizedAtDestinationInMetaNonce > 0,
+		DestinationShard:        tx.DestinationShard,
+		Receiver:                tx.Tx.GetRcvAddr(),
+		TransactionData:         tx.Data,
+		SelfShard:               n.shardCoordinator.SelfId(),
 	}).ComputeStatusWhenInStorageKnowingMiniblock()
 
 	return tx, nil

--- a/node/nodeTransactions.go
+++ b/node/nodeTransactions.go
@@ -86,12 +86,12 @@ func (n *Node) lookupHistoricalTransaction(hash []byte) (*transaction.ApiTransac
 	putMiniblockFieldsInTransaction(tx, miniblockMetadata)
 
 	tx.Status = (&transaction.StatusComputer{
-		MiniblockType:             block.Type(miniblockMetadata.Type),
-		IsMiniblockFullyNotarized: tx.NotarizedAtDestinationInMetaNonce > 0,
-		DestinationShard:          tx.DestinationShard,
-		Receiver:                  tx.Tx.GetRcvAddr(),
-		TransactionData:           tx.Data,
-		SelfShard:                 n.shardCoordinator.SelfId(),
+		MiniblockType:        block.Type(miniblockMetadata.Type),
+		IsMiniblockFinalized: tx.NotarizedAtDestinationInMetaNonce > 0,
+		DestinationShard:     tx.DestinationShard,
+		Receiver:             tx.Tx.GetRcvAddr(),
+		TransactionData:      tx.Data,
+		SelfShard:            n.shardCoordinator.SelfId(),
 	}).ComputeStatusWhenInStorageKnowingMiniblock()
 
 	return tx, nil


### PR DESCRIPTION
The metachain directly notarizes miniblocks towards it - at commit block time. Therefore, there's the time to set the hyperblock coordinates for the miniblocks in question. At the source shard, the "block notarized" notifications arrive in a slightly different manner - the payload is a `block.Header`, not a `block.MetaBlock`.

Therefore,

 - Gather hyperblock coordinates for transactions towards meta as well
 - Refactoring: separate normal from invalid transactions in `nodeTransactions.go`
 - Return extra fields for `unsigned` transactions (e.g. return message, original transaction hash)
 - Improve transaction status (API) reporting when `DatabaseLookupExtensions` are enabled (that is, return `executed` if hyperblock coordinates are fully set, that is, if parent miniblock is fully notarized)
 - Fix value of transaction type (API) when `DatabaseLookupExtensions`, and miniblock metadata is present.

How to test:
 - Send a staking transaction, then inspect its hyperblock coordinates
 - Send invalid transaction, check its Type field
 - Also inspect hyperblock coordinates for some rewards transactions (as a regression test)