### PR TITLE
Bugfix import db testnet version T1.1.3.0 compatibility issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/beevik/ntp v0.2.0
 	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
+	github.com/davecgh/go-spew v1.1.1
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/elastic/go-elasticsearch/v7 v7.1.0
 	github.com/gin-contrib/cors v0.0.0-20190301062745-f9e10995c85a

--- a/process/block/postprocess/intermediateResults.go
+++ b/process/block/postprocess/intermediateResults.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"sort"
 
+	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/data"
@@ -14,6 +15,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/sharding"
+	"github.com/davecgh/go-spew/spew"
 )
 
 var _ process.IntermediateTransactionHandler = (*intermediateResultsProcessor)(nil)
@@ -213,7 +215,11 @@ func (irp *intermediateResultsProcessor) AddIntermediateTransactions(txs []data.
 			return err
 		}
 
-		log.Trace("scr added", "txHash", addScr.PrevTxHash, "hash", scrHash, "nonce", addScr.Nonce, "gasLimit", addScr.GasLimit, "value", addScr.Value)
+		if log.GetLevel() == logger.LogTrace {
+			//spew.Sdump is very useful when debugging errors like `receipts hash mismatch`
+			log.Trace("scr added", "txHash", addScr.PrevTxHash, "hash", scrHash, "nonce", addScr.Nonce, "gasLimit", addScr.GasLimit, "value", addScr.Value,
+				"dump", spew.Sdump(addScr))
+		}
 
 		sndShId, dstShId, err := irp.getShardIdsFromAddresses(addScr.SndAddr, addScr.RcvAddr)
 		if err != nil {

--- a/process/smartContract/process.go
+++ b/process/smartContract/process.go
@@ -1286,6 +1286,10 @@ func (sc *scProcessor) createSmartContractResults(
 			result := createBaseSCR(outAcc, tx, txHash)
 			result.Code = outAcc.Code
 			result.Value.Set(outAcc.BalanceDelta)
+			if result.Value.Cmp(zero) > 0 {
+				result.OriginalSender = tx.GetSndAddr()
+			}
+
 			return []data.TransactionHandler{result}
 		}
 

--- a/process/smartContract/process_test.go
+++ b/process/smartContract/process_test.go
@@ -2091,14 +2091,14 @@ func TestScProcessor_penalizeUserIfNeededShouldWork(t *testing.T) {
 		GasRemaining: maxGasToRemain,
 	}
 	sc.penalizeUserIfNeeded(&transaction.Transaction{}, []byte("txHash"), callType, gasProvided, vmOutput)
-	assert.Equal(t, uint64(maxGasToRemain), vmOutput.GasRemaining)
+	assert.Equal(t, maxGasToRemain, vmOutput.GasRemaining)
 
 	callType = vmcommon.AsynchronousCall
 	vmOutput = &vmcommon.VMOutput{
 		GasRemaining: maxGasToRemain + 1,
 	}
 	sc.penalizeUserIfNeeded(&transaction.Transaction{}, []byte("txHash"), callType, gasProvided, vmOutput)
-	assert.Equal(t, uint64(maxGasToRemain+1), vmOutput.GasRemaining)
+	assert.Equal(t, maxGasToRemain+1, vmOutput.GasRemaining)
 
 	callType = vmcommon.DirectCall
 	vmOutput = &vmcommon.VMOutput{
@@ -2143,7 +2143,7 @@ func TestScProcessor_penalizeUserIfNeededShouldWorkOnFlagActivation(t *testing.T
 
 	sc.EpochConfirmed(0)
 	sc.penalizeUserIfNeeded(&transaction.Transaction{}, []byte("txHash"), callType, gasProvided, vmOutput)
-	assert.Equal(t, uint64(maxGasToRemain+1), vmOutput.GasRemaining)
+	assert.Equal(t, maxGasToRemain+1, vmOutput.GasRemaining)
 
 	sc.EpochConfirmed(1)
 	sc.penalizeUserIfNeeded(&transaction.Transaction{}, []byte("txHash"), callType, gasProvided, vmOutput)


### PR DESCRIPTION
- fixed testnet compatibility issue that happened when trying to import a DB on the testnet version T1.1.3.0

Manual testing procedure: import-db on shard 0 with the T1.1.3.0 version configs & resulted DB. The process will work up until epoch 6 where the new "bad" code kicked-in. (by using a small hack that reverted this fix for epochs>=5, I was able to fully sync the 12 epochs)