### PR TITLE
EN-6936: log route on seednode

### DIFF
--- a/cmd/seednode/api/api.go
+++ b/cmd/seednode/api/api.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 
 	logger "github.com/ElrondNetwork/elrond-go-logger"
@@ -15,13 +14,13 @@ import (
 var log = logger.GetOrCreate("seednode/api")
 
 // Start will boot up the api and appropriate routes, handlers and validators
-func Start(port int, marshalizer marshal.Marshalizer) error {
+func Start(restApiInterface string, marshalizer marshal.Marshalizer) error {
 	ws := gin.Default()
 	ws.Use(cors.Default())
 
 	registerRoutes(ws, marshalizer)
 
-	return ws.Run(fmt.Sprintf(":%d", port))
+	return ws.Run(restApiInterface)
 }
 
 func registerRoutes(ws *gin.Engine, marshalizer marshal.Marshalizer) {

--- a/cmd/seednode/api/api.go
+++ b/cmd/seednode/api/api.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-go/api/logs"
+	"github.com/ElrondNetwork/elrond-go/marshal"
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+var log = logger.GetOrCreate("seednode/api")
+
+// Start will boot up the api and appropriate routes, handlers and validators
+func Start(port int, marshalizer marshal.Marshalizer) error {
+	ws := gin.Default()
+	ws.Use(cors.Default())
+
+	registerRoutes(ws, marshalizer)
+
+	return ws.Run(fmt.Sprintf(":%d", port))
+}
+
+func registerRoutes(ws *gin.Engine, marshalizer marshal.Marshalizer) {
+	registerLoggerWsRoute(ws, marshalizer)
+}
+
+func registerLoggerWsRoute(ws *gin.Engine, marshalizer marshal.Marshalizer) {
+	upgrader := websocket.Upgrader{}
+
+	ws.GET("/log", func(c *gin.Context) {
+		upgrader.CheckOrigin = func(r *http.Request) bool {
+			return true
+		}
+
+		conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+		if err != nil {
+			log.Error(err.Error())
+			return
+		}
+
+		ls, err := logs.NewLogSender(marshalizer, conn, log)
+		if err != nil {
+			log.Error(err.Error())
+			return
+		}
+
+		ls.StartSendingBlocking()
+	})
+}


### PR DESCRIPTION
Added the `/log` route inside the seednode. If enabled (Rest API interface is not set to "off") then the logs can be fetched via the `logviewer` app. 

Testing procedure:
-run the seednode. Default API interface is `localhost:8080` and can be replaced with the `--rest-api-interface X` flag 
-try to connect via the `logviewer` app: `./logviewer -address 127.0.0.1:8080` . If seednode's Rest API interface is not "off", it should work and fetch logs real time. If seednode's Rest API interface was set to "off" (`./seednode --rest-api-interface off`), then no connection should be made.