### PR TITLE
Resize termui gauge label

### DIFF
--- a/cmd/node/config/ratings.toml
+++ b/cmd/node/config/ratings.toml
@@ -33,14 +33,14 @@
     ProposerValidatorImportance = 1.0
     ProposerDecreaseFactor = -4.0
     ValidatorDecreaseFactor = -4.0
-    ConsecutiveMissedBlocksPenalty = 1.10
+    ConsecutiveMissedBlocksPenalty = 1.50
 
 [MetaChain.RatingSteps]
     HoursToMaxRatingFromStartRating = 55
     ProposerValidatorImportance = 1.0
     ProposerDecreaseFactor = -4.0
     ValidatorDecreaseFactor = -4.0
-    ConsecutiveMissedBlocksPenalty = 1.10
+    ConsecutiveMissedBlocksPenalty = 1.50
 
 [PeerHonesty]
     #this value will be multiplied with the current value for a public key each DecayUpdateIntervalInSeconds seconds

--- a/statusHandler/view/termuic/termuiRenders/widgetsRender.go
+++ b/statusHandler/view/termuic/termuiRenders/widgetsRender.go
@@ -338,6 +338,23 @@ func (wr *WidgetsRender) prepareLogLines(logData []string, size int) []string {
 	return logData
 }
 
+func fitStringToWidth(original string, maxWidth int) string {
+	suffixDots := "..."
+	numPadding := 2
+
+	if len(original)+numPadding < maxWidth {
+		return original
+	}
+
+	nothingToShow := maxWidth <= len(suffixDots)+numPadding ||
+		len(original)-len(suffixDots)-numPadding < 0
+	if nothingToShow {
+		return ""
+	}
+
+	return original[:maxWidth-len(suffixDots)-numPadding] + "..."
+}
+
 func (wr *WidgetsRender) prepareLoads() {
 	cpuLoadPercent := wr.presenter.GetCpuLoadPercent()
 	wr.cpuLoad.Title = "CPU load"
@@ -348,37 +365,39 @@ func (wr *WidgetsRender) prepareLoads() {
 	memUsed := wr.presenter.GetMemUsedByNode()
 	wr.memoryLoad.Title = "Memory load"
 	wr.memoryLoad.Percent = int(memLoadPercent)
-	wr.memoryLoad.Label = fmt.Sprintf("%d%% / used: %s / total: %s", memLoadPercent, core.ConvertBytes(memUsed), core.ConvertBytes(memTotalMemoryBytes))
+	str := fmt.Sprintf("%d%% / used: %s / total: %s", memLoadPercent, core.ConvertBytes(memUsed), core.ConvertBytes(memTotalMemoryBytes))
+	wr.memoryLoad.Label = fitStringToWidth(str, wr.memoryLoad.Size().X)
 
 	recvLoad := wr.presenter.GetNetworkRecvPercent()
 	recvBps := wr.presenter.GetNetworkRecvBps()
 	recvBpsPeak := wr.presenter.GetNetworkRecvBpsPeak()
 	wr.networkRecv.Title = "Network - received per host:"
 	wr.networkRecv.Percent = int(recvLoad)
-	wr.networkRecv.Label = fmt.Sprintf("%d%% / current: %s/s / peak: %s/s",
-		recvLoad, core.ConvertBytes(recvBps), core.ConvertBytes(recvBpsPeak))
+	str = fmt.Sprintf("%d%% / current: %s/s / peak: %s/s", recvLoad, core.ConvertBytes(recvBps), core.ConvertBytes(recvBpsPeak))
+	wr.networkRecv.Label = fitStringToWidth(str, wr.networkRecv.Size().X)
 
 	sentLoad := wr.presenter.GetNetworkSentPercent()
 	sentBps := wr.presenter.GetNetworkSentBps()
 	sentBpsPeak := wr.presenter.GetNetworkSentBpsPeak()
 	wr.networkSent.Title = "Network - sent per host:"
 	wr.networkSent.Percent = int(sentLoad)
-	wr.networkSent.Label = fmt.Sprintf("%d%% / current: %s/s / peak: %s/s",
-		sentLoad, core.ConvertBytes(sentBps), core.ConvertBytes(sentBpsPeak))
+	str = fmt.Sprintf("%d%% / current: %s/s / peak: %s/s", sentLoad, core.ConvertBytes(sentBps), core.ConvertBytes(sentBpsPeak))
+	wr.networkSent.Label = fitStringToWidth(str, wr.networkSent.Size().X)
 
 	// epoch info
 	currentEpochRound, currentEpochFinishRound, epochLoadPercent, remainingTime := wr.presenter.GetEpochInfo()
 	wr.epochLoad.Title = "Epoch - info:"
 	wr.epochLoad.Percent = epochLoadPercent
-	wr.epochLoad.Label = fmt.Sprintf("%d / %d rounds (~%sremaining)", currentEpochRound, currentEpochFinishRound, remainingTime)
+	str = fmt.Sprintf("%d / %d rounds (~%sremaining)", currentEpochRound, currentEpochFinishRound, remainingTime)
+	wr.epochLoad.Label = fitStringToWidth(str, wr.epochLoad.Size().X)
 
 	totalBytesSentInEpoch := wr.presenter.GetNetworkSentBytesInEpoch()
 	totalBytesReceivedInEpoch := wr.presenter.GetNetworkReceivedBytesInEpoch()
 
 	wr.networkBytesInEpoch.Title = "Epoch - traffic per host:"
 	wr.networkBytesInEpoch.Percent = 0
-	wr.networkBytesInEpoch.Label = fmt.Sprintf("sent: %s / received: %s", core.ConvertBytes(totalBytesSentInEpoch), core.ConvertBytes(totalBytesReceivedInEpoch))
-
+	str = fmt.Sprintf("sent: %s / received: %s", core.ConvertBytes(totalBytesSentInEpoch), core.ConvertBytes(totalBytesReceivedInEpoch))
+	wr.networkBytesInEpoch.Label = fitStringToWidth(str, wr.networkBytesInEpoch.Size().X)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/statusHandler/view/termuic/termuiRenders/widgetsRender.go
+++ b/statusHandler/view/termuic/termuiRenders/widgetsRender.go
@@ -339,20 +339,20 @@ func (wr *WidgetsRender) prepareLogLines(logData []string, size int) []string {
 }
 
 func fitStringToWidth(original string, maxWidth int) string {
-	suffixDots := "..."
-	numPadding := 2
+	suffixString := "..."
+	numExtraPadding := 2
 
-	if len(original)+numPadding < maxWidth {
+	if len(original)+numExtraPadding < maxWidth {
 		return original
 	}
 
-	nothingToShow := maxWidth <= len(suffixDots)+numPadding ||
-		len(original)-len(suffixDots)-numPadding < 0
+	nothingToShow := maxWidth <= len(suffixString)+numExtraPadding ||
+		len(original)-len(suffixString)-numExtraPadding < 0
 	if nothingToShow {
 		return ""
 	}
 
-	return original[:maxWidth-len(suffixDots)-numPadding] + "..."
+	return original[:maxWidth-len(suffixString)-numExtraPadding] + suffixString
 }
 
 func (wr *WidgetsRender) prepareLoads() {


### PR DESCRIPTION
- fixed the wrong termui gauge display when a too long label was provided by trimming the label according to the actual space that a gauge has