### PR TITLE
EN 7439 transaction routing fixes

### DIFF
--- a/integrationTests/multiShard/relayedTx/common.go
+++ b/integrationTests/multiShard/relayedTx/common.go
@@ -54,6 +54,7 @@ func CreateGeneralSetupForRelayTxTest() ([]*integrationTests.TestProcessorNode, 
 	return nodes, idxProposers, players, relayerAccount, advertiser
 }
 
+// CreateAndSendRelayedAndUserTx will create and send a relayed user transaction
 func CreateAndSendRelayedAndUserTx(
 	nodes []*integrationTests.TestProcessorNode,
 	relayer *integrationTests.TestWalletAccount,
@@ -63,7 +64,7 @@ func CreateAndSendRelayedAndUserTx(
 	gasLimit uint64,
 	txData []byte,
 ) *transaction.Transaction {
-	txDispatcherNode := getNodeWithinSameShardAsPlayer(nodes, player.Address)
+	txDispatcherNode := getNodeWithinSameShardAsPlayer(nodes, relayer.Address)
 
 	userTx := createUserTx(player, rcvAddr, value, gasLimit, txData)
 	relayedTx := createRelayedTx(txDispatcherNode.EconomicsData, relayer, userTx)

--- a/integrationTests/singleShard/transaction/interceptedBulkTx/interceptedBulkTx_test.go
+++ b/integrationTests/singleShard/transaction/interceptedBulkTx/interceptedBulkTx_test.go
@@ -2,6 +2,7 @@ package interceptedBulkTx
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -114,4 +115,38 @@ func TestNode_GenerateSendInterceptBulkTransactionsWithMessenger(t *testing.T) {
 		n.DataPool.Transactions(),
 		n.ShardCoordinator,
 	)
+}
+
+func TestNode_SendTransactionFromAnUnmintedAccountShouldReturnErrorAtApiLevel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	var nrOfShards uint32 = 1
+	var shardID uint32 = 0
+	var txSignPrivKeyShardId uint32 = 0
+	nodeAddr := "0"
+
+	node := integrationTests.NewTestProcessorNode(nrOfShards, shardID, txSignPrivKeyShardId, nodeAddr)
+
+	defer func() {
+		_ = node.Messenger.Close()
+	}()
+
+	tx := &transaction.Transaction{
+		Nonce:    node.OwnAccount.Nonce,
+		Value:    big.NewInt(1),
+		SndAddr:  node.OwnAccount.Address,
+		RcvAddr:  integrationTests.CreateRandomBytes(32),
+		GasPrice: integrationTests.MinTxGasPrice,
+		GasLimit: integrationTests.MinTxGasLimit,
+		ChainID:  integrationTests.ChainID,
+		Version:  integrationTests.MinTransactionVersion,
+	}
+
+	txBuff, _ := tx.GetDataForSigning(integrationTests.TestAddressPubkeyConverter, integrationTests.TestTxSignMarshalizer)
+	tx.Signature, _ = node.OwnAccount.SingleSigner.Sign(node.OwnAccount.SkTxSign, txBuff)
+
+	err := node.Node.ValidateTransaction(tx)
+	assert.True(t, errors.Is(err, process.ErrAccountNotFound))
 }

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -75,6 +75,7 @@ var P2pBootstrapDelay = 5 * time.Second
 // InitialRating is used to initiate a node's info
 var InitialRating = uint32(50)
 
+// AdditionalGasLimit is the value that can be added on a transaction in the GasLimit
 var AdditionalGasLimit = uint64(999000)
 
 var log = logger.GetOrCreate("integrationtests")
