### PR TITLE
Bugfix/stake unstake stake claim

### DIFF
--- a/process/smartContract/process.go
+++ b/process/smartContract/process.go
@@ -1285,6 +1285,7 @@ func (sc *scProcessor) createSmartContractResults(
 		if !sc.flagDeploy.IsSet() {
 			result := createBaseSCR(outAcc, tx, txHash)
 			result.Code = outAcc.Code
+			result.Value.Set(outAcc.BalanceDelta)
 			return []data.TransactionHandler{result}
 		}
 

--- a/process/smartContract/process.go
+++ b/process/smartContract/process.go
@@ -1282,6 +1282,12 @@ func (sc *scProcessor) createSmartContractResults(
 	txHash []byte,
 ) []data.TransactionHandler {
 	if len(outAcc.OutputTransfers) == 0 {
+		if !sc.flagDeploy.IsSet() {
+			result := createBaseSCR(outAcc, tx, txHash)
+			result.Code = outAcc.Code
+			return []data.TransactionHandler{result}
+		}
+
 		return nil
 	}
 

--- a/vm/systemSmartContracts/auction.go
+++ b/vm/systemSmartContracts/auction.go
@@ -855,7 +855,9 @@ func (s *stakingAuctionSC) activateStakingFor(
 			s.eei.Finish([]byte{waiting})
 		}
 
-		numRegistered++
+		if stakedData.UnStakedNonce == 0 {
+			numRegistered++
+		}
 	}
 
 	registrationData.NumRegistered = uint32(numRegistered)


### PR DESCRIPTION
fix scenario of stake unstake stake the same key, both stakes with value. Claim should return the nodePrice.

The problem was counting the numRegistered nodes used for lockedStake.