### PR TITLE
Sync tracker pool with headers pool

### DIFF
--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -255,7 +255,9 @@ func (bp *baseProcessor) requestHeadersIfMissing(
 		missingNonces = append(missingNonces, nonces...)
 	}
 
+	headersPool := bp.dataPool.Headers()
 	for _, nonce := range missingNonces {
+		headersPool.RemoveHeaderByNonceAndShardId(nonce, shardId)
 		go bp.requestHeaderByShardAndNonce(shardId, nonce)
 	}
 

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -999,7 +999,7 @@ func TestBlockProcessor_PruneStateOnRollbackPrunesPeerTrieIfSameRootHashButDiffe
 	assert.Equal(t, 2, pruningCalled)
 }
 
-func TestBlocProcessor_RequestHeadersIfMissingShouldWorkWhenSortedHeadersListIsEmpty(t *testing.T) {
+func TestBlockProcessor_RequestHeadersIfMissingShouldWorkWhenSortedHeadersListIsEmpty(t *testing.T) {
 	t.Parallel()
 
 	var requestedNonces []uint64
@@ -1045,7 +1045,7 @@ func TestBlocProcessor_RequestHeadersIfMissingShouldWorkWhenSortedHeadersListIsE
 	assert.Equal(t, expectedNonces, requestedNonces)
 }
 
-func TestBlocProcessor_RequestHeadersIfMissingShouldWork(t *testing.T) {
+func TestBlockProcessor_RequestHeadersIfMissingShouldWork(t *testing.T) {
 	t.Parallel()
 
 	var requestedNonces []uint64
@@ -1113,4 +1113,60 @@ func TestBlocProcessor_RequestHeadersIfMissingShouldWork(t *testing.T) {
 	mutRequestedNonces.Unlock()
 	expectedNonces = []uint64{6, 7, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25}
 	assert.Equal(t, expectedNonces, requestedNonces)
+}
+
+func TestBlockProcessor_RequestHeadersIfMissingShouldCleanHeadersPool(t *testing.T) {
+	t.Parallel()
+
+	var removedNonces []uint64
+
+	arguments := CreateMockArguments()
+	rounder := &mock.RounderMock{}
+	arguments.Rounder = rounder
+
+	poolsHolderStub := initDataPool([]byte(""))
+	poolsHolderStub.HeadersCalled = func() dataRetriever.HeadersPool {
+		return &mock.HeadersCacherStub{
+			RemoveHeaderByNonceAndShardIdCalled: func(hdrNonce uint64, shardId uint32) {
+				removedNonces = append(removedNonces, hdrNonce)
+			},
+		}
+	}
+	arguments.DataPool = poolsHolderStub
+
+	sp, _ := blproc.NewShardProcessor(arguments)
+
+	sortedHeaders := make([]data.HeaderHandler, 0)
+
+	crossNotarizedHeader := &block.MetaBlock{
+		Nonce: 5,
+		Round: 5,
+	}
+	arguments.BlockTracker.AddCrossNotarizedHeader(core.MetachainShardId, crossNotarizedHeader, []byte("hash"))
+
+	hdr1 := &block.MetaBlock{
+		Nonce: 1,
+		Round: 1,
+	}
+	sortedHeaders = append(sortedHeaders, hdr1)
+
+	hdr2 := &block.MetaBlock{
+		Nonce: 8,
+		Round: 8,
+	}
+	sortedHeaders = append(sortedHeaders, hdr2)
+
+	hdr3 := &block.MetaBlock{
+		Nonce: 10,
+		Round: 10,
+	}
+	sortedHeaders = append(sortedHeaders, hdr3)
+
+	removedNonces = make([]uint64, 0)
+
+	rounder.RoundIndex = 12
+	_ = sp.RequestHeadersIfMissing(sortedHeaders, core.MetachainShardId)
+
+	expectedNonces := []uint64{6, 7, 9}
+	assert.Equal(t, expectedNonces, removedNonces)
 }

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -357,3 +357,11 @@ func (sp *shardProcessor) GetBootstrapHeadersInfo(
 ) []bootstrapStorage.BootstrapHeaderInfo {
 	return sp.getBootstrapHeadersInfo(selfNotarizedHeaders, selfNotarizedHeadersHashes)
 }
+
+func (sp *shardProcessor) RequestMetaHeadersIfNeeded(hdrsAdded uint32, lastMetaHdr data.HeaderHandler) {
+	sp.requestMetaHeadersIfNeeded(hdrsAdded, lastMetaHdr)
+}
+
+func (mp *metaProcessor) RequestShardHeadersIfNeeded(hdrsAddedForShard map[uint32]uint32, lastShardHdr map[uint32]data.HeaderHandler) {
+	mp.requestShardHeadersIfNeeded(hdrsAddedForShard, lastShardHdr)
+}

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -966,6 +966,7 @@ func (mp *metaProcessor) requestShardHeadersIfNeeded(
 	hdrsAddedForShard map[uint32]uint32,
 	lastShardHdr map[uint32]data.HeaderHandler,
 ) {
+	headersPool := mp.dataPool.Headers()
 	for shardID := uint32(0); shardID < mp.shardCoordinator.NumberOfShards(); shardID++ {
 		log.Debug("shard headers added",
 			"shard", shardID,
@@ -978,6 +979,7 @@ func (mp *metaProcessor) requestShardHeadersIfNeeded(
 			fromNonce := lastShardHdr[shardID].GetNonce() + 1
 			toNonce := fromNonce + uint64(mp.shardBlockFinality)
 			for nonce := fromNonce; nonce <= toNonce; nonce++ {
+				headersPool.RemoveHeaderByNonceAndShardId(nonce, shardID)
 				go mp.requestHandler.RequestShardHeaderByNonce(shardID, nonce)
 			}
 		}

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -1639,7 +1639,9 @@ func (sp *shardProcessor) requestMetaHeadersIfNeeded(hdrsAdded uint32, lastMetaH
 	if shouldRequestCrossHeaders {
 		fromNonce := lastMetaHdr.GetNonce() + 1
 		toNonce := fromNonce + uint64(sp.metaBlockFinality)
+		headersPool := sp.dataPool.Headers()
 		for nonce := fromNonce; nonce <= toNonce; nonce++ {
+			headersPool.RemoveHeaderByNonceAndShardId(nonce, core.MetachainShardId)
 			go sp.requestHandler.RequestMetaHeaderByNonce(nonce)
 		}
 	}

--- a/process/mock/blockTrackerHandlerMock.go
+++ b/process/mock/blockTrackerHandlerMock.go
@@ -11,6 +11,7 @@ type BlockTrackerHandlerMock struct {
 	ComputeCrossInfoCalled        func(headers []data.HeaderHandler)
 	ComputeLongestSelfChainCalled func() (data.HeaderHandler, []byte, []data.HeaderHandler, [][]byte)
 	SortHeadersFromNonceCalled    func(shardID uint32, nonce uint64) ([]data.HeaderHandler, [][]byte)
+	RemoveHeaderFromPoolCalled    func(shardID uint32, nonce uint64)
 }
 
 // GetSelfHeaders -
@@ -45,6 +46,13 @@ func (bthm *BlockTrackerHandlerMock) SortHeadersFromNonce(shardID uint32, nonce 
 	}
 
 	return nil, nil
+}
+
+// RemoveHeaderFromPool -
+func (bthm *BlockTrackerHandlerMock) RemoveHeaderFromPool(shardID uint32, nonce uint64) {
+	if bthm.RemoveHeaderFromPoolCalled != nil {
+		bthm.RemoveHeaderFromPoolCalled(shardID, nonce)
+	}
 }
 
 // IsInterfaceNil -

--- a/process/track/baseBlockTrack.go
+++ b/process/track/baseBlockTrack.go
@@ -554,6 +554,11 @@ func (bbt *baseBlockTrack) SortHeadersFromNonce(shardID uint32, nonce uint64) ([
 	return headers, headersHashes
 }
 
+// RemoveHeaderFromPool removes the header with the given shard and nonce from pool
+func (bbt *baseBlockTrack) RemoveHeaderFromPool(shardID uint32, nonce uint64) {
+	bbt.headersPool.RemoveHeaderByNonceAndShardId(nonce, shardID)
+}
+
 // GetTrackedHeadersWithNonce returns tracked headers for a given shard and nonce
 func (bbt *baseBlockTrack) GetTrackedHeadersWithNonce(shardID uint32, nonce uint64) ([]data.HeaderHandler, [][]byte) {
 	bbt.mutHeaders.RLock()

--- a/process/track/baseBlockTrack_test.go
+++ b/process/track/baseBlockTrack_test.go
@@ -1580,6 +1580,30 @@ func TestSortHeadersFromNonce_ShouldWork(t *testing.T) {
 	assert.Equal(t, headers[0], shardHeader2)
 }
 
+func TestRemoveHeaderFromPool_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	shardID := core.MetachainShardId
+	nonce := uint64(1)
+	wasCalled := false
+	shardArguments := CreateShardTrackerMockArguments()
+	shardArguments.PoolsHolder = &testscommon.PoolsHolderStub{
+		HeadersCalled: func() dataRetriever.HeadersPool {
+			return &mock.HeadersCacherStub{
+				RemoveHeaderByNonceAndShardIdCalled: func(hdrNonce uint64, shardId uint32) {
+					if hdrNonce == nonce && shardId == shardID {
+						wasCalled = true
+					}
+				},
+			}
+		},
+	}
+	sbt, _ := track.NewShardBlockTrack(shardArguments)
+	sbt.RemoveHeaderFromPool(shardID, nonce)
+
+	assert.True(t, wasCalled)
+}
+
 func TestGetTrackedHeadersWithNonce_ShouldReturnNilWhenTrackedHeadersSliceForShardIsEmpty(t *testing.T) {
 	t.Parallel()
 

--- a/process/track/blockProcessor.go
+++ b/process/track/blockProcessor.go
@@ -435,6 +435,8 @@ func (bp *blockProcessor) requestHeaders(shardID uint32, fromNonce uint64) {
 			"shard", shardID,
 			"nonce", nonce)
 
+		bp.blockTracker.RemoveHeaderFromPool(shardID, nonce)
+
 		if shardID == core.MetachainShardId {
 			go bp.requestHandler.RequestMetaHeaderByNonce(nonce)
 		} else {

--- a/process/track/export_test.go
+++ b/process/track/export_test.go
@@ -207,6 +207,10 @@ func (bp *blockProcessor) RequestHeadersIfNothingNewIsReceived(lastNotarizedHead
 	bp.requestHeadersIfNothingNewIsReceived(lastNotarizedHeaderNonce, latestValidHeader, highestRoundInReceivedHeaders)
 }
 
+func (bp *blockProcessor) RequestHeaders(shardID uint32, fromNonce uint64) {
+	bp.requestHeaders(shardID, fromNonce)
+}
+
 func (bp *blockProcessor) ShouldProcessReceivedHeader(headerHandler data.HeaderHandler) bool {
 	return bp.shouldProcessReceivedHeader(headerHandler)
 }

--- a/process/track/interface.go
+++ b/process/track/interface.go
@@ -36,6 +36,7 @@ type blockTrackerHandler interface {
 	ComputeCrossInfo(headers []data.HeaderHandler)
 	ComputeLongestSelfChain() (data.HeaderHandler, []byte, []data.HeaderHandler, [][]byte)
 	SortHeadersFromNonce(shardID uint32, nonce uint64) ([]data.HeaderHandler, [][]byte)
+	RemoveHeaderFromPool(shardID uint32, nonce uint64)
 	IsInterfaceNil() bool
 }
 


### PR DESCRIPTION
* Sync tracker pool with headers pool LRU cacher when missing headers from tracker are requested (in this situation a delete will be done in headers pool, just to be sure that the notifiy event will be called for the requested/received header, even if in some edge case situations the requested header exists only in headers pool but not in tracker pool)

This situation could appear only in some rare events of restarting the node after more than 1000 rounds from its last commit