### PR TITLE
Fix set of final block after restart in epoch

### DIFF
--- a/consensus/mock/forkDetectorMock.go
+++ b/consensus/mock/forkDetectorMock.go
@@ -18,6 +18,7 @@ type ForkDetectorMock struct {
 	SetRollBackNonceCalled          func(nonce uint64)
 	RestoreToGenesisCalled          func()
 	ResetProbableHighestNonceCalled func()
+	SetFinalToLastCheckpointCalled  func()
 }
 
 // RestoreToGenesis -
@@ -76,6 +77,13 @@ func (fdm *ForkDetectorMock) GetNotarizedHeaderHash(nonce uint64) []byte {
 func (fdm *ForkDetectorMock) ResetProbableHighestNonce() {
 	if fdm.ResetProbableHighestNonceCalled != nil {
 		fdm.ResetProbableHighestNonceCalled()
+	}
+}
+
+// SetFinalToLastCheckpoint -
+func (fdm *ForkDetectorMock) SetFinalToLastCheckpoint() {
+	if fdm.SetFinalToLastCheckpointCalled != nil {
+		fdm.SetFinalToLastCheckpointCalled()
 	}
 }
 

--- a/integrationTests/mock/forkDetectorStub.go
+++ b/integrationTests/mock/forkDetectorStub.go
@@ -18,6 +18,7 @@ type ForkDetectorStub struct {
 	RestoreToGenesisCalled          func()
 	SetRollBackNonceCalled          func(nonce uint64)
 	ResetProbableHighestNonceCalled func()
+	SetFinalToLastCheckpointCalled  func()
 }
 
 // RestoreToGenesis -
@@ -103,6 +104,13 @@ func (fdm *ForkDetectorStub) GetNotarizedHeaderHash(nonce uint64) []byte {
 func (fdm *ForkDetectorStub) ResetProbableHighestNonce() {
 	if fdm.ResetProbableHighestNonceCalled != nil {
 		fdm.ResetProbableHighestNonceCalled()
+	}
+}
+
+// SetFinalToLastCheckpoint -
+func (fdm *ForkDetectorStub) SetFinalToLastCheckpoint() {
+	if fdm.SetFinalToLastCheckpointCalled != nil {
+		fdm.SetFinalToLastCheckpointCalled()
 	}
 }
 

--- a/node/mock/forkDetectorMock.go
+++ b/node/mock/forkDetectorMock.go
@@ -18,6 +18,7 @@ type ForkDetectorMock struct {
 	SetRollBackNonceCalled          func(nonce uint64)
 	RestoreToGenesisCalled          func()
 	ResetProbableHighestNonceCalled func()
+	SetFinalToLastCheckpointCalled  func()
 }
 
 // RestoreToGenesis -
@@ -76,6 +77,13 @@ func (fdm *ForkDetectorMock) GetNotarizedHeaderHash(nonce uint64) []byte {
 func (fdm *ForkDetectorMock) ResetProbableHighestNonce() {
 	if fdm.ResetProbableHighestNonceCalled != nil {
 		fdm.ResetProbableHighestNonceCalled()
+	}
+}
+
+// SetFinalToLastCheckpoint -
+func (fdm *ForkDetectorMock) SetFinalToLastCheckpoint() {
+	if fdm.SetFinalToLastCheckpointCalled != nil {
+		fdm.SetFinalToLastCheckpointCalled()
 	}
 }
 

--- a/process/interface.go
+++ b/process/interface.go
@@ -319,6 +319,7 @@ type ForkDetector interface {
 	RestoreToGenesis()
 	GetNotarizedHeaderHash(nonce uint64) []byte
 	ResetProbableHighestNonce()
+	SetFinalToLastCheckpoint()
 	IsInterfaceNil() bool
 }
 

--- a/process/mock/forkDetectorMock.go
+++ b/process/mock/forkDetectorMock.go
@@ -18,6 +18,7 @@ type ForkDetectorMock struct {
 	SetRollBackNonceCalled          func(nonce uint64)
 	RestoreToGenesisCalled          func()
 	ResetProbableHighestNonceCalled func()
+	SetFinalToLastCheckpointCalled  func()
 }
 
 // RestoreToGenesis -
@@ -79,6 +80,13 @@ func (fdm *ForkDetectorMock) GetNotarizedHeaderHash(nonce uint64) []byte {
 func (fdm *ForkDetectorMock) ResetProbableHighestNonce() {
 	if fdm.ResetProbableHighestNonceCalled != nil {
 		fdm.ResetProbableHighestNonceCalled()
+	}
+}
+
+// SetFinalToLastCheckpoint -
+func (fdm *ForkDetectorMock) SetFinalToLastCheckpoint() {
+	if fdm.SetFinalToLastCheckpointCalled != nil {
+		fdm.SetFinalToLastCheckpointCalled()
 	}
 }
 

--- a/process/sync/baseForkDetector.go
+++ b/process/sync/baseForkDetector.go
@@ -721,7 +721,7 @@ func (bfd *baseForkDetector) processReceivedBlock(
 		"final check point nonce", bfd.finalCheckpoint().nonce)
 }
 
-// SetFinalToLastCheckpoint sets the final checkpoint to the last check point added in list
+// SetFinalToLastCheckpoint sets the final checkpoint to the last checkpoint added in list
 func (bfd *baseForkDetector) SetFinalToLastCheckpoint() {
 	bfd.setFinalCheckpoint(bfd.lastCheckpoint())
 }

--- a/process/sync/baseForkDetector.go
+++ b/process/sync/baseForkDetector.go
@@ -720,3 +720,8 @@ func (bfd *baseForkDetector) processReceivedBlock(
 		"last check point nonce", bfd.lastCheckpoint().nonce,
 		"final check point nonce", bfd.finalCheckpoint().nonce)
 }
+
+// SetFinalToLastCheckpoint sets the final checkpoint to the last check point added in list
+func (bfd *baseForkDetector) SetFinalToLastCheckpoint() {
+	bfd.setFinalCheckpoint(bfd.lastCheckpoint())
+}

--- a/process/sync/baseForkDetector_test.go
+++ b/process/sync/baseForkDetector_test.go
@@ -1153,3 +1153,29 @@ func TestBasicForkDetector_CheckForkMetaHeaderProcessedShouldWorkOnEqualRoundWit
 	assert.Equal(t, uint64(math.MaxUint64), forkInfo.Round)
 	assert.Nil(t, forkInfo.Hash)
 }
+
+func TestBasicForkDetector_SetFinalToLastCheckpointShouldWork(t *testing.T) {
+	rounderMock := &mock.RounderMock{}
+	bfd, _ := sync.NewMetaForkDetector(
+		rounderMock,
+		&mock.BlackListHandlerStub{},
+		&mock.BlockTrackerMock{},
+		0,
+	)
+
+	rounderMock.RoundIndex = 1000
+	_ = bfd.AddHeader(
+		&block.MetaBlock{Nonce: 900, Round: 1000, PubKeysBitmap: []byte("X")},
+		[]byte("hash"),
+		process.BHProcessed,
+		nil,
+		nil)
+
+	assert.Equal(t, uint64(0), bfd.GetHighestFinalBlockNonce())
+	assert.Nil(t, bfd.GetHighestFinalBlockHash())
+
+	bfd.SetFinalToLastCheckpoint()
+
+	assert.Equal(t, uint64(900), bfd.GetHighestFinalBlockNonce())
+	assert.Equal(t, []byte("hash"), bfd.GetHighestFinalBlockHash())
+}

--- a/process/sync/storageBootstrap/baseStorageBootstrapper.go
+++ b/process/sync/storageBootstrap/baseStorageBootstrapper.go
@@ -349,6 +349,10 @@ func (st *storageBootstrapper) applyBootInfos(bootInfos []bootstrapStorage.Boots
 		st.blockTracker.AddTrackedHeader(header, bootInfos[i].LastHeader.Hash)
 	}
 
+	if len(bootInfos) == 1 {
+		st.forkDetector.SetFinalToLastCheckpoint()
+	}
+
 	err = st.nodesCoordinator.LoadState(bootInfos[0].NodesCoordinatorConfigKey)
 	if err != nil {
 		log.Debug("cannot load nodes coordinator state", "error", err.Error())


### PR DESCRIPTION
* Implemented a mechanism of setting the final checkpoint to the last checkpoint added in list, when a node starts in epoch and it has only one block (start of epoch block) added in fork detector. This should prevent the possible rollbacks behind final block which would been done if the node would not been received the next requested block from the network in some few number of rounds.