### PR TITLE
Bug fix panic tps benchmark

### DIFF
--- a/core/statistics/tpsBenchmark.go
+++ b/core/statistics/tpsBenchmark.go
@@ -179,13 +179,13 @@ func (s *TpsBenchmark) NrOfShards() uint32 {
 // ShardStatistics returns the current statistical state for a given shard
 func (s *TpsBenchmark) ShardStatistics() map[uint32]ShardStatistic {
 	s.mut.RLock()
-	copyMapShardStatistics := make(map[uint32]ShardStatistic)
+	shardStatisticsMapCopy := make(map[uint32]ShardStatistic)
 	for key, value := range s.shardStatistics {
-		copyMapShardStatistics[key] = value
+		shardStatisticsMapCopy[key] = value
 	}
 	s.mut.RUnlock()
 
-	return copyMapShardStatistics
+	return shardStatisticsMapCopy
 }
 
 // ShardStatistic returns the current statistical state for a given shard

--- a/core/statistics/tpsBenchmark.go
+++ b/core/statistics/tpsBenchmark.go
@@ -179,8 +179,13 @@ func (s *TpsBenchmark) NrOfShards() uint32 {
 // ShardStatistics returns the current statistical state for a given shard
 func (s *TpsBenchmark) ShardStatistics() map[uint32]ShardStatistic {
 	s.mut.RLock()
-	defer s.mut.RUnlock()
-	return s.shardStatistics
+	copyMapShardStatistics := make(map[uint32]ShardStatistic)
+	for key, value := range s.shardStatistics {
+		copyMapShardStatistics[key] = value
+	}
+	s.mut.RUnlock()
+
+	return copyMapShardStatistics
 }
 
 // ShardStatistic returns the current statistical state for a given shard

--- a/core/statistics/tpsBenchmark_test.go
+++ b/core/statistics/tpsBenchmark_test.go
@@ -637,7 +637,7 @@ func TestTpsBenchmark_ZeroTxMetaBlockAndEmptyShardHeader(t *testing.T) {
 	assert.Equal(t, bigTxCount, tpsBenchmark.TotalProcessedTxCount())
 }
 
-func TestTpsBenchmark_ShardStatisticConcurrentAccessBla(t *testing.T) {
+func TestTpsBenchmark_ShardStatisticConcurrentAccess(t *testing.T) {
 	t.Parallel()
 
 	tpsBenchmark, _ := statistics.NewTPSBenchmark(12, 4)

--- a/core/statistics/tpsBenchmark_test.go
+++ b/core/statistics/tpsBenchmark_test.go
@@ -640,6 +640,12 @@ func TestTpsBenchmark_ZeroTxMetaBlockAndEmptyShardHeader(t *testing.T) {
 func TestTpsBenchmark_ShardStatisticConcurrentAccess(t *testing.T) {
 	t.Parallel()
 
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("code should not panic")
+		}
+	}()
+
 	tpsBenchmark, _ := statistics.NewTPSBenchmark(12, 4)
 
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
Fix concurrent access on map that store shard statistics information for TPS Benchmark. 
When method ShardStatistics() is called will return a copy of map that contains shard statistics.