### PR TITLE
Fix execution order of cross mini blocks

### DIFF
--- a/consensus/mock/headerHandlerStub.go
+++ b/consensus/mock/headerHandlerStub.go
@@ -8,17 +8,18 @@ import (
 
 // HeaderHandlerStub -
 type HeaderHandlerStub struct {
-	GetMiniBlockHeadersWithDstCalled func(destId uint32) map[string]uint32
-	GetPubKeysBitmapCalled           func() []byte
-	GetSignatureCalled               func() []byte
-	GetRootHashCalled                func() []byte
-	GetRandSeedCalled                func() []byte
-	GetPrevRandSeedCalled            func() []byte
-	GetPrevHashCalled                func() []byte
-	CloneCalled                      func() data.HeaderHandler
-	GetChainIDCalled                 func() []byte
-	CheckChainIDCalled               func(reference []byte) error
-	GetReservedCalled                func() []byte
+	GetMiniBlockHeadersWithDstCalled       func(destId uint32) map[string]uint32
+	GetOrderedCrossMiniblocksWithDstCalled func(destId uint32) []*data.MiniBlockInfo
+	GetPubKeysBitmapCalled                 func() []byte
+	GetSignatureCalled                     func() []byte
+	GetRootHashCalled                      func() []byte
+	GetRandSeedCalled                      func() []byte
+	GetPrevRandSeedCalled                  func() []byte
+	GetPrevHashCalled                      func() []byte
+	CloneCalled                            func() data.HeaderHandler
+	GetChainIDCalled                       func() []byte
+	CheckChainIDCalled                     func(reference []byte) error
+	GetReservedCalled                      func() []byte
 }
 
 // GetAccumulatedFees -
@@ -205,6 +206,11 @@ func (hhs *HeaderHandlerStub) SetTxCount(_ uint32) {
 // GetMiniBlockHeadersWithDst -
 func (hhs *HeaderHandlerStub) GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32 {
 	return hhs.GetMiniBlockHeadersWithDstCalled(destId)
+}
+
+// GetOrderedCrossMiniblocksWithDst -
+func (hhs *HeaderHandlerStub) GetOrderedCrossMiniblocksWithDst(destId uint32) []*data.MiniBlockInfo {
+	return hhs.GetOrderedCrossMiniblocksWithDstCalled(destId)
 }
 
 // GetMiniBlockHeadersHashes -

--- a/data/block/block.go
+++ b/data/block/block.go
@@ -3,7 +3,6 @@ package block
 
 import (
 	"math/big"
-	"sort"
 
 	"github.com/ElrondNetwork/elrond-go/data"
 )
@@ -131,10 +130,6 @@ func (h *Header) GetOrderedCrossMiniblocksWithDst(destId uint32) []*data.MiniBlo
 			})
 		}
 	}
-
-	sort.Slice(miniBlocks, func(i, j int) bool {
-		return miniBlocks[i].Round < miniBlocks[j].Round
-	})
 
 	return miniBlocks
 }

--- a/data/block/block.go
+++ b/data/block/block.go
@@ -3,6 +3,7 @@ package block
 
 import (
 	"math/big"
+	"sort"
 
 	"github.com/ElrondNetwork/elrond-go/data"
 )
@@ -114,6 +115,28 @@ func (h *Header) GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32 {
 		}
 	}
 	return hashDst
+}
+
+// GetOrderedCrossMiniblocksWithDst gets all cross miniblocks with the given destination shard ID, ordered in a
+// chronological way, taking into consideration the round in which they were created/executed in the sender shard
+func (h *Header) GetOrderedCrossMiniblocksWithDst(destId uint32) []*data.MiniBlockInfo {
+	miniBlocks := make([]*data.MiniBlockInfo, 0)
+
+	for _, mb := range h.MiniBlockHeaders {
+		if mb.ReceiverShardID == destId && mb.SenderShardID != destId {
+			miniBlocks = append(miniBlocks, &data.MiniBlockInfo{
+				Hash:          mb.Hash,
+				SenderShardID: mb.SenderShardID,
+				Round:         h.Round,
+			})
+		}
+	}
+
+	sort.Slice(miniBlocks, func(i, j int) bool {
+		return miniBlocks[i].Round < miniBlocks[j].Round
+	})
+
+	return miniBlocks
 }
 
 // GetMiniBlockHeadersHashes gets the miniblock hashes