@@ -1353,7 +1354,53 @@ func CreateAndSendTransaction(
 
 	_, err := node.SendTransaction(tx)
 	if err != nil {
-		log.Warn("could not create transaction", "address", node.OwnAccount.Address, "error", err)
+		log.Error("could not create transaction", "address", node.OwnAccount.Address, "error", err)
+	}
+	node.OwnAccount.Nonce++
+}
+
+// CreateAndSendTransactionOnTheCorrectShard will generate a transaction with provided parameters, sign it with the provided
+// node's tx sign private key and send it on the transaction topic using the correct node that can send the transaction
+func CreateAndSendTransactionOnTheCorrectShard(
+	node *TestProcessorNode,
+	nodes []*TestProcessorNode,
+	txValue *big.Int,
+	rcvAddress []byte,
+	txData string,
+	additionalGasLimit uint64,
+) {
+	tx := &transaction.Transaction{
+		Nonce:    node.OwnAccount.Nonce,
+		Value:    new(big.Int).Set(txValue),
+		SndAddr:  node.OwnAccount.Address,
+		RcvAddr:  rcvAddress,
+		Data:     []byte(txData),
+		GasPrice: MinTxGasPrice,
+		GasLimit: MinTxGasLimit + uint64(len(txData)) + additionalGasLimit,
+		ChainID:  ChainID,
+		Version:  MinTransactionVersion,
+	}
+
+	txBuff, _ := tx.GetDataForSigning(TestAddressPubkeyConverter, TestTxSignMarshalizer)
+	tx.Signature, _ = node.OwnAccount.SingleSigner.Sign(node.OwnAccount.SkTxSign, txBuff)
+	senderShardID := node.ShardCoordinator.ComputeId(node.OwnAccount.Address)
+
+	wasSend := false
+	for _, senderNode := range nodes {
+		if senderNode.ShardCoordinator.SelfId() != senderShardID {
+			continue
+		}
+
+		_, err := senderNode.SendTransaction(tx)
+		if err != nil {
+			log.Error("could not create transaction", "address", node.OwnAccount.Address, "error", err)
+		}
+		wasSend = true
+		break
+	}
+
+	if !wasSend {
+		log.Error("no suitable node found to send the provided transaction", "address", node.OwnAccount.Address)
 	}
 	node.OwnAccount.Nonce++
 }

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -1393,7 +1393,7 @@ func CreateAndSendTransactionOnTheCorrectShard(
 
 		_, err := senderNode.SendTransaction(tx)
 		if err != nil {
-			log.Error("could not create transaction", "address", node.OwnAccount.Address, "error", err)
+			log.Error("could not send transaction", "address", node.OwnAccount.Address, "error", err)
 		}
 		wasSend = true
 		break

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -1556,6 +1556,8 @@ func (tpn *TestProcessorNode) initNode() {
 		node.WithChainID(tpn.ChainID),
 		node.WithMinTransactionVersion(tpn.MinTransactionVersion),
 		node.WithHistoryRepository(tpn.HistoryRepository),
+		node.WithWhiteListHandlerVerified(tpn.WhiteListerVerifiedTxs),
+		node.WithWhiteListHandler(tpn.WhiteListHandler),
 	)
 	log.LogIfError(err)
 

--- a/integrationTests/vm/systemVM/stakingSC_test.go
+++ b/integrationTests/vm/systemVM/stakingSC_test.go
@@ -71,7 +71,7 @@ func TestStakingUnstakingAndUnboundingOnMultiShardEnvironment(t *testing.T) {
 	for index, node := range nodes {
 		pubKey := generateUniqueKey(index)
 		txData = "stake" + "@" + oneEncoded + "@" + pubKey + "@" + hex.EncodeToString([]byte("msg"))
-		integrationTests.CreateAndSendTransaction(node, nodePrice, vm.AuctionSCAddress, txData, 1)
+		integrationTests.CreateAndSendTransactionOnTheCorrectShard(node, nodes, nodePrice, vm.AuctionSCAddress, txData, 1)
 	}
 
 	time.Sleep(time.Second)
@@ -88,7 +88,7 @@ func TestStakingUnstakingAndUnboundingOnMultiShardEnvironment(t *testing.T) {
 	for index, node := range nodes {
 		pubKey := generateUniqueKey(index)
 		txData = "unStake" + "@" + pubKey
-		integrationTests.CreateAndSendTransaction(node, big.NewInt(0), vm.AuctionSCAddress, txData, 1)
+		integrationTests.CreateAndSendTransactionOnTheCorrectShard(node, nodes, big.NewInt(0), vm.AuctionSCAddress, txData, 1)
 	}
 
 	time.Sleep(time.Second)
@@ -106,7 +106,7 @@ func TestStakingUnstakingAndUnboundingOnMultiShardEnvironment(t *testing.T) {
 	for index, node := range nodes {
 		pubKey := generateUniqueKey(index)
 		txData = "unBond" + "@" + pubKey
-		integrationTests.CreateAndSendTransaction(node, big.NewInt(0), vm.AuctionSCAddress, txData, 1)
+		integrationTests.CreateAndSendTransactionOnTheCorrectShard(node, nodes, big.NewInt(0), vm.AuctionSCAddress, txData, 1)
 	}
 
 	time.Sleep(time.Second)
@@ -186,7 +186,7 @@ func TestStakingUnstakingAndUnboundingOnMultiShardEnvironmentWithValidatorStatis
 	for index, node := range nodes {
 		pubKey := generateUniqueKey(index)
 		txData = "stake" + "@" + oneEncoded + "@" + pubKey + "@" + hex.EncodeToString([]byte("msg"))
-		integrationTests.CreateAndSendTransaction(node, nodePrice, vm.AuctionSCAddress, txData, 1)
+		integrationTests.CreateAndSendTransactionOnTheCorrectShard(node, nodes, nodePrice, vm.AuctionSCAddress, txData, 1)
 	}
 
 	time.Sleep(time.Second)
@@ -208,7 +208,7 @@ func TestStakingUnstakingAndUnboundingOnMultiShardEnvironmentWithValidatorStatis
 	for index, node := range nodes {
 		pubKey := generateUniqueKey(index)
 		txData = "unStake" + "@" + pubKey
-		integrationTests.CreateAndSendTransaction(node, big.NewInt(0), vm.AuctionSCAddress, txData, 1)
+		integrationTests.CreateAndSendTransactionOnTheCorrectShard(node, nodes, big.NewInt(0), vm.AuctionSCAddress, txData, 1)
 	}
 	consumed := big.NewInt(0).Add(big.NewInt(0).SetUint64(integrationTests.MinTxGasLimit), big.NewInt(int64(len(txData))))
 	consumed.Mul(consumed, big.NewInt(0).SetUint64(integrationTests.MinTxGasPrice))
@@ -227,7 +227,7 @@ func TestStakingUnstakingAndUnboundingOnMultiShardEnvironmentWithValidatorStatis
 	for index, node := range nodes {
 		pubKey := generateUniqueKey(index)
 		txData = "unBond" + "@" + pubKey
-		integrationTests.CreateAndSendTransaction(node, big.NewInt(0), vm.AuctionSCAddress, txData, 1)
+		integrationTests.CreateAndSendTransactionOnTheCorrectShard(node, nodes, big.NewInt(0), vm.AuctionSCAddress, txData, 1)
 	}
 	consumed = big.NewInt(0).Add(big.NewInt(0).SetUint64(integrationTests.MinTxGasLimit), big.NewInt(int64(len(txData))))
 	consumed.Mul(consumed, big.NewInt(0).SetUint64(integrationTests.MinTxGasPrice))

--- a/node/errors.go
+++ b/node/errors.go
@@ -195,3 +195,6 @@ var ErrTransactionNotFound = errors.New("transaction not found")
 
 // ErrCannotRetrieveTransaction signals that a transaction was not found
 var ErrCannotRetrieveTransaction = errors.New("transaction cannot be retrieved")
+
+// ErrDifferentSenderShardId signals that a different shard ID was detected between the sender shard ID and the current node shard ID
+var ErrDifferentSenderShardId = errors.New("different shard ID between the transaction sender shard ID and current node shard ID")

--- a/node/node.go
+++ b/node/node.go
@@ -829,7 +829,9 @@ func (n *Node) ValidateTransaction(tx *transaction.Transaction) error {
 		core.MaxTxNonceDeltaAllowed,
 	)
 	if err != nil {
-		return fmt.Errorf("%w in Node.ValidateTransaction", err)
+		log.Warn("node.ValidateTransaction: can not instantiate a TxValidator",
+			"error", err)
+		return err
 	}
 
 	marshalizedTx, err := n.internalMarshalizer.Marshal(tx)

--- a/node/node.go
+++ b/node/node.go
@@ -816,6 +816,11 @@ func (n *Node) sendBulkTransactions(txs []*transaction.Transaction) {
 
 // ValidateTransaction will validate a transaction
 func (n *Node) ValidateTransaction(tx *transaction.Transaction) error {
+	err := n.checkSenderIsInShard(tx)
+	if err != nil {
+		return err
+	}
+
 	txValidator, err := dataValidators.NewTxValidator(
 		n.accounts,
 		n.shardCoordinator,
@@ -824,7 +829,7 @@ func (n *Node) ValidateTransaction(tx *transaction.Transaction) error {
 		core.MaxTxNonceDeltaAllowed,
 	)
 	if err != nil {
-		return nil
+		return fmt.Errorf("%w in Node.ValidateTransaction", err)
 	}
 
 	marshalizedTx, err := n.internalMarshalizer.Marshal(tx)
@@ -857,13 +862,17 @@ func (n *Node) ValidateTransaction(tx *transaction.Transaction) error {
 		return err
 	}
 
-	err = txValidator.CheckTxValidity(intTx)
-	if errors.Is(err, process.ErrAccountNotFound) {
-		// we allow the broadcast of provided transaction even if that transaction is not targeted on the current shard
-		return nil
+	return txValidator.CheckTxValidity(intTx)
+}
+
+func (n *Node) checkSenderIsInShard(tx *transaction.Transaction) error {
+	senderShardID := n.shardCoordinator.ComputeId(tx.SndAddr)
+	if senderShardID != n.shardCoordinator.SelfId() {
+		return fmt.Errorf("%w, tx sender shard ID: %d, node's shard ID %d",
+			ErrDifferentSenderShardId, senderShardID, n.shardCoordinator.SelfId())
 	}
 
-	return err
+	return nil
 }
 
 func (n *Node) sendBulkTransactionsFromShard(transactions [][]byte, senderShardId uint32) error {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -75,7 +75,7 @@ func getMessenger() *mock.MessengerStub {
 }
 
 func getMarshalizer() marshal.Marshalizer {
-	return &mock.MarshalizerMock{}
+	return &mock.MarshalizerFake{}
 }
 
 func getHasher() hashing.Hasher {
@@ -607,10 +607,13 @@ func TestCreateTransaction_InvalidTxVersionShouldErr(t *testing.T) {
 	assert.Equal(t, node.ErrInvalidTransactionVersion, err)
 }
 
-func TestCreateTransaction_OkValsShouldWork(t *testing.T) {
+func TestCreateTransaction_SenderShardIdIsInDifferentShardShouldNotValidate(t *testing.T) {
 	t.Parallel()
 
 	expectedHash := []byte("expected hash")
+	crtShardID := uint32(1)
+	chainID := []byte("chain ID")
+	version := uint32(1)
 	n, _ := node.NewNode(
 		node.WithInternalMarshalizer(getMarshalizer(), testSizeCheckDelta),
 		node.WithVmMarshalizer(getMarshalizer()),
@@ -629,6 +632,23 @@ func TestCreateTransaction_OkValsShouldWork(t *testing.T) {
 				},
 			}),
 		node.WithAccountsAdapter(&mock.AccountsStub{}),
+		node.WithShardCoordinator(&mock.ShardCoordinatorMock{
+			ComputeIdCalled: func(i []byte) uint32 {
+				return crtShardID + 1
+			},
+			SelfShardId: crtShardID,
+		}),
+		node.WithWhiteListHandler(&mock.WhiteListHandlerStub{}),
+		node.WithWhiteListHandlerVerified(&mock.WhiteListHandlerStub{}),
+		node.WithKeyGenForAccounts(&mock.KeyGenMock{}),
+		node.WithTxSingleSigner(&mock.SingleSignerMock{}),
+		node.WithTxFeeHandler(&mock.FeeHandlerStub{
+			CheckValidityTxValuesCalled: func(tx process.TransactionWithFeeHandler) error {
+				return nil
+			},
+		}),
+		node.WithChainID(chainID),
+		node.WithMinTransactionVersion(version),
 	)
 
 	nonce := uint64(0)
@@ -640,7 +660,72 @@ func TestCreateTransaction_OkValsShouldWork(t *testing.T) {
 	txData := []byte("-")
 	signature := "617eff4f"
 
-	tx, txHash, err := n.CreateTransaction(nonce, value.String(), receiver, sender, gasPrice, gasLimit, txData, signature, "chainID", 1)
+	tx, txHash, err := n.CreateTransaction(nonce, value.String(), receiver, sender, gasPrice, gasLimit, txData, signature, string(chainID), version)
+	assert.NotNil(t, tx)
+	assert.Equal(t, expectedHash, txHash)
+	assert.Nil(t, err)
+	assert.Equal(t, nonce, tx.Nonce)
+	assert.Equal(t, value, tx.Value)
+	assert.True(t, bytes.Equal([]byte(receiver), tx.RcvAddr))
+
+	err = n.ValidateTransaction(tx)
+	assert.True(t, errors.Is(err, node.ErrDifferentSenderShardId))
+}
+
+func TestCreateTransaction_OkValsShouldWork(t *testing.T) {
+	t.Parallel()
+
+	expectedHash := []byte("expected hash")
+	crtShardID := uint32(1)
+	chainID := []byte("chain ID")
+	version := uint32(1)
+	n, _ := node.NewNode(
+		node.WithInternalMarshalizer(getMarshalizer(), testSizeCheckDelta),
+		node.WithVmMarshalizer(getMarshalizer()),
+		node.WithTxSignMarshalizer(getMarshalizer()),
+		node.WithHasher(
+			mock.HasherMock{
+				ComputeCalled: func(s string) []byte {
+					return expectedHash
+				},
+			},
+		),
+		node.WithAddressPubkeyConverter(
+			&mock.PubkeyConverterStub{
+				DecodeCalled: func(hexAddress string) ([]byte, error) {
+					return []byte(hexAddress), nil
+				},
+			}),
+		node.WithAccountsAdapter(&mock.AccountsStub{}),
+		node.WithShardCoordinator(&mock.ShardCoordinatorMock{
+			ComputeIdCalled: func(i []byte) uint32 {
+				return crtShardID
+			},
+			SelfShardId: crtShardID,
+		}),
+		node.WithWhiteListHandler(&mock.WhiteListHandlerStub{}),
+		node.WithWhiteListHandlerVerified(&mock.WhiteListHandlerStub{}),
+		node.WithKeyGenForAccounts(&mock.KeyGenMock{}),
+		node.WithTxSingleSigner(&mock.SingleSignerMock{}),
+		node.WithTxFeeHandler(&mock.FeeHandlerStub{
+			CheckValidityTxValuesCalled: func(tx process.TransactionWithFeeHandler) error {
+				return nil
+			},
+		}),
+		node.WithChainID(chainID),
+		node.WithMinTransactionVersion(version),
+	)
+
+	nonce := uint64(0)
+	value := new(big.Int).SetInt64(10)
+	receiver := "rcv"
+	sender := "snd"
+	gasPrice := uint64(10)
+	gasLimit := uint64(20)
+	txData := []byte("-")
+	signature := "617eff4f"
+
+	tx, txHash, err := n.CreateTransaction(nonce, value.String(), receiver, sender, gasPrice, gasLimit, txData, signature, string(chainID), version)
 	assert.NotNil(t, tx)
 	assert.Equal(t, expectedHash, txHash)
 	assert.Nil(t, err)


### PR DESCRIPTION
- removed the possibility to broadcast a transaction from any node in the network. Each transaction will get broadcast only if it will be routed to the sender's shard ID node.
- added unit and integration tests that prove that the transaction validation works as expected