### PR TITLE
Fixed meta smart contract processor arguments

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -1401,6 +1401,7 @@ func newBlockProcessor(
 			processArgs.historyRepo,
 			processArgs.epochNotifier,
 			txSimulatorProcessorArgs,
+			processArgs.mainConfig.GeneralSettings,
 		)
 	}
 
@@ -1735,6 +1736,7 @@ func newMetaBlockProcessor(
 	historyRepository dblookupext.HistoryRepository,
 	epochNotifier process.EpochNotifier,
 	txSimulatorProcessorArgs *txsimulator.ArgsTxSimulator,
+	generalSettingsConfig config.GeneralSettingsConfig,
 ) (process.BlockProcessor, error) {
 
 	builtInFuncs := builtInFunctions.NewBuiltInFunctionContainer()
@@ -1819,24 +1821,27 @@ func newMetaBlockProcessor(
 	}
 
 	argsNewScProcessor := smartContract.ArgsNewSmartContractProcessor{
-		VmContainer:      vmContainer,
-		ArgsParser:       argsParser,
-		Hasher:           core.Hasher,
-		Marshalizer:      core.InternalMarshalizer,
-		AccountsDB:       stateComponents.AccountsAdapter,
-		BlockChainHook:   vmFactory.BlockChainHookImpl(),
-		PubkeyConv:       stateComponents.AddressPubkeyConverter,
-		Coordinator:      shardCoordinator,
-		ScrForwarder:     scForwarder,
-		TxFeeHandler:     txFeeHandler,
-		EconomicsFee:     economicsData,
-		TxTypeHandler:    txTypeHandler,
-		GasHandler:       gasHandler,
-		GasSchedule:      gasSchedule,
-		BuiltInFunctions: vmFactory.BlockChainHookImpl().GetBuiltInFunctions(),
-		TxLogsProcessor:  txLogsProcessor,
-		BadTxForwarder:   badTxForwarder,
-		EpochNotifier:    epochNotifier,
+		VmContainer:                    vmContainer,
+		ArgsParser:                     argsParser,
+		Hasher:                         core.Hasher,
+		Marshalizer:                    core.InternalMarshalizer,
+		AccountsDB:                     stateComponents.AccountsAdapter,
+		BlockChainHook:                 vmFactory.BlockChainHookImpl(),
+		PubkeyConv:                     stateComponents.AddressPubkeyConverter,
+		Coordinator:                    shardCoordinator,
+		ScrForwarder:                   scForwarder,
+		TxFeeHandler:                   txFeeHandler,
+		EconomicsFee:                   economicsData,
+		TxTypeHandler:                  txTypeHandler,
+		GasHandler:                     gasHandler,
+		GasSchedule:                    gasSchedule,
+		BuiltInFunctions:               vmFactory.BlockChainHookImpl().GetBuiltInFunctions(),
+		TxLogsProcessor:                txLogsProcessor,
+		DeployEnableEpoch:              generalSettingsConfig.SCDeployEnableEpoch,
+		BuiltinEnableEpoch:             generalSettingsConfig.BuiltInFunctionsEnableEpoch,
+		PenalizedTooMuchGasEnableEpoch: generalSettingsConfig.PenalizedTooMuchGasEnableEpoch,
+		BadTxForwarder:                 badTxForwarder,
+		EpochNotifier:                  epochNotifier,
 	}
 	scProcessor, err := smartContract.NewSmartContractProcessor(argsNewScProcessor)
 	if err != nil {


### PR DESCRIPTION
- passed the enabled epoch configs to the smart contract processor for the metachain nodes
This caused the mainnet import DB folder to cause a stuck situation on a meta node @ nonce 12801

Manual testing procedure:
import a meta node full history from epoch 0. The process should work (should get pass of the nonce 12801)