### PR TITLE
bugFix/failed-relayed-with-value

### DIFF
--- a/integrationTests/multiShard/relayedTx/relayedTx_test.go
+++ b/integrationTests/multiShard/relayedTx/relayedTx_test.go
@@ -331,6 +331,8 @@ func TestRelayedTransactionInMultiShardEnvironmentWithAttestationContract(t *tes
 	for i, player := range players {
 		_ = CreateAndSendRelayedAndUserTx(nodes, relayer, player, scAddress, big.NewInt(0), attestVMGas,
 			[]byte("attest@"+hex.EncodeToString([]byte(uniqueIDs[i]))+"@"+hex.EncodeToString([]byte(privateInfos[i]))))
+		_ = CreateAndSendRelayedAndUserTx(nodes, relayer, player, scAddress, registerValue,
+			registerVMGas, []byte("register@"+hex.EncodeToString([]byte(uniqueIDs[i]))))
 	}
 	time.Sleep(time.Second)
 

--- a/process/smartContract/process.go
+++ b/process/smartContract/process.go
@@ -518,7 +518,7 @@ func (sc *scProcessor) ProcessIfError(
 		return err
 	}
 
-	err = sc.processForRelayerWhenError(tx, returnMessage)
+	err = sc.processForRelayerWhenError(tx, txHash, returnMessage)
 	if err != nil {
 		return err
 	}
@@ -530,6 +530,7 @@ func (sc *scProcessor) ProcessIfError(
 
 func (sc *scProcessor) processForRelayerWhenError(
 	originalTx data.TransactionHandler,
+	txHash []byte,
 	returnMessage []byte,
 ) error {
 	relayedSCR, isRelayedTx := isRelayedTx(originalTx)
@@ -543,7 +544,7 @@ func (sc *scProcessor) processForRelayerWhenError(
 	}
 
 	if !check.IfNil(relayerAcnt) {
-		err := relayerAcnt.AddToBalance(relayedSCR.RelayedValue)
+		err = relayerAcnt.AddToBalance(relayedSCR.RelayedValue)
 		if err != nil {
 			return err
 		}
@@ -561,6 +562,7 @@ func (sc *scProcessor) processForRelayerWhenError(
 		RcvAddr:        relayedSCR.RelayerAddr,
 		SndAddr:        relayedSCR.RcvAddr,
 		OriginalTxHash: relayedSCR.OriginalTxHash,
+		PrevTxHash:     txHash,
 		ReturnMessage:  returnMessage,
 	}
 


### PR DESCRIPTION
fix relayed tx when transaction fails and the value has to be sent back to the relayer. With old code the shard would stuck.