### PR TITLE
Fix epoch set in manual epoch notifier

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -895,7 +895,6 @@ func newStorageResolver(
 	}
 
 	manualEpochStartNotifier := notifier.NewManualEpochStartNotifier()
-	manualEpochStartNotifier.NewEpoch(currentEpoch + 1)
 	storageServiceCreator, err := storageFactory.NewStorageServiceFactory(
 		config,
 		shardCoordinator,
@@ -913,6 +912,8 @@ func newStorageResolver(
 			return nil, errStore
 		}
 
+		manualEpochStartNotifier.NewEpoch(currentEpoch + 1)
+
 		return createStorageResolversForMeta(
 			shardCoordinator,
 			coreData,
@@ -927,6 +928,8 @@ func newStorageResolver(
 	if err != nil {
 		return nil, err
 	}
+
+	manualEpochStartNotifier.NewEpoch(currentEpoch + 1)
 
 	return createStorageResolversForShard(
 		shardCoordinator,

--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -895,6 +895,7 @@ func newStorageResolver(
 	}
 
 	manualEpochStartNotifier := notifier.NewManualEpochStartNotifier()
+	manualEpochStartNotifier.NewEpoch(currentEpoch + 1)
 	storageServiceCreator, err := storageFactory.NewStorageServiceFactory(
 		config,
 		shardCoordinator,

--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -645,23 +645,24 @@ func indexGenesisBlocks(args *processComponentsFactoryArgs, genesisBlocks map[ui
 	args.indexer.SaveBlock(&dataBlock.Body{}, genesisBlockHeader, nil, nil, nil)
 
 	// In "dblookupext" index, record both the metachain and the shard blocks
-	for shard, genesisBlockHeader := range genesisBlocks {
-		if args.shardCoordinator.SelfId() != shard {
+	var shardID uint32
+	for shardID, genesisBlockHeader = range genesisBlocks {
+		if args.shardCoordinator.SelfId() != shardID {
 			continue
 		}
 
-		genesisBlockHash, err := core.CalculateHash(args.coreData.InternalMarshalizer, args.coreData.Hasher, genesisBlockHeader)
+		genesisBlockHash, err = core.CalculateHash(args.coreData.InternalMarshalizer, args.coreData.Hasher, genesisBlockHeader)
 		if err != nil {
 			return err
 		}
 
-		log.Info("indexGenesisBlocks(): historyRepo.RecordBlock", "shard", shard, "hash", genesisBlockHash)
+		log.Info("indexGenesisBlocks(): historyRepo.RecordBlock", "shard", shardID, "hash", genesisBlockHash)
 		err = args.historyRepo.RecordBlock(genesisBlockHash, genesisBlockHeader, &dataBlock.Body{})
 		if err != nil {
 			return err
 		}
 
-		nonceByHashDataUnit := dataRetriever.GetHdrNonceHashDataUnit(shard)
+		nonceByHashDataUnit := dataRetriever.GetHdrNonceHashDataUnit(shardID)
 		nonceAsBytes := args.coreData.Uint64ByteSliceConverter.ToByteSlice(genesisBlockHeader.GetNonce())
 		err = args.data.Store.Put(nonceByHashDataUnit, nonceAsBytes, genesisBlockHash)
 		if err != nil {

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -95,6 +95,7 @@ const (
 	secondsToWaitForP2PBootstrap = 20
 	maxTimeToClose               = 10 * time.Second
 	maxMachineIDLen              = 10
+	checkpointRoundsModulus      = 14400
 )
 
 var (
@@ -1489,8 +1490,13 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 func applyCompatibleConfigs(log logger.Logger, config *config.Config, ctx *cli.Context) {
 	importDbDirectoryValue := ctx.GlobalString(importDbDirectory.Name)
 	if len(importDbDirectoryValue) > 0 {
-		log.Info("import DB directory is set, turning off start in epoch", "value", importDbDirectoryValue)
+		log.Info("import DB directory is set, altering config values!",
+			"GeneralSettings.StartInEpochEnabled", "false",
+			"StateTriesConfig.CheckpointRoundsModulus", checkpointRoundsModulus,
+			"import DB path", importDbDirectoryValue,
+		)
 		config.GeneralSettings.StartInEpochEnabled = false
+		config.StateTriesConfig.CheckpointRoundsModulus = checkpointRoundsModulus
 	}
 }
 

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -88,14 +88,13 @@ import (
 )
 
 const (
-	defaultStatsPath              = "stats"
-	defaultLogsPath               = "logs"
-	notSetDestinationShardID      = "disabled"
-	metachainShardName            = "metachain"
-	secondsToWaitForP2PBootstrap  = 20
-	maxTimeToClose                = 10 * time.Second
-	maxMachineIDLen               = 10
-	importCheckpointRoundsModulus = 14400
+	defaultStatsPath             = "stats"
+	defaultLogsPath              = "logs"
+	notSetDestinationShardID     = "disabled"
+	metachainShardName           = "metachain"
+	secondsToWaitForP2PBootstrap = 20
+	maxTimeToClose               = 10 * time.Second
+	maxMachineIDLen              = 10
 )
 
 var (
@@ -1490,6 +1489,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 func applyCompatibleConfigs(log logger.Logger, config *config.Config, ctx *cli.Context) {
 	importDbDirectoryValue := ctx.GlobalString(importDbDirectory.Name)
 	if len(importDbDirectoryValue) > 0 {
+		importCheckpointRoundsModulus := uint(config.EpochStartConfig.RoundsPerEpoch)
 		log.Info("import DB directory is set, altering config values!",
 			"GeneralSettings.StartInEpochEnabled", "false",
 			"StateTriesConfig.CheckpointRoundsModulus", importCheckpointRoundsModulus,

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -88,14 +88,14 @@ import (
 )
 
 const (
-	defaultStatsPath             = "stats"
-	defaultLogsPath              = "logs"
-	notSetDestinationShardID     = "disabled"
-	metachainShardName           = "metachain"
-	secondsToWaitForP2PBootstrap = 20
-	maxTimeToClose               = 10 * time.Second
-	maxMachineIDLen              = 10
-	checkpointRoundsModulus      = 14400
+	defaultStatsPath              = "stats"
+	defaultLogsPath               = "logs"
+	notSetDestinationShardID      = "disabled"
+	metachainShardName            = "metachain"
+	secondsToWaitForP2PBootstrap  = 20
+	maxTimeToClose                = 10 * time.Second
+	maxMachineIDLen               = 10
+	importCheckpointRoundsModulus = 14400
 )
 
 var (
@@ -1492,11 +1492,11 @@ func applyCompatibleConfigs(log logger.Logger, config *config.Config, ctx *cli.C
 	if len(importDbDirectoryValue) > 0 {
 		log.Info("import DB directory is set, altering config values!",
 			"GeneralSettings.StartInEpochEnabled", "false",
-			"StateTriesConfig.CheckpointRoundsModulus", checkpointRoundsModulus,
+			"StateTriesConfig.CheckpointRoundsModulus", importCheckpointRoundsModulus,
 			"import DB path", importDbDirectoryValue,
 		)
 		config.GeneralSettings.StartInEpochEnabled = false
-		config.StateTriesConfig.CheckpointRoundsModulus = checkpointRoundsModulus
+		config.StateTriesConfig.CheckpointRoundsModulus = importCheckpointRoundsModulus
 	}
 }
 

--- a/epochStart/notifier/manualEpochStartNotifier.go
+++ b/epochStart/notifier/manualEpochStartNotifier.go
@@ -10,6 +10,8 @@ import (
 
 var log = logger.GetOrCreate("epochstart/notifier")
 
+// manualEpochStartNotifier will notice all recorded handlers to a provided epoch (from other components)
+// TODO think about a better name as this does not get its data from the exterior of the node
 type manualEpochStartNotifier struct {
 	mutHandlers     sync.RWMutex
 	handlers        []epochStart.ActionHandler


### PR DESCRIPTION
- fixed the initial epoch after the instantiation of the manualEpochStartNotifier object
- automatically alter checkpoint modulus value when importing DB

Testing procedures:
- start the import process, let it sync for about 5 epochs
- close the node that does the import
- restart the process
Expected results:
- the node should resume its import process, should not close prematurely stating:
```
terminating at internal stop signal      reason = importComplete description = import ended because data from epochs 0 or 1 does not exist
```