### PR TITLE
receipt-hash-unjail

### DIFF
--- a/vm/systemSmartContracts/staking.go
+++ b/vm/systemSmartContracts/staking.go
@@ -152,9 +152,9 @@ func (r *stakingSC) Execute(args *vmcommon.ContractCallInput) vmcommon.ReturnCod
 		return r.changeValidatorKey(args)
 	case "switchJailedWithWaiting":
 		return r.switchJailedWithWaiting(args)
-	case "getWaitingListIndex":
+	case "getQueueIndex":
 		return r.getWaitingListIndex(args)
-	case "getWaitingListSize":
+	case "getQueueSize":
 		return r.getWaitingListSize(args)
 	case "getRewardAddress":
 		return r.getRewardAddress(args)
@@ -162,7 +162,7 @@ func (r *stakingSC) Execute(args *vmcommon.ContractCallInput) vmcommon.ReturnCod
 		return r.getBLSKeyStatus(args)
 	case "getRemainingUnBondPeriod":
 		return r.getRemainingUnbondPeriod(args)
-	case "getWaitingListRegisterNonceAndRewardAddress":
+	case "getQueueRegisterNonceAndRewardAddress":
 		return r.getWaitingListRegisterNonceAndRewardAddress(args)
 	}
 

--- a/vm/systemSmartContracts/staking.go
+++ b/vm/systemSmartContracts/staking.go
@@ -311,6 +311,14 @@ func (r *stakingSC) changeRewardAddress(args *vmcommon.ContractCallInput) vmcomm
 	return vmcommon.Ok
 }
 
+func (r *stakingSC) removeFromJailedNodes() {
+	stakeConfig := r.getConfig()
+	if stakeConfig.JailedNodes > 0 {
+		stakeConfig.JailedNodes--
+	}
+	r.setConfig(stakeConfig)
+}
+
 func (r *stakingSC) unJailV1(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
 	if !bytes.Equal(args.CallerAddr, r.stakeAccessAddr) {
 		r.eei.AddReturnMessage("unJail function not allowed to be called by address " + string(args.CallerAddr))
@@ -326,6 +334,10 @@ func (r *stakingSC) unJailV1(args *vmcommon.ContractCallInput) vmcommon.ReturnCo
 		if len(stakedData.RewardAddress) == 0 {
 			r.eei.AddReturnMessage("cannot unJail a key that is not registered")
 			return vmcommon.UserError
+		}
+
+		if stakedData.UnJailedNonce <= stakedData.JailedNonce {
+			r.removeFromJailedNodes()
 		}
 
 		stakedData.JailedRound = math.MaxUint64

--- a/vm/systemSmartContracts/staking_test.go
+++ b/vm/systemSmartContracts/staking_test.go
@@ -1494,7 +1494,7 @@ func doGetStatus(t *testing.T, sc *stakingSC, eei *vmContext, blsKey []byte, exp
 
 func doGetWaitingListSize(t *testing.T, sc *stakingSC, eei *vmContext, expectedSize int) {
 	arguments := CreateVmContractCallInput()
-	arguments.Function = "getWaitingListSize"
+	arguments.Function = "getQueueSize"
 
 	retCode := sc.Execute(arguments)
 	assert.Equal(t, vmcommon.Ok, retCode)
@@ -1505,7 +1505,7 @@ func doGetWaitingListSize(t *testing.T, sc *stakingSC, eei *vmContext, expectedS
 
 func doGetWaitingListRegisterNonceAndRewardAddress(t *testing.T, sc *stakingSC, eei *vmContext) [][]byte {
 	arguments := CreateVmContractCallInput()
-	arguments.Function = "getWaitingListRegisterNonceAndRewardAddress"
+	arguments.Function = "getQueueRegisterNonceAndRewardAddress"
 	arguments.CallerAddr = sc.stakeAccessAddr
 
 	currentOutPutIndex := len(eei.output)
@@ -1518,7 +1518,7 @@ func doGetWaitingListRegisterNonceAndRewardAddress(t *testing.T, sc *stakingSC, 
 
 func doGetWaitingListIndex(t *testing.T, sc *stakingSC, eei *vmContext, blsKey []byte, expectedCode vmcommon.ReturnCode, expectedIndex int) {
 	arguments := CreateVmContractCallInput()
-	arguments.Function = "getWaitingListIndex"
+	arguments.Function = "getQueueIndex"
 	arguments.CallerAddr = sc.stakeAccessAddr
 	arguments.Arguments = [][]byte{blsKey}
 


### PR DESCRIPTION
receipt hash missmatch because config was not added into scr as in mainnet