--- a/data/block/metaBlock_test.go
+++ b/data/block/metaBlock_test.go
@@ -310,21 +310,39 @@ func TestMetaBlock_GetOrderedCrossMiniblocksWithDstShouldWork(t *testing.T) {
 		ReceiverShardID: 1,
 	})
 
+	metaHdr.MiniBlockHeaders = append(metaHdr.MiniBlockHeaders, block.MiniBlockHeader{
+		Hash:            []byte("hash7"),
+		SenderShardID:   core.MetachainShardId,
+		ReceiverShardID: core.AllShardId,
+	})
+
+	metaHdr.MiniBlockHeaders = append(metaHdr.MiniBlockHeaders, block.MiniBlockHeader{
+		Hash:            []byte("hash8"),
+		SenderShardID:   core.MetachainShardId,
+		ReceiverShardID: 2,
+	})
+
 	miniBlocksInfo := metaHdr.GetOrderedCrossMiniblocksWithDst(1)
-	require.Equal(t, 5, len(miniBlocksInfo))
+	require.Equal(t, 6, len(miniBlocksInfo))
 	assert.Equal(t, miniBlocksInfo[0].Hash, []byte("hash6"))
 	assert.Equal(t, miniBlocksInfo[0].Round, uint64(6))
-	assert.Equal(t, miniBlocksInfo[1].Hash, []byte("hash4"))
-	assert.Equal(t, miniBlocksInfo[1].Round, uint64(8))
-	assert.Equal(t, miniBlocksInfo[2].Hash, []byte("hash2"))
-	assert.Equal(t, miniBlocksInfo[2].Round, uint64(9))
-	assert.Equal(t, miniBlocksInfo[3].Hash, []byte("hash3"))
-	assert.Equal(t, miniBlocksInfo[3].Round, uint64(10))
-	assert.Equal(t, miniBlocksInfo[4].Hash, []byte("hash1"))
-	assert.Equal(t, miniBlocksInfo[4].Round, uint64(11))
+	assert.Equal(t, miniBlocksInfo[1].Hash, []byte("hash7"))
+	assert.Equal(t, miniBlocksInfo[1].Round, uint64(6))
+	assert.Equal(t, miniBlocksInfo[2].Hash, []byte("hash4"))
+	assert.Equal(t, miniBlocksInfo[2].Round, uint64(8))
+	assert.Equal(t, miniBlocksInfo[3].Hash, []byte("hash2"))
+	assert.Equal(t, miniBlocksInfo[3].Round, uint64(9))
+	assert.Equal(t, miniBlocksInfo[4].Hash, []byte("hash3"))
+	assert.Equal(t, miniBlocksInfo[4].Round, uint64(10))
+	assert.Equal(t, miniBlocksInfo[5].Hash, []byte("hash1"))
+	assert.Equal(t, miniBlocksInfo[5].Round, uint64(11))
 
 	miniBlocksInfo = metaHdr.GetOrderedCrossMiniblocksWithDst(2)
-	require.Equal(t, 1, len(miniBlocksInfo))
-	assert.Equal(t, miniBlocksInfo[0].Hash, []byte("hash5"))
-	assert.Equal(t, miniBlocksInfo[0].Round, uint64(7))
+	require.Equal(t, 3, len(miniBlocksInfo))
+	assert.Equal(t, miniBlocksInfo[0].Hash, []byte("hash7"))
+	assert.Equal(t, miniBlocksInfo[0].Round, uint64(6))
+	assert.Equal(t, miniBlocksInfo[1].Hash, []byte("hash8"))
+	assert.Equal(t, miniBlocksInfo[1].Round, uint64(6))
+	assert.Equal(t, miniBlocksInfo[2].Hash, []byte("hash5"))
+	assert.Equal(t, miniBlocksInfo[2].Round, uint64(7))
 }

