### PR TITLE
changed condition for ok smart contract results indexing

### DIFF
--- a/core/indexer/processTransactions.go
+++ b/core/indexer/processTransactions.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/process"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
 
 const (
@@ -99,7 +100,7 @@ func (tdp *txDatabaseProcessor) prepareTransactionsForDatabase(
 		if nrScResult < minimumNumberOfSmartContractResults {
 			if len(transactions[hash].SmartContractResults) > 0 {
 				scResultData := transactions[hash].SmartContractResults[0].Data
-				if bytes.Contains(scResultData, []byte("@ok")) {
+				if isScResultSuccessful(scResultData) {
 					// ESDT contract calls generate just one smart contract result
 					continue
 				}
@@ -127,6 +128,11 @@ func (tdp *txDatabaseProcessor) prepareTransactionsForDatabase(
 	tdp.txLogsProcessor.Clean()
 
 	return append(convertMapTxsToSlice(transactions), rewardsTxs...)
+}
+
+func isScResultSuccessful(scResultData []byte) bool {
+	okReturnData := []byte("@" + hex.EncodeToString([]byte(vmcommon.Ok.String())))
+	return bytes.Contains(scResultData, okReturnData)
 }
 
 func findAllChildScrResults(hash string, scrs map[string]*smartContractResult.SmartContractResult) map[string]*smartContractResult.SmartContractResult {

--- a/core/indexer/processTransactions.go
+++ b/core/indexer/processTransactions.go
@@ -110,7 +110,7 @@ func (tdp *txDatabaseProcessor) prepareTransactionsForDatabase(
 				continue
 			}
 
-			transactions[hash].Status = transaction.TxStatusUnsuccessful.String()
+			transactions[hash].Status = transaction.TxStatusFail.String()
 		}
 	}
 
@@ -220,7 +220,7 @@ func (tdp *txDatabaseProcessor) groupNormalTxsAndRewards(
 
 		mbTxStatus := transaction.TxStatusPending.String()
 		if selfShardID == mb.ReceiverShardID {
-			mbTxStatus = transaction.TxStatusSuccessful.String()
+			mbTxStatus = transaction.TxStatusSuccess.String()
 		}
 
 		switch mb.Type {

--- a/core/indexer/processTransactions.go
+++ b/core/indexer/processTransactions.go
@@ -131,8 +131,9 @@ func (tdp *txDatabaseProcessor) prepareTransactionsForDatabase(
 }
 
 func isScResultSuccessful(scResultData []byte) bool {
-	okReturnData := []byte("@" + hex.EncodeToString([]byte(vmcommon.Ok.String())))
-	return bytes.Contains(scResultData, okReturnData)
+	okReturnDataNewVersion := []byte("@" + hex.EncodeToString([]byte(vmcommon.Ok.String())))
+	okReturnDataOldVersion := []byte("@" + vmcommon.Ok.String()) // backwards compatible
+	return bytes.Contains(scResultData, okReturnDataNewVersion) || bytes.Contains(scResultData, okReturnDataOldVersion)
 }
 
 func findAllChildScrResults(hash string, scrs map[string]*smartContractResult.SmartContractResult) map[string]*smartContractResult.SmartContractResult {

--- a/core/indexer/processTransactions_test.go
+++ b/core/indexer/processTransactions_test.go
@@ -231,7 +231,7 @@ func TestRelayedTransactions(t *testing.T) {
 	transactions := txDbProc.prepareTransactionsForDatabase(body, header, txPool, 0)
 	assert.Equal(t, 1, len(transactions))
 	assert.Equal(t, 3, len(transactions[0].SmartContractResults))
-	assert.Equal(t, transaction.TxStatusSuccessful.String(), transactions[0].Status)
+	assert.Equal(t, transaction.TxStatusSuccess.String(), transactions[0].Status)
 }
 
 func TestSetTransactionSearchOrder(t *testing.T) {

--- a/data/transaction/status.go
+++ b/data/transaction/status.go
@@ -11,10 +11,10 @@ type TxStatus string
 const (
 	// TxStatusPending = received and maybe executed on source shard, but not on destination shard
 	TxStatusPending TxStatus = "pending"
-	// TxStatusSuccessful = received and executed
-	TxStatusSuccessful TxStatus = "successful"
-	// TxStatusUnsuccessful = received and executed with error
-	TxStatusUnsuccessful TxStatus = "unsuccessful"
+	// TxStatusSuccess = received and executed
+	TxStatusSuccess TxStatus = "success"
+	// TxStatusFail = received and executed with error
+	TxStatusFail TxStatus = "fail"
 	// TxStatusInvalid = considered invalid
 	TxStatusInvalid TxStatus = "invalid"
 )
@@ -41,7 +41,7 @@ func (params *StatusComputer) ComputeStatusWhenInStorageKnowingMiniblock() TxSta
 		return TxStatusInvalid
 	}
 	if params.IsMiniblockFinalized || params.isDestinationMe() || params.isContractDeploy() {
-		return TxStatusSuccessful
+		return TxStatusSuccess
 	}
 
 	return TxStatusPending
@@ -52,7 +52,7 @@ func (params *StatusComputer) ComputeStatusWhenInStorageKnowingMiniblock() TxSta
 // However, when "dblookupext" indexing is enabled, this function is not used.
 func (params *StatusComputer) ComputeStatusWhenInStorageNotKnowingMiniblock() TxStatus {
 	if params.isDestinationMe() || params.isContractDeploy() {
-		return TxStatusSuccessful
+		return TxStatusSuccess
 	}
 
 	// At least partially executed (since in source's storage)

--- a/data/transaction/status_test.go
+++ b/data/transaction/status_test.go
@@ -25,7 +25,7 @@ func TestStatusComputer_ComputeStatusWhenInStorageKnowingMiniblock(t *testing.T)
 		DestinationShard: 12,
 		SelfShard:        12,
 	}
-	require.Equal(t, TxStatusSuccessful, computer.ComputeStatusWhenInStorageKnowingMiniblock())
+	require.Equal(t, TxStatusSuccess, computer.ComputeStatusWhenInStorageKnowingMiniblock())
 
 	// Cross, at source
 	computer = &StatusComputer{
@@ -44,7 +44,7 @@ func TestStatusComputer_ComputeStatusWhenInStorageKnowingMiniblock(t *testing.T)
 		DestinationShard:     13,
 		SelfShard:            12,
 	}
-	require.Equal(t, TxStatusSuccessful, computer.ComputeStatusWhenInStorageKnowingMiniblock())
+	require.Equal(t, TxStatusSuccess, computer.ComputeStatusWhenInStorageKnowingMiniblock())
 
 	// Cross, destination me
 	computer = &StatusComputer{
@@ -53,7 +53,7 @@ func TestStatusComputer_ComputeStatusWhenInStorageKnowingMiniblock(t *testing.T)
 		DestinationShard: 12,
 		SelfShard:        12,
 	}
-	require.Equal(t, TxStatusSuccessful, computer.ComputeStatusWhenInStorageKnowingMiniblock())
+	require.Equal(t, TxStatusSuccess, computer.ComputeStatusWhenInStorageKnowingMiniblock())
 
 	computer = &StatusComputer{
 		MiniblockType:    block.RewardsBlock,
@@ -61,7 +61,7 @@ func TestStatusComputer_ComputeStatusWhenInStorageKnowingMiniblock(t *testing.T)
 		DestinationShard: 12,
 		SelfShard:        12,
 	}
-	require.Equal(t, TxStatusSuccessful, computer.ComputeStatusWhenInStorageKnowingMiniblock())
+	require.Equal(t, TxStatusSuccess, computer.ComputeStatusWhenInStorageKnowingMiniblock())
 
 	// Contract deploy
 	computer = &StatusComputer{
@@ -71,7 +71,7 @@ func TestStatusComputer_ComputeStatusWhenInStorageKnowingMiniblock(t *testing.T)
 		TransactionData:  []byte("deployingAContract"),
 		SelfShard:        13,
 	}
-	require.Equal(t, TxStatusSuccessful, computer.ComputeStatusWhenInStorageKnowingMiniblock())
+	require.Equal(t, TxStatusSuccess, computer.ComputeStatusWhenInStorageKnowingMiniblock())
 }
 
 func TestStatusComputer_ComputeStatusWhenInStorageNotKnowingMiniblock(t *testing.T) {
@@ -81,7 +81,7 @@ func TestStatusComputer_ComputeStatusWhenInStorageNotKnowingMiniblock(t *testing
 		DestinationShard: 12,
 		SelfShard:        12,
 	}
-	require.Equal(t, TxStatusSuccessful, computer.ComputeStatusWhenInStorageNotKnowingMiniblock())
+	require.Equal(t, TxStatusSuccess, computer.ComputeStatusWhenInStorageNotKnowingMiniblock())
 
 	// Cross, at source
 	computer = &StatusComputer{
@@ -97,14 +97,14 @@ func TestStatusComputer_ComputeStatusWhenInStorageNotKnowingMiniblock(t *testing
 		DestinationShard: 12,
 		SelfShard:        12,
 	}
-	require.Equal(t, TxStatusSuccessful, computer.ComputeStatusWhenInStorageNotKnowingMiniblock())
+	require.Equal(t, TxStatusSuccess, computer.ComputeStatusWhenInStorageNotKnowingMiniblock())
 
 	computer = &StatusComputer{
 		SourceShard:      core.MetachainShardId,
 		DestinationShard: 12,
 		SelfShard:        12,
 	}
-	require.Equal(t, TxStatusSuccessful, computer.ComputeStatusWhenInStorageNotKnowingMiniblock())
+	require.Equal(t, TxStatusSuccess, computer.ComputeStatusWhenInStorageNotKnowingMiniblock())
 
 	// Contract deploy
 	computer = &StatusComputer{
@@ -114,5 +114,5 @@ func TestStatusComputer_ComputeStatusWhenInStorageNotKnowingMiniblock(t *testing
 		TransactionData:  []byte("deployingAContract"),
 		SelfShard:        13,
 	}
-	require.Equal(t, TxStatusSuccessful, computer.ComputeStatusWhenInStorageNotKnowingMiniblock())
+	require.Equal(t, TxStatusSuccess, computer.ComputeStatusWhenInStorageNotKnowingMiniblock())
 }

--- a/node/nodeTransactions_test.go
+++ b/node/nodeTransactions_test.go
@@ -123,8 +123,8 @@ func TestNode_GetTransaction_FromStorage(t *testing.T) {
 	require.Equal(t, txB.Nonce, actualB.Nonce)
 	require.Equal(t, txC.Nonce, actualC.Nonce)
 	require.Equal(t, transaction.TxStatusPending, actualA.Status)
-	require.Equal(t, transaction.TxStatusSuccessful, actualB.Status)
-	require.Equal(t, transaction.TxStatusSuccessful, actualC.Status)
+	require.Equal(t, transaction.TxStatusSuccess, actualB.Status)
+	require.Equal(t, transaction.TxStatusSuccess, actualC.Status)
 
 	// Reward transactions
 
@@ -134,7 +134,7 @@ func TestNode_GetTransaction_FromStorage(t *testing.T) {
 	actualD, err := n.GetTransaction(hex.EncodeToString([]byte("d")))
 	require.Nil(t, err)
 	require.Equal(t, txD.Round, actualD.Round)
-	require.Equal(t, transaction.TxStatusSuccessful, actualD.Status)
+	require.Equal(t, transaction.TxStatusSuccess, actualD.Status)
 
 	// Unsigned transactions
 
@@ -159,8 +159,8 @@ func TestNode_GetTransaction_FromStorage(t *testing.T) {
 	require.Equal(t, txF.GasLimit, actualF.GasLimit)
 	require.Equal(t, txG.GasLimit, actualG.GasLimit)
 	require.Equal(t, transaction.TxStatusPending, actualE.Status)
-	require.Equal(t, transaction.TxStatusSuccessful, actualF.Status)
-	require.Equal(t, transaction.TxStatusSuccessful, actualG.Status)
+	require.Equal(t, transaction.TxStatusSuccess, actualF.Status)
+	require.Equal(t, transaction.TxStatusSuccess, actualG.Status)
 
 	// Missing transaction
 	tx, err := n.GetTransaction(hex.EncodeToString([]byte("missing")))
@@ -202,7 +202,7 @@ func TestNode_lookupHistoricalTransaction(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, txB.Nonce, actualB.Nonce)
 	require.Equal(t, 42, int(actualB.Epoch))
-	require.Equal(t, transaction.TxStatusSuccessful, actualB.Status)
+	require.Equal(t, transaction.TxStatusSuccess, actualB.Status)
 
 	// Intra-shard
 	txC := &transaction.Transaction{Nonce: 7, SndAddr: []byte("alice"), RcvAddr: []byte("alice")}
@@ -213,7 +213,7 @@ func TestNode_lookupHistoricalTransaction(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, txC.Nonce, actualC.Nonce)
 	require.Equal(t, 42, int(actualC.Epoch))
-	require.Equal(t, transaction.TxStatusSuccessful, actualC.Status)
+	require.Equal(t, transaction.TxStatusSuccess, actualC.Status)
 
 	// Invalid transaction
 	txInvalid := &transaction.Transaction{Nonce: 7, SndAddr: []byte("alice"), RcvAddr: []byte("alice")}
@@ -237,7 +237,7 @@ func TestNode_lookupHistoricalTransaction(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 42, int(actualD.Epoch))
 	require.Equal(t, string(transaction.TxTypeReward), actualD.Type)
-	require.Equal(t, transaction.TxStatusSuccessful, actualD.Status)
+	require.Equal(t, transaction.TxStatusSuccess, actualD.Status)
 
 	// Unsigned transactions
 
@@ -263,7 +263,7 @@ func TestNode_lookupHistoricalTransaction(t *testing.T) {
 	require.Equal(t, 42, int(actualF.Epoch))
 	require.Equal(t, txF.GasLimit, actualF.GasLimit)
 	require.Equal(t, string(transaction.TxTypeUnsigned), actualF.Type)
-	require.Equal(t, transaction.TxStatusSuccessful, actualF.Status)
+	require.Equal(t, transaction.TxStatusSuccess, actualF.Status)
 
 	// Intra-shard
 	txG := &smartContractResult.SmartContractResult{GasLimit: 15, SndAddr: []byte("alice"), RcvAddr: []byte("alice")}
@@ -275,7 +275,7 @@ func TestNode_lookupHistoricalTransaction(t *testing.T) {
 	require.Equal(t, 42, int(actualG.Epoch))
 	require.Equal(t, txG.GasLimit, actualG.GasLimit)
 	require.Equal(t, string(transaction.TxTypeUnsigned), actualG.Type)
-	require.Equal(t, transaction.TxStatusSuccessful, actualG.Status)
+	require.Equal(t, transaction.TxStatusSuccess, actualG.Status)
 
 	// Missing transaction
 	historyRepo.GetMiniblockMetadataByTxHashCalled = func(hash []byte) (*dblookupext.MiniblockMetadata, error) {

--- a/node/txsimulator/txSimulator.go
+++ b/node/txsimulator/txSimulator.go
@@ -60,11 +60,11 @@ func (ts *transactionSimulator) ProcessTx(tx *transaction.Transaction) (*transac
 	retCode, err := ts.txProcessor.ProcessTransaction(tx)
 	if err != nil {
 		failReason = err.Error()
-		txStatus = transaction.TxStatusUnsuccessful
+		txStatus = transaction.TxStatusFail
 	}
 
 	if retCode == vmcommon.Ok {
-		txStatus = transaction.TxStatusSuccessful
+		txStatus = transaction.TxStatusSuccess
 	}
 
 	results := &transaction.SimulationResults{


### PR DESCRIPTION
data field for ok smart contract results changed from `@ok` to `@hex("ok")` 
updated the condition in elastic search indexer

Also changed transactions' statuses messages:
```
successful -> success
unsuccessful -> fail
invalid -> invalid
pending -> pending
```