### PR TITLE
Refined import db process

### DIFF
--- a/cmd/node/config/p2p.toml
+++ b/cmd/node/config/p2p.toml
@@ -20,6 +20,10 @@
     #p2p identity generation
     Seed = ""
 
+    #ThresholdMinConnectedPeers represents the minimum number of connections a node should have before it can start
+    #the sync and consensus mechanisms
+    ThresholdMinConnectedPeers = 3
+
 # P2P peer discovery section
 
 #The following sections correspond to the way new peers will be discovered

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -1497,7 +1497,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 func applyCompatibleConfigs(isInImportMode bool, log logger.Logger, config *config.Config, p2pConfig *config.P2PConfig) {
 	if isInImportMode {
 		importCheckpointRoundsModulus := uint(config.EpochStartConfig.RoundsPerEpoch)
-		log.Warn("the node is import mode! Will auto-set some config values",
+		log.Warn("the node is in import mode! Will auto-set some config values",
 			"GeneralSettings.StartInEpochEnabled", "false",
 			"StateTriesConfig.CheckpointRoundsModulus", importCheckpointRoundsModulus,
 			"p2p.ThresholdMinConnectedPeers", 0,

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -528,7 +528,16 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 	}
 	log.Debug("config", "file", configurationFileName)
 
-	applyCompatibleConfigs(log, generalConfig, ctx)
+	p2pConfigurationFileName := ctx.GlobalString(p2pConfigurationFile.Name)
+	p2pConfig, err := core.LoadP2PConfig(p2pConfigurationFileName)
+	if err != nil {
+		return err
+	}
+	log.Debug("config", "file", p2pConfigurationFileName)
+
+	importDbDirectoryValue := ctx.GlobalString(importDbDirectory.Name)
+	isInImportMode := len(importDbDirectoryValue) > 0
+	applyCompatibleConfigs(isInImportMode, log, generalConfig, p2pConfig)
 
 	configurationApiFileName := ctx.GlobalString(configurationApiFile.Name)
 	apiRoutesConfig, err := loadApiConfig(configurationApiFileName)
@@ -572,13 +581,6 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 	}
 	log.Debug("config", "file", externalConfigurationFileName)
 
-	p2pConfigurationFileName := ctx.GlobalString(p2pConfigurationFile.Name)
-	p2pConfig, err := core.LoadP2PConfig(p2pConfigurationFileName)
-	if err != nil {
-		return err
-	}
-
-	log.Debug("config", "file", p2pConfigurationFileName)
 	if ctx.IsSet(port.Name) {
 		p2pConfig.Node.Port = ctx.GlobalString(port.Name)
 	}
@@ -676,6 +678,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		ctx.GlobalInt(validatorKeyIndex.Name),
 		validatorKeyPemFileName,
 		suite,
+		isInImportMode,
 	)
 	if err != nil {
 		return err
@@ -1491,17 +1494,17 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 	return nil
 }
 
-func applyCompatibleConfigs(log logger.Logger, config *config.Config, ctx *cli.Context) {
-	importDbDirectoryValue := ctx.GlobalString(importDbDirectory.Name)
-	if len(importDbDirectoryValue) > 0 {
+func applyCompatibleConfigs(isInImportMode bool, log logger.Logger, config *config.Config, p2pConfig *config.P2PConfig) {
+	if isInImportMode {
 		importCheckpointRoundsModulus := uint(config.EpochStartConfig.RoundsPerEpoch)
-		log.Info("import DB directory is set, altering config values!",
+		log.Warn("the node is import mode! Will auto-set some config values",
 			"GeneralSettings.StartInEpochEnabled", "false",
 			"StateTriesConfig.CheckpointRoundsModulus", importCheckpointRoundsModulus,
-			"import DB path", importDbDirectoryValue,
+			"p2p.ThresholdMinConnectedPeers", 0,
 		)
 		config.GeneralSettings.StartInEpochEnabled = false
 		config.StateTriesConfig.CheckpointRoundsModulus = importCheckpointRoundsModulus
+		p2pConfig.Node.ThresholdMinConnectedPeers = 0
 	}
 }
 

--- a/cmd/seednode/config/p2p.toml
+++ b/cmd/seednode/config/p2p.toml
@@ -23,6 +23,10 @@
     # The maximum peers that will connect to this node
     MaximumExpectedPeerCount = 1024
 
+    #ThresholdMinConnectedPeers can be any value when used in conjunction with a seednode because the seednode does
+    #not have a sync and consensus mechanism. Default is 0.
+    ThresholdMinConnectedPeers = 0
+
 # P2P peer discovery section
 
 #The following sections correspond to the way new peers will be discovered

--- a/config/p2pConfig.go
+++ b/config/p2pConfig.go
@@ -9,9 +9,10 @@ type P2PConfig struct {
 
 // NodeConfig will hold basic p2p settings
 type NodeConfig struct {
-	Port                     string
-	Seed                     string
-	MaximumExpectedPeerCount uint64
+	Port                       string
+	Seed                       string
+	MaximumExpectedPeerCount   uint64
+	ThresholdMinConnectedPeers uint32
 }
 
 // KadDhtPeerDiscoveryConfig will hold the kad-dht discovery config settings

--- a/dataRetriever/factory/storageResolversContainer/baseResolversContainerFactory.go
+++ b/dataRetriever/factory/storageResolversContainer/baseResolversContainerFactory.go
@@ -1,6 +1,8 @@
 package storageResolversContainers
 
 import (
+	"time"
+
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/data/endProcess"
@@ -11,6 +13,8 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process/factory"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 )
+
+const defaultBeforeGracefulClose = time.Minute
 
 type baseResolversContainerFactory struct {
 	container                dataRetriever.ResolversContainer
@@ -102,6 +106,7 @@ func (brcf *baseResolversContainerFactory) createTxResolver(
 		Marshalizer:              brcf.marshalizer,
 		ManualEpochStartNotifier: brcf.manualEpochStartNotifier,
 		ChanGracefullyClose:      brcf.chanGracefullyClose,
+		DelayBeforeGracefulClose: defaultBeforeGracefulClose,
 	}
 	resolver, err := storageResolvers.NewSliceResolver(arg)
 	if err != nil {
@@ -160,6 +165,7 @@ func (brcf *baseResolversContainerFactory) createMiniBlocksResolver(responseTopi
 		Marshalizer:              brcf.marshalizer,
 		ManualEpochStartNotifier: brcf.manualEpochStartNotifier,
 		ChanGracefullyClose:      brcf.chanGracefullyClose,
+		DelayBeforeGracefulClose: defaultBeforeGracefulClose,
 	}
 	mbResolver, err := storageResolvers.NewSliceResolver(arg)
 	if err != nil {

--- a/dataRetriever/factory/storageResolversContainer/metaResolversContainerFactory.go
+++ b/dataRetriever/factory/storageResolversContainer/metaResolversContainerFactory.go
@@ -153,6 +153,7 @@ func (mrcf *metaResolversContainerFactory) createShardHeaderResolver(
 		HeadersNoncesStorage:     hdrNonceStore,
 		ManualEpochStartNotifier: mrcf.manualEpochStartNotifier,
 		ChanGracefullyClose:      mrcf.chanGracefullyClose,
+		DelayBeforeGracefulClose: defaultBeforeGracefulClose,
 	}
 	resolver, err := storageResolvers.NewHeaderResolver(arg)
 	if err != nil {
@@ -186,6 +187,7 @@ func (mrcf *metaResolversContainerFactory) createMetaChainHeaderResolver() (data
 		HeadersNoncesStorage:     hdrNonceStore,
 		ManualEpochStartNotifier: mrcf.manualEpochStartNotifier,
 		ChanGracefullyClose:      mrcf.chanGracefullyClose,
+		DelayBeforeGracefulClose: defaultBeforeGracefulClose,
 	}
 	resolver, err := storageResolvers.NewHeaderResolver(arg)
 	if err != nil {

--- a/dataRetriever/factory/storageResolversContainer/shardResolversContainerFactory.go
+++ b/dataRetriever/factory/storageResolversContainer/shardResolversContainerFactory.go
@@ -110,6 +110,7 @@ func (srcf *shardResolversContainerFactory) generateHeaderResolvers() error {
 		HeadersNoncesStorage:     hdrNonceStore,
 		ManualEpochStartNotifier: srcf.manualEpochStartNotifier,
 		ChanGracefullyClose:      srcf.chanGracefullyClose,
+		DelayBeforeGracefulClose: defaultBeforeGracefulClose,
 	}
 	resolver, err := storageResolvers.NewHeaderResolver(arg)
 	if err != nil {
@@ -136,6 +137,7 @@ func (srcf *shardResolversContainerFactory) generateMetablockHeaderResolvers() e
 		HeadersNoncesStorage:     hdrNonceStore,
 		ManualEpochStartNotifier: srcf.manualEpochStartNotifier,
 		ChanGracefullyClose:      srcf.chanGracefullyClose,
+		DelayBeforeGracefulClose: defaultBeforeGracefulClose,
 	}
 	resolver, err := storageResolvers.NewHeaderResolver(arg)
 	if err != nil {

--- a/dataRetriever/storageResolvers/headerResolver.go
+++ b/dataRetriever/storageResolvers/headerResolver.go
@@ -2,6 +2,7 @@ package storageResolvers
 
 import (
 	"sync"
+	"time"
 
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/core/check"
@@ -23,6 +24,7 @@ type ArgHeaderResolver struct {
 	HeadersNoncesStorage     storage.Storer
 	ManualEpochStartNotifier dataRetriever.ManualEpochStartNotifier
 	ChanGracefullyClose      chan endProcess.ArgEndProcess
+	DelayBeforeGracefulClose time.Duration
 }
 
 type headerResolver struct {
@@ -62,6 +64,7 @@ func NewHeaderResolver(arg ArgHeaderResolver) (*headerResolver, error) {
 			responseTopicName:        arg.ResponseTopicName,
 			manualEpochStartNotifier: arg.ManualEpochStartNotifier,
 			chanGracefullyClose:      arg.ChanGracefullyClose,
+			delayBeforeGracefulClose: arg.DelayBeforeGracefulClose,
 		},
 		hdrStorage:       arg.HdrStorage,
 		hdrNoncesStorage: arg.HeadersNoncesStorage,

--- a/dataRetriever/storageResolvers/headerResolver_test.go
+++ b/dataRetriever/storageResolvers/headerResolver_test.go
@@ -3,6 +3,7 @@ package storageResolvers
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
@@ -197,6 +198,9 @@ func TestHeaderResolver_RequestDataFromHashNotFoundShouldErr(t *testing.T) {
 	assert.Equal(t, expectedErr, err)
 	assert.True(t, newEpochCalled)
 	assert.False(t, sendCalled)
+
+	time.Sleep(time.Second)
+
 	select {
 	case argClose := <-arg.ChanGracefullyClose:
 		assert.Equal(t, core.ImportComplete, argClose.Reason)

--- a/dataRetriever/storageResolvers/sliceResolver.go
+++ b/dataRetriever/storageResolvers/sliceResolver.go
@@ -2,6 +2,7 @@ package storageResolvers
 
 import (
 	"fmt"
+	"time"
 
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/core/check"
@@ -24,6 +25,7 @@ type ArgSliceResolver struct {
 	Marshalizer              marshal.Marshalizer
 	ManualEpochStartNotifier dataRetriever.ManualEpochStartNotifier
 	ChanGracefullyClose      chan endProcess.ArgEndProcess
+	DelayBeforeGracefulClose time.Duration
 }
 
 type sliceResolver struct {
@@ -60,6 +62,7 @@ func NewSliceResolver(arg ArgSliceResolver) (*sliceResolver, error) {
 			responseTopicName:        arg.ResponseTopicName,
 			manualEpochStartNotifier: arg.ManualEpochStartNotifier,
 			chanGracefullyClose:      arg.ChanGracefullyClose,
+			delayBeforeGracefulClose: arg.DelayBeforeGracefulClose,
 		},
 		storage:     arg.Storage,
 		dataPacker:  arg.DataPacker,

--- a/dataRetriever/storageResolvers/sliceResolver_test.go
+++ b/dataRetriever/storageResolvers/sliceResolver_test.go
@@ -3,6 +3,7 @@ package storageResolvers
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
@@ -125,6 +126,9 @@ func TestSliceResolver_RequestDataFromHashNotFoundShouldErr(t *testing.T) {
 
 	assert.Equal(t, expectedErr, err)
 	assert.False(t, sendWasCalled)
+
+	time.Sleep(time.Second)
+
 	select {
 	case argClose := <-arg.ChanGracefullyClose:
 		assert.Equal(t, core.ImportComplete, argClose.Reason)
@@ -217,6 +221,9 @@ func TestSliceResolver_GetErroredShouldReturnErr(t *testing.T) {
 	assert.True(t, errors.Is(err, expectedErr))
 	assert.Equal(t, len(hashes)-1, numSendCalled)
 	assert.Equal(t, len(hashes), numGetCalled)
+
+	time.Sleep(time.Second)
+
 	select {
 	case argClose := <-arg.ChanGracefullyClose:
 		assert.Equal(t, core.ImportComplete, argClose.Reason)

--- a/dataRetriever/storageResolvers/storageResolver_test.go
+++ b/dataRetriever/storageResolvers/storageResolver_test.go
@@ -3,9 +3,15 @@ package storageResolvers
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/ElrondNetwork/elrond-go/core"
+	"github.com/ElrondNetwork/elrond-go/data/endProcess"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever/mock"
 	"github.com/stretchr/testify/assert"
 )
+
+const timeout = time.Second * 2
 
 func TestStorageResolver_ImplementedMethodsShouldNotPanic(t *testing.T) {
 	t.Parallel()
@@ -24,4 +30,86 @@ func TestStorageResolver_ImplementedMethodsShouldNotPanic(t *testing.T) {
 	v1, v2 := sr.NumPeersToQuery()
 	assert.Equal(t, 0, v1)
 	assert.Equal(t, 0, v2)
+}
+
+func TestStorageResolver_signalGracefullyClose(t *testing.T) {
+	t.Parallel()
+
+	chanClose := make(chan endProcess.ArgEndProcess, 1)
+	timeToWait := time.Millisecond * 100
+	sr := &storageResolver{
+		chanGracefullyClose: chanClose,
+		manualEpochStartNotifier: &mock.ManualEpochStartNotifierStub{
+			CurrentEpochCalled: func() uint32 {
+				return 0
+			},
+		},
+		delayBeforeGracefulClose: timeToWait,
+	}
+
+	startTime := time.Now()
+	endTime := time.Now()
+	sr.signalGracefullyClose()
+	endArg := endProcess.ArgEndProcess{}
+
+	select {
+	case endArg = <-chanClose:
+		endTime = time.Now()
+	case <-time.After(timeout):
+		assert.Fail(t, "timeout. Should have written on the output chan")
+	}
+
+	assert.True(t, timeToWait <= endTime.Sub(startTime))
+	assert.Equal(t, endArg.Reason, core.ImportComplete)
+}
+
+func TestStorageResolver_signalGracefullyCloseCanNotWriteOnChanShouldNotPanic(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		r := recover()
+		if r != nil {
+			assert.Fail(t, fmt.Sprintf("should have not panic: %v", r))
+		}
+	}()
+
+	chanClose := make(chan endProcess.ArgEndProcess, 0)
+	sr := &storageResolver{
+		chanGracefullyClose: chanClose,
+		manualEpochStartNotifier: &mock.ManualEpochStartNotifierStub{
+			CurrentEpochCalled: func() uint32 {
+				return 0
+			},
+		},
+	}
+
+	sr.signalGracefullyClose()
+
+	time.Sleep(time.Second)
+}
+
+func TestStorageResolver_signalGracefullyCloseDoubleSignalShouldNotPanic(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		r := recover()
+		if r != nil {
+			assert.Fail(t, fmt.Sprintf("should have not panic: %v", r))
+		}
+	}()
+
+	chanClose := make(chan endProcess.ArgEndProcess, 0)
+	sr := &storageResolver{
+		chanGracefullyClose: chanClose,
+		manualEpochStartNotifier: &mock.ManualEpochStartNotifierStub{
+			CurrentEpochCalled: func() uint32 {
+				return 0
+			},
+		},
+	}
+
+	sr.signalGracefullyClose()
+	sr.signalGracefullyClose()
+
+	time.Sleep(time.Second)
 }

--- a/factory/cryptoSigningParams.go
+++ b/factory/cryptoSigningParams.go
@@ -92,7 +92,7 @@ func (cspf *cryptoSigningParamsLoader) readCryptoParams(cryptoParams *CryptoPara
 }
 
 func (cspf *cryptoSigningParamsLoader) generateCryptoParams(cryptoParams *CryptoParams) (*CryptoParams, error) {
-	log.Warn("the node is import mode! Will generate a fresh new BLS key")
+	log.Warn("the node is in import mode! Will generate a fresh new BLS key")
 	cryptoParams.PrivateKey, cryptoParams.PublicKey = cryptoParams.KeyGenerator.GeneratePair()
 
 	var err error

--- a/factory/cryptoSigningParams_test.go
+++ b/factory/cryptoSigningParams_test.go
@@ -12,7 +12,7 @@ import (
 func TestNewCryptoSigningParamsLoader_NilPubKeyConverterShoulldErr(t *testing.T) {
 	t.Parallel()
 
-	cspf, err := NewCryptoSigningParamsLoader(nil, 0, "name", &mock.SuiteStub{})
+	cspf, err := NewCryptoSigningParamsLoader(nil, 0, "name", &mock.SuiteStub{}, false)
 	require.Nil(t, cspf)
 	require.Equal(t, ErrNilPubKeyConverter, err)
 }
@@ -20,7 +20,7 @@ func TestNewCryptoSigningParamsLoader_NilPubKeyConverterShoulldErr(t *testing.T)
 func TestNewCryptoSigningParamsLoader_NilSuiteShouldErr(t *testing.T) {
 	t.Parallel()
 
-	cspf, err := NewCryptoSigningParamsLoader(&mock.PubkeyConverterStub{}, 0, "name", nil)
+	cspf, err := NewCryptoSigningParamsLoader(&mock.PubkeyConverterStub{}, 0, "name", nil, false)
 	require.Nil(t, cspf)
 	require.Equal(t, ErrNilSuite, err)
 }
@@ -28,7 +28,7 @@ func TestNewCryptoSigningParamsLoader_NilSuiteShouldErr(t *testing.T) {
 func TestNewCryptoSigningParamsLoader_OkValsShouldWork(t *testing.T) {
 	t.Parallel()
 
-	cspf, err := NewCryptoSigningParamsLoader(&mock.PubkeyConverterStub{}, 0, "name", &mock.SuiteStub{})
+	cspf, err := NewCryptoSigningParamsLoader(&mock.PubkeyConverterStub{}, 0, "name", &mock.SuiteStub{}, false)
 	require.NoError(t, err)
 	require.NotNil(t, cspf)
 }
@@ -37,7 +37,7 @@ func TestCryptoSigningParamsLoader_Create_GetSkPkErrorsShouldErr(t *testing.T) {
 	t.Parallel()
 
 	expectedErr := errors.New("error while getting the sk and pk")
-	cspf, _ := NewCryptoSigningParamsLoader(&mock.PubkeyConverterStub{}, 0, "name", &mock.SuiteStub{})
+	cspf, _ := NewCryptoSigningParamsLoader(&mock.PubkeyConverterStub{}, 0, "name", &mock.SuiteStub{}, false)
 
 	cspf.SetSkPkProviderHandler(func() ([]byte, []byte, error) {
 		return nil, nil, expectedErr
@@ -70,7 +70,7 @@ func TestCryptoSigningParamsLoader_Create_PubKeyMissmatchShouldErr(t *testing.T)
 			}
 		},
 	}
-	cspf, _ := NewCryptoSigningParamsLoader(&mock.PubkeyConverterStub{}, 0, "name", suite)
+	cspf, _ := NewCryptoSigningParamsLoader(&mock.PubkeyConverterStub{}, 0, "name", suite, false)
 
 	cspf.SetSkPkProviderHandler(func() ([]byte, []byte, error) {
 		return []byte("sk"), diffPubkey2, nil
@@ -103,7 +103,7 @@ func TestCryptoSigningParamsLoader_CreateShouldWork(t *testing.T) {
 			}
 		},
 	}
-	cspf, _ := NewCryptoSigningParamsLoader(&mock.PubkeyConverterStub{}, 0, "name", suite)
+	cspf, _ := NewCryptoSigningParamsLoader(&mock.PubkeyConverterStub{}, 0, "name", suite, false)
 
 	cspf.SetSkPkProviderHandler(func() ([]byte, []byte, error) {
 		return []byte("sk"), pubKey, nil
@@ -116,7 +116,7 @@ func TestCryptoSigningParamsLoader_CreateShouldWork(t *testing.T) {
 func TestCryptoSigningParamsLoader_GetSkPk_PathNotFound(t *testing.T) {
 	t.Parallel()
 
-	cspf, _ := NewCryptoSigningParamsLoader(&mock.PubkeyConverterStub{}, 0, "name", &mock.SuiteStub{})
+	cspf, _ := NewCryptoSigningParamsLoader(&mock.PubkeyConverterStub{}, 0, "name", &mock.SuiteStub{}, false)
 	sk, pk, err := cspf.GetSkPk()
 	require.Error(t, err)
 	require.Nil(t, sk)

--- a/integrationTests/p2p/peerDisconnecting/peerDisconnecting_test.go
+++ b/integrationTests/p2p/peerDisconnecting/peerDisconnecting_test.go
@@ -37,6 +37,7 @@ func TestPeerDisconnectionWithOneAdvertiserWithShardingWithLists(t *testing.T) {
 		MaxCrossShardObservers:  1,
 		Type:                    p2p.ListsSharder,
 	}
+	p2pConfig.Node.ThresholdMinConnectedPeers = 3
 
 	testPeerDisconnectionWithOneAdvertiser(t, p2pConfig)
 }

--- a/p2p/libp2p/connectionMonitor/factory/connectionMonitorFactory.go
+++ b/p2p/libp2p/connectionMonitor/factory/connectionMonitorFactory.go
@@ -12,7 +12,7 @@ import (
 type ArgsConnectionMonitorFactory struct {
 	Reconnecter                p2p.Reconnecter
 	Sharder                    p2p.CommonSharder
-	ThresholdMinConnectedPeers int
+	ThresholdMinConnectedPeers uint32
 	TargetCount                int
 }
 

--- a/p2p/libp2p/connectionMonitor/libp2pConnectionMonitorSimple.go
+++ b/p2p/libp2p/connectionMonitor/libp2pConnectionMonitorSimple.go
@@ -24,12 +24,9 @@ type libp2pConnectionMonitorSimple struct {
 //about pausing and resuming the discovery process)
 func NewLibp2pConnectionMonitorSimple(
 	reconnecter p2p.Reconnecter,
-	thresholdMinConnectedPeers int,
+	thresholdMinConnectedPeers uint32,
 	sharder Sharder,
 ) (*libp2pConnectionMonitorSimple, error) {
-	if thresholdMinConnectedPeers < 0 {
-		return nil, p2p.ErrInvalidValue
-	}
 	if check.IfNil(reconnecter) {
 		return nil, p2p.ErrNilReconnecter
 	}
@@ -40,7 +37,7 @@ func NewLibp2pConnectionMonitorSimple(
 	cm := &libp2pConnectionMonitorSimple{
 		reconnecter:                reconnecter,
 		chDoReconnect:              make(chan struct{}),
-		thresholdMinConnectedPeers: thresholdMinConnectedPeers,
+		thresholdMinConnectedPeers: int(thresholdMinConnectedPeers),
 		sharder:                    sharder,
 	}
 

--- a/p2p/libp2p/connectionMonitor/libp2pConnectionMonitorSimple_test.go
+++ b/p2p/libp2p/connectionMonitor/libp2pConnectionMonitorSimple_test.go
@@ -14,15 +14,6 @@ import (
 const durationTimeoutWaiting = time.Second * 2
 const durationStartGoRoutine = time.Second
 
-func TestNewLibp2pConnectionMonitorSimple_WithNegativeThresholdShouldErr(t *testing.T) {
-	t.Parallel()
-
-	lcms, err := NewLibp2pConnectionMonitorSimple(&mock.ReconnecterStub{}, -1, &mock.SharderStub{})
-
-	assert.Equal(t, p2p.ErrInvalidValue, err)
-	assert.True(t, check.IfNil(lcms))
-}
-
 func TestNewLibp2pConnectionMonitorSimple_WithNilReconnecterShouldErr(t *testing.T) {
 	t.Parallel()
 
@@ -162,12 +153,12 @@ func TestLibp2pConnectionMonitorSimple_SetThresholdMinConnectedPeers(t *testing.
 func TestLibp2pConnectionMonitorSimple_SetThresholdMinConnectedPeersNilNetwShouldDoNothing(t *testing.T) {
 	t.Parallel()
 
-	minConnPeers := 3
+	minConnPeers := uint32(3)
 	lcms, _ := NewLibp2pConnectionMonitorSimple(&mock.ReconnecterStub{}, minConnPeers, &mock.SharderStub{})
 
 	thr := 10
 	lcms.SetThresholdMinConnectedPeers(thr, nil)
 	thrSet := lcms.ThresholdMinConnectedPeers()
 
-	assert.Equal(t, thrSet, minConnPeers)
+	assert.Equal(t, uint32(thrSet), minConnPeers)
 }

--- a/p2p/libp2p/netMessenger.go
+++ b/p2p/libp2p/netMessenger.go
@@ -55,7 +55,6 @@ const acceptMessagesInAdvanceDuration = 5 * time.Second //we are accepting the m
 const broadcastGoRoutines = 1000
 const timeBetweenPeerPrints = time.Second * 20
 const timeBetweenExternalLoggersCheck = time.Second * 20
-const defaultThresholdMinConnectedPeers = 3
 const minRangePortValue = 1025
 const noSignPolicy = pubsub.MessageSignaturePolicy(0) //should be used only in tests
 
@@ -357,7 +356,7 @@ func (netMes *networkMessenger) createConnectionMonitor(p2pConfig config.P2PConf
 	args := connMonitorFactory.ArgsConnectionMonitorFactory{
 		Reconnecter:                reconnecter,
 		Sharder:                    netMes.sharder,
-		ThresholdMinConnectedPeers: defaultThresholdMinConnectedPeers,
+		ThresholdMinConnectedPeers: p2pConfig.Node.ThresholdMinConnectedPeers,
 		TargetCount:                p2pConfig.Sharding.TargetPeerCount,
 	}
 	var err error


### PR DESCRIPTION
Improved the import-db process:
- added a delay before the import process will stop the node in order to have the time to commit received data
- added ThresholdMinConnectedPeers as a config in order to be overridden by the import db process
- made the import-db process automatically generate a new BLS key in order to avoid accidental usage of a validator BLS key that migh trigger the node shuffle-out