--- a/data/block/metaBlock_test.go
+++ b/data/block/metaBlock_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data/block"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMetaBlock_GetEpoch(t *testing.T) {
@@ -268,4 +269,62 @@ func TestMetaBlock_GetMiniBlockHeadersWithDst(t *testing.T) {
 	assert.Equal(t, 0, len(mbDst0))
 	mbDst1 := metaHdr.GetMiniBlockHeadersWithDst(1)
 	assert.Equal(t, len(shardMBHeader), len(mbDst1))
+}
+
+func TestMetaBlock_GetOrderedCrossMiniblocksWithDstShouldWork(t *testing.T) {
+	t.Parallel()
+
+	metaHdr := &block.MetaBlock{Round: 6}
+	metaHdr.ShardInfo = make([]block.ShardData, 0)
+
+	shardMBHeader1 := make([]block.MiniBlockHeader, 0)
+	shMBHdr1 := block.MiniBlockHeader{SenderShardID: 0, ReceiverShardID: 1, Hash: []byte("hash1")}
+	shardMBHeader1 = append(shardMBHeader1, shMBHdr1)
+	shData1 := block.ShardData{Round: 11, ShardID: 0, HeaderHash: []byte("sh1"), ShardMiniBlockHeaders: shardMBHeader1}
+
+	shardMBHeader2 := make([]block.MiniBlockHeader, 0)
+	shMBHdr2 := block.MiniBlockHeader{SenderShardID: 0, ReceiverShardID: 1, Hash: []byte("hash2")}
+	shardMBHeader2 = append(shardMBHeader2, shMBHdr2)
+	shData2 := block.ShardData{Round: 9, ShardID: 0, HeaderHash: []byte("sh2"), ShardMiniBlockHeaders: shardMBHeader2}
+
+	shardMBHeader3 := make([]block.MiniBlockHeader, 0)
+	shMBHdr3 := block.MiniBlockHeader{SenderShardID: 2, ReceiverShardID: 1, Hash: []byte("hash3")}
+	shardMBHeader3 = append(shardMBHeader3, shMBHdr3)
+	shData3 := block.ShardData{Round: 10, ShardID: 2, HeaderHash: []byte("sh3"), ShardMiniBlockHeaders: shardMBHeader3}
+
+	shardMBHeader4 := make([]block.MiniBlockHeader, 0)
+	shMBHdr4 := block.MiniBlockHeader{SenderShardID: 2, ReceiverShardID: 1, Hash: []byte("hash4")}
+	shardMBHeader4 = append(shardMBHeader4, shMBHdr4)
+	shData4 := block.ShardData{Round: 8, ShardID: 2, HeaderHash: []byte("sh4"), ShardMiniBlockHeaders: shardMBHeader4}
+
+	shardMBHeader5 := make([]block.MiniBlockHeader, 0)
+	shMBHdr5 := block.MiniBlockHeader{SenderShardID: 1, ReceiverShardID: 2, Hash: []byte("hash5")}
+	shardMBHeader5 = append(shardMBHeader5, shMBHdr5)
+	shData5 := block.ShardData{Round: 7, ShardID: 1, HeaderHash: []byte("sh5"), ShardMiniBlockHeaders: shardMBHeader5}
+
+	metaHdr.ShardInfo = append(metaHdr.ShardInfo, shData1, shData2, shData3, shData4, shData5)
+
+	metaHdr.MiniBlockHeaders = append(metaHdr.MiniBlockHeaders, block.MiniBlockHeader{
+		Hash:            []byte("hash6"),
+		SenderShardID:   core.MetachainShardId,
+		ReceiverShardID: 1,
+	})
+
+	miniBlocksInfo := metaHdr.GetOrderedCrossMiniblocksWithDst(1)
+	require.Equal(t, 5, len(miniBlocksInfo))
+	assert.Equal(t, miniBlocksInfo[0].Hash, []byte("hash6"))
+	assert.Equal(t, miniBlocksInfo[0].Round, uint64(6))
+	assert.Equal(t, miniBlocksInfo[1].Hash, []byte("hash4"))
+	assert.Equal(t, miniBlocksInfo[1].Round, uint64(8))
+	assert.Equal(t, miniBlocksInfo[2].Hash, []byte("hash2"))
+	assert.Equal(t, miniBlocksInfo[2].Round, uint64(9))
+	assert.Equal(t, miniBlocksInfo[3].Hash, []byte("hash3"))
+	assert.Equal(t, miniBlocksInfo[3].Round, uint64(10))
+	assert.Equal(t, miniBlocksInfo[4].Hash, []byte("hash1"))
+	assert.Equal(t, miniBlocksInfo[4].Round, uint64(11))
+
+	miniBlocksInfo = metaHdr.GetOrderedCrossMiniblocksWithDst(2)
+	require.Equal(t, 1, len(miniBlocksInfo))
+	assert.Equal(t, miniBlocksInfo[0].Hash, []byte("hash5"))
+	assert.Equal(t, miniBlocksInfo[0].Round, uint64(7))
 }

