### PR TITLE
wrapped vm output api response

### DIFF
--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -8,11 +8,11 @@ import (
 	"github.com/ElrondNetwork/elrond-go/core/statistics"
 	"github.com/ElrondNetwork/elrond-go/data/state"
 	"github.com/ElrondNetwork/elrond-go/data/transaction"
+	"github.com/ElrondNetwork/elrond-go/data/vm"
 	"github.com/ElrondNetwork/elrond-go/debug"
 	"github.com/ElrondNetwork/elrond-go/heartbeat/data"
 	"github.com/ElrondNetwork/elrond-go/node/external"
 	"github.com/ElrondNetwork/elrond-go/process"
-	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
 
 // Facade is the mock implementation of a node router handler
@@ -29,7 +29,7 @@ type Facade struct {
 		gasLimit uint64, data []byte, signatureHex string, chainID string, version uint32) (*transaction.Transaction, []byte, error)
 	ValidateTransactionHandler              func(tx *transaction.Transaction) error
 	SendBulkTransactionsHandler             func(txs []*transaction.Transaction) (uint64, error)
-	ExecuteSCQueryHandler                   func(query *process.SCQuery) (*vmcommon.VMOutput, error)
+	ExecuteSCQueryHandler                   func(query *process.SCQuery) (*vm.VMOutputApi, error)
 	StatusMetricsHandler                    func() external.StatusMetricsHandler
 	ValidatorStatisticsHandler              func() (map[string]*state.ValidatorApiResponse, error)
 	ComputeTransactionGasLimitHandler       func(tx *transaction.Transaction) (uint64, error)
@@ -151,7 +151,7 @@ func (f *Facade) ValidatorStatisticsApi() (map[string]*state.ValidatorApiRespons
 }
 
 // ExecuteSCQuery is a mock implementation.
-func (f *Facade) ExecuteSCQuery(query *process.SCQuery) (*vmcommon.VMOutput, error) {
+func (f *Facade) ExecuteSCQuery(query *process.SCQuery) (*vm.VMOutputApi, error) {
 	return f.ExecuteSCQueryHandler(query)
 }
 

--- a/api/vmValues/routes.go
+++ b/api/vmValues/routes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/api/errors"
 	"github.com/ElrondNetwork/elrond-go/api/shared"
 	"github.com/ElrondNetwork/elrond-go/api/wrapper"
+	"github.com/ElrondNetwork/elrond-go/data/vm"
 	"github.com/ElrondNetwork/elrond-go/process"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/gin-gonic/gin"
@@ -23,7 +24,7 @@ const (
 
 // FacadeHandler interface defines methods that can be used by the gin webserver
 type FacadeHandler interface {
-	ExecuteSCQuery(*process.SCQuery) (*vmcommon.VMOutput, error)
+	ExecuteSCQuery(*process.SCQuery) (*vm.VMOutputApi, error)
 	DecodeAddressPubkey(pk string) ([]byte, error)
 	IsInterfaceNil() bool
 }
@@ -88,7 +89,7 @@ func executeQuery(context *gin.Context) {
 	returnOkResponse(context, vmOutput)
 }
 
-func doExecuteQuery(context *gin.Context) (*vmcommon.VMOutput, error) {
+func doExecuteQuery(context *gin.Context) (*vm.VMOutputApi, error) {
 	efObj, ok := context.Get("facade")
 	if !ok {
 		return nil, errors.ErrNilAppContext

--- a/api/vmValues/routes_test.go
+++ b/api/vmValues/routes_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/api/shared"
 	"github.com/ElrondNetwork/elrond-go/api/wrapper"
 	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/data/vm"
 	"github.com/ElrondNetwork/elrond-go/process"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/gin-contrib/cors"
@@ -46,8 +47,8 @@ func TestGetHex_ShouldWork(t *testing.T) {
 	valueBuff, _ := hex.DecodeString("DEADBEEF")
 
 	facade := mock.Facade{
-		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vmcommon.VMOutput, e error) {
-			return &vmcommon.VMOutput{
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
+			return &vm.VMOutputApi{
 				ReturnData: [][]byte{valueBuff},
 			}, nil
 		},
@@ -73,8 +74,8 @@ func TestGetString_ShouldWork(t *testing.T) {
 	valueBuff := "DEADBEEF"
 
 	facade := mock.Facade{
-		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vmcommon.VMOutput, e error) {
-			return &vmcommon.VMOutput{
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
+			return &vm.VMOutputApi{
 				ReturnData: [][]byte{[]byte(valueBuff)},
 			}, nil
 		},
@@ -100,10 +101,10 @@ func TestGetInt_ShouldWork(t *testing.T) {
 	value := "1234567"
 
 	facade := mock.Facade{
-		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vmcommon.VMOutput, e error) {
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
 			returnData := big.NewInt(0)
 			returnData.SetString(value, 10)
-			return &vmcommon.VMOutput{
+			return &vm.VMOutputApi{
 				ReturnData: [][]byte{returnData.Bytes()},
 			}, nil
 		},
@@ -127,9 +128,9 @@ func TestQuery_ShouldWork(t *testing.T) {
 	t.Parallel()
 
 	facade := mock.Facade{
-		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vmcommon.VMOutput, e error) {
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
 
-			return &vmcommon.VMOutput{
+			return &vm.VMOutputApi{
 				ReturnData: [][]byte{big.NewInt(42).Bytes()},
 			}, nil
 		},
@@ -166,7 +167,7 @@ func TestAllRoutes_FacadeErrorsShouldErr(t *testing.T) {
 
 	errExpected := errors.New("some random error")
 	facade := mock.Facade{
-		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vmcommon.VMOutput, e error) {
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
 			return nil, errExpected
 		},
 	}
@@ -185,8 +186,8 @@ func TestAllRoutes_WhenBadAddressShouldErr(t *testing.T) {
 
 	errExpected := errors.New("not a valid address")
 	facade := mock.Facade{
-		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vmcommon.VMOutput, e error) {
-			return &vmcommon.VMOutput{}, nil
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
+			return &vm.VMOutputApi{}, nil
 		},
 	}
 
@@ -204,8 +205,8 @@ func TestAllRoutes_WhenBadArgumentsShouldErr(t *testing.T) {
 
 	errExpected := errors.New("not a valid hex string")
 	facade := mock.Facade{
-		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vmcommon.VMOutput, e error) {
-			return &vmcommon.VMOutput{}, nil
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
+			return &vm.VMOutputApi{}, nil
 		},
 	}
 
@@ -223,8 +224,8 @@ func TestAllRoutes_WhenNoVMReturnDataShouldErr(t *testing.T) {
 
 	errExpected := errors.New("no return data")
 	facade := mock.Facade{
-		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vmcommon.VMOutput, e error) {
-			return &vmcommon.VMOutput{}, nil
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
+			return &vm.VMOutputApi{}, nil
 		},
 	}
 
@@ -241,8 +242,8 @@ func TestAllRoutes_WhenBadJsonShouldErr(t *testing.T) {
 	t.Parallel()
 
 	facade := mock.Facade{
-		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vmcommon.VMOutput, e error) {
-			return &vmcommon.VMOutput{}, nil
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
+			return &vm.VMOutputApi{}, nil
 		},
 	}
 

--- a/data/vm/vmOutputApi.go
+++ b/data/vm/vmOutputApi.go
@@ -1,0 +1,72 @@
+package vm
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+)
+
+// VMOutputApi is a wrapper over the vmcommon's VMOutput
+type VMOutputApi struct {
+	ReturnData      [][]byte                     `json:"returnData"`
+	ReturnCode      string                       `json:"returnCode"`
+	ReturnMessage   string                       `json:"returnMessage"`
+	GasRemaining    uint64                       `json:"gasRemaining"`
+	GasRefund       *big.Int                     `json:"gasRefund"`
+	OutputAccounts  map[string]*OutputAccountApi `json:"outputAccounts"`
+	DeletedAccounts [][]byte                     `json:"deletedAccounts"`
+	TouchedAccounts [][]byte                     `json:"touchedAccounts"`
+	Logs            []*LogEntryApi               `json:"logs"`
+}
+
+// StorageUpdateApi is a wrapper over vmcommon's StorageUpdate
+type StorageUpdateApi struct {
+	Offset []byte `json:"offset"`
+	Data   []byte `json:"data"`
+}
+
+// OutputAccountApi is a wrapper over vmcommon's OutputAccount
+type OutputAccountApi struct {
+	Address        string                       `json:"address"`
+	Nonce          uint64                       `json:"nonce"`
+	Balance        *big.Int                     `json:"balance"`
+	BalanceDelta   *big.Int                     `json:"balanceDelta"`
+	StorageUpdates map[string]*StorageUpdateApi `json:"storageUpdates"`
+	Code           []byte                       `json:"code"`
+	CodeMetadata   []byte                       `json:"codeMetaData"`
+	Data           []byte                       `json:"data"`
+	GasLimit       uint64                       `json:"gasLimit"`
+	CallType       vmcommon.CallType            `json:"callType"`
+}
+
+// LogEntryApi is a wrapper over vmcommon's LogEntry
+type LogEntryApi struct {
+	Identifier []byte   `json:"identifier"`
+	Address    string   `json:"address"`
+	Topics     [][]byte `json:"topics"`
+	Data       []byte   `json:"data"`
+}
+
+// GetFirstReturnData is a helper function that returns the first ReturnData of VMOutput, interpreted as specified.
+func (vmOutput *VMOutputApi) GetFirstReturnData(asType vmcommon.ReturnDataKind) (interface{}, error) {
+	if len(vmOutput.ReturnData) == 0 {
+		return nil, fmt.Errorf("no return data")
+	}
+
+	returnData := vmOutput.ReturnData[0]
+
+	switch asType {
+	case vmcommon.AsBigInt:
+		return big.NewInt(0).SetBytes(returnData), nil
+	case vmcommon.AsBigIntString:
+		return big.NewInt(0).SetBytes(returnData).String(), nil
+	case vmcommon.AsString:
+		return string(returnData), nil
+	case vmcommon.AsHex:
+		return hex.EncodeToString(returnData), nil
+	}
+
+	return nil, fmt.Errorf("can't interpret return data")
+}

--- a/data/vm/vmOutputApi_test.go
+++ b/data/vm/vmOutputApi_test.go
@@ -1,0 +1,79 @@
+package vm
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVMOutputApi_GetFirstReturnDataAsBigInt(t *testing.T) {
+	t.Parallel()
+
+	expectedRes := 37
+
+	vmOutputApi := VMOutputApi{
+		ReturnData: [][]byte{big.NewInt(int64(expectedRes)).Bytes()},
+	}
+
+	res, err := vmOutputApi.GetFirstReturnData(vmcommon.AsBigInt)
+	require.NoError(t, err)
+
+	resBigInt, ok := res.(*big.Int)
+	require.True(t, ok)
+	require.Equal(t, uint64(expectedRes), resBigInt.Uint64())
+}
+
+func TestVMOutputApi_GetFirstReturnDataAsBigIntString(t *testing.T) {
+	t.Parallel()
+
+	expectedRes := "37"
+
+	bi, _ := big.NewInt(0).SetString(expectedRes, 10)
+	vmOutputApi := VMOutputApi{
+		ReturnData: [][]byte{bi.Bytes()},
+	}
+
+	res, err := vmOutputApi.GetFirstReturnData(vmcommon.AsBigIntString)
+	require.NoError(t, err)
+
+	resBigIntString, ok := res.(string)
+	require.True(t, ok)
+	require.Equal(t, expectedRes, resBigIntString)
+}
+
+func TestVMOutputApi_GetFirstReturnDataAsHex(t *testing.T) {
+	t.Parallel()
+
+	expectedRes := hex.EncodeToString([]byte("37"))
+
+	resBytes, _ := hex.DecodeString(expectedRes)
+	vmOutputApi := VMOutputApi{
+		ReturnData: [][]byte{resBytes},
+	}
+
+	res, err := vmOutputApi.GetFirstReturnData(vmcommon.AsHex)
+	require.NoError(t, err)
+
+	resHexString, ok := res.(string)
+	require.True(t, ok)
+	require.Equal(t, expectedRes, resHexString)
+}
+
+func TestVMOutputApi_GetFirstReturnDataAsString(t *testing.T) {
+	t.Parallel()
+
+	expectedRes := "37"
+	vmOutputApi := VMOutputApi{
+		ReturnData: [][]byte{[]byte(expectedRes)},
+	}
+
+	res, err := vmOutputApi.GetFirstReturnData(vmcommon.AsString)
+	require.NoError(t, err)
+
+	resString, ok := res.(string)
+	require.True(t, ok)
+	require.Equal(t, expectedRes, resString)
+}

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -421,10 +421,10 @@ func (nf *nodeFacade) GetNumCheckpointsFromPeerState() uint32 {
 func (nf *nodeFacade) convertVmOutputToApiResponse(input *vmcommon.VMOutput) *vm.VMOutputApi {
 	outputAccounts := make(map[string]*vm.OutputAccountApi)
 	for key, acc := range input.OutputAccounts {
-		outPutAddress, err := nf.node.EncodeAddressPubkey(acc.Address)
+		outputAddress, err := nf.node.EncodeAddressPubkey(acc.Address)
 		if err != nil {
 			log.Warn("cannot encode address", "error", err)
-			outPutAddress = ""
+			outputAddress = ""
 		}
 
 		storageUpdates := make(map[string]*vm.StorageUpdateApi)
@@ -435,7 +435,7 @@ func (nf *nodeFacade) convertVmOutputToApiResponse(input *vmcommon.VMOutput) *vm
 			}
 		}
 		outputAccounts[hex.EncodeToString([]byte(key))] = &vm.OutputAccountApi{
-			Address:        outPutAddress,
+			Address:        outputAddress,
 			Nonce:          acc.Nonce,
 			Balance:        acc.Balance,
 			BalanceDelta:   acc.BalanceDelta,


### PR DESCRIPTION
created a wrapped structure which will be returned when calling a `vm-values` endpoint. Now it will display addresses in bech32 format when needed and added custom json tags (with lowercase)

Testing procedure:
- run a testnet
- make a POST request to `vm-values/query` for example and the output should follow json format and not having unreadable characters