### PR TITLE
Fixing buffer too large

### DIFF
--- a/p2p/libp2p/directSender.go
+++ b/p2p/libp2p/directSender.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -152,7 +153,7 @@ func (ds *directSender) NextSeqno() []byte {
 // Send will send a direct message to the connected peer
 func (ds *directSender) Send(topic string, buff []byte, peer core.PeerID) error {
 	if len(buff) >= maxSendBuffSize {
-		return p2p.ErrMessageTooLarge
+		return fmt.Errorf("%w, maximum: %d, received %d", p2p.ErrMessageTooLarge, maxSendBuffSize, len(buff))
 	}
 
 	mut := ds.mutexForPeer.Get(string(peer))

--- a/p2p/libp2p/netMessenger.go
+++ b/p2p/libp2p/netMessenger.go
@@ -718,7 +718,7 @@ func (netMes *networkMessenger) BroadcastOnChannelBlocking(channel string, topic
 
 func (netMes *networkMessenger) checkSendableData(buff []byte) error {
 	if len(buff) > maxSendBuffSize {
-		return p2p.ErrMessageTooLarge
+		return fmt.Errorf("%w, maximum: %d, received %d", p2p.ErrMessageTooLarge, maxSendBuffSize, len(buff))
 	}
 	if len(buff) == 0 {
 		return p2p.ErrEmptyBufferToSend

--- a/process/coordinator/process.go
+++ b/process/coordinator/process.go
@@ -522,12 +522,6 @@ func (tc *transactionCoordinator) CreateMbsAndProcessCrossShardTransactionsDstMe
 			break
 		}
 
-		if tc.blockSizeComputation.IsMaxBlockSizeReached(0, 0) {
-			log.Debug("CreateMbsAndProcessCrossShardTransactionsDstMe",
-				"stop creating", "max block size has been reached")
-			break
-		}
-
 		_, ok := processedMiniBlocksHashes[key]
 		if ok {
 			nrMiniBlocksProcessed++
@@ -543,6 +537,12 @@ func (tc *transactionCoordinator) CreateMbsAndProcessCrossShardTransactionsDstMe
 		miniBlock, ok := miniVal.(*block.MiniBlock)
 		if !ok {
 			continue
+		}
+
+		if tc.blockSizeComputation.IsMaxBlockSizeReached(1, len(miniBlock.TxHashes)) {
+			log.Debug("CreateMbsAndProcessCrossShardTransactionsDstMe",
+				"stop creating", "max block size has been reached")
+			break
 		}
 
 		preproc := tc.getPreProcessor(miniBlock.Type)


### PR DESCRIPTION
- fixed `buffer to large` error by limiting also the miniblock number in case of executing transactions with destination me
- made p2p `buffer too large` error message carry more info