### PR TITLE
set-to-jail-from-inactive

### DIFF
--- a/cmd/node/config/ratings.toml
+++ b/cmd/node/config/ratings.toml
@@ -33,14 +33,14 @@
     ProposerValidatorImportance = 1.0
     ProposerDecreaseFactor = -4.0
     ValidatorDecreaseFactor = -4.0
-    ConsecutiveMissedBlocksPenalty = 1.10
+    ConsecutiveMissedBlocksPenalty = 1.50
 
 [MetaChain.RatingSteps]
     HoursToMaxRatingFromStartRating = 55
     ProposerValidatorImportance = 1.0
     ProposerDecreaseFactor = -4.0
     ValidatorDecreaseFactor = -4.0
-    ConsecutiveMissedBlocksPenalty = 1.10
+    ConsecutiveMissedBlocksPenalty = 1.50
 
 [PeerHonesty]
     #this value will be multiplied with the current value for a public key each DecayUpdateIntervalInSeconds seconds


### PR DESCRIPTION
set to jailed when account is inactive and with infinite unstaked epoch after jailing is enabled.