--- a/data/interface.go
+++ b/data/interface.go
@@ -66,6 +66,7 @@ type HeaderHandler interface {
 
 	IsStartOfEpochBlock() bool
 	GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32
+	GetOrderedCrossMiniblocksWithDst(destId uint32) []*MiniBlockInfo
 	GetMiniBlockHeadersHashes() [][]byte
 
 	IsInterfaceNil() bool
@@ -256,4 +257,11 @@ type SnapshotDbHandler interface {
 	IncreaseNumReferences()
 	MarkForRemoval()
 	SetPath(string)
+}
+
+// MiniBlockInfo holds information about a cross miniblock referenced in a received block
+type MiniBlockInfo struct {
+	Hash          []byte
+	SenderShardID uint32
+	Round         uint64
 }

--- a/integrationTests/multiShard/relayedTx/edgecases/edgecases_test.go
+++ b/integrationTests/multiShard/relayedTx/edgecases/edgecases_test.go
@@ -12,9 +12,6 @@ import (
 )
 
 func TestRelayedTransactionInMultiShardEnvironmentWithNormalTxButWrongNonce(t *testing.T) {
-	//TODO fix this test: task EN-7532
-	t.Skip("fixme")
-
 	if testing.Short() {
 		t.Skip("this is not a short test")
 	}
@@ -81,9 +78,6 @@ func TestRelayedTransactionInMultiShardEnvironmentWithNormalTxButWrongNonce(t *t
 }
 
 func TestRelayedTransactionInMultiShardEnvironmentWithNormalTxButWithTooMuchGas(t *testing.T) {
-	//TODO fix this test: task EN-7532
-	t.Skip("fixme")
-
 	if testing.Short() {
 		t.Skip("this is not a short test")
 	}

--- a/integrationTests/multiShard/relayedTx/relayedTx_test.go
+++ b/integrationTests/multiShard/relayedTx/relayedTx_test.go
@@ -22,9 +22,6 @@ import (
 )
 
 func TestRelayedTransactionInMultiShardEnvironmentWithNormalTx(t *testing.T) {
-	//TODO fix this test: task EN-7532
-	t.Skip("fixme")
-
 	if testing.Short() {
 		t.Skip("this is not a short test")
 	}
@@ -79,9 +76,6 @@ func TestRelayedTransactionInMultiShardEnvironmentWithNormalTx(t *testing.T) {
 }
 
 func TestRelayedTransactionInMultiShardEnvironmentWithSmartContractTX(t *testing.T) {
-	//TODO fix this test: task EN-7532
-	t.Skip("fixme")
-
 	if testing.Short() {
 		t.Skip("this is not a short test")
 	}
@@ -171,9 +165,6 @@ func TestRelayedTransactionInMultiShardEnvironmentWithSmartContractTX(t *testing
 }
 
 func TestRelayedTransactionInMultiShardEnvironmentWithESDTTX(t *testing.T) {
-	//TODO fix this test: task EN-7532
-	t.Skip("fixme")
-
 	if testing.Short() {
 		t.Skip("this is not a short test")
 	}
@@ -263,9 +254,6 @@ func TestRelayedTransactionInMultiShardEnvironmentWithESDTTX(t *testing.T) {
 }
 
 func TestRelayedTransactionInMultiShardEnvironmentWithAttestationContract(t *testing.T) {
-	//TODO fix this test: task EN-7532
-	t.Skip("fixme")
-
 	if testing.Short() {
 		t.Skip("this is not a short test")
 	}

--- a/process/coordinator/process.go
+++ b/process/coordinator/process.go
@@ -520,8 +520,8 @@ func (tc *transactionCoordinator) CreateMbsAndProcessCrossShardTransactionsDstMe
 
 	shouldSkipShard := make(map[uint32]bool)
 
-	crossMiniBlockHashes := hdr.GetOrderedCrossMiniblocksWithDst(tc.shardCoordinator.SelfId())
-	for _, miniBlockInfo := range crossMiniBlockHashes {
+	crossMiniBlockInfos := hdr.GetOrderedCrossMiniblocksWithDst(tc.shardCoordinator.SelfId())
+	for _, miniBlockInfo := range crossMiniBlockInfos {
 		if !haveTime() {
 			log.Debug("CreateMbsAndProcessCrossShardTransactionsDstMe",
 				"stop creating", "time is out")
@@ -611,7 +611,7 @@ func (tc *transactionCoordinator) CreateMbsAndProcessCrossShardTransactionsDstMe
 		nrMiniBlocksProcessed++
 	}
 
-	allMBsProcessed := nrMiniBlocksProcessed == len(crossMiniBlockHashes)
+	allMBsProcessed := nrMiniBlocksProcessed == len(crossMiniBlockInfos)
 
 	return miniBlocks, nrTxAdded, allMBsProcessed, nil
 }

--- a/process/mock/headerHandlerStub.go
+++ b/process/mock/headerHandlerStub.go
@@ -8,19 +8,20 @@ import (
 
 // HeaderHandlerStub -
 type HeaderHandlerStub struct {
-	GetMiniBlockHeadersWithDstCalled func(destId uint32) map[string]uint32
-	GetPubKeysBitmapCalled           func() []byte
-	GetSignatureCalled               func() []byte
-	GetRootHashCalled                func() []byte
-	GetRandSeedCalled                func() []byte
-	GetPrevRandSeedCalled            func() []byte
-	GetPrevHashCalled                func() []byte
-	CloneCalled                      func() data.HeaderHandler
-	GetChainIDCalled                 func() []byte
-	CheckChainIDCalled               func(reference []byte) error
-	GetAccumulatedFeesCalled         func() *big.Int
-	GetDeveloperFeesCalled           func() *big.Int
-	GetReservedCalled                func() []byte
+	GetMiniBlockHeadersWithDstCalled       func(destId uint32) map[string]uint32
+	GetOrderedCrossMiniblocksWithDstCalled func(destId uint32) []*data.MiniBlockInfo
+	GetPubKeysBitmapCalled                 func() []byte
+	GetSignatureCalled                     func() []byte
+	GetRootHashCalled                      func() []byte
+	GetRandSeedCalled                      func() []byte
+	GetPrevRandSeedCalled                  func() []byte
+	GetPrevHashCalled                      func() []byte
+	CloneCalled                            func() data.HeaderHandler
+	GetChainIDCalled                       func() []byte
+	CheckChainIDCalled                     func(reference []byte) error
+	GetAccumulatedFeesCalled               func() *big.Int
+	GetDeveloperFeesCalled                 func() *big.Int
+	GetReservedCalled                      func() []byte
 }
 
 // GetAccumulatedFees -
@@ -215,6 +216,11 @@ func (hhs *HeaderHandlerStub) SetTxCount(_ uint32) {
 // GetMiniBlockHeadersWithDst -
 func (hhs *HeaderHandlerStub) GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32 {
 	return hhs.GetMiniBlockHeadersWithDstCalled(destId)
+}
+
+// GetOrderedCrossMiniblocksWithDst -
+func (hhs *HeaderHandlerStub) GetOrderedCrossMiniblocksWithDst(destId uint32) []*data.MiniBlockInfo {
+	return hhs.GetOrderedCrossMiniblocksWithDstCalled(destId)
 }
 
 // GetMiniBlockHeadersHashes -

--- a/sharding/mock/headerHandlerStub.go
+++ b/sharding/mock/headerHandlerStub.go
@@ -214,6 +214,11 @@ func (hhs *HeaderHandlerStub) GetMiniBlockHeadersWithDst(_ uint32) map[string]ui
 	panic("implement me")
 }
 
+// GetOrderedCrossMiniblocksWithDst -
+func (hhs *HeaderHandlerStub) GetOrderedCrossMiniblocksWithDst(destId uint32) []*data.MiniBlockInfo {
+	panic("implement me")
+}
+
 // GetMiniBlockHeadersHashes -
 func (hhs *HeaderHandlerStub) GetMiniBlockHeadersHashes() [][]byte {
 	panic("implement me")


### PR DESCRIPTION
* Implemented execution in a chronological way for cross shard mini blocks, taking into consideration the round in which they were created/executed in sender shard

* Unskipped the relayed integration tests
