### PR TITLE
En 7744 top up staking v2

### DIFF
--- a/epochStart/metachain/systemSCs.go
+++ b/epochStart/metachain/systemSCs.go
@@ -259,7 +259,7 @@ func (s *systemSCProcessor) stakingToValidatorStatistics(
 		return nil, err
 	}
 
-	var stakingData systemSmartContracts.StakedDataV2
+	var stakingData systemSmartContracts.StakedDataV2P0
 	err = s.marshalizer.Unmarshal(&stakingData, activeStorageUpdate.Data)
 	if err != nil {
 		return nil, err

--- a/epochStart/metachain/systemSCs.go
+++ b/epochStart/metachain/systemSCs.go
@@ -259,7 +259,7 @@ func (s *systemSCProcessor) stakingToValidatorStatistics(
 		return nil, err
 	}
 
-	var stakingData systemSmartContracts.StakedDataV2P0
+	var stakingData systemSmartContracts.StakedDataV2_0
 	err = s.marshalizer.Unmarshal(&stakingData, activeStorageUpdate.Data)
 	if err != nil {
 		return nil, err

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -112,7 +112,7 @@ func createStakingScAcc(accountsDB state.AccountsAdapter) state.UserAccountHandl
 
 func createEligibleNodes(numNodes int, stakingSCAcc state.UserAccountHandler, marshalizer marshal.Marshalizer) {
 	for i := 0; i < numNodes; i++ {
-		stakedData := &systemSmartContracts.StakedDataV2P0{
+		stakedData := &systemSmartContracts.StakedDataV2_0{
 			Waiting:       false,
 			Staked:        true,
 			StakedNonce:   0,
@@ -128,7 +128,7 @@ func createJailedNodes(numNodes int, stakingSCAcc state.UserAccountHandler, user
 	validatorInfos := make([]*state.ValidatorInfo, 0)
 
 	for i := 0; i < numNodes; i++ {
-		stakedData := &systemSmartContracts.StakedDataV2P0{
+		stakedData := &systemSmartContracts.StakedDataV2_0{
 			Staked:        true,
 			RewardAddress: []byte(fmt.Sprintf("rewardAddress_j%d", i)),
 			StakeValue:    big.NewInt(100),
@@ -160,7 +160,7 @@ func createWaitingNodes(numNodes int, stakingSCAcc state.UserAccountHandler, use
 	validatorInfos := make([]*state.ValidatorInfo, 0)
 
 	for i := 0; i < numNodes; i++ {
-		stakedData := &systemSmartContracts.StakedDataV2P0{
+		stakedData := &systemSmartContracts.StakedDataV2_0{
 			Waiting:       true,
 			RewardAddress: []byte(fmt.Sprintf("rewardAddress_w%d", i)),
 			StakeValue:    big.NewInt(100),
@@ -210,7 +210,7 @@ func prepareStakingContractWithData(
 ) {
 	stakingSCAcc := createStakingScAcc(accountsDB)
 
-	stakedData := &systemSmartContracts.StakedDataV2P0{
+	stakedData := &systemSmartContracts.StakedDataV2_0{
 		Staked:        true,
 		RewardAddress: []byte("rewardAddress"),
 		StakeValue:    big.NewInt(100),
@@ -218,7 +218,7 @@ func prepareStakingContractWithData(
 	marshaledData, _ := marshalizer.Marshal(stakedData)
 	stakingSCAcc.DataTrieTracker().SaveKeyValue(stakedKey, marshaledData)
 
-	stakedData = &systemSmartContracts.StakedDataV2P0{
+	stakedData = &systemSmartContracts.StakedDataV2_0{
 		Waiting:       true,
 		RewardAddress: []byte("rewardAddress"),
 		StakeValue:    big.NewInt(100),

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -112,7 +112,7 @@ func createStakingScAcc(accountsDB state.AccountsAdapter) state.UserAccountHandl
 
 func createEligibleNodes(numNodes int, stakingSCAcc state.UserAccountHandler, marshalizer marshal.Marshalizer) {
 	for i := 0; i < numNodes; i++ {
-		stakedData := &systemSmartContracts.StakedDataV2{
+		stakedData := &systemSmartContracts.StakedDataV2P0{
 			Waiting:       false,
 			Staked:        true,
 			StakedNonce:   0,
@@ -128,7 +128,7 @@ func createJailedNodes(numNodes int, stakingSCAcc state.UserAccountHandler, user
 	validatorInfos := make([]*state.ValidatorInfo, 0)
 
 	for i := 0; i < numNodes; i++ {
-		stakedData := &systemSmartContracts.StakedDataV2{
+		stakedData := &systemSmartContracts.StakedDataV2P0{
 			Staked:        true,
 			RewardAddress: []byte(fmt.Sprintf("rewardAddress_j%d", i)),
 			StakeValue:    big.NewInt(100),
@@ -160,7 +160,7 @@ func createWaitingNodes(numNodes int, stakingSCAcc state.UserAccountHandler, use
 	validatorInfos := make([]*state.ValidatorInfo, 0)
 
 	for i := 0; i < numNodes; i++ {
-		stakedData := &systemSmartContracts.StakedDataV2{
+		stakedData := &systemSmartContracts.StakedDataV2P0{
 			Waiting:       true,
 			RewardAddress: []byte(fmt.Sprintf("rewardAddress_w%d", i)),
 			StakeValue:    big.NewInt(100),
@@ -210,7 +210,7 @@ func prepareStakingContractWithData(
 ) {
 	stakingSCAcc := createStakingScAcc(accountsDB)
 
-	stakedData := &systemSmartContracts.StakedDataV2{
+	stakedData := &systemSmartContracts.StakedDataV2P0{
 		Staked:        true,
 		RewardAddress: []byte("rewardAddress"),
 		StakeValue:    big.NewInt(100),
@@ -218,7 +218,7 @@ func prepareStakingContractWithData(
 	marshaledData, _ := marshalizer.Marshal(stakedData)
 	stakingSCAcc.DataTrieTracker().SaveKeyValue(stakedKey, marshaledData)
 
-	stakedData = &systemSmartContracts.StakedDataV2{
+	stakedData = &systemSmartContracts.StakedDataV2P0{
 		Waiting:       true,
 		RewardAddress: []byte("rewardAddress"),
 		StakeValue:    big.NewInt(100),

--- a/process/scToProtocol/stakingToPeer.go
+++ b/process/scToProtocol/stakingToPeer.go
@@ -183,7 +183,7 @@ func (stp *stakingToPeer) UpdateProtocol(body *block.Body, nonce uint64) error {
 			continue
 		}
 
-		var stakingData systemSmartContracts.StakedDataV2
+		var stakingData systemSmartContracts.StakedDataV2P0
 		err = stp.marshalizer.Unmarshal(&stakingData, data)
 		if err != nil {
 			return err
@@ -199,7 +199,7 @@ func (stp *stakingToPeer) UpdateProtocol(body *block.Body, nonce uint64) error {
 }
 
 func (stp *stakingToPeer) updatePeerStateV1(
-	stakingData systemSmartContracts.StakedDataV2,
+	stakingData systemSmartContracts.StakedDataV2P0,
 	blsPubKey []byte,
 	nonce uint64,
 ) error {
@@ -261,7 +261,7 @@ func (stp *stakingToPeer) updatePeerStateV1(
 }
 
 func (stp *stakingToPeer) updatePeerState(
-	stakingData systemSmartContracts.StakedDataV2,
+	stakingData systemSmartContracts.StakedDataV2P0,
 	blsPubKey []byte,
 	nonce uint64,
 ) error {

--- a/process/scToProtocol/stakingToPeer.go
+++ b/process/scToProtocol/stakingToPeer.go
@@ -183,7 +183,7 @@ func (stp *stakingToPeer) UpdateProtocol(body *block.Body, nonce uint64) error {
 			continue
 		}
 
-		var stakingData systemSmartContracts.StakedDataV2P0
+		var stakingData systemSmartContracts.StakedDataV2_0
 		err = stp.marshalizer.Unmarshal(&stakingData, data)
 		if err != nil {
 			return err
@@ -199,7 +199,7 @@ func (stp *stakingToPeer) UpdateProtocol(body *block.Body, nonce uint64) error {
 }
 
 func (stp *stakingToPeer) updatePeerStateV1(
-	stakingData systemSmartContracts.StakedDataV2P0,
+	stakingData systemSmartContracts.StakedDataV2_0,
 	blsPubKey []byte,
 	nonce uint64,
 ) error {
@@ -261,7 +261,7 @@ func (stp *stakingToPeer) updatePeerStateV1(
 }
 
 func (stp *stakingToPeer) updatePeerState(
-	stakingData systemSmartContracts.StakedDataV2P0,
+	stakingData systemSmartContracts.StakedDataV2_0,
 	blsPubKey []byte,
 	nonce uint64,
 ) error {

--- a/process/scToProtocol/stakingToPeer_test.go
+++ b/process/scToProtocol/stakingToPeer_test.go
@@ -286,7 +286,7 @@ func TestStakingToPeer_UpdateProtocolCannotSetRewardAddressShouldErr(t *testing.
 		return peerAcc, nil
 	}
 
-	stakingData := systemSmartContracts.StakedDataV2{
+	stakingData := systemSmartContracts.StakedDataV2P0{
 		StakeValue: big.NewInt(100),
 	}
 	marshalizer := &mock.MarshalizerMock{}
@@ -348,7 +348,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveAccountShouldErr(t *testing.T) {
 		return peerAccount, nil
 	}
 
-	stakingData := systemSmartContracts.StakedDataV2{
+	stakingData := systemSmartContracts.StakedDataV2P0{
 		StakeValue:    big.NewInt(100),
 		RewardAddress: []byte(address),
 	}
@@ -411,7 +411,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveAccountNonceShouldErr(t *testing.
 		return peerAccount, nil
 	}
 
-	stakingData := systemSmartContracts.StakedDataV2{
+	stakingData := systemSmartContracts.StakedDataV2P0{
 		StakeValue:    big.NewInt(100),
 		RewardAddress: []byte(address),
 	}
@@ -473,7 +473,7 @@ func TestStakingToPeer_UpdateProtocol(t *testing.T) {
 		return peerAccount, nil
 	}
 
-	stakingData := systemSmartContracts.StakedDataV2{
+	stakingData := systemSmartContracts.StakedDataV2P0{
 		StakeValue:    big.NewInt(100),
 		RewardAddress: []byte(address),
 	}
@@ -536,7 +536,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveUnStakedNonceShouldErr(t *testing
 		return peerAccount, nil
 	}
 
-	stakingData := systemSmartContracts.StakedDataV2{
+	stakingData := systemSmartContracts.StakedDataV2P0{
 		StakeValue:    big.NewInt(100),
 		RewardAddress: []byte(address),
 	}
@@ -577,7 +577,7 @@ func TestStakingToPeer_UpdatePeerState(t *testing.T) {
 	arguments.PeerState = peerAccountsDB
 	stp, _ := NewStakingToPeer(arguments)
 
-	stakingData := systemSmartContracts.StakedDataV2{
+	stakingData := systemSmartContracts.StakedDataV2P0{
 		RegisterNonce: 0,
 		Staked:        false,
 		UnStakedNonce: 0,

--- a/process/scToProtocol/stakingToPeer_test.go
+++ b/process/scToProtocol/stakingToPeer_test.go
@@ -286,7 +286,7 @@ func TestStakingToPeer_UpdateProtocolCannotSetRewardAddressShouldErr(t *testing.
 		return peerAcc, nil
 	}
 
-	stakingData := systemSmartContracts.StakedDataV2P0{
+	stakingData := systemSmartContracts.StakedDataV2_0{
 		StakeValue: big.NewInt(100),
 	}
 	marshalizer := &mock.MarshalizerMock{}
@@ -348,7 +348,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveAccountShouldErr(t *testing.T) {
 		return peerAccount, nil
 	}
 
-	stakingData := systemSmartContracts.StakedDataV2P0{
+	stakingData := systemSmartContracts.StakedDataV2_0{
 		StakeValue:    big.NewInt(100),
 		RewardAddress: []byte(address),
 	}
@@ -411,7 +411,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveAccountNonceShouldErr(t *testing.
 		return peerAccount, nil
 	}
 
-	stakingData := systemSmartContracts.StakedDataV2P0{
+	stakingData := systemSmartContracts.StakedDataV2_0{
 		StakeValue:    big.NewInt(100),
 		RewardAddress: []byte(address),
 	}
@@ -473,7 +473,7 @@ func TestStakingToPeer_UpdateProtocol(t *testing.T) {
 		return peerAccount, nil
 	}
 
-	stakingData := systemSmartContracts.StakedDataV2P0{
+	stakingData := systemSmartContracts.StakedDataV2_0{
 		StakeValue:    big.NewInt(100),
 		RewardAddress: []byte(address),
 	}
@@ -536,7 +536,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveUnStakedNonceShouldErr(t *testing
 		return peerAccount, nil
 	}
 
-	stakingData := systemSmartContracts.StakedDataV2P0{
+	stakingData := systemSmartContracts.StakedDataV2_0{
 		StakeValue:    big.NewInt(100),
 		RewardAddress: []byte(address),
 	}
@@ -577,7 +577,7 @@ func TestStakingToPeer_UpdatePeerState(t *testing.T) {
 	arguments.PeerState = peerAccountsDB
 	stp, _ := NewStakingToPeer(arguments)
 
-	stakingData := systemSmartContracts.StakedDataV2P0{
+	stakingData := systemSmartContracts.StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        false,
 		UnStakedNonce: 0,

--- a/vm/systemSmartContracts/auction.go
+++ b/vm/systemSmartContracts/auction.go
@@ -976,9 +976,9 @@ func (s *stakingAuctionSC) saveRegistrationDataV1(key []byte, auction *AuctionDa
 	return nil
 }
 
-func (s *stakingAuctionSC) getStakedData(key []byte) (*StakedDataV2P0, error) {
+func (s *stakingAuctionSC) getStakedData(key []byte) (*StakedDataV2_0, error) {
 	data := s.eei.GetStorageFromAddress(s.stakingSCAddress, key)
-	stakedData := &StakedDataV2P0{
+	stakedData := &StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        false,
 		UnStakedNonce: 0,

--- a/vm/systemSmartContracts/auctionSaveLoad.go
+++ b/vm/systemSmartContracts/auctionSaveLoad.go
@@ -1,0 +1,175 @@
+package systemSmartContracts
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+
+	"github.com/ElrondNetwork/elrond-go/core"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+)
+
+func (s *stakingAuctionSC) setConfig(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
+	ownerAddress := s.eei.GetStorage([]byte(ownerKey))
+	if !bytes.Equal(ownerAddress, args.CallerAddr) {
+		s.eei.AddReturnMessage("setConfig function was not called by the owner address")
+		return vmcommon.UserError
+	}
+
+	if len(args.Arguments) != 7 {
+		retMessage := fmt.Sprintf("setConfig function called with wrong number of arguments expected %d, got %d", 7, len(args.Arguments))
+		s.eei.AddReturnMessage(retMessage)
+		return vmcommon.UserError
+	}
+
+	auctionConfig := &AuctionConfig{
+		MinStakeValue: big.NewInt(0).SetBytes(args.Arguments[0]),
+		NumNodes:      uint32(big.NewInt(0).SetBytes(args.Arguments[1]).Uint64()),
+		TotalSupply:   big.NewInt(0).SetBytes(args.Arguments[2]),
+		MinStep:       big.NewInt(0).SetBytes(args.Arguments[3]),
+		NodePrice:     big.NewInt(0).SetBytes(args.Arguments[4]),
+		UnJailPrice:   big.NewInt(0).SetBytes(args.Arguments[5]),
+	}
+
+	code := s.verifyConfig(auctionConfig)
+	if code != vmcommon.Ok {
+		return code
+	}
+
+	configData, err := s.marshalizer.Marshal(auctionConfig)
+	if err != nil {
+		s.eei.AddReturnMessage("setConfig marshal auctionConfig error")
+		return vmcommon.UserError
+	}
+
+	epochBytes := args.Arguments[6]
+	s.eei.SetStorage(epochBytes, configData)
+
+	return vmcommon.Ok
+}
+
+func (s *stakingAuctionSC) getConfig(epoch uint32) AuctionConfig {
+	epochKey := big.NewInt(int64(epoch)).Bytes()
+	configData := s.eei.GetStorage(epochKey)
+	if len(configData) == 0 {
+		return s.baseConfig
+	}
+
+	auctionConfig := &AuctionConfig{}
+	err := s.marshalizer.Unmarshal(auctionConfig, configData)
+	if err != nil {
+		log.Warn("unmarshal error on getConfig function, returning baseConfig",
+			"error", err.Error(),
+		)
+		return s.baseConfig
+	}
+
+	if s.checkConfigCorrectness(*auctionConfig) != nil {
+		baseConfigData, errMarshal := s.marshalizer.Marshal(&s.baseConfig)
+		if errMarshal != nil {
+			log.Warn("marshal error on getConfig function, returning baseConfig", "error", errMarshal)
+			return s.baseConfig
+		}
+		s.eei.SetStorage(epochKey, baseConfigData)
+		return s.baseConfig
+	}
+
+	return *auctionConfig
+}
+
+func (s *stakingAuctionSC) getOrCreateRegistrationData(key []byte) (*AuctionDataV2, error) {
+	data := s.eei.GetStorage(key)
+	registrationData := &AuctionDataV2{
+		RewardAddress:   nil,
+		RegisterNonce:   0,
+		Epoch:           0,
+		BlsPubKeys:      nil,
+		TotalStakeValue: big.NewInt(0),
+		LockedStake:     big.NewInt(0),
+		MaxStakePerNode: big.NewInt(0),
+		TotalUnstaked:   big.NewInt(0),
+		UnstakedInfo:    make([]*UnstakedValue, 0),
+	}
+
+	if len(data) > 0 {
+		err := s.marshalizer.Unmarshal(registrationData, data)
+		if err != nil {
+			log.Debug("unmarshal error on auction SC stake function",
+				"error", err.Error(),
+			)
+			return nil, err
+		}
+	}
+
+	return registrationData, nil
+}
+
+func (s *stakingAuctionSC) saveRegistrationData(key []byte, auction *AuctionDataV2) error {
+	if !s.flagEnableTopUp.IsSet() {
+		return s.saveRegistrationDataV1(key, auction)
+	}
+
+	data, err := s.marshalizer.Marshal(auction)
+	if err != nil {
+		log.Debug("marshal error on staking SC stake function in saveRegistrationData",
+			"error", err.Error(),
+		)
+		return err
+	}
+
+	s.eei.SetStorage(key, data)
+	return nil
+}
+
+func (s *stakingAuctionSC) saveRegistrationDataV1(key []byte, auction *AuctionDataV2) error {
+	auctionDataV1 := &AuctionDataV1{
+		RegisterNonce:   auction.RegisterNonce,
+		Epoch:           auction.Epoch,
+		RewardAddress:   auction.RewardAddress,
+		TotalStakeValue: auction.TotalStakeValue,
+		LockedStake:     auction.LockedStake,
+		MaxStakePerNode: auction.MaxStakePerNode,
+		BlsPubKeys:      auction.BlsPubKeys,
+		NumRegistered:   auction.NumRegistered,
+	}
+
+	data, err := s.marshalizer.Marshal(auctionDataV1)
+	if err != nil {
+		log.Debug("marshal error on staking SC stake function in saveRegistrationDataV1",
+			"error", err.Error(),
+		)
+		return err
+	}
+
+	s.eei.SetStorage(key, data)
+	return nil
+}
+
+func (s *stakingAuctionSC) getStakedData(key []byte) (*StakedDataV2_0, error) {
+	data := s.eei.GetStorageFromAddress(s.stakingSCAddress, key)
+	stakedData := &StakedDataV2_0{
+		RegisterNonce: 0,
+		Staked:        false,
+		UnStakedNonce: 0,
+		UnStakedEpoch: core.DefaultUnstakedEpoch,
+		RewardAddress: nil,
+		StakeValue:    big.NewInt(0),
+		SlashValue:    big.NewInt(0),
+	}
+
+	if len(data) > 0 {
+		err := s.marshalizer.Unmarshal(stakedData, data)
+		if err != nil {
+			log.Debug("unmarshal error on auction SC getStakedData function",
+				"error", err.Error(),
+			)
+			return nil, err
+		}
+
+		if stakedData.SlashValue == nil {
+			stakedData.SlashValue = big.NewInt(0)
+		}
+	}
+
+	return stakedData, nil
+}

--- a/vm/systemSmartContracts/auction_test.go
+++ b/vm/systemSmartContracts/auction_test.go
@@ -532,7 +532,7 @@ func TestStakingAuctionSC_ExecuteStakeWithRewardAddress(t *testing.T) {
 
 	eei.SetSCAddress(args.StakingSCAddress)
 	marshaledData := eei.GetStorage(stakerPubKey)
-	stakedData := &StakedDataV2P0{}
+	stakedData := &StakedDataV2_0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.True(t, bytes.Equal(stakedData.RewardAddress, rwdAddress))
 }
@@ -592,7 +592,7 @@ func TestStakingAuctionSC_ExecuteStakeUnStakeOneBlsPubKey(t *testing.T) {
 	auctionData := createABid(25000000, 2, 12500000)
 	auctionDataBytes, _ := json.Marshal(&auctionData)
 
-	stakedData := StakedDataV2P0{
+	stakedData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        true,
 		UnStakedNonce: 1,
@@ -613,7 +613,7 @@ func TestStakingAuctionSC_ExecuteStakeUnStakeOneBlsPubKey(t *testing.T) {
 		return nil
 	}
 	eei.SetStorageCalled = func(key []byte, value []byte) {
-		var stakedDataRecovered StakedDataV2P0
+		var stakedDataRecovered StakedDataV2_0
 		_ = json.Unmarshal(value, &stakedDataRecovered)
 
 		assert.Equal(t, false, stakedDataRecovered.Staked)
@@ -691,7 +691,7 @@ func TestStakingAuctionSC_ExecuteStakeStakeClaim(t *testing.T) {
 
 	eei.SetSCAddress(args.StakingSCAddress)
 	marshaledData := eei.GetStorage(stakerPubKey.Bytes())
-	stakedData := &StakedDataV2P0{}
+	stakedData := &StakedDataV2_0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.True(t, stakedData.Staked)
 }
@@ -764,7 +764,7 @@ func TestStakingAuctionSC_ExecuteStakeUnStakeStakeClaim(t *testing.T) {
 
 	eei.SetSCAddress(args.StakingSCAddress)
 	marshaledData := eei.GetStorage(stakerPubKey.Bytes())
-	stakedData := &StakedDataV2P0{}
+	stakedData := &StakedDataV2_0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.True(t, stakedData.Staked)
 }
@@ -843,7 +843,7 @@ func TestStakingAuctionSC_ExecuteStakeUnStakeOneBlsPubKeyAndRestake(t *testing.T
 
 	eei.SetSCAddress(args.StakingSCAddress)
 	marshaledData := eei.GetStorage(stakerPubKey.Bytes())
-	stakedData := &StakedDataV2P0{}
+	stakedData := &StakedDataV2_0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.True(t, stakedData.Staked)
 }
@@ -1130,13 +1130,13 @@ func TestStakingAuctionSC_ExecuteStakeChangeRewardAddresStakeUnStake(t *testing.
 
 	eei.SetSCAddress(args.StakingSCAddress)
 	marshaledData := eei.GetStorage(stakerPubKey)
-	stakedData := &StakedDataV2P0{}
+	stakedData := &StakedDataV2_0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.True(t, stakedData.Staked)
 	assert.True(t, bytes.Equal(rewardAddress, stakedData.RewardAddress))
 
 	marshaledData = eei.GetStorage(blsKey2)
-	stakedData = &StakedDataV2P0{}
+	stakedData = &StakedDataV2_0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.False(t, stakedData.Staked)
 	assert.True(t, bytes.Equal(rewardAddress, stakedData.RewardAddress))
@@ -1216,7 +1216,7 @@ func TestStakingAuctionSC_ExecuteStakeUnStakeUnBondBlsPubKeyAndReStake(t *testin
 
 	eei.SetSCAddress(args.StakingSCAddress)
 	marshaledData := eei.GetStorage(stakerPubKey.Bytes())
-	stakedData := &StakedDataV2P0{}
+	stakedData := &StakedDataV2_0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.True(t, stakedData.Staked)
 }
@@ -1230,7 +1230,7 @@ func TestStakingAuctionSC_ExecuteUnBound(t *testing.T) {
 	auctionData := createABid(totalStake, 2, 12500000)
 	auctionDataBytes, _ := json.Marshal(&auctionData)
 
-	stakedData := StakedDataV2P0{
+	stakedData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        false,
 		UnStakedNonce: 1,
@@ -1385,7 +1385,7 @@ func TestAuctionStakingSC_ExecuteStakeAlreadyStakedShouldNotErr(t *testing.T) {
 
 	stakerBlsKey1 := big.NewInt(101)
 	expectedCallerAddress := []byte("caller")
-	stakedRegistrationData := StakedDataV2P0{
+	stakedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        true,
 		UnStakedNonce: 0,
@@ -1453,7 +1453,7 @@ func TestAuctionStakingSC_ExecuteStakeStakedInStakingButNotInAuctionShouldErr(t 
 
 	stakerBlsKey1 := big.NewInt(101)
 	expectedCallerAddress := []byte("caller")
-	stakedRegistrationData := StakedDataV2P0{
+	stakedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        true,
 		UnStakedNonce: 0,
@@ -1583,7 +1583,7 @@ func TestAuctionStakingSC_ExecuteStakeNotEnoughArgsShouldErr(t *testing.T) {
 
 	eei := &mock.SystemEIStub{}
 	eei.GetStorageCalled = func(key []byte) []byte {
-		registrationDataMarshalized, _ := json.Marshal(&StakedDataV2P0{})
+		registrationDataMarshalized, _ := json.Marshal(&StakedDataV2_0{})
 		return registrationDataMarshalized
 	}
 	args := createMockArgumentsForAuction()
@@ -1910,7 +1910,7 @@ func TestAuctionStakingSC_ExecuteUnStakeAlreadyUnStakedAddrShouldNotErr(t *testi
 	t.Parallel()
 
 	expectedCallerAddress := []byte("caller")
-	stakedRegistrationData := StakedDataV2P0{
+	stakedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        false,
 		UnStakedNonce: 0,
@@ -1968,7 +1968,7 @@ func TestAuctionStakingSC_ExecuteUnStakeFailsWithWrongCaller(t *testing.T) {
 	expectedCallerAddress := []byte("caller")
 	wrongCallerAddress := []byte("wrongCaller")
 
-	stakedRegistrationData := StakedDataV2P0{
+	stakedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        true,
 		UnStakedNonce: 0,
@@ -2000,7 +2000,7 @@ func TestAuctionStakingSC_ExecuteUnStake(t *testing.T) {
 	args.StakingSCConfig.UnBondPeriod = 10
 	callerAddress := []byte("caller")
 	nodePrice, _ := big.NewInt(0).SetString(args.StakingSCConfig.GenesisNodePrice, 10)
-	expectedRegistrationData := StakedDataV2P0{
+	expectedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        false,
 		UnStakedNonce: 0,
@@ -2010,7 +2010,7 @@ func TestAuctionStakingSC_ExecuteUnStake(t *testing.T) {
 		SlashValue:    big.NewInt(0),
 	}
 
-	stakedRegistrationData := StakedDataV2P0{
+	stakedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        true,
 		UnStakedNonce: 0,
@@ -2053,7 +2053,7 @@ func TestAuctionStakingSC_ExecuteUnStake(t *testing.T) {
 	marshaledRegistrationData, _ := json.Marshal(auctionData)
 	eei.SetStorage(arguments.CallerAddr, marshaledRegistrationData)
 
-	stakedData := StakedDataV2P0{
+	stakedData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        true,
 		UnStakedNonce: 0,
@@ -2072,7 +2072,7 @@ func TestAuctionStakingSC_ExecuteUnStake(t *testing.T) {
 	retCode := stakingSmartContract.Execute(arguments)
 	assert.Equal(t, vmcommon.Ok, retCode)
 
-	var registrationData StakedDataV2P0
+	var registrationData StakedDataV2_0
 	eei.SetSCAddress(args.StakingSCAddress)
 	data := eei.GetStorage(arguments.Arguments[0])
 	err := json.Unmarshal(data, &registrationData)
@@ -2110,7 +2110,7 @@ func TestAuctionStakingSC_ExecuteUnBoundValidatorNotUnStakeShouldErr(t *testing.
 			return []byte("data")
 		default:
 			registrationDataMarshalized, _ := json.Marshal(
-				&StakedDataV2P0{
+				&StakedDataV2_0{
 					UnStakedNonce: 0,
 				})
 			return registrationDataMarshalized
@@ -2176,7 +2176,7 @@ func TestAuctionStakingSC_ExecuteUnBondBeforePeriodEnds(t *testing.T) {
 	t.Parallel()
 
 	unstakedNonce := uint64(10)
-	registrationData := StakedDataV2P0{
+	registrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        true,
 		UnStakedNonce: unstakedNonce,
@@ -2218,7 +2218,7 @@ func TestAuctionStakingSC_ExecuteUnBond(t *testing.T) {
 	unBondPeriod := uint64(100)
 	unStakedNonce := uint64(10)
 	stakeValue := big.NewInt(100)
-	stakedData := StakedDataV2P0{
+	stakedData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        false,
 		UnStakedNonce: unStakedNonce,
@@ -2345,7 +2345,7 @@ func TestAuctionStakingSC_ExecuteUnStakeAndUnBondStake(t *testing.T) {
 	arguments.CallerAddr = stakerAddress
 	arguments.RecipientAddr = []byte(smartcontractAddress)
 
-	stakedRegistrationData := StakedDataV2P0{
+	stakedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        true,
 		UnStakedNonce: 0,
@@ -2382,13 +2382,13 @@ func TestAuctionStakingSC_ExecuteUnStakeAndUnBondStake(t *testing.T) {
 	retCode := stakingSmartContract.Execute(arguments)
 	assert.Equal(t, vmcommon.Ok, retCode)
 
-	var registrationData StakedDataV2P0
+	var registrationData StakedDataV2_0
 	eei.SetSCAddress(args.StakingSCAddress)
 	data := eei.GetStorage(arguments.Arguments[0])
 	err := json.Unmarshal(data, &registrationData)
 	assert.Nil(t, err)
 
-	expectedRegistrationData := StakedDataV2P0{
+	expectedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        false,
 		UnStakedNonce: unStakeNonce,
@@ -2715,7 +2715,7 @@ func TestAuctionStakingSC_getBlsStatusShouldWork(t *testing.T) {
 	}
 	serializedAuctionData, _ := args.Marshalizer.Marshal(auctionData)
 
-	registrationData1 := &StakedDataV2P0{
+	registrationData1 := &StakedDataV2_0{
 		Staked:        true,
 		UnStakedEpoch: core.DefaultUnstakedEpoch,
 		RewardAddress: []byte("rewards addr"),
@@ -2724,7 +2724,7 @@ func TestAuctionStakingSC_getBlsStatusShouldWork(t *testing.T) {
 	}
 	serializedRegistrationData1, _ := args.Marshalizer.Marshal(registrationData1)
 
-	registrationData2 := &StakedDataV2P0{
+	registrationData2 := &StakedDataV2_0{
 		UnStakedEpoch: core.DefaultUnstakedEpoch,
 		RewardAddress: []byte("rewards addr"),
 		JailedRound:   math.MaxUint64,
@@ -2774,7 +2774,7 @@ func TestAuctionStakingSC_getBlsStatusShouldWorkEvenIfAnErrorOccursForOneOfTheBl
 	}
 	serializedAuctionData, _ := args.Marshalizer.Marshal(auctionData)
 
-	registrationData := &StakedDataV2P0{
+	registrationData := &StakedDataV2_0{
 		Staked:        true,
 		UnStakedEpoch: core.DefaultUnstakedEpoch,
 		RewardAddress: []byte("rewards addr"),

--- a/vm/systemSmartContracts/auction_test.go
+++ b/vm/systemSmartContracts/auction_test.go
@@ -496,7 +496,7 @@ func TestStakingAuctionSC_ExecuteStakeAddedNewPubKeysShouldWork(t *testing.T) {
 func TestStakingAuctionSC_ExecuteStakeWithRewardAddress(t *testing.T) {
 	t.Parallel()
 
-	stakerAddress := []byte("stakerAddress")
+	stakerAddress := []byte("staker1")
 	stakerPubKey := []byte("stakerBLSPubKey")
 
 	blockChainHook := &mock.BlockChainHookStub{}
@@ -519,7 +519,7 @@ func TestStakingAuctionSC_ExecuteStakeWithRewardAddress(t *testing.T) {
 	args.Eei = eei
 	args.StakingSCConfig = argsStaking.StakingSCConfig
 
-	rwdAddress := []byte("rewardAddress")
+	rwdAddress := []byte("reward1")
 	sc, _ := NewStakingAuctionSmartContract(args)
 	arguments := CreateVmContractCallInput()
 	arguments.Function = "stake"

--- a/vm/systemSmartContracts/common.go
+++ b/vm/systemSmartContracts/common.go
@@ -1,6 +1,12 @@
 package systemSmartContracts
 
 import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"math/rand"
+
 	"github.com/ElrondNetwork/elrond-go/vm"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
@@ -24,4 +30,101 @@ func CheckIfNil(args *vmcommon.ContractCallInput) error {
 	}
 
 	return nil
+}
+
+func verifyBLSPublicKeys(registrationData *AuctionDataV2, arguments [][]byte) error {
+	for _, argKey := range arguments {
+		found := false
+		for _, blsKey := range registrationData.BlsPubKeys {
+			if bytes.Equal(argKey, blsKey) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("%w, key %s not found", vm.ErrBLSPublicKeyMismatch, hex.EncodeToString(argKey))
+		}
+	}
+
+	return nil
+}
+
+func calcTotalQualifyingStake(nodePrice *big.Int, bids []AuctionDataV2) *big.Int {
+	totalQualifyingStake := big.NewInt(0)
+	for _, validator := range bids {
+		if validator.MaxStakePerNode.Cmp(nodePrice) < 0 {
+			continue
+		}
+
+		maxPossibleNodes := big.NewInt(0).Div(validator.TotalStakeValue, nodePrice)
+		if maxPossibleNodes.Uint64() > uint64(len(validator.BlsPubKeys)) {
+			validatorQualifyingStake := big.NewInt(0).Mul(nodePrice, big.NewInt(int64(len(validator.BlsPubKeys))))
+			totalQualifyingStake.Add(totalQualifyingStake, validatorQualifyingStake)
+		} else {
+			totalQualifyingStake.Add(totalQualifyingStake, validator.TotalStakeValue)
+		}
+	}
+
+	return totalQualifyingStake
+}
+
+func calcNumQualifiedNodes(nodePrice *big.Int, bids []AuctionDataV2) uint32 {
+	numQualifiedNodes := uint32(0)
+	for _, validator := range bids {
+		if validator.MaxStakePerNode.Cmp(nodePrice) < 0 {
+			continue
+		}
+		if validator.TotalStakeValue.Cmp(nodePrice) < 0 {
+			continue
+		}
+
+		maxPossibleNodes := big.NewInt(0).Div(validator.TotalStakeValue, nodePrice)
+		if maxPossibleNodes.Uint64() > uint64(len(validator.BlsPubKeys)) {
+			numQualifiedNodes += uint32(len(validator.BlsPubKeys))
+		} else {
+			numQualifiedNodes += uint32(maxPossibleNodes.Uint64())
+		}
+	}
+
+	return numQualifiedNodes
+}
+
+func calcNumAllocatedAndProportion(
+	validator AuctionDataV2,
+	nodePrice *big.Int,
+	totalQualifyingStake *big.Float,
+) (uint64, float64) {
+	maxPossibleNodes := big.NewInt(0).Div(validator.TotalStakeValue, nodePrice)
+	validatorQualifyingStake := big.NewFloat(0).SetInt(validator.TotalStakeValue)
+	qualifiedNodes := maxPossibleNodes.Uint64()
+
+	if maxPossibleNodes.Uint64() > uint64(len(validator.BlsPubKeys)) {
+		validatorQualifyingStake = big.NewFloat(0).SetInt(big.NewInt(0).Mul(nodePrice, big.NewInt(int64(len(validator.BlsPubKeys)))))
+		qualifiedNodes = uint64(len(validator.BlsPubKeys))
+	}
+
+	proportionOfTotalStake := big.NewFloat(0).Quo(validatorQualifyingStake, totalQualifyingStake)
+	proportion, _ := proportionOfTotalStake.Float64()
+	allocatedNodes := float64(qualifiedNodes) * proportion
+	numAllocatedNodes := uint64(allocatedNodes)
+
+	return numAllocatedNodes, allocatedNodes
+}
+
+func shuffleList(list []string, random []byte) {
+	randomSeed := big.NewInt(0).SetBytes(random[:8])
+	r := rand.New(rand.NewSource(randomSeed.Int64()))
+
+	for n := len(list); n > 0; n-- {
+		randIndex := r.Intn(n)
+		list[n-1], list[randIndex] = list[randIndex], list[n-1]
+	}
+}
+
+func isNumArgsCorrectToStake(args [][]byte) bool {
+	maxNodesToRun := big.NewInt(0).SetBytes(args[0]).Uint64()
+	areEnoughArgs := uint64(len(args)) >= 2*maxNodesToRun+1       // NumNodes + LIST(BLS_KEY+SignedMessage)
+	areNotTooManyArgs := uint64(len(args)) <= 2*maxNodesToRun+1+2 // +2 are the optionals - reward address, maxStakePerNode
+	return areEnoughArgs && areNotTooManyArgs
 }

--- a/vm/systemSmartContracts/governance.go
+++ b/vm/systemSmartContracts/governance.go
@@ -809,7 +809,7 @@ func (g *governanceContract) numOfStakedNodes(address []byte) (uint32, error) {
 			continue
 		}
 
-		nodeData := &StakedDataV2P0{}
+		nodeData := &StakedDataV2_0{}
 		err = g.marshalizer.Unmarshal(nodeData, marshaledData)
 		if err != nil {
 			return 0, err

--- a/vm/systemSmartContracts/governance.go
+++ b/vm/systemSmartContracts/governance.go
@@ -809,7 +809,7 @@ func (g *governanceContract) numOfStakedNodes(address []byte) (uint32, error) {
 			continue
 		}
 
-		nodeData := &StakedDataV2{}
+		nodeData := &StakedDataV2P0{}
 		err = g.marshalizer.Unmarshal(nodeData, marshaledData)
 		if err != nil {
 			return 0, err

--- a/vm/systemSmartContracts/governance_test.go
+++ b/vm/systemSmartContracts/governance_test.go
@@ -465,7 +465,7 @@ func testExecuteVote(t *testing.T, vote []byte) {
 		BlsPubKeys:    [][]byte{[]byte("blsPubKey")},
 	}
 	auctionDataBytes, _ := json.Marshal(autionData)
-	nodeData := &StakedDataV2P0{
+	nodeData := &StakedDataV2_0{
 		Staked: true,
 	}
 	nodeDataBytes, _ := json.Marshal(nodeData)
@@ -552,7 +552,7 @@ func TestGovernanceContract_ExecuteProposalCloseProposal(t *testing.T) {
 	auctionDataBytes, _ = json.Marshal(auctionData)
 	eei.SetStorageForAddress(args.AuctionSCAddress, validatorAddress2, auctionDataBytes)
 
-	nodeData := &StakedDataV2P0{
+	nodeData := &StakedDataV2_0{
 		Staked: true,
 	}
 	stakedDataBytes, _ := json.Marshal(nodeData)

--- a/vm/systemSmartContracts/governance_test.go
+++ b/vm/systemSmartContracts/governance_test.go
@@ -465,7 +465,9 @@ func testExecuteVote(t *testing.T, vote []byte) {
 		BlsPubKeys:    [][]byte{[]byte("blsPubKey")},
 	}
 	auctionDataBytes, _ := json.Marshal(autionData)
-	nodeData := &StakedDataV2{Staked: true}
+	nodeData := &StakedDataV2P0{
+		Staked: true,
+	}
 	nodeDataBytes, _ := json.Marshal(nodeData)
 
 	args.Eei = &mock.SystemEIStub{
@@ -550,7 +552,9 @@ func TestGovernanceContract_ExecuteProposalCloseProposal(t *testing.T) {
 	auctionDataBytes, _ = json.Marshal(auctionData)
 	eei.SetStorageForAddress(args.AuctionSCAddress, validatorAddress2, auctionDataBytes)
 
-	nodeData := &StakedDataV2{Staked: true}
+	nodeData := &StakedDataV2P0{
+		Staked: true,
+	}
 	stakedDataBytes, _ := json.Marshal(nodeData)
 	eei.SetStorageForAddress(args.StakingSCAddress, blsKey1, stakedDataBytes)
 	eei.SetStorageForAddress(args.StakingSCAddress, blsKey2, stakedDataBytes)

--- a/vm/systemSmartContracts/proto/staking.proto
+++ b/vm/systemSmartContracts/proto/staking.proto
@@ -7,7 +7,7 @@ option (gogoproto.stable_marshaler_all) = true;
 
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
-message StakedDataV1p0 {
+message StakedDataV1_0 {
 	uint64   RegisterNonce = 1 [(gogoproto.jsontag) = "RegisterNonce"];
 	uint64   StakedNonce   = 2 [(gogoproto.jsontag) = "StakedNonce"];
 	bool     Staked        = 3 [(gogoproto.jsontag) = "Staked"];
@@ -22,7 +22,7 @@ message StakedDataV1p0 {
 	bool     Waiting       = 12 [(gogoproto.jsontag) = "Waiting"];
 }
 
-message StakedDataV1p1 {
+message StakedDataV1_1 {
 	uint64   RegisterNonce = 1 [(gogoproto.jsontag) = "RegisterNonce"];
 	uint64   StakedNonce   = 2 [(gogoproto.jsontag) = "StakedNonce"];
 	bool     Staked        = 3 [(gogoproto.jsontag) = "Staked"];
@@ -39,7 +39,7 @@ message StakedDataV1p1 {
 	bytes    SlashValue    = 14 [(gogoproto.jsontag) = "SlashValue", (gogoproto.casttypewith) = "math/big.Int;github.com/ElrondNetwork/elrond-go/data.BigIntCaster"];
 }
 
-message StakedDataV2p0 {
+message StakedDataV2_0 {
 	uint64   RegisterNonce = 1 [(gogoproto.jsontag) = "RegisterNonce"];
 	uint64   StakedNonce   = 2 [(gogoproto.jsontag) = "StakedNonce"];
 	bool     Staked        = 3 [(gogoproto.jsontag) = "Staked"];

--- a/vm/systemSmartContracts/proto/staking.proto
+++ b/vm/systemSmartContracts/proto/staking.proto
@@ -7,7 +7,7 @@ option (gogoproto.stable_marshaler_all) = true;
 
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
-message StakedDataV1 {
+message StakedDataV1p0 {
 	uint64   RegisterNonce = 1 [(gogoproto.jsontag) = "RegisterNonce"];
 	uint64   StakedNonce   = 2 [(gogoproto.jsontag) = "StakedNonce"];
 	bool     Staked        = 3 [(gogoproto.jsontag) = "Staked"];
@@ -22,7 +22,7 @@ message StakedDataV1 {
 	bool     Waiting       = 12 [(gogoproto.jsontag) = "Waiting"];
 }
 
-message StakedDataV2 {
+message StakedDataV1p1 {
 	uint64   RegisterNonce = 1 [(gogoproto.jsontag) = "RegisterNonce"];
 	uint64   StakedNonce   = 2 [(gogoproto.jsontag) = "StakedNonce"];
 	bool     Staked        = 3 [(gogoproto.jsontag) = "Staked"];
@@ -37,6 +37,24 @@ message StakedDataV2 {
 	bool     Waiting       = 12 [(gogoproto.jsontag) = "Waiting"];
 	uint32   NumJailed     = 13 [(gogoproto.jsontag) = "NumJailed"];
 	bytes    SlashValue    = 14 [(gogoproto.jsontag) = "SlashValue", (gogoproto.casttypewith) = "math/big.Int;github.com/ElrondNetwork/elrond-go/data.BigIntCaster"];
+}
+
+message StakedDataV2p0 {
+	uint64   RegisterNonce = 1 [(gogoproto.jsontag) = "RegisterNonce"];
+	uint64   StakedNonce   = 2 [(gogoproto.jsontag) = "StakedNonce"];
+	bool     Staked        = 3 [(gogoproto.jsontag) = "Staked"];
+	uint64   UnStakedNonce = 4 [(gogoproto.jsontag) = "UnStakedNonce"];
+	uint32   UnStakedEpoch = 5 [(gogoproto.jsontag) = "UnStakedEpoch"];
+	bytes    RewardAddress = 6 [(gogoproto.jsontag) = "RewardAddress"];
+	bytes    StakeValue    = 7 [(gogoproto.jsontag) = "StakeValue", (gogoproto.casttypewith) = "math/big.Int;github.com/ElrondNetwork/elrond-go/data.BigIntCaster"];
+	uint64   JailedRound   = 8 [(gogoproto.jsontag) = "JailedRound"];
+	uint64   JailedNonce   = 9 [(gogoproto.jsontag) = "JailedNonce"];
+	uint64   UnJailedNonce = 10 [(gogoproto.jsontag) = "UnJailedNonce"];
+	bool     Jailed        = 11 [(gogoproto.jsontag) = "Jailed"];
+	bool     Waiting       = 12 [(gogoproto.jsontag) = "Waiting"];
+	uint32   NumJailed     = 13 [(gogoproto.jsontag) = "NumJailed"];
+	bytes    SlashValue    = 14 [(gogoproto.jsontag) = "SlashValue", (gogoproto.casttypewith) = "math/big.Int;github.com/ElrondNetwork/elrond-go/data.BigIntCaster"];
+    bytes    OwnerAddress  = 15 [(gogoproto.jsontag) = "OwnerAddress"];
 }
 
 message StakingNodesConfig {

--- a/vm/systemSmartContracts/staking.go
+++ b/vm/systemSmartContracts/staking.go
@@ -406,8 +406,8 @@ func (r *stakingSC) unJail(args *vmcommon.ContractCallInput) vmcommon.ReturnCode
 	return vmcommon.Ok
 }
 
-func (r *stakingSC) getOrCreateRegisteredData(key []byte) (*StakedDataV2P0, error) {
-	registrationData := &StakedDataV2P0{
+func (r *stakingSC) getOrCreateRegisteredData(key []byte) (*StakedDataV2_0, error) {
+	registrationData := &StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        false,
 		UnStakedNonce: 0,
@@ -438,7 +438,7 @@ func (r *stakingSC) getOrCreateRegisteredData(key []byte) (*StakedDataV2P0, erro
 	return registrationData, nil
 }
 
-func (r *stakingSC) saveStakingData(key []byte, stakedData *StakedDataV2P0) error {
+func (r *stakingSC) saveStakingData(key []byte, stakedData *StakedDataV2_0) error {
 	if !r.flagStake.IsSet() {
 		return r.saveAsStakingDataV1P0(key, stakedData)
 	}
@@ -458,8 +458,8 @@ func (r *stakingSC) saveStakingData(key []byte, stakedData *StakedDataV2P0) erro
 	return nil
 }
 
-func (r *stakingSC) saveAsStakingDataV1P0(key []byte, stakedData *StakedDataV2P0) error {
-	stakedDataV1 := &StakedDataV1P0{
+func (r *stakingSC) saveAsStakingDataV1P0(key []byte, stakedData *StakedDataV2_0) error {
+	stakedDataV1 := &StakedDataV1_0{
 		RegisterNonce: stakedData.RegisterNonce,
 		StakedNonce:   stakedData.StakedNonce,
 		Staked:        stakedData.Staked,
@@ -486,8 +486,8 @@ func (r *stakingSC) saveAsStakingDataV1P0(key []byte, stakedData *StakedDataV2P0
 	return nil
 }
 
-func (r *stakingSC) saveAsStakingDataV1P1(key []byte, stakedData *StakedDataV2P0) error {
-	stakedDataV1 := &StakedDataV1P1{
+func (r *stakingSC) saveAsStakingDataV1P1(key []byte, stakedData *StakedDataV2_0) error {
+	stakedDataV1 := &StakedDataV1_1{
 		RegisterNonce: stakedData.RegisterNonce,
 		StakedNonce:   stakedData.StakedNonce,
 		Staked:        stakedData.Staked,
@@ -620,7 +620,7 @@ func (r *stakingSC) stake(args *vmcommon.ContractCallInput, onlyRegister bool) v
 	return vmcommon.Ok
 }
 
-func (r *stakingSC) processStake(blsKey []byte, registrationData *StakedDataV2P0, addFirst bool) error {
+func (r *stakingSC) processStake(blsKey []byte, registrationData *StakedDataV2_0, addFirst bool) error {
 	if registrationData.Staked {
 		return nil
 	}
@@ -1233,7 +1233,7 @@ func (r *stakingSC) updateConfigMinNodes(args *vmcommon.ContractCallInput) vmcom
 	return vmcommon.Ok
 }
 
-func (r *stakingSC) isNodeJailedOrWithBadRating(registrationData *StakedDataV2P0, blsKey []byte) bool {
+func (r *stakingSC) isNodeJailedOrWithBadRating(registrationData *StakedDataV2_0, blsKey []byte) bool {
 	return registrationData.Jailed || r.eei.CanUnJail(blsKey) || r.eei.IsBadRating(blsKey)
 }
 
@@ -1335,7 +1335,7 @@ func (r *stakingSC) getRewardAddress(args *vmcommon.ContractCallInput) vmcommon.
 	return vmcommon.Ok
 }
 
-func (r *stakingSC) getStakedDataIfExists(args *vmcommon.ContractCallInput) (*StakedDataV2P0, vmcommon.ReturnCode) {
+func (r *stakingSC) getStakedDataIfExists(args *vmcommon.ContractCallInput) (*StakedDataV2_0, vmcommon.ReturnCode) {
 	err := r.eei.UseGas(r.gasCost.MetaChainSystemSCsCost.Get)
 	if err != nil {
 		r.eei.AddReturnMessage("insufficient gas")

--- a/vm/systemSmartContracts/staking.go
+++ b/vm/systemSmartContracts/staking.go
@@ -41,9 +41,10 @@ type stakingSC struct {
 	marshalizer              marshal.Marshalizer
 	enableStakingEpoch       uint32
 	stakeValue               *big.Int
-	flagStake                atomic.Flag
-	flagStakingV2            atomic.Flag
+	flagEnableStaking        atomic.Flag
+	flagSetOwner             atomic.Flag
 	stakingV2Epoch           uint32
+	walletAddressLen         int
 }
 
 // ArgsNewStakingSmartContract holds the arguments needed to create a StakingSmartContract
@@ -109,6 +110,7 @@ func NewStakingSmartContract(
 		endOfEpochAccessAddr:     args.EndOfEpochAccessAddr,
 		enableStakingEpoch:       args.StakingSCConfig.StakeEnableEpoch,
 		stakingV2Epoch:           args.StakingSCConfig.StakingV2Epoch,
+		walletAddressLen:         len(args.StakingAccessAddr),
 	}
 
 	conversionOk := true
@@ -174,42 +176,6 @@ func (r *stakingSC) Execute(args *vmcommon.ContractCallInput) vmcommon.ReturnCod
 	}
 
 	return vmcommon.UserError
-}
-
-func (r *stakingSC) getConfig() *StakingNodesConfig {
-	stakeConfig := &StakingNodesConfig{
-		MinNumNodes: int64(r.minNumNodes),
-		MaxNumNodes: int64(r.maxNumNodes),
-	}
-	configData := r.eei.GetStorage([]byte(nodesConfigKey))
-	if len(configData) == 0 {
-		return stakeConfig
-	}
-
-	err := r.marshalizer.Unmarshal(stakeConfig, configData)
-	if err != nil {
-		log.Warn("unmarshal error on getConfig function, returning baseConfig",
-			"error", err.Error(),
-		)
-		return &StakingNodesConfig{
-			MinNumNodes: int64(r.minNumNodes),
-			MaxNumNodes: int64(r.maxNumNodes),
-		}
-	}
-
-	return stakeConfig
-}
-
-func (r *stakingSC) setConfig(config *StakingNodesConfig) {
-	configData, err := r.marshalizer.Marshal(config)
-	if err != nil {
-		log.Warn("marshal error on setConfig function",
-			"error", err.Error(),
-		)
-		return
-	}
-
-	r.eei.SetStorage([]byte(nodesConfigKey), configData)
 }
 
 func (r *stakingSC) addToStakedNodes() {
@@ -292,7 +258,7 @@ func (r *stakingSC) changeRewardAddress(args *vmcommon.ContractCallInput) vmcomm
 	}
 
 	newRewardAddress := args.Arguments[0]
-	if len(newRewardAddress) != len(args.CallerAddr) {
+	if len(newRewardAddress) != r.walletAddressLen {
 		r.eei.AddReturnMessage("invalid reward address")
 		return vmcommon.UserError
 	}
@@ -361,7 +327,7 @@ func (r *stakingSC) unJailV1(args *vmcommon.ContractCallInput) vmcommon.ReturnCo
 }
 
 func (r *stakingSC) unJail(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
-	if !r.flagStake.IsSet() {
+	if !r.flagEnableStaking.IsSet() {
 		return r.unJailV1(args)
 	}
 
@@ -404,116 +370,6 @@ func (r *stakingSC) unJail(args *vmcommon.ContractCallInput) vmcommon.ReturnCode
 	}
 
 	return vmcommon.Ok
-}
-
-func (r *stakingSC) getOrCreateRegisteredData(key []byte) (*StakedDataV2_0, error) {
-	registrationData := &StakedDataV2_0{
-		RegisterNonce: 0,
-		Staked:        false,
-		UnStakedNonce: 0,
-		UnStakedEpoch: core.DefaultUnstakedEpoch,
-		RewardAddress: nil,
-		StakeValue:    big.NewInt(0),
-		JailedRound:   math.MaxUint64,
-		UnJailedNonce: 0,
-		JailedNonce:   0,
-		StakedNonce:   math.MaxUint64,
-		SlashValue:    big.NewInt(0),
-	}
-
-	data := r.eei.GetStorage(key)
-	if len(data) > 0 {
-		err := r.marshalizer.Unmarshal(registrationData, data)
-		if err != nil {
-			log.Debug("unmarshal error on staking SC stake function",
-				"error", err.Error(),
-			)
-			return nil, err
-		}
-	}
-	if registrationData.SlashValue == nil {
-		registrationData.SlashValue = big.NewInt(0)
-	}
-
-	return registrationData, nil
-}
-
-func (r *stakingSC) saveStakingData(key []byte, stakedData *StakedDataV2_0) error {
-	if !r.flagStake.IsSet() {
-		return r.saveAsStakingDataV1P0(key, stakedData)
-	}
-	if !r.flagStakingV2.IsSet() {
-		return r.saveAsStakingDataV1P1(key, stakedData)
-	}
-
-	data, err := r.marshalizer.Marshal(stakedData)
-	if err != nil {
-		log.Debug("marshal error in saveStakingData ",
-			"error", err.Error(),
-		)
-		return err
-	}
-
-	r.eei.SetStorage(key, data)
-	return nil
-}
-
-func (r *stakingSC) saveAsStakingDataV1P0(key []byte, stakedData *StakedDataV2_0) error {
-	stakedDataV1 := &StakedDataV1_0{
-		RegisterNonce: stakedData.RegisterNonce,
-		StakedNonce:   stakedData.StakedNonce,
-		Staked:        stakedData.Staked,
-		UnStakedNonce: stakedData.UnStakedNonce,
-		UnStakedEpoch: stakedData.UnStakedEpoch,
-		RewardAddress: stakedData.RewardAddress,
-		StakeValue:    stakedData.StakeValue,
-		JailedRound:   stakedData.JailedRound,
-		JailedNonce:   stakedData.JailedNonce,
-		UnJailedNonce: stakedData.UnJailedNonce,
-		Jailed:        stakedData.Jailed,
-		Waiting:       stakedData.Waiting,
-	}
-
-	data, err := r.marshalizer.Marshal(stakedDataV1)
-	if err != nil {
-		log.Debug("marshal error in saveAsStakingDataV1P0 ",
-			"error", err.Error(),
-		)
-		return err
-	}
-
-	r.eei.SetStorage(key, data)
-	return nil
-}
-
-func (r *stakingSC) saveAsStakingDataV1P1(key []byte, stakedData *StakedDataV2_0) error {
-	stakedDataV1 := &StakedDataV1_1{
-		RegisterNonce: stakedData.RegisterNonce,
-		StakedNonce:   stakedData.StakedNonce,
-		Staked:        stakedData.Staked,
-		UnStakedNonce: stakedData.UnStakedNonce,
-		UnStakedEpoch: stakedData.UnStakedEpoch,
-		RewardAddress: stakedData.RewardAddress,
-		StakeValue:    stakedData.StakeValue,
-		JailedRound:   stakedData.JailedRound,
-		JailedNonce:   stakedData.JailedNonce,
-		UnJailedNonce: stakedData.UnJailedNonce,
-		Jailed:        stakedData.Jailed,
-		Waiting:       stakedData.Waiting,
-		NumJailed:     stakedData.NumJailed,
-		SlashValue:    stakedData.SlashValue,
-	}
-
-	data, err := r.marshalizer.Marshal(stakedDataV1)
-	if err != nil {
-		log.Debug("marshal error in saveAsStakingDataV1P1 ",
-			"error", err.Error(),
-		)
-		return err
-	}
-
-	r.eei.SetStorage(key, data)
-	return nil
 }
 
 func (r *stakingSC) jail(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
@@ -587,8 +443,8 @@ func (r *stakingSC) stake(args *vmcommon.ContractCallInput, onlyRegister bool) v
 		r.eei.AddReturnMessage("stake function not allowed to be called by address " + string(args.CallerAddr))
 		return vmcommon.UserError
 	}
-	if len(args.Arguments) < 2 {
-		r.eei.AddReturnMessage("not enough arguments, needed BLS key and reward address")
+	if len(args.Arguments) < 3 {
+		r.eei.AddReturnMessage("not enough arguments, needed BLS key, reward address and owner address")
 		return vmcommon.UserError
 	}
 
@@ -603,6 +459,7 @@ func (r *stakingSC) stake(args *vmcommon.ContractCallInput, onlyRegister bool) v
 	}
 
 	registrationData.RewardAddress = args.Arguments[1]
+	registrationData.OwnerAddress = args.Arguments[2]
 	registrationData.StakeValue.Set(r.stakeValue)
 	if !onlyRegister {
 		err = r.processStake(args.Arguments[0], registrationData, false)
@@ -1460,8 +1317,7 @@ func (r *stakingSC) getWaitingListRegisterNonceAndRewardAddress(args *vmcommon.C
 }
 
 func (r *stakingSC) setOwner(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
-	if !r.flagStakingV2.IsSet() {
-		//setOwner function will become available after enabling staking v2
+	if !r.flagSetOwner.IsSet() {
 		r.eei.AddReturnMessage("invalid method to call")
 		return vmcommon.UserError
 	}
@@ -1491,11 +1347,11 @@ func (r *stakingSC) setOwner(args *vmcommon.ContractCallInput) vmcommon.ReturnCo
 
 // EpochConfirmed is called whenever a new epoch is confirmed
 func (r *stakingSC) EpochConfirmed(epoch uint32) {
-	r.flagStake.Toggle(epoch >= r.enableStakingEpoch)
-	log.Debug("stakingSC: stake/unstake/unbond", "enabled", r.flagStake.IsSet())
+	r.flagEnableStaking.Toggle(epoch >= r.enableStakingEpoch)
+	log.Debug("stakingSC: stake/unstake/unbond", "enabled", r.flagEnableStaking.IsSet())
 
-	r.flagStakingV2.Toggle(epoch >= r.stakingV2Epoch)
-	log.Debug("stakingSC: staking v2", "enabled", r.flagStakingV2.IsSet())
+	r.flagSetOwner.Toggle(epoch >= r.stakingV2Epoch)
+	log.Debug("stakingSC: set owner", "enabled", r.flagSetOwner.IsSet())
 }
 
 // IsInterfaceNil verifies if the underlying object is nil or not

--- a/vm/systemSmartContracts/staking.pb.go
+++ b/vm/systemSmartContracts/staking.pb.go
@@ -28,7 +28,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-type StakedDataV1 struct {
+type StakedDataV1P0 struct {
 	RegisterNonce uint64        `protobuf:"varint,1,opt,name=RegisterNonce,proto3" json:"RegisterNonce"`
 	StakedNonce   uint64        `protobuf:"varint,2,opt,name=StakedNonce,proto3" json:"StakedNonce"`
 	Staked        bool          `protobuf:"varint,3,opt,name=Staked,proto3" json:"Staked"`
@@ -43,15 +43,15 @@ type StakedDataV1 struct {
 	Waiting       bool          `protobuf:"varint,12,opt,name=Waiting,proto3" json:"Waiting"`
 }
 
-func (m *StakedDataV1) Reset()      { *m = StakedDataV1{} }
-func (*StakedDataV1) ProtoMessage() {}
-func (*StakedDataV1) Descriptor() ([]byte, []int) {
+func (m *StakedDataV1P0) Reset()      { *m = StakedDataV1P0{} }
+func (*StakedDataV1P0) ProtoMessage() {}
+func (*StakedDataV1P0) Descriptor() ([]byte, []int) {
 	return fileDescriptor_289e7c8aea278311, []int{0}
 }
-func (m *StakedDataV1) XXX_Unmarshal(b []byte) error {
+func (m *StakedDataV1P0) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *StakedDataV1) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *StakedDataV1P0) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	b = b[:cap(b)]
 	n, err := m.MarshalToSizedBuffer(b)
 	if err != nil {
@@ -59,103 +59,103 @@ func (m *StakedDataV1) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 	}
 	return b[:n], nil
 }
-func (m *StakedDataV1) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StakedDataV1.Merge(m, src)
+func (m *StakedDataV1P0) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StakedDataV1P0.Merge(m, src)
 }
-func (m *StakedDataV1) XXX_Size() int {
+func (m *StakedDataV1P0) XXX_Size() int {
 	return m.Size()
 }
-func (m *StakedDataV1) XXX_DiscardUnknown() {
-	xxx_messageInfo_StakedDataV1.DiscardUnknown(m)
+func (m *StakedDataV1P0) XXX_DiscardUnknown() {
+	xxx_messageInfo_StakedDataV1P0.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_StakedDataV1 proto.InternalMessageInfo
+var xxx_messageInfo_StakedDataV1P0 proto.InternalMessageInfo
 
-func (m *StakedDataV1) GetRegisterNonce() uint64 {
+func (m *StakedDataV1P0) GetRegisterNonce() uint64 {
 	if m != nil {
 		return m.RegisterNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV1) GetStakedNonce() uint64 {
+func (m *StakedDataV1P0) GetStakedNonce() uint64 {
 	if m != nil {
 		return m.StakedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV1) GetStaked() bool {
+func (m *StakedDataV1P0) GetStaked() bool {
 	if m != nil {
 		return m.Staked
 	}
 	return false
 }
 
-func (m *StakedDataV1) GetUnStakedNonce() uint64 {
+func (m *StakedDataV1P0) GetUnStakedNonce() uint64 {
 	if m != nil {
 		return m.UnStakedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV1) GetUnStakedEpoch() uint32 {
+func (m *StakedDataV1P0) GetUnStakedEpoch() uint32 {
 	if m != nil {
 		return m.UnStakedEpoch
 	}
 	return 0
 }
 
-func (m *StakedDataV1) GetRewardAddress() []byte {
+func (m *StakedDataV1P0) GetRewardAddress() []byte {
 	if m != nil {
 		return m.RewardAddress
 	}
 	return nil
 }
 
-func (m *StakedDataV1) GetStakeValue() *math_big.Int {
+func (m *StakedDataV1P0) GetStakeValue() *math_big.Int {
 	if m != nil {
 		return m.StakeValue
 	}
 	return nil
 }
 
-func (m *StakedDataV1) GetJailedRound() uint64 {
+func (m *StakedDataV1P0) GetJailedRound() uint64 {
 	if m != nil {
 		return m.JailedRound
 	}
 	return 0
 }
 
-func (m *StakedDataV1) GetJailedNonce() uint64 {
+func (m *StakedDataV1P0) GetJailedNonce() uint64 {
 	if m != nil {
 		return m.JailedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV1) GetUnJailedNonce() uint64 {
+func (m *StakedDataV1P0) GetUnJailedNonce() uint64 {
 	if m != nil {
 		return m.UnJailedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV1) GetJailed() bool {
+func (m *StakedDataV1P0) GetJailed() bool {
 	if m != nil {
 		return m.Jailed
 	}
 	return false
 }
 
-func (m *StakedDataV1) GetWaiting() bool {
+func (m *StakedDataV1P0) GetWaiting() bool {
 	if m != nil {
 		return m.Waiting
 	}
 	return false
 }
 
-type StakedDataV2 struct {
+type StakedDataV1P1 struct {
 	RegisterNonce uint64        `protobuf:"varint,1,opt,name=RegisterNonce,proto3" json:"RegisterNonce"`
 	StakedNonce   uint64        `protobuf:"varint,2,opt,name=StakedNonce,proto3" json:"StakedNonce"`
 	Staked        bool          `protobuf:"varint,3,opt,name=Staked,proto3" json:"Staked"`
@@ -172,15 +172,15 @@ type StakedDataV2 struct {
 	SlashValue    *math_big.Int `protobuf:"bytes,14,opt,name=SlashValue,proto3,casttypewith=math/big.Int;github.com/ElrondNetwork/elrond-go/data.BigIntCaster" json:"SlashValue"`
 }
 
-func (m *StakedDataV2) Reset()      { *m = StakedDataV2{} }
-func (*StakedDataV2) ProtoMessage() {}
-func (*StakedDataV2) Descriptor() ([]byte, []int) {
+func (m *StakedDataV1P1) Reset()      { *m = StakedDataV1P1{} }
+func (*StakedDataV1P1) ProtoMessage() {}
+func (*StakedDataV1P1) Descriptor() ([]byte, []int) {
 	return fileDescriptor_289e7c8aea278311, []int{1}
 }
-func (m *StakedDataV2) XXX_Unmarshal(b []byte) error {
+func (m *StakedDataV1P1) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *StakedDataV2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *StakedDataV1P1) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	b = b[:cap(b)]
 	n, err := m.MarshalToSizedBuffer(b)
 	if err != nil {
@@ -188,112 +188,263 @@ func (m *StakedDataV2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 	}
 	return b[:n], nil
 }
-func (m *StakedDataV2) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StakedDataV2.Merge(m, src)
+func (m *StakedDataV1P1) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StakedDataV1P1.Merge(m, src)
 }
-func (m *StakedDataV2) XXX_Size() int {
+func (m *StakedDataV1P1) XXX_Size() int {
 	return m.Size()
 }
-func (m *StakedDataV2) XXX_DiscardUnknown() {
-	xxx_messageInfo_StakedDataV2.DiscardUnknown(m)
+func (m *StakedDataV1P1) XXX_DiscardUnknown() {
+	xxx_messageInfo_StakedDataV1P1.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_StakedDataV2 proto.InternalMessageInfo
+var xxx_messageInfo_StakedDataV1P1 proto.InternalMessageInfo
 
-func (m *StakedDataV2) GetRegisterNonce() uint64 {
+func (m *StakedDataV1P1) GetRegisterNonce() uint64 {
 	if m != nil {
 		return m.RegisterNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV2) GetStakedNonce() uint64 {
+func (m *StakedDataV1P1) GetStakedNonce() uint64 {
 	if m != nil {
 		return m.StakedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV2) GetStaked() bool {
+func (m *StakedDataV1P1) GetStaked() bool {
 	if m != nil {
 		return m.Staked
 	}
 	return false
 }
 
-func (m *StakedDataV2) GetUnStakedNonce() uint64 {
+func (m *StakedDataV1P1) GetUnStakedNonce() uint64 {
 	if m != nil {
 		return m.UnStakedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV2) GetUnStakedEpoch() uint32 {
+func (m *StakedDataV1P1) GetUnStakedEpoch() uint32 {
 	if m != nil {
 		return m.UnStakedEpoch
 	}
 	return 0
 }
 
-func (m *StakedDataV2) GetRewardAddress() []byte {
+func (m *StakedDataV1P1) GetRewardAddress() []byte {
 	if m != nil {
 		return m.RewardAddress
 	}
 	return nil
 }
 
-func (m *StakedDataV2) GetStakeValue() *math_big.Int {
+func (m *StakedDataV1P1) GetStakeValue() *math_big.Int {
 	if m != nil {
 		return m.StakeValue
 	}
 	return nil
 }
 
-func (m *StakedDataV2) GetJailedRound() uint64 {
+func (m *StakedDataV1P1) GetJailedRound() uint64 {
 	if m != nil {
 		return m.JailedRound
 	}
 	return 0
 }
 
-func (m *StakedDataV2) GetJailedNonce() uint64 {
+func (m *StakedDataV1P1) GetJailedNonce() uint64 {
 	if m != nil {
 		return m.JailedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV2) GetUnJailedNonce() uint64 {
+func (m *StakedDataV1P1) GetUnJailedNonce() uint64 {
 	if m != nil {
 		return m.UnJailedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV2) GetJailed() bool {
+func (m *StakedDataV1P1) GetJailed() bool {
 	if m != nil {
 		return m.Jailed
 	}
 	return false
 }
 
-func (m *StakedDataV2) GetWaiting() bool {
+func (m *StakedDataV1P1) GetWaiting() bool {
 	if m != nil {
 		return m.Waiting
 	}
 	return false
 }
 
-func (m *StakedDataV2) GetNumJailed() uint32 {
+func (m *StakedDataV1P1) GetNumJailed() uint32 {
 	if m != nil {
 		return m.NumJailed
 	}
 	return 0
 }
 
-func (m *StakedDataV2) GetSlashValue() *math_big.Int {
+func (m *StakedDataV1P1) GetSlashValue() *math_big.Int {
 	if m != nil {
 		return m.SlashValue
+	}
+	return nil
+}
+
+type StakedDataV2P0 struct {
+	RegisterNonce uint64        `protobuf:"varint,1,opt,name=RegisterNonce,proto3" json:"RegisterNonce"`
+	StakedNonce   uint64        `protobuf:"varint,2,opt,name=StakedNonce,proto3" json:"StakedNonce"`
+	Staked        bool          `protobuf:"varint,3,opt,name=Staked,proto3" json:"Staked"`
+	UnStakedNonce uint64        `protobuf:"varint,4,opt,name=UnStakedNonce,proto3" json:"UnStakedNonce"`
+	UnStakedEpoch uint32        `protobuf:"varint,5,opt,name=UnStakedEpoch,proto3" json:"UnStakedEpoch"`
+	RewardAddress []byte        `protobuf:"bytes,6,opt,name=RewardAddress,proto3" json:"RewardAddress"`
+	StakeValue    *math_big.Int `protobuf:"bytes,7,opt,name=StakeValue,proto3,casttypewith=math/big.Int;github.com/ElrondNetwork/elrond-go/data.BigIntCaster" json:"StakeValue"`
+	JailedRound   uint64        `protobuf:"varint,8,opt,name=JailedRound,proto3" json:"JailedRound"`
+	JailedNonce   uint64        `protobuf:"varint,9,opt,name=JailedNonce,proto3" json:"JailedNonce"`
+	UnJailedNonce uint64        `protobuf:"varint,10,opt,name=UnJailedNonce,proto3" json:"UnJailedNonce"`
+	Jailed        bool          `protobuf:"varint,11,opt,name=Jailed,proto3" json:"Jailed"`
+	Waiting       bool          `protobuf:"varint,12,opt,name=Waiting,proto3" json:"Waiting"`
+	NumJailed     uint32        `protobuf:"varint,13,opt,name=NumJailed,proto3" json:"NumJailed"`
+	SlashValue    *math_big.Int `protobuf:"bytes,14,opt,name=SlashValue,proto3,casttypewith=math/big.Int;github.com/ElrondNetwork/elrond-go/data.BigIntCaster" json:"SlashValue"`
+	OwnerAddress  []byte        `protobuf:"bytes,15,opt,name=OwnerAddress,proto3" json:"OwnerAddress"`
+}
+
+func (m *StakedDataV2P0) Reset()      { *m = StakedDataV2P0{} }
+func (*StakedDataV2P0) ProtoMessage() {}
+func (*StakedDataV2P0) Descriptor() ([]byte, []int) {
+	return fileDescriptor_289e7c8aea278311, []int{2}
+}
+func (m *StakedDataV2P0) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *StakedDataV2P0) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	b = b[:cap(b)]
+	n, err := m.MarshalToSizedBuffer(b)
+	if err != nil {
+		return nil, err
+	}
+	return b[:n], nil
+}
+func (m *StakedDataV2P0) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StakedDataV2P0.Merge(m, src)
+}
+func (m *StakedDataV2P0) XXX_Size() int {
+	return m.Size()
+}
+func (m *StakedDataV2P0) XXX_DiscardUnknown() {
+	xxx_messageInfo_StakedDataV2P0.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StakedDataV2P0 proto.InternalMessageInfo
+
+func (m *StakedDataV2P0) GetRegisterNonce() uint64 {
+	if m != nil {
+		return m.RegisterNonce
+	}
+	return 0
+}
+
+func (m *StakedDataV2P0) GetStakedNonce() uint64 {
+	if m != nil {
+		return m.StakedNonce
+	}
+	return 0
+}
+
+func (m *StakedDataV2P0) GetStaked() bool {
+	if m != nil {
+		return m.Staked
+	}
+	return false
+}
+
+func (m *StakedDataV2P0) GetUnStakedNonce() uint64 {
+	if m != nil {
+		return m.UnStakedNonce
+	}
+	return 0
+}
+
+func (m *StakedDataV2P0) GetUnStakedEpoch() uint32 {
+	if m != nil {
+		return m.UnStakedEpoch
+	}
+	return 0
+}
+
+func (m *StakedDataV2P0) GetRewardAddress() []byte {
+	if m != nil {
+		return m.RewardAddress
+	}
+	return nil
+}
+
+func (m *StakedDataV2P0) GetStakeValue() *math_big.Int {
+	if m != nil {
+		return m.StakeValue
+	}
+	return nil
+}
+
+func (m *StakedDataV2P0) GetJailedRound() uint64 {
+	if m != nil {
+		return m.JailedRound
+	}
+	return 0
+}
+
+func (m *StakedDataV2P0) GetJailedNonce() uint64 {
+	if m != nil {
+		return m.JailedNonce
+	}
+	return 0
+}
+
+func (m *StakedDataV2P0) GetUnJailedNonce() uint64 {
+	if m != nil {
+		return m.UnJailedNonce
+	}
+	return 0
+}
+
+func (m *StakedDataV2P0) GetJailed() bool {
+	if m != nil {
+		return m.Jailed
+	}
+	return false
+}
+
+func (m *StakedDataV2P0) GetWaiting() bool {
+	if m != nil {
+		return m.Waiting
+	}
+	return false
+}
+
+func (m *StakedDataV2P0) GetNumJailed() uint32 {
+	if m != nil {
+		return m.NumJailed
+	}
+	return 0
+}
+
+func (m *StakedDataV2P0) GetSlashValue() *math_big.Int {
+	if m != nil {
+		return m.SlashValue
+	}
+	return nil
+}
+
+func (m *StakedDataV2P0) GetOwnerAddress() []byte {
+	if m != nil {
+		return m.OwnerAddress
 	}
 	return nil
 }
@@ -308,7 +459,7 @@ type StakingNodesConfig struct {
 func (m *StakingNodesConfig) Reset()      { *m = StakingNodesConfig{} }
 func (*StakingNodesConfig) ProtoMessage() {}
 func (*StakingNodesConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_289e7c8aea278311, []int{2}
+	return fileDescriptor_289e7c8aea278311, []int{3}
 }
 func (m *StakingNodesConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -370,7 +521,7 @@ type ElementInList struct {
 func (m *ElementInList) Reset()      { *m = ElementInList{} }
 func (*ElementInList) ProtoMessage() {}
 func (*ElementInList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_289e7c8aea278311, []int{3}
+	return fileDescriptor_289e7c8aea278311, []int{4}
 }
 func (m *ElementInList) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -426,7 +577,7 @@ type WaitingList struct {
 func (m *WaitingList) Reset()      { *m = WaitingList{} }
 func (*WaitingList) ProtoMessage() {}
 func (*WaitingList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_289e7c8aea278311, []int{4}
+	return fileDescriptor_289e7c8aea278311, []int{5}
 }
 func (m *WaitingList) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -480,8 +631,9 @@ func (m *WaitingList) GetLastJailedKey() []byte {
 }
 
 func init() {
-	proto.RegisterType((*StakedDataV1)(nil), "proto.StakedDataV1")
-	proto.RegisterType((*StakedDataV2)(nil), "proto.StakedDataV2")
+	proto.RegisterType((*StakedDataV1P0)(nil), "proto.StakedDataV1p0")
+	proto.RegisterType((*StakedDataV1P1)(nil), "proto.StakedDataV1p1")
+	proto.RegisterType((*StakedDataV2P0)(nil), "proto.StakedDataV2p0")
 	proto.RegisterType((*StakingNodesConfig)(nil), "proto.StakingNodesConfig")
 	proto.RegisterType((*ElementInList)(nil), "proto.ElementInList")
 	proto.RegisterType((*WaitingList)(nil), "proto.WaitingList")
@@ -490,63 +642,65 @@ func init() {
 func init() { proto.RegisterFile("staking.proto", fileDescriptor_289e7c8aea278311) }
 
 var fileDescriptor_289e7c8aea278311 = []byte{
-	// 722 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x56, 0xbd, 0x6e, 0xdb, 0x3c,
-	0x14, 0x35, 0x6d, 0xc7, 0x49, 0x68, 0xfb, 0xfb, 0x11, 0xbe, 0x41, 0xf8, 0x06, 0xc9, 0x30, 0x50,
-	0xc0, 0x40, 0x11, 0x1b, 0x69, 0x0b, 0x74, 0xe8, 0x14, 0xa7, 0x29, 0x90, 0xd6, 0x35, 0x02, 0x1a,
-	0x4d, 0x81, 0x6e, 0xb4, 0xc5, 0xc8, 0x44, 0x2c, 0x32, 0x90, 0xa8, 0x26, 0xd9, 0xfa, 0x08, 0x7d,
-	0x83, 0xae, 0x41, 0x5f, 0xa1, 0x2f, 0x50, 0x74, 0xca, 0x98, 0x49, 0x4d, 0x94, 0xa5, 0xd0, 0x94,
-	0x47, 0x28, 0x48, 0xca, 0x16, 0xd5, 0xb9, 0x43, 0x87, 0x4c, 0xbc, 0xe7, 0x90, 0xe7, 0xf2, 0xfa,
-	0xde, 0x43, 0xdb, 0xb0, 0x1d, 0x09, 0x7c, 0x4c, 0x99, 0xdf, 0x3f, 0x09, 0xb9, 0xe0, 0xd6, 0x9a,
-	0x5a, 0xfe, 0xdf, 0xf2, 0xa9, 0x98, 0xc7, 0xd3, 0xfe, 0x8c, 0x07, 0x03, 0x9f, 0xfb, 0x7c, 0xa0,
-	0xe8, 0x69, 0x7c, 0xa4, 0x90, 0x02, 0x2a, 0xd2, 0xaa, 0xee, 0xc5, 0x1a, 0x6c, 0x4d, 0x04, 0x3e,
-	0x26, 0xde, 0x73, 0x2c, 0xf0, 0xe1, 0xb6, 0xf5, 0x14, 0xb6, 0x11, 0xf1, 0x69, 0x24, 0x48, 0x38,
-	0xe6, 0x6c, 0x46, 0x6c, 0xd0, 0x01, 0xbd, 0xfa, 0xf0, 0xdf, 0x2c, 0x71, 0xcb, 0x1b, 0xa8, 0x0c,
-	0xad, 0x6d, 0xd8, 0xd4, 0x89, 0xb4, 0xac, 0xaa, 0x64, 0x7f, 0x67, 0x89, 0x6b, 0xd2, 0xc8, 0x04,
-	0x56, 0x17, 0x36, 0x34, 0xb4, 0x6b, 0x1d, 0xd0, 0xdb, 0x18, 0xc2, 0x2c, 0x71, 0x73, 0x06, 0xe5,
-	0xab, 0xac, 0xe7, 0x0d, 0x33, 0x13, 0xd7, 0x8b, 0x7a, 0x4a, 0x1b, 0xa8, 0x0c, 0x4d, 0xe1, 0xde,
-	0x09, 0x9f, 0xcd, 0xed, 0xb5, 0x0e, 0xe8, 0xb5, 0xcb, 0x42, 0xb5, 0x81, 0xca, 0x50, 0x77, 0xe0,
-	0x14, 0x87, 0xde, 0x8e, 0xe7, 0x85, 0x24, 0x8a, 0xec, 0x46, 0x07, 0xf4, 0x5a, 0xcb, 0x0e, 0x18,
-	0x1b, 0xa8, 0x0c, 0xad, 0x08, 0x42, 0x95, 0xe7, 0x10, 0x2f, 0x62, 0x62, 0xaf, 0x2b, 0xd5, 0x24,
-	0x4b, 0x5c, 0x83, 0xfd, 0xfc, 0xdd, 0xdd, 0x09, 0xb0, 0x98, 0x0f, 0xa6, 0xd4, 0xef, 0xef, 0x33,
-	0xf1, 0xcc, 0x98, 0xd6, 0xde, 0x22, 0xe4, 0xcc, 0x1b, 0x13, 0x71, 0xca, 0xc3, 0xe3, 0x01, 0x51,
-	0x68, 0xcb, 0xe7, 0x03, 0x0f, 0x0b, 0xdc, 0x1f, 0x52, 0x7f, 0x9f, 0x89, 0x5d, 0x2c, 0xfb, 0x8d,
-	0x8c, 0x84, 0xb2, 0xed, 0x2f, 0x31, 0x5d, 0x10, 0x0f, 0xf1, 0x98, 0x79, 0xf6, 0x46, 0xd1, 0x76,
-	0x83, 0x46, 0x26, 0x28, 0x24, 0xba, 0xa1, 0x9b, 0xbf, 0x4a, 0xf2, 0x49, 0x19, 0x40, 0x37, 0xd3,
-	0x14, 0x41, 0x73, 0x0a, 0xa6, 0xac, 0x0c, 0xe5, 0x88, 0x35, 0xb4, 0x9b, 0xc5, 0x88, 0xf3, 0x62,
-	0xf2, 0xd5, 0x7a, 0x00, 0xd7, 0xdf, 0x62, 0x2a, 0x28, 0xf3, 0xed, 0x96, 0x3a, 0xd4, 0xcc, 0x12,
-	0x77, 0x49, 0xa1, 0x65, 0xd0, 0xfd, 0xd6, 0x28, 0x59, 0xf5, 0xd1, 0xbd, 0x55, 0xef, 0xad, 0xfa,
-	0x67, 0x5a, 0xd5, 0x7a, 0x08, 0x37, 0xc7, 0x71, 0x90, 0x67, 0x6b, 0xab, 0x61, 0xb6, 0xb3, 0xc4,
-	0x2d, 0x48, 0x54, 0x84, 0x6a, 0x16, 0x0b, 0x1c, 0xcd, 0xf5, 0x2c, 0xfe, 0x32, 0x66, 0xb1, 0x62,
-	0x7f, 0xd7, 0x2c, 0x56, 0x09, 0xbb, 0xd7, 0x00, 0x5a, 0x13, 0xfd, 0xfb, 0x31, 0xe6, 0x1e, 0x89,
-	0x76, 0x39, 0x3b, 0xa2, 0xbe, 0xec, 0xf7, 0x6b, 0xca, 0xc6, 0x71, 0xa0, 0x48, 0xf5, 0xa0, 0x6a,
-	0xba, 0xdf, 0x06, 0x8d, 0x4c, 0xa0, 0x24, 0xf8, 0x6c, 0x25, 0xa9, 0x1a, 0x92, 0x82, 0x46, 0x26,
-	0x30, 0xdf, 0x9f, 0x94, 0xd4, 0x0a, 0x89, 0x41, 0x23, 0x13, 0x98, 0x46, 0x90, 0x92, 0x7a, 0x21,
-	0x31, 0x68, 0x64, 0x82, 0xee, 0x27, 0x00, 0xdb, 0x7b, 0x0b, 0x12, 0x10, 0x26, 0xf6, 0xd9, 0x88,
-	0x46, 0xc2, 0x7a, 0x02, 0x5b, 0xc3, 0xd1, 0xe4, 0x20, 0x9e, 0x2e, 0xe8, 0xec, 0x15, 0x39, 0x57,
-	0x1f, 0xaf, 0x35, 0xfc, 0x27, 0x4b, 0xdc, 0x12, 0x8f, 0x4a, 0x48, 0x5e, 0x7d, 0x10, 0x92, 0xf7,
-	0x94, 0xc7, 0x91, 0x14, 0x55, 0x95, 0x48, 0x5d, 0x6d, 0xd0, 0xc8, 0x04, 0xd2, 0x26, 0x63, 0x72,
-	0x26, 0xe4, 0xf1, 0x9a, 0x3a, 0xae, 0x6c, 0x92, 0x53, 0x68, 0x19, 0x74, 0xbf, 0x00, 0xd8, 0xcc,
-	0x2d, 0xa3, 0xea, 0xeb, 0xc1, 0x8d, 0x17, 0x34, 0x8c, 0x44, 0x51, 0x5b, 0x2b, 0x4b, 0xdc, 0x15,
-	0x87, 0x56, 0x91, 0xbc, 0x60, 0x84, 0xf5, 0xc1, 0x6a, 0x71, 0x41, 0x4e, 0xa1, 0x65, 0x20, 0x2d,
-	0x3d, 0x22, 0xcc, 0x17, 0x73, 0x55, 0x46, 0x5b, 0x5b, 0x5a, 0x33, 0x28, 0x5f, 0xe5, 0x7b, 0x91,
-	0xc7, 0x75, 0xe7, 0x64, 0xc2, 0x7a, 0xf1, 0x1d, 0x52, 0xda, 0x40, 0x65, 0x38, 0x1c, 0x5f, 0xde,
-	0x38, 0x95, 0xab, 0x1b, 0xa7, 0x72, 0x77, 0xe3, 0x80, 0x0f, 0xa9, 0x03, 0x2e, 0x52, 0x07, 0x7c,
-	0x4d, 0x1d, 0x70, 0x99, 0x3a, 0xe0, 0x2a, 0x75, 0xc0, 0x75, 0xea, 0x80, 0x1f, 0xa9, 0x53, 0xb9,
-	0x4b, 0x1d, 0xf0, 0xf1, 0xd6, 0xa9, 0x5c, 0xde, 0x3a, 0x95, 0xab, 0x5b, 0xa7, 0xf2, 0xee, 0xbf,
-	0xe8, 0x3c, 0x12, 0x24, 0x98, 0x04, 0x38, 0x14, 0xbb, 0x9c, 0x89, 0x10, 0xcf, 0x44, 0x34, 0x6d,
-	0xa8, 0x7f, 0x24, 0x8f, 0x7f, 0x06, 0x00, 0x00, 0xff, 0xff, 0x1f, 0x47, 0x66, 0x7d, 0xd8, 0x08,
-	0x00, 0x00,
+	// 758 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x57, 0xb1, 0x6e, 0xd3, 0x40,
+	0x18, 0xce, 0x25, 0x69, 0xda, 0x5e, 0x92, 0x16, 0x2c, 0x06, 0x8b, 0xc1, 0x8e, 0x22, 0x21, 0x45,
+	0x42, 0x4d, 0x28, 0x20, 0x31, 0x30, 0x35, 0xa5, 0x48, 0x85, 0x10, 0xaa, 0x8b, 0x28, 0x12, 0xdb,
+	0x25, 0xbe, 0x3a, 0x56, 0x93, 0xbb, 0xca, 0x3e, 0xd3, 0x76, 0x43, 0x3c, 0x01, 0x6f, 0xc0, 0x8a,
+	0xfa, 0x0a, 0xbc, 0x00, 0x03, 0x43, 0xc7, 0x4e, 0xa6, 0x75, 0x17, 0xe4, 0xa9, 0x8f, 0x80, 0xee,
+	0xce, 0x89, 0xcf, 0x1d, 0x11, 0x03, 0x43, 0xa6, 0xbb, 0xef, 0xbb, 0xfb, 0xfe, 0xfb, 0xfb, 0x7f,
+	0xff, 0x6f, 0x35, 0xb0, 0x1e, 0x70, 0x7c, 0xe8, 0x51, 0xb7, 0x7d, 0xe4, 0x33, 0xce, 0x8c, 0x25,
+	0xb9, 0xdc, 0xdf, 0x70, 0x3d, 0x3e, 0x0e, 0x87, 0xed, 0x11, 0x9b, 0x76, 0x5c, 0xe6, 0xb2, 0x8e,
+	0xa4, 0x87, 0xe1, 0x81, 0x44, 0x12, 0xc8, 0x9d, 0x52, 0x35, 0xcf, 0x96, 0xe0, 0xda, 0x80, 0xe3,
+	0x43, 0xe2, 0xbc, 0xc0, 0x1c, 0xef, 0x6f, 0x1e, 0x3d, 0x32, 0x9e, 0xc1, 0x3a, 0x22, 0xae, 0x17,
+	0x70, 0xe2, 0xf7, 0x19, 0x1d, 0x11, 0x13, 0x34, 0x40, 0xab, 0xdc, 0xbd, 0x9b, 0x44, 0x76, 0xfe,
+	0x00, 0xe5, 0xa1, 0xb1, 0x09, 0xab, 0x2a, 0x94, 0x92, 0x15, 0xa5, 0x6c, 0x3d, 0x89, 0x6c, 0x9d,
+	0x46, 0x3a, 0x30, 0x9a, 0xb0, 0xa2, 0xa0, 0x59, 0x6a, 0x80, 0xd6, 0x4a, 0x17, 0x26, 0x91, 0x9d,
+	0x32, 0x28, 0x5d, 0x45, 0x3e, 0xef, 0xa8, 0x1e, 0xb8, 0x9c, 0xe5, 0x93, 0x3b, 0x40, 0x79, 0xa8,
+	0x0b, 0x77, 0x8e, 0xd8, 0x68, 0x6c, 0x2e, 0x35, 0x40, 0xab, 0x9e, 0x17, 0xca, 0x03, 0x94, 0x87,
+	0xaa, 0x02, 0xc7, 0xd8, 0x77, 0xb6, 0x1c, 0xc7, 0x27, 0x41, 0x60, 0x56, 0x1a, 0xa0, 0x55, 0x9b,
+	0x55, 0x40, 0x3b, 0x40, 0x79, 0x68, 0x04, 0x10, 0xca, 0x38, 0xfb, 0x78, 0x12, 0x12, 0x73, 0x59,
+	0xaa, 0x06, 0x49, 0x64, 0x6b, 0xec, 0xd9, 0x2f, 0x7b, 0x6b, 0x8a, 0xf9, 0xb8, 0x33, 0xf4, 0xdc,
+	0xf6, 0x2e, 0xe5, 0xcf, 0x35, 0xbf, 0x76, 0x26, 0x3e, 0xa3, 0x4e, 0x9f, 0xf0, 0x63, 0xe6, 0x1f,
+	0x76, 0x88, 0x44, 0x1b, 0x2e, 0xeb, 0x38, 0x98, 0xe3, 0x76, 0xd7, 0x73, 0x77, 0x29, 0xdf, 0xc6,
+	0xa2, 0xde, 0x48, 0x0b, 0x28, 0xca, 0xfe, 0x0a, 0x7b, 0x13, 0xe2, 0x20, 0x16, 0x52, 0xc7, 0x5c,
+	0xc9, 0xca, 0xae, 0xd1, 0x48, 0x07, 0x99, 0x44, 0x15, 0x74, 0xf5, 0xb6, 0x24, 0x75, 0x4a, 0x03,
+	0xaa, 0x98, 0xba, 0x08, 0xea, 0x2e, 0xe8, 0xb2, 0x3c, 0x14, 0x16, 0x2b, 0x68, 0x56, 0x33, 0x8b,
+	0xd3, 0x64, 0xd2, 0xd5, 0x78, 0x00, 0x97, 0xdf, 0x63, 0x8f, 0x7b, 0xd4, 0x35, 0x6b, 0xf2, 0x52,
+	0x35, 0x89, 0xec, 0x19, 0x85, 0x66, 0x9b, 0xe6, 0xcf, 0xca, 0xad, 0x66, 0xdd, 0x5c, 0x34, 0xeb,
+	0xa2, 0x59, 0xff, 0xcf, 0x66, 0x35, 0x1e, 0xc2, 0xd5, 0x7e, 0x38, 0x4d, 0xa3, 0xd5, 0xa5, 0x99,
+	0xf5, 0x24, 0xb2, 0x33, 0x12, 0x65, 0x5b, 0xe9, 0xc5, 0x04, 0x07, 0x63, 0xe5, 0xc5, 0x9a, 0xe6,
+	0xc5, 0x9c, 0xfd, 0x57, 0x5e, 0xcc, 0x03, 0x36, 0x3f, 0x2f, 0xe7, 0xc6, 0xe9, 0xf1, 0xe2, 0xdb,
+	0xbf, 0x18, 0xa7, 0xc5, 0x38, 0xfd, 0xed, 0x38, 0x19, 0x4f, 0x61, 0xed, 0xed, 0x31, 0x25, 0xfe,
+	0xac, 0x71, 0xd6, 0xe5, 0xb3, 0x77, 0x92, 0xc8, 0xce, 0xf1, 0x28, 0x87, 0x9a, 0x97, 0x00, 0x1a,
+	0x03, 0xf5, 0x8f, 0x5c, 0x9f, 0x39, 0x24, 0xd8, 0x66, 0xf4, 0xc0, 0x73, 0x85, 0x4b, 0x6f, 0x3c,
+	0xda, 0x0f, 0xa7, 0x92, 0x94, 0x63, 0x58, 0x52, 0x2e, 0x69, 0x34, 0xd2, 0x81, 0x94, 0xe0, 0x93,
+	0xb9, 0xa4, 0xa8, 0x49, 0x32, 0x1a, 0xe9, 0x40, 0x9f, 0x5a, 0x21, 0x29, 0x65, 0x12, 0x8d, 0x46,
+	0x3a, 0xd0, 0xdb, 0x47, 0x48, 0xca, 0x99, 0x44, 0xa3, 0x91, 0x0e, 0x9a, 0x5f, 0x01, 0xac, 0xef,
+	0x4c, 0xc8, 0x94, 0x50, 0xbe, 0x4b, 0x7b, 0x5e, 0xc0, 0x45, 0xa9, 0xba, 0xbd, 0xc1, 0x5e, 0x38,
+	0x9c, 0x78, 0xa3, 0xd7, 0xe4, 0x54, 0xfe, 0x79, 0x69, 0xa9, 0x74, 0x1e, 0xe5, 0x90, 0x78, 0x7a,
+	0xcf, 0x27, 0x1f, 0x3d, 0x16, 0x06, 0x42, 0x54, 0x94, 0x22, 0xf9, 0xb4, 0x46, 0x23, 0x1d, 0x88,
+	0xe6, 0xea, 0x93, 0x13, 0x2e, 0xae, 0x97, 0xe4, 0x75, 0xd9, 0x5c, 0x29, 0x85, 0x66, 0x9b, 0xe6,
+	0x77, 0x00, 0xab, 0x69, 0xa3, 0xc9, 0xfc, 0x5a, 0x70, 0xe5, 0xa5, 0xe7, 0x07, 0x3c, 0xcb, 0xad,
+	0x96, 0x44, 0xf6, 0x9c, 0x43, 0xf3, 0x9d, 0x78, 0xa0, 0x87, 0xd5, 0xc5, 0x62, 0xf6, 0x40, 0x4a,
+	0xa1, 0xd9, 0x46, 0x0c, 0x42, 0x8f, 0x50, 0x97, 0x8f, 0x65, 0x1a, 0x75, 0x35, 0x08, 0x8a, 0x41,
+	0xe9, 0x2a, 0xa6, 0x4c, 0x5c, 0x57, 0x95, 0x13, 0x01, 0xcb, 0xd9, 0x97, 0x27, 0x77, 0x80, 0xf2,
+	0xb0, 0xdb, 0x3f, 0xbf, 0xb2, 0x0a, 0x17, 0x57, 0x56, 0xe1, 0xe6, 0xca, 0x02, 0x9f, 0x62, 0x0b,
+	0x7c, 0x8b, 0x2d, 0xf0, 0x23, 0xb6, 0xc0, 0x79, 0x6c, 0x81, 0x8b, 0xd8, 0x02, 0x97, 0xb1, 0x05,
+	0x7e, 0xc7, 0x56, 0xe1, 0x26, 0xb6, 0xc0, 0x97, 0x6b, 0xab, 0x70, 0x7e, 0x6d, 0x15, 0x2e, 0xae,
+	0xad, 0xc2, 0x87, 0x7b, 0xc1, 0x69, 0xc0, 0xc9, 0x74, 0x30, 0xc5, 0x3e, 0xdf, 0x66, 0x94, 0xfb,
+	0x78, 0xc4, 0x83, 0x61, 0x45, 0xfe, 0x34, 0x78, 0xf2, 0x27, 0x00, 0x00, 0xff, 0xff, 0x98, 0x46,
+	0x5c, 0x88, 0x61, 0x0c, 0x00, 0x00,
 }
 
-func (this *StakedDataV1) Equal(that interface{}) bool {
+func (this *StakedDataV1P0) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
 	}
 
-	that1, ok := that.(*StakedDataV1)
+	that1, ok := that.(*StakedDataV1P0)
 	if !ok {
-		that2, ok := that.(StakedDataV1)
+		that2, ok := that.(StakedDataV1P0)
 		if ok {
 			that1 = &that2
 		} else {
@@ -599,14 +753,14 @@ func (this *StakedDataV1) Equal(that interface{}) bool {
 	}
 	return true
 }
-func (this *StakedDataV2) Equal(that interface{}) bool {
+func (this *StakedDataV1P1) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
 	}
 
-	that1, ok := that.(*StakedDataV2)
+	that1, ok := that.(*StakedDataV1P1)
 	if !ok {
-		that2, ok := that.(StakedDataV2)
+		that2, ok := that.(StakedDataV1P1)
 		if ok {
 			that1 = &that2
 		} else {
@@ -665,6 +819,78 @@ func (this *StakedDataV2) Equal(that interface{}) bool {
 		if !__caster.Equal(this.SlashValue, that1.SlashValue) {
 			return false
 		}
+	}
+	return true
+}
+func (this *StakedDataV2P0) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*StakedDataV2P0)
+	if !ok {
+		that2, ok := that.(StakedDataV2P0)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.RegisterNonce != that1.RegisterNonce {
+		return false
+	}
+	if this.StakedNonce != that1.StakedNonce {
+		return false
+	}
+	if this.Staked != that1.Staked {
+		return false
+	}
+	if this.UnStakedNonce != that1.UnStakedNonce {
+		return false
+	}
+	if this.UnStakedEpoch != that1.UnStakedEpoch {
+		return false
+	}
+	if !bytes.Equal(this.RewardAddress, that1.RewardAddress) {
+		return false
+	}
+	{
+		__caster := &github_com_ElrondNetwork_elrond_go_data.BigIntCaster{}
+		if !__caster.Equal(this.StakeValue, that1.StakeValue) {
+			return false
+		}
+	}
+	if this.JailedRound != that1.JailedRound {
+		return false
+	}
+	if this.JailedNonce != that1.JailedNonce {
+		return false
+	}
+	if this.UnJailedNonce != that1.UnJailedNonce {
+		return false
+	}
+	if this.Jailed != that1.Jailed {
+		return false
+	}
+	if this.Waiting != that1.Waiting {
+		return false
+	}
+	if this.NumJailed != that1.NumJailed {
+		return false
+	}
+	{
+		__caster := &github_com_ElrondNetwork_elrond_go_data.BigIntCaster{}
+		if !__caster.Equal(this.SlashValue, that1.SlashValue) {
+			return false
+		}
+	}
+	if !bytes.Equal(this.OwnerAddress, that1.OwnerAddress) {
+		return false
 	}
 	return true
 }
@@ -764,12 +990,12 @@ func (this *WaitingList) Equal(that interface{}) bool {
 	}
 	return true
 }
-func (this *StakedDataV1) GoString() string {
+func (this *StakedDataV1P0) GoString() string {
 	if this == nil {
 		return "nil"
 	}
 	s := make([]string, 0, 16)
-	s = append(s, "&systemSmartContracts.StakedDataV1{")
+	s = append(s, "&systemSmartContracts.StakedDataV1P0{")
 	s = append(s, "RegisterNonce: "+fmt.Sprintf("%#v", this.RegisterNonce)+",\n")
 	s = append(s, "StakedNonce: "+fmt.Sprintf("%#v", this.StakedNonce)+",\n")
 	s = append(s, "Staked: "+fmt.Sprintf("%#v", this.Staked)+",\n")
@@ -785,12 +1011,12 @@ func (this *StakedDataV1) GoString() string {
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
-func (this *StakedDataV2) GoString() string {
+func (this *StakedDataV1P1) GoString() string {
 	if this == nil {
 		return "nil"
 	}
 	s := make([]string, 0, 18)
-	s = append(s, "&systemSmartContracts.StakedDataV2{")
+	s = append(s, "&systemSmartContracts.StakedDataV1P1{")
 	s = append(s, "RegisterNonce: "+fmt.Sprintf("%#v", this.RegisterNonce)+",\n")
 	s = append(s, "StakedNonce: "+fmt.Sprintf("%#v", this.StakedNonce)+",\n")
 	s = append(s, "Staked: "+fmt.Sprintf("%#v", this.Staked)+",\n")
@@ -805,6 +1031,30 @@ func (this *StakedDataV2) GoString() string {
 	s = append(s, "Waiting: "+fmt.Sprintf("%#v", this.Waiting)+",\n")
 	s = append(s, "NumJailed: "+fmt.Sprintf("%#v", this.NumJailed)+",\n")
 	s = append(s, "SlashValue: "+fmt.Sprintf("%#v", this.SlashValue)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *StakedDataV2P0) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 19)
+	s = append(s, "&systemSmartContracts.StakedDataV2P0{")
+	s = append(s, "RegisterNonce: "+fmt.Sprintf("%#v", this.RegisterNonce)+",\n")
+	s = append(s, "StakedNonce: "+fmt.Sprintf("%#v", this.StakedNonce)+",\n")
+	s = append(s, "Staked: "+fmt.Sprintf("%#v", this.Staked)+",\n")
+	s = append(s, "UnStakedNonce: "+fmt.Sprintf("%#v", this.UnStakedNonce)+",\n")
+	s = append(s, "UnStakedEpoch: "+fmt.Sprintf("%#v", this.UnStakedEpoch)+",\n")
+	s = append(s, "RewardAddress: "+fmt.Sprintf("%#v", this.RewardAddress)+",\n")
+	s = append(s, "StakeValue: "+fmt.Sprintf("%#v", this.StakeValue)+",\n")
+	s = append(s, "JailedRound: "+fmt.Sprintf("%#v", this.JailedRound)+",\n")
+	s = append(s, "JailedNonce: "+fmt.Sprintf("%#v", this.JailedNonce)+",\n")
+	s = append(s, "UnJailedNonce: "+fmt.Sprintf("%#v", this.UnJailedNonce)+",\n")
+	s = append(s, "Jailed: "+fmt.Sprintf("%#v", this.Jailed)+",\n")
+	s = append(s, "Waiting: "+fmt.Sprintf("%#v", this.Waiting)+",\n")
+	s = append(s, "NumJailed: "+fmt.Sprintf("%#v", this.NumJailed)+",\n")
+	s = append(s, "SlashValue: "+fmt.Sprintf("%#v", this.SlashValue)+",\n")
+	s = append(s, "OwnerAddress: "+fmt.Sprintf("%#v", this.OwnerAddress)+",\n")
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
@@ -854,7 +1104,7 @@ func valueToGoStringStaking(v interface{}, typ string) string {
 	pv := reflect.Indirect(rv).Interface()
 	return fmt.Sprintf("func(v %v) *%v { return &v } ( %#v )", typ, typ, pv)
 }
-func (m *StakedDataV1) Marshal() (dAtA []byte, err error) {
+func (m *StakedDataV1P0) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -864,12 +1114,12 @@ func (m *StakedDataV1) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *StakedDataV1) MarshalTo(dAtA []byte) (int, error) {
+func (m *StakedDataV1P0) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *StakedDataV1) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *StakedDataV1P0) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -960,7 +1210,7 @@ func (m *StakedDataV1) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *StakedDataV2) Marshal() (dAtA []byte, err error) {
+func (m *StakedDataV1P1) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -970,16 +1220,145 @@ func (m *StakedDataV2) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *StakedDataV2) MarshalTo(dAtA []byte) (int, error) {
+func (m *StakedDataV1P1) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *StakedDataV2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *StakedDataV1P1) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
+	{
+		__caster := &github_com_ElrondNetwork_elrond_go_data.BigIntCaster{}
+		size := __caster.Size(m.SlashValue)
+		i -= size
+		if _, err := __caster.MarshalTo(m.SlashValue, dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintStaking(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x72
+	if m.NumJailed != 0 {
+		i = encodeVarintStaking(dAtA, i, uint64(m.NumJailed))
+		i--
+		dAtA[i] = 0x68
+	}
+	if m.Waiting {
+		i--
+		if m.Waiting {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x60
+	}
+	if m.Jailed {
+		i--
+		if m.Jailed {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x58
+	}
+	if m.UnJailedNonce != 0 {
+		i = encodeVarintStaking(dAtA, i, uint64(m.UnJailedNonce))
+		i--
+		dAtA[i] = 0x50
+	}
+	if m.JailedNonce != 0 {
+		i = encodeVarintStaking(dAtA, i, uint64(m.JailedNonce))
+		i--
+		dAtA[i] = 0x48
+	}
+	if m.JailedRound != 0 {
+		i = encodeVarintStaking(dAtA, i, uint64(m.JailedRound))
+		i--
+		dAtA[i] = 0x40
+	}
+	{
+		__caster := &github_com_ElrondNetwork_elrond_go_data.BigIntCaster{}
+		size := __caster.Size(m.StakeValue)
+		i -= size
+		if _, err := __caster.MarshalTo(m.StakeValue, dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintStaking(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x3a
+	if len(m.RewardAddress) > 0 {
+		i -= len(m.RewardAddress)
+		copy(dAtA[i:], m.RewardAddress)
+		i = encodeVarintStaking(dAtA, i, uint64(len(m.RewardAddress)))
+		i--
+		dAtA[i] = 0x32
+	}
+	if m.UnStakedEpoch != 0 {
+		i = encodeVarintStaking(dAtA, i, uint64(m.UnStakedEpoch))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.UnStakedNonce != 0 {
+		i = encodeVarintStaking(dAtA, i, uint64(m.UnStakedNonce))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.Staked {
+		i--
+		if m.Staked {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.StakedNonce != 0 {
+		i = encodeVarintStaking(dAtA, i, uint64(m.StakedNonce))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.RegisterNonce != 0 {
+		i = encodeVarintStaking(dAtA, i, uint64(m.RegisterNonce))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *StakedDataV2P0) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StakedDataV2P0) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *StakedDataV2P0) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.OwnerAddress) > 0 {
+		i -= len(m.OwnerAddress)
+		copy(dAtA[i:], m.OwnerAddress)
+		i = encodeVarintStaking(dAtA, i, uint64(len(m.OwnerAddress)))
+		i--
+		dAtA[i] = 0x7a
+	}
 	{
 		__caster := &github_com_ElrondNetwork_elrond_go_data.BigIntCaster{}
 		size := __caster.Size(m.SlashValue)
@@ -1229,7 +1608,7 @@ func encodeVarintStaking(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-func (m *StakedDataV1) Size() (n int) {
+func (m *StakedDataV1P0) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1277,7 +1656,7 @@ func (m *StakedDataV1) Size() (n int) {
 	return n
 }
 
-func (m *StakedDataV2) Size() (n int) {
+func (m *StakedDataV1P1) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1328,6 +1707,66 @@ func (m *StakedDataV2) Size() (n int) {
 	{
 		__caster := &github_com_ElrondNetwork_elrond_go_data.BigIntCaster{}
 		l = __caster.Size(m.SlashValue)
+		n += 1 + l + sovStaking(uint64(l))
+	}
+	return n
+}
+
+func (m *StakedDataV2P0) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.RegisterNonce != 0 {
+		n += 1 + sovStaking(uint64(m.RegisterNonce))
+	}
+	if m.StakedNonce != 0 {
+		n += 1 + sovStaking(uint64(m.StakedNonce))
+	}
+	if m.Staked {
+		n += 2
+	}
+	if m.UnStakedNonce != 0 {
+		n += 1 + sovStaking(uint64(m.UnStakedNonce))
+	}
+	if m.UnStakedEpoch != 0 {
+		n += 1 + sovStaking(uint64(m.UnStakedEpoch))
+	}
+	l = len(m.RewardAddress)
+	if l > 0 {
+		n += 1 + l + sovStaking(uint64(l))
+	}
+	{
+		__caster := &github_com_ElrondNetwork_elrond_go_data.BigIntCaster{}
+		l = __caster.Size(m.StakeValue)
+		n += 1 + l + sovStaking(uint64(l))
+	}
+	if m.JailedRound != 0 {
+		n += 1 + sovStaking(uint64(m.JailedRound))
+	}
+	if m.JailedNonce != 0 {
+		n += 1 + sovStaking(uint64(m.JailedNonce))
+	}
+	if m.UnJailedNonce != 0 {
+		n += 1 + sovStaking(uint64(m.UnJailedNonce))
+	}
+	if m.Jailed {
+		n += 2
+	}
+	if m.Waiting {
+		n += 2
+	}
+	if m.NumJailed != 0 {
+		n += 1 + sovStaking(uint64(m.NumJailed))
+	}
+	{
+		__caster := &github_com_ElrondNetwork_elrond_go_data.BigIntCaster{}
+		l = __caster.Size(m.SlashValue)
+		n += 1 + l + sovStaking(uint64(l))
+	}
+	l = len(m.OwnerAddress)
+	if l > 0 {
 		n += 1 + l + sovStaking(uint64(l))
 	}
 	return n
@@ -1405,11 +1844,11 @@ func sovStaking(x uint64) (n int) {
 func sozStaking(x uint64) (n int) {
 	return sovStaking(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-func (this *StakedDataV1) String() string {
+func (this *StakedDataV1P0) String() string {
 	if this == nil {
 		return "nil"
 	}
-	s := strings.Join([]string{`&StakedDataV1{`,
+	s := strings.Join([]string{`&StakedDataV1P0{`,
 		`RegisterNonce:` + fmt.Sprintf("%v", this.RegisterNonce) + `,`,
 		`StakedNonce:` + fmt.Sprintf("%v", this.StakedNonce) + `,`,
 		`Staked:` + fmt.Sprintf("%v", this.Staked) + `,`,
@@ -1426,11 +1865,11 @@ func (this *StakedDataV1) String() string {
 	}, "")
 	return s
 }
-func (this *StakedDataV2) String() string {
+func (this *StakedDataV1P1) String() string {
 	if this == nil {
 		return "nil"
 	}
-	s := strings.Join([]string{`&StakedDataV2{`,
+	s := strings.Join([]string{`&StakedDataV1P1{`,
 		`RegisterNonce:` + fmt.Sprintf("%v", this.RegisterNonce) + `,`,
 		`StakedNonce:` + fmt.Sprintf("%v", this.StakedNonce) + `,`,
 		`Staked:` + fmt.Sprintf("%v", this.Staked) + `,`,
@@ -1445,6 +1884,30 @@ func (this *StakedDataV2) String() string {
 		`Waiting:` + fmt.Sprintf("%v", this.Waiting) + `,`,
 		`NumJailed:` + fmt.Sprintf("%v", this.NumJailed) + `,`,
 		`SlashValue:` + fmt.Sprintf("%v", this.SlashValue) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *StakedDataV2P0) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&StakedDataV2P0{`,
+		`RegisterNonce:` + fmt.Sprintf("%v", this.RegisterNonce) + `,`,
+		`StakedNonce:` + fmt.Sprintf("%v", this.StakedNonce) + `,`,
+		`Staked:` + fmt.Sprintf("%v", this.Staked) + `,`,
+		`UnStakedNonce:` + fmt.Sprintf("%v", this.UnStakedNonce) + `,`,
+		`UnStakedEpoch:` + fmt.Sprintf("%v", this.UnStakedEpoch) + `,`,
+		`RewardAddress:` + fmt.Sprintf("%v", this.RewardAddress) + `,`,
+		`StakeValue:` + fmt.Sprintf("%v", this.StakeValue) + `,`,
+		`JailedRound:` + fmt.Sprintf("%v", this.JailedRound) + `,`,
+		`JailedNonce:` + fmt.Sprintf("%v", this.JailedNonce) + `,`,
+		`UnJailedNonce:` + fmt.Sprintf("%v", this.UnJailedNonce) + `,`,
+		`Jailed:` + fmt.Sprintf("%v", this.Jailed) + `,`,
+		`Waiting:` + fmt.Sprintf("%v", this.Waiting) + `,`,
+		`NumJailed:` + fmt.Sprintf("%v", this.NumJailed) + `,`,
+		`SlashValue:` + fmt.Sprintf("%v", this.SlashValue) + `,`,
+		`OwnerAddress:` + fmt.Sprintf("%v", this.OwnerAddress) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -1495,7 +1958,7 @@ func valueToStringStaking(v interface{}) string {
 	pv := reflect.Indirect(rv).Interface()
 	return fmt.Sprintf("*%v", pv)
 }
-func (m *StakedDataV1) Unmarshal(dAtA []byte) error {
+func (m *StakedDataV1P0) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1518,10 +1981,10 @@ func (m *StakedDataV1) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: StakedDataV1: wiretype end group for non-group")
+			return fmt.Errorf("proto: StakedDataV1p0: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: StakedDataV1: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: StakedDataV1p0: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -1813,7 +2276,7 @@ func (m *StakedDataV1) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *StakedDataV2) Unmarshal(dAtA []byte) error {
+func (m *StakedDataV1P1) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1836,10 +2299,10 @@ func (m *StakedDataV2) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: StakedDataV2: wiretype end group for non-group")
+			return fmt.Errorf("proto: StakedDataV1p1: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: StakedDataV2: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: StakedDataV1p1: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -2162,6 +2625,415 @@ func (m *StakedDataV2) Unmarshal(dAtA []byte) error {
 				} else {
 					m.SlashValue = tmp
 				}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipStaking(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthStaking
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthStaking
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StakedDataV2P0) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowStaking
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StakedDataV2p0: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StakedDataV2p0: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RegisterNonce", wireType)
+			}
+			m.RegisterNonce = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStaking
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.RegisterNonce |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StakedNonce", wireType)
+			}
+			m.StakedNonce = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStaking
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.StakedNonce |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Staked", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStaking
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Staked = bool(v != 0)
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UnStakedNonce", wireType)
+			}
+			m.UnStakedNonce = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStaking
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.UnStakedNonce |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UnStakedEpoch", wireType)
+			}
+			m.UnStakedEpoch = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStaking
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.UnStakedEpoch |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RewardAddress", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStaking
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthStaking
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthStaking
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RewardAddress = append(m.RewardAddress[:0], dAtA[iNdEx:postIndex]...)
+			if m.RewardAddress == nil {
+				m.RewardAddress = []byte{}
+			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StakeValue", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStaking
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthStaking
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthStaking
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			{
+				__caster := &github_com_ElrondNetwork_elrond_go_data.BigIntCaster{}
+				if tmp, err := __caster.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				} else {
+					m.StakeValue = tmp
+				}
+			}
+			iNdEx = postIndex
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field JailedRound", wireType)
+			}
+			m.JailedRound = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStaking
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.JailedRound |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field JailedNonce", wireType)
+			}
+			m.JailedNonce = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStaking
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.JailedNonce |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UnJailedNonce", wireType)
+			}
+			m.UnJailedNonce = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStaking
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.UnJailedNonce |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 11:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Jailed", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStaking
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Jailed = bool(v != 0)
+		case 12:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Waiting", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStaking
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Waiting = bool(v != 0)
+		case 13:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NumJailed", wireType)
+			}
+			m.NumJailed = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStaking
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.NumJailed |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 14:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SlashValue", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStaking
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthStaking
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthStaking
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			{
+				__caster := &github_com_ElrondNetwork_elrond_go_data.BigIntCaster{}
+				if tmp, err := __caster.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				} else {
+					m.SlashValue = tmp
+				}
+			}
+			iNdEx = postIndex
+		case 15:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OwnerAddress", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStaking
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthStaking
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthStaking
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.OwnerAddress = append(m.OwnerAddress[:0], dAtA[iNdEx:postIndex]...)
+			if m.OwnerAddress == nil {
+				m.OwnerAddress = []byte{}
 			}
 			iNdEx = postIndex
 		default:

--- a/vm/systemSmartContracts/staking.pb.go
+++ b/vm/systemSmartContracts/staking.pb.go
@@ -28,7 +28,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-type StakedDataV1P0 struct {
+type StakedDataV1_0 struct {
 	RegisterNonce uint64        `protobuf:"varint,1,opt,name=RegisterNonce,proto3" json:"RegisterNonce"`
 	StakedNonce   uint64        `protobuf:"varint,2,opt,name=StakedNonce,proto3" json:"StakedNonce"`
 	Staked        bool          `protobuf:"varint,3,opt,name=Staked,proto3" json:"Staked"`
@@ -43,15 +43,15 @@ type StakedDataV1P0 struct {
 	Waiting       bool          `protobuf:"varint,12,opt,name=Waiting,proto3" json:"Waiting"`
 }
 
-func (m *StakedDataV1P0) Reset()      { *m = StakedDataV1P0{} }
-func (*StakedDataV1P0) ProtoMessage() {}
-func (*StakedDataV1P0) Descriptor() ([]byte, []int) {
+func (m *StakedDataV1_0) Reset()      { *m = StakedDataV1_0{} }
+func (*StakedDataV1_0) ProtoMessage() {}
+func (*StakedDataV1_0) Descriptor() ([]byte, []int) {
 	return fileDescriptor_289e7c8aea278311, []int{0}
 }
-func (m *StakedDataV1P0) XXX_Unmarshal(b []byte) error {
+func (m *StakedDataV1_0) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *StakedDataV1P0) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *StakedDataV1_0) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	b = b[:cap(b)]
 	n, err := m.MarshalToSizedBuffer(b)
 	if err != nil {
@@ -59,103 +59,103 @@ func (m *StakedDataV1P0) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 	}
 	return b[:n], nil
 }
-func (m *StakedDataV1P0) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StakedDataV1P0.Merge(m, src)
+func (m *StakedDataV1_0) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StakedDataV1_0.Merge(m, src)
 }
-func (m *StakedDataV1P0) XXX_Size() int {
+func (m *StakedDataV1_0) XXX_Size() int {
 	return m.Size()
 }
-func (m *StakedDataV1P0) XXX_DiscardUnknown() {
-	xxx_messageInfo_StakedDataV1P0.DiscardUnknown(m)
+func (m *StakedDataV1_0) XXX_DiscardUnknown() {
+	xxx_messageInfo_StakedDataV1_0.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_StakedDataV1P0 proto.InternalMessageInfo
+var xxx_messageInfo_StakedDataV1_0 proto.InternalMessageInfo
 
-func (m *StakedDataV1P0) GetRegisterNonce() uint64 {
+func (m *StakedDataV1_0) GetRegisterNonce() uint64 {
 	if m != nil {
 		return m.RegisterNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV1P0) GetStakedNonce() uint64 {
+func (m *StakedDataV1_0) GetStakedNonce() uint64 {
 	if m != nil {
 		return m.StakedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV1P0) GetStaked() bool {
+func (m *StakedDataV1_0) GetStaked() bool {
 	if m != nil {
 		return m.Staked
 	}
 	return false
 }
 
-func (m *StakedDataV1P0) GetUnStakedNonce() uint64 {
+func (m *StakedDataV1_0) GetUnStakedNonce() uint64 {
 	if m != nil {
 		return m.UnStakedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV1P0) GetUnStakedEpoch() uint32 {
+func (m *StakedDataV1_0) GetUnStakedEpoch() uint32 {
 	if m != nil {
 		return m.UnStakedEpoch
 	}
 	return 0
 }
 
-func (m *StakedDataV1P0) GetRewardAddress() []byte {
+func (m *StakedDataV1_0) GetRewardAddress() []byte {
 	if m != nil {
 		return m.RewardAddress
 	}
 	return nil
 }
 
-func (m *StakedDataV1P0) GetStakeValue() *math_big.Int {
+func (m *StakedDataV1_0) GetStakeValue() *math_big.Int {
 	if m != nil {
 		return m.StakeValue
 	}
 	return nil
 }
 
-func (m *StakedDataV1P0) GetJailedRound() uint64 {
+func (m *StakedDataV1_0) GetJailedRound() uint64 {
 	if m != nil {
 		return m.JailedRound
 	}
 	return 0
 }
 
-func (m *StakedDataV1P0) GetJailedNonce() uint64 {
+func (m *StakedDataV1_0) GetJailedNonce() uint64 {
 	if m != nil {
 		return m.JailedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV1P0) GetUnJailedNonce() uint64 {
+func (m *StakedDataV1_0) GetUnJailedNonce() uint64 {
 	if m != nil {
 		return m.UnJailedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV1P0) GetJailed() bool {
+func (m *StakedDataV1_0) GetJailed() bool {
 	if m != nil {
 		return m.Jailed
 	}
 	return false
 }
 
-func (m *StakedDataV1P0) GetWaiting() bool {
+func (m *StakedDataV1_0) GetWaiting() bool {
 	if m != nil {
 		return m.Waiting
 	}
 	return false
 }
 
-type StakedDataV1P1 struct {
+type StakedDataV1_1 struct {
 	RegisterNonce uint64        `protobuf:"varint,1,opt,name=RegisterNonce,proto3" json:"RegisterNonce"`
 	StakedNonce   uint64        `protobuf:"varint,2,opt,name=StakedNonce,proto3" json:"StakedNonce"`
 	Staked        bool          `protobuf:"varint,3,opt,name=Staked,proto3" json:"Staked"`
@@ -172,15 +172,15 @@ type StakedDataV1P1 struct {
 	SlashValue    *math_big.Int `protobuf:"bytes,14,opt,name=SlashValue,proto3,casttypewith=math/big.Int;github.com/ElrondNetwork/elrond-go/data.BigIntCaster" json:"SlashValue"`
 }
 
-func (m *StakedDataV1P1) Reset()      { *m = StakedDataV1P1{} }
-func (*StakedDataV1P1) ProtoMessage() {}
-func (*StakedDataV1P1) Descriptor() ([]byte, []int) {
+func (m *StakedDataV1_1) Reset()      { *m = StakedDataV1_1{} }
+func (*StakedDataV1_1) ProtoMessage() {}
+func (*StakedDataV1_1) Descriptor() ([]byte, []int) {
 	return fileDescriptor_289e7c8aea278311, []int{1}
 }
-func (m *StakedDataV1P1) XXX_Unmarshal(b []byte) error {
+func (m *StakedDataV1_1) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *StakedDataV1P1) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *StakedDataV1_1) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	b = b[:cap(b)]
 	n, err := m.MarshalToSizedBuffer(b)
 	if err != nil {
@@ -188,117 +188,117 @@ func (m *StakedDataV1P1) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 	}
 	return b[:n], nil
 }
-func (m *StakedDataV1P1) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StakedDataV1P1.Merge(m, src)
+func (m *StakedDataV1_1) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StakedDataV1_1.Merge(m, src)
 }
-func (m *StakedDataV1P1) XXX_Size() int {
+func (m *StakedDataV1_1) XXX_Size() int {
 	return m.Size()
 }
-func (m *StakedDataV1P1) XXX_DiscardUnknown() {
-	xxx_messageInfo_StakedDataV1P1.DiscardUnknown(m)
+func (m *StakedDataV1_1) XXX_DiscardUnknown() {
+	xxx_messageInfo_StakedDataV1_1.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_StakedDataV1P1 proto.InternalMessageInfo
+var xxx_messageInfo_StakedDataV1_1 proto.InternalMessageInfo
 
-func (m *StakedDataV1P1) GetRegisterNonce() uint64 {
+func (m *StakedDataV1_1) GetRegisterNonce() uint64 {
 	if m != nil {
 		return m.RegisterNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV1P1) GetStakedNonce() uint64 {
+func (m *StakedDataV1_1) GetStakedNonce() uint64 {
 	if m != nil {
 		return m.StakedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV1P1) GetStaked() bool {
+func (m *StakedDataV1_1) GetStaked() bool {
 	if m != nil {
 		return m.Staked
 	}
 	return false
 }
 
-func (m *StakedDataV1P1) GetUnStakedNonce() uint64 {
+func (m *StakedDataV1_1) GetUnStakedNonce() uint64 {
 	if m != nil {
 		return m.UnStakedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV1P1) GetUnStakedEpoch() uint32 {
+func (m *StakedDataV1_1) GetUnStakedEpoch() uint32 {
 	if m != nil {
 		return m.UnStakedEpoch
 	}
 	return 0
 }
 
-func (m *StakedDataV1P1) GetRewardAddress() []byte {
+func (m *StakedDataV1_1) GetRewardAddress() []byte {
 	if m != nil {
 		return m.RewardAddress
 	}
 	return nil
 }
 
-func (m *StakedDataV1P1) GetStakeValue() *math_big.Int {
+func (m *StakedDataV1_1) GetStakeValue() *math_big.Int {
 	if m != nil {
 		return m.StakeValue
 	}
 	return nil
 }
 
-func (m *StakedDataV1P1) GetJailedRound() uint64 {
+func (m *StakedDataV1_1) GetJailedRound() uint64 {
 	if m != nil {
 		return m.JailedRound
 	}
 	return 0
 }
 
-func (m *StakedDataV1P1) GetJailedNonce() uint64 {
+func (m *StakedDataV1_1) GetJailedNonce() uint64 {
 	if m != nil {
 		return m.JailedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV1P1) GetUnJailedNonce() uint64 {
+func (m *StakedDataV1_1) GetUnJailedNonce() uint64 {
 	if m != nil {
 		return m.UnJailedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV1P1) GetJailed() bool {
+func (m *StakedDataV1_1) GetJailed() bool {
 	if m != nil {
 		return m.Jailed
 	}
 	return false
 }
 
-func (m *StakedDataV1P1) GetWaiting() bool {
+func (m *StakedDataV1_1) GetWaiting() bool {
 	if m != nil {
 		return m.Waiting
 	}
 	return false
 }
 
-func (m *StakedDataV1P1) GetNumJailed() uint32 {
+func (m *StakedDataV1_1) GetNumJailed() uint32 {
 	if m != nil {
 		return m.NumJailed
 	}
 	return 0
 }
 
-func (m *StakedDataV1P1) GetSlashValue() *math_big.Int {
+func (m *StakedDataV1_1) GetSlashValue() *math_big.Int {
 	if m != nil {
 		return m.SlashValue
 	}
 	return nil
 }
 
-type StakedDataV2P0 struct {
+type StakedDataV2_0 struct {
 	RegisterNonce uint64        `protobuf:"varint,1,opt,name=RegisterNonce,proto3" json:"RegisterNonce"`
 	StakedNonce   uint64        `protobuf:"varint,2,opt,name=StakedNonce,proto3" json:"StakedNonce"`
 	Staked        bool          `protobuf:"varint,3,opt,name=Staked,proto3" json:"Staked"`
@@ -316,15 +316,15 @@ type StakedDataV2P0 struct {
 	OwnerAddress  []byte        `protobuf:"bytes,15,opt,name=OwnerAddress,proto3" json:"OwnerAddress"`
 }
 
-func (m *StakedDataV2P0) Reset()      { *m = StakedDataV2P0{} }
-func (*StakedDataV2P0) ProtoMessage() {}
-func (*StakedDataV2P0) Descriptor() ([]byte, []int) {
+func (m *StakedDataV2_0) Reset()      { *m = StakedDataV2_0{} }
+func (*StakedDataV2_0) ProtoMessage() {}
+func (*StakedDataV2_0) Descriptor() ([]byte, []int) {
 	return fileDescriptor_289e7c8aea278311, []int{2}
 }
-func (m *StakedDataV2P0) XXX_Unmarshal(b []byte) error {
+func (m *StakedDataV2_0) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *StakedDataV2P0) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *StakedDataV2_0) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	b = b[:cap(b)]
 	n, err := m.MarshalToSizedBuffer(b)
 	if err != nil {
@@ -332,117 +332,117 @@ func (m *StakedDataV2P0) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 	}
 	return b[:n], nil
 }
-func (m *StakedDataV2P0) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StakedDataV2P0.Merge(m, src)
+func (m *StakedDataV2_0) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StakedDataV2_0.Merge(m, src)
 }
-func (m *StakedDataV2P0) XXX_Size() int {
+func (m *StakedDataV2_0) XXX_Size() int {
 	return m.Size()
 }
-func (m *StakedDataV2P0) XXX_DiscardUnknown() {
-	xxx_messageInfo_StakedDataV2P0.DiscardUnknown(m)
+func (m *StakedDataV2_0) XXX_DiscardUnknown() {
+	xxx_messageInfo_StakedDataV2_0.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_StakedDataV2P0 proto.InternalMessageInfo
+var xxx_messageInfo_StakedDataV2_0 proto.InternalMessageInfo
 
-func (m *StakedDataV2P0) GetRegisterNonce() uint64 {
+func (m *StakedDataV2_0) GetRegisterNonce() uint64 {
 	if m != nil {
 		return m.RegisterNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV2P0) GetStakedNonce() uint64 {
+func (m *StakedDataV2_0) GetStakedNonce() uint64 {
 	if m != nil {
 		return m.StakedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV2P0) GetStaked() bool {
+func (m *StakedDataV2_0) GetStaked() bool {
 	if m != nil {
 		return m.Staked
 	}
 	return false
 }
 
-func (m *StakedDataV2P0) GetUnStakedNonce() uint64 {
+func (m *StakedDataV2_0) GetUnStakedNonce() uint64 {
 	if m != nil {
 		return m.UnStakedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV2P0) GetUnStakedEpoch() uint32 {
+func (m *StakedDataV2_0) GetUnStakedEpoch() uint32 {
 	if m != nil {
 		return m.UnStakedEpoch
 	}
 	return 0
 }
 
-func (m *StakedDataV2P0) GetRewardAddress() []byte {
+func (m *StakedDataV2_0) GetRewardAddress() []byte {
 	if m != nil {
 		return m.RewardAddress
 	}
 	return nil
 }
 
-func (m *StakedDataV2P0) GetStakeValue() *math_big.Int {
+func (m *StakedDataV2_0) GetStakeValue() *math_big.Int {
 	if m != nil {
 		return m.StakeValue
 	}
 	return nil
 }
 
-func (m *StakedDataV2P0) GetJailedRound() uint64 {
+func (m *StakedDataV2_0) GetJailedRound() uint64 {
 	if m != nil {
 		return m.JailedRound
 	}
 	return 0
 }
 
-func (m *StakedDataV2P0) GetJailedNonce() uint64 {
+func (m *StakedDataV2_0) GetJailedNonce() uint64 {
 	if m != nil {
 		return m.JailedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV2P0) GetUnJailedNonce() uint64 {
+func (m *StakedDataV2_0) GetUnJailedNonce() uint64 {
 	if m != nil {
 		return m.UnJailedNonce
 	}
 	return 0
 }
 
-func (m *StakedDataV2P0) GetJailed() bool {
+func (m *StakedDataV2_0) GetJailed() bool {
 	if m != nil {
 		return m.Jailed
 	}
 	return false
 }
 
-func (m *StakedDataV2P0) GetWaiting() bool {
+func (m *StakedDataV2_0) GetWaiting() bool {
 	if m != nil {
 		return m.Waiting
 	}
 	return false
 }
 
-func (m *StakedDataV2P0) GetNumJailed() uint32 {
+func (m *StakedDataV2_0) GetNumJailed() uint32 {
 	if m != nil {
 		return m.NumJailed
 	}
 	return 0
 }
 
-func (m *StakedDataV2P0) GetSlashValue() *math_big.Int {
+func (m *StakedDataV2_0) GetSlashValue() *math_big.Int {
 	if m != nil {
 		return m.SlashValue
 	}
 	return nil
 }
 
-func (m *StakedDataV2P0) GetOwnerAddress() []byte {
+func (m *StakedDataV2_0) GetOwnerAddress() []byte {
 	if m != nil {
 		return m.OwnerAddress
 	}
@@ -631,9 +631,9 @@ func (m *WaitingList) GetLastJailedKey() []byte {
 }
 
 func init() {
-	proto.RegisterType((*StakedDataV1P0)(nil), "proto.StakedDataV1p0")
-	proto.RegisterType((*StakedDataV1P1)(nil), "proto.StakedDataV1p1")
-	proto.RegisterType((*StakedDataV2P0)(nil), "proto.StakedDataV2p0")
+	proto.RegisterType((*StakedDataV1_0)(nil), "proto.StakedDataV1_0")
+	proto.RegisterType((*StakedDataV1_1)(nil), "proto.StakedDataV1_1")
+	proto.RegisterType((*StakedDataV2_0)(nil), "proto.StakedDataV2_0")
 	proto.RegisterType((*StakingNodesConfig)(nil), "proto.StakingNodesConfig")
 	proto.RegisterType((*ElementInList)(nil), "proto.ElementInList")
 	proto.RegisterType((*WaitingList)(nil), "proto.WaitingList")
@@ -642,65 +642,65 @@ func init() {
 func init() { proto.RegisterFile("staking.proto", fileDescriptor_289e7c8aea278311) }
 
 var fileDescriptor_289e7c8aea278311 = []byte{
-	// 758 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x57, 0xb1, 0x6e, 0xd3, 0x40,
-	0x18, 0xce, 0x25, 0x69, 0xda, 0x5e, 0x92, 0x16, 0x2c, 0x06, 0x8b, 0xc1, 0x8e, 0x22, 0x21, 0x45,
-	0x42, 0x4d, 0x28, 0x20, 0x31, 0x30, 0x35, 0xa5, 0x48, 0x85, 0x10, 0xaa, 0x8b, 0x28, 0x12, 0xdb,
-	0x25, 0xbe, 0x3a, 0x56, 0x93, 0xbb, 0xca, 0x3e, 0xd3, 0x76, 0x43, 0x3c, 0x01, 0x6f, 0xc0, 0x8a,
-	0xfa, 0x0a, 0xbc, 0x00, 0x03, 0x43, 0xc7, 0x4e, 0xa6, 0x75, 0x17, 0xe4, 0xa9, 0x8f, 0x80, 0xee,
-	0xce, 0x89, 0xcf, 0x1d, 0x11, 0x03, 0x43, 0xa6, 0xbb, 0xef, 0xbb, 0xfb, 0xfe, 0xfb, 0xfb, 0x7f,
-	0xff, 0x6f, 0x35, 0xb0, 0x1e, 0x70, 0x7c, 0xe8, 0x51, 0xb7, 0x7d, 0xe4, 0x33, 0xce, 0x8c, 0x25,
-	0xb9, 0xdc, 0xdf, 0x70, 0x3d, 0x3e, 0x0e, 0x87, 0xed, 0x11, 0x9b, 0x76, 0x5c, 0xe6, 0xb2, 0x8e,
-	0xa4, 0x87, 0xe1, 0x81, 0x44, 0x12, 0xc8, 0x9d, 0x52, 0x35, 0xcf, 0x96, 0xe0, 0xda, 0x80, 0xe3,
-	0x43, 0xe2, 0xbc, 0xc0, 0x1c, 0xef, 0x6f, 0x1e, 0x3d, 0x32, 0x9e, 0xc1, 0x3a, 0x22, 0xae, 0x17,
-	0x70, 0xe2, 0xf7, 0x19, 0x1d, 0x11, 0x13, 0x34, 0x40, 0xab, 0xdc, 0xbd, 0x9b, 0x44, 0x76, 0xfe,
-	0x00, 0xe5, 0xa1, 0xb1, 0x09, 0xab, 0x2a, 0x94, 0x92, 0x15, 0xa5, 0x6c, 0x3d, 0x89, 0x6c, 0x9d,
-	0x46, 0x3a, 0x30, 0x9a, 0xb0, 0xa2, 0xa0, 0x59, 0x6a, 0x80, 0xd6, 0x4a, 0x17, 0x26, 0x91, 0x9d,
-	0x32, 0x28, 0x5d, 0x45, 0x3e, 0xef, 0xa8, 0x1e, 0xb8, 0x9c, 0xe5, 0x93, 0x3b, 0x40, 0x79, 0xa8,
-	0x0b, 0x77, 0x8e, 0xd8, 0x68, 0x6c, 0x2e, 0x35, 0x40, 0xab, 0x9e, 0x17, 0xca, 0x03, 0x94, 0x87,
-	0xaa, 0x02, 0xc7, 0xd8, 0x77, 0xb6, 0x1c, 0xc7, 0x27, 0x41, 0x60, 0x56, 0x1a, 0xa0, 0x55, 0x9b,
-	0x55, 0x40, 0x3b, 0x40, 0x79, 0x68, 0x04, 0x10, 0xca, 0x38, 0xfb, 0x78, 0x12, 0x12, 0x73, 0x59,
-	0xaa, 0x06, 0x49, 0x64, 0x6b, 0xec, 0xd9, 0x2f, 0x7b, 0x6b, 0x8a, 0xf9, 0xb8, 0x33, 0xf4, 0xdc,
-	0xf6, 0x2e, 0xe5, 0xcf, 0x35, 0xbf, 0x76, 0x26, 0x3e, 0xa3, 0x4e, 0x9f, 0xf0, 0x63, 0xe6, 0x1f,
-	0x76, 0x88, 0x44, 0x1b, 0x2e, 0xeb, 0x38, 0x98, 0xe3, 0x76, 0xd7, 0x73, 0x77, 0x29, 0xdf, 0xc6,
-	0xa2, 0xde, 0x48, 0x0b, 0x28, 0xca, 0xfe, 0x0a, 0x7b, 0x13, 0xe2, 0x20, 0x16, 0x52, 0xc7, 0x5c,
-	0xc9, 0xca, 0xae, 0xd1, 0x48, 0x07, 0x99, 0x44, 0x15, 0x74, 0xf5, 0xb6, 0x24, 0x75, 0x4a, 0x03,
-	0xaa, 0x98, 0xba, 0x08, 0xea, 0x2e, 0xe8, 0xb2, 0x3c, 0x14, 0x16, 0x2b, 0x68, 0x56, 0x33, 0x8b,
-	0xd3, 0x64, 0xd2, 0xd5, 0x78, 0x00, 0x97, 0xdf, 0x63, 0x8f, 0x7b, 0xd4, 0x35, 0x6b, 0xf2, 0x52,
-	0x35, 0x89, 0xec, 0x19, 0x85, 0x66, 0x9b, 0xe6, 0xcf, 0xca, 0xad, 0x66, 0xdd, 0x5c, 0x34, 0xeb,
-	0xa2, 0x59, 0xff, 0xcf, 0x66, 0x35, 0x1e, 0xc2, 0xd5, 0x7e, 0x38, 0x4d, 0xa3, 0xd5, 0xa5, 0x99,
-	0xf5, 0x24, 0xb2, 0x33, 0x12, 0x65, 0x5b, 0xe9, 0xc5, 0x04, 0x07, 0x63, 0xe5, 0xc5, 0x9a, 0xe6,
-	0xc5, 0x9c, 0xfd, 0x57, 0x5e, 0xcc, 0x03, 0x36, 0x3f, 0x2f, 0xe7, 0xc6, 0xe9, 0xf1, 0xe2, 0xdb,
-	0xbf, 0x18, 0xa7, 0xc5, 0x38, 0xfd, 0xed, 0x38, 0x19, 0x4f, 0x61, 0xed, 0xed, 0x31, 0x25, 0xfe,
-	0xac, 0x71, 0xd6, 0xe5, 0xb3, 0x77, 0x92, 0xc8, 0xce, 0xf1, 0x28, 0x87, 0x9a, 0x97, 0x00, 0x1a,
-	0x03, 0xf5, 0x8f, 0x5c, 0x9f, 0x39, 0x24, 0xd8, 0x66, 0xf4, 0xc0, 0x73, 0x85, 0x4b, 0x6f, 0x3c,
-	0xda, 0x0f, 0xa7, 0x92, 0x94, 0x63, 0x58, 0x52, 0x2e, 0x69, 0x34, 0xd2, 0x81, 0x94, 0xe0, 0x93,
-	0xb9, 0xa4, 0xa8, 0x49, 0x32, 0x1a, 0xe9, 0x40, 0x9f, 0x5a, 0x21, 0x29, 0x65, 0x12, 0x8d, 0x46,
-	0x3a, 0xd0, 0xdb, 0x47, 0x48, 0xca, 0x99, 0x44, 0xa3, 0x91, 0x0e, 0x9a, 0x5f, 0x01, 0xac, 0xef,
-	0x4c, 0xc8, 0x94, 0x50, 0xbe, 0x4b, 0x7b, 0x5e, 0xc0, 0x45, 0xa9, 0xba, 0xbd, 0xc1, 0x5e, 0x38,
-	0x9c, 0x78, 0xa3, 0xd7, 0xe4, 0x54, 0xfe, 0x79, 0x69, 0xa9, 0x74, 0x1e, 0xe5, 0x90, 0x78, 0x7a,
-	0xcf, 0x27, 0x1f, 0x3d, 0x16, 0x06, 0x42, 0x54, 0x94, 0x22, 0xf9, 0xb4, 0x46, 0x23, 0x1d, 0x88,
-	0xe6, 0xea, 0x93, 0x13, 0x2e, 0xae, 0x97, 0xe4, 0x75, 0xd9, 0x5c, 0x29, 0x85, 0x66, 0x9b, 0xe6,
-	0x77, 0x00, 0xab, 0x69, 0xa3, 0xc9, 0xfc, 0x5a, 0x70, 0xe5, 0xa5, 0xe7, 0x07, 0x3c, 0xcb, 0xad,
-	0x96, 0x44, 0xf6, 0x9c, 0x43, 0xf3, 0x9d, 0x78, 0xa0, 0x87, 0xd5, 0xc5, 0x62, 0xf6, 0x40, 0x4a,
-	0xa1, 0xd9, 0x46, 0x0c, 0x42, 0x8f, 0x50, 0x97, 0x8f, 0x65, 0x1a, 0x75, 0x35, 0x08, 0x8a, 0x41,
-	0xe9, 0x2a, 0xa6, 0x4c, 0x5c, 0x57, 0x95, 0x13, 0x01, 0xcb, 0xd9, 0x97, 0x27, 0x77, 0x80, 0xf2,
-	0xb0, 0xdb, 0x3f, 0xbf, 0xb2, 0x0a, 0x17, 0x57, 0x56, 0xe1, 0xe6, 0xca, 0x02, 0x9f, 0x62, 0x0b,
-	0x7c, 0x8b, 0x2d, 0xf0, 0x23, 0xb6, 0xc0, 0x79, 0x6c, 0x81, 0x8b, 0xd8, 0x02, 0x97, 0xb1, 0x05,
-	0x7e, 0xc7, 0x56, 0xe1, 0x26, 0xb6, 0xc0, 0x97, 0x6b, 0xab, 0x70, 0x7e, 0x6d, 0x15, 0x2e, 0xae,
-	0xad, 0xc2, 0x87, 0x7b, 0xc1, 0x69, 0xc0, 0xc9, 0x74, 0x30, 0xc5, 0x3e, 0xdf, 0x66, 0x94, 0xfb,
-	0x78, 0xc4, 0x83, 0x61, 0x45, 0xfe, 0x34, 0x78, 0xf2, 0x27, 0x00, 0x00, 0xff, 0xff, 0x98, 0x46,
-	0x5c, 0x88, 0x61, 0x0c, 0x00, 0x00,
+	// 761 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x57, 0x31, 0x6f, 0xd3, 0x4c,
+	0x18, 0xce, 0x25, 0x69, 0xda, 0x5e, 0x92, 0xf6, 0xfb, 0x2c, 0x06, 0x8b, 0xc1, 0x8e, 0x22, 0x21,
+	0x45, 0x42, 0x4d, 0x28, 0x20, 0x31, 0x30, 0x35, 0xa5, 0x48, 0x85, 0x10, 0xaa, 0x8b, 0x28, 0x12,
+	0x0b, 0xba, 0xc4, 0x57, 0xc7, 0x6a, 0x72, 0x57, 0xd9, 0x67, 0xda, 0x6e, 0x88, 0x5f, 0xc0, 0x3f,
+	0x60, 0x45, 0xfd, 0x0b, 0xfc, 0x01, 0x06, 0x86, 0x8e, 0x9d, 0x4c, 0xeb, 0x2e, 0xc8, 0x53, 0x7f,
+	0x02, 0xba, 0x3b, 0x27, 0x3e, 0x77, 0x44, 0x0c, 0x0c, 0x99, 0xee, 0x9e, 0xe7, 0xee, 0x79, 0xef,
+	0xed, 0xfb, 0xbc, 0xaf, 0xd5, 0xc0, 0x7a, 0xc0, 0xf1, 0xa1, 0x47, 0xdd, 0xf6, 0x91, 0xcf, 0x38,
+	0x33, 0x96, 0xe4, 0x72, 0x77, 0xc3, 0xf5, 0xf8, 0x38, 0x1c, 0xb6, 0x47, 0x6c, 0xda, 0x71, 0x99,
+	0xcb, 0x3a, 0x92, 0x1e, 0x86, 0x07, 0x12, 0x49, 0x20, 0x77, 0x4a, 0xd5, 0x3c, 0x5b, 0x82, 0x6b,
+	0x03, 0x8e, 0x0f, 0x89, 0xf3, 0x0c, 0x73, 0xbc, 0xbf, 0xf9, 0xfe, 0x81, 0xf1, 0x04, 0xd6, 0x11,
+	0x71, 0xbd, 0x80, 0x13, 0xbf, 0xcf, 0xe8, 0x88, 0x98, 0xa0, 0x01, 0x5a, 0xe5, 0xee, 0xff, 0x49,
+	0x64, 0xe7, 0x0f, 0x50, 0x1e, 0x1a, 0x9b, 0xb0, 0xaa, 0x42, 0x29, 0x59, 0x51, 0xca, 0xd6, 0x93,
+	0xc8, 0xd6, 0x69, 0xa4, 0x03, 0xa3, 0x09, 0x2b, 0x0a, 0x9a, 0xa5, 0x06, 0x68, 0xad, 0x74, 0x61,
+	0x12, 0xd9, 0x29, 0x83, 0xd2, 0x55, 0xe4, 0xf3, 0x86, 0xea, 0x81, 0xcb, 0x59, 0x3e, 0xb9, 0x03,
+	0x94, 0x87, 0xba, 0x70, 0xe7, 0x88, 0x8d, 0xc6, 0xe6, 0x52, 0x03, 0xb4, 0xea, 0x79, 0xa1, 0x3c,
+	0x40, 0x79, 0xa8, 0x2a, 0x70, 0x8c, 0x7d, 0x67, 0xcb, 0x71, 0x7c, 0x12, 0x04, 0x66, 0xa5, 0x01,
+	0x5a, 0xb5, 0x59, 0x05, 0xb4, 0x03, 0x94, 0x87, 0x46, 0x00, 0xa1, 0x8c, 0xb3, 0x8f, 0x27, 0x21,
+	0x31, 0x97, 0xa5, 0x6a, 0x90, 0x44, 0xb6, 0xc6, 0x9e, 0xfd, 0xb4, 0xb7, 0xa6, 0x98, 0x8f, 0x3b,
+	0x43, 0xcf, 0x6d, 0xef, 0x52, 0xfe, 0x54, 0xf3, 0x6b, 0x67, 0xe2, 0x33, 0xea, 0xf4, 0x09, 0x3f,
+	0x66, 0xfe, 0x61, 0x87, 0x48, 0xb4, 0xe1, 0xb2, 0x8e, 0x83, 0x39, 0x6e, 0x77, 0x3d, 0x77, 0x97,
+	0xf2, 0x6d, 0x2c, 0xea, 0x8d, 0xb4, 0x80, 0xa2, 0xec, 0x2f, 0xb0, 0x37, 0x21, 0x0e, 0x62, 0x21,
+	0x75, 0xcc, 0x95, 0xac, 0xec, 0x1a, 0x8d, 0x74, 0x90, 0x49, 0x54, 0x41, 0x57, 0x6f, 0x4b, 0x52,
+	0xa7, 0x34, 0xa0, 0x8a, 0xa9, 0x8b, 0xa0, 0xee, 0x82, 0x2e, 0xcb, 0x43, 0x61, 0xb1, 0x82, 0x66,
+	0x35, 0xb3, 0x38, 0x4d, 0x26, 0x5d, 0x8d, 0x7b, 0x70, 0xf9, 0x2d, 0xf6, 0xb8, 0x47, 0x5d, 0xb3,
+	0x26, 0x2f, 0x55, 0x93, 0xc8, 0x9e, 0x51, 0x68, 0xb6, 0x69, 0xfe, 0xa8, 0xdc, 0x6a, 0xd6, 0xcd,
+	0x45, 0xb3, 0x2e, 0x9a, 0xf5, 0xdf, 0x6c, 0x56, 0xe3, 0x3e, 0x5c, 0xed, 0x87, 0xd3, 0x34, 0x5a,
+	0x5d, 0x9a, 0x59, 0x4f, 0x22, 0x3b, 0x23, 0x51, 0xb6, 0x95, 0x5e, 0x4c, 0x70, 0x30, 0x56, 0x5e,
+	0xac, 0x69, 0x5e, 0xcc, 0xd9, 0xbf, 0xe5, 0xc5, 0x3c, 0x60, 0xf3, 0xd3, 0x72, 0x6e, 0x9c, 0x1e,
+	0x2e, 0xbe, 0xfd, 0x8b, 0x71, 0x5a, 0x8c, 0xd3, 0x9f, 0x8e, 0x93, 0xf1, 0x18, 0xd6, 0x5e, 0x1f,
+	0x53, 0xe2, 0xcf, 0x1a, 0x67, 0x5d, 0x3e, 0xfb, 0x5f, 0x12, 0xd9, 0x39, 0x1e, 0xe5, 0x50, 0xf3,
+	0x12, 0x40, 0x63, 0xa0, 0xfe, 0x91, 0xeb, 0x33, 0x87, 0x04, 0xdb, 0x8c, 0x1e, 0x78, 0xae, 0x70,
+	0xe9, 0x95, 0x47, 0xfb, 0xe1, 0x54, 0x92, 0x72, 0x0c, 0x4b, 0xca, 0x25, 0x8d, 0x46, 0x3a, 0x90,
+	0x12, 0x7c, 0x32, 0x97, 0x14, 0x35, 0x49, 0x46, 0x23, 0x1d, 0xe8, 0x53, 0x2b, 0x24, 0xa5, 0x4c,
+	0xa2, 0xd1, 0x48, 0x07, 0x7a, 0xfb, 0x08, 0x49, 0x39, 0x93, 0x68, 0x34, 0xd2, 0x41, 0xf3, 0x0b,
+	0x80, 0xf5, 0x9d, 0x09, 0x99, 0x12, 0xca, 0x77, 0x69, 0xcf, 0x0b, 0xb8, 0x28, 0x55, 0xb7, 0x37,
+	0xd8, 0x0b, 0x87, 0x13, 0x6f, 0xf4, 0x92, 0x9c, 0xca, 0x3f, 0x2f, 0x2d, 0x95, 0xce, 0xa3, 0x1c,
+	0x12, 0x4f, 0xef, 0xf9, 0xe4, 0x83, 0xc7, 0xc2, 0x40, 0x88, 0x8a, 0x52, 0x24, 0x9f, 0xd6, 0x68,
+	0xa4, 0x03, 0xd1, 0x5c, 0x7d, 0x72, 0xc2, 0xc5, 0xf5, 0x92, 0xbc, 0x2e, 0x9b, 0x2b, 0xa5, 0xd0,
+	0x6c, 0xd3, 0xfc, 0x06, 0x60, 0x35, 0x6d, 0x34, 0x99, 0x5f, 0x0b, 0xae, 0x3c, 0xf7, 0xfc, 0x80,
+	0x67, 0xb9, 0xd5, 0x92, 0xc8, 0x9e, 0x73, 0x68, 0xbe, 0x13, 0x0f, 0xf4, 0xb0, 0xba, 0x58, 0xcc,
+	0x1e, 0x48, 0x29, 0x34, 0xdb, 0x88, 0x41, 0xe8, 0x11, 0xea, 0xf2, 0xb1, 0x4c, 0xa3, 0xae, 0x06,
+	0x41, 0x31, 0x28, 0x5d, 0xc5, 0x94, 0x89, 0xeb, 0xaa, 0x72, 0x22, 0x60, 0x39, 0xfb, 0xf2, 0xe4,
+	0x0e, 0x50, 0x1e, 0x76, 0xfb, 0xe7, 0x57, 0x56, 0xe1, 0xe2, 0xca, 0x2a, 0xdc, 0x5c, 0x59, 0xe0,
+	0x63, 0x6c, 0x81, 0xaf, 0xb1, 0x05, 0xbe, 0xc7, 0x16, 0x38, 0x8f, 0x2d, 0x70, 0x11, 0x5b, 0xe0,
+	0x32, 0xb6, 0xc0, 0xaf, 0xd8, 0x2a, 0xdc, 0xc4, 0x16, 0xf8, 0x7c, 0x6d, 0x15, 0xce, 0xaf, 0xad,
+	0xc2, 0xc5, 0xb5, 0x55, 0x78, 0x77, 0x27, 0x38, 0x0d, 0x38, 0x99, 0x0e, 0xa6, 0xd8, 0xe7, 0xdb,
+	0x8c, 0x72, 0x1f, 0x8f, 0x78, 0x30, 0xac, 0xc8, 0x9f, 0x06, 0x8f, 0x7e, 0x07, 0x00, 0x00, 0xff,
+	0xff, 0x9c, 0xc2, 0xf8, 0xd3, 0x61, 0x0c, 0x00, 0x00,
 }
 
-func (this *StakedDataV1P0) Equal(that interface{}) bool {
+func (this *StakedDataV1_0) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
 	}
 
-	that1, ok := that.(*StakedDataV1P0)
+	that1, ok := that.(*StakedDataV1_0)
 	if !ok {
-		that2, ok := that.(StakedDataV1P0)
+		that2, ok := that.(StakedDataV1_0)
 		if ok {
 			that1 = &that2
 		} else {
@@ -753,14 +753,14 @@ func (this *StakedDataV1P0) Equal(that interface{}) bool {
 	}
 	return true
 }
-func (this *StakedDataV1P1) Equal(that interface{}) bool {
+func (this *StakedDataV1_1) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
 	}
 
-	that1, ok := that.(*StakedDataV1P1)
+	that1, ok := that.(*StakedDataV1_1)
 	if !ok {
-		that2, ok := that.(StakedDataV1P1)
+		that2, ok := that.(StakedDataV1_1)
 		if ok {
 			that1 = &that2
 		} else {
@@ -822,14 +822,14 @@ func (this *StakedDataV1P1) Equal(that interface{}) bool {
 	}
 	return true
 }
-func (this *StakedDataV2P0) Equal(that interface{}) bool {
+func (this *StakedDataV2_0) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
 	}
 
-	that1, ok := that.(*StakedDataV2P0)
+	that1, ok := that.(*StakedDataV2_0)
 	if !ok {
-		that2, ok := that.(StakedDataV2P0)
+		that2, ok := that.(StakedDataV2_0)
 		if ok {
 			that1 = &that2
 		} else {
@@ -990,12 +990,12 @@ func (this *WaitingList) Equal(that interface{}) bool {
 	}
 	return true
 }
-func (this *StakedDataV1P0) GoString() string {
+func (this *StakedDataV1_0) GoString() string {
 	if this == nil {
 		return "nil"
 	}
 	s := make([]string, 0, 16)
-	s = append(s, "&systemSmartContracts.StakedDataV1P0{")
+	s = append(s, "&systemSmartContracts.StakedDataV1_0{")
 	s = append(s, "RegisterNonce: "+fmt.Sprintf("%#v", this.RegisterNonce)+",\n")
 	s = append(s, "StakedNonce: "+fmt.Sprintf("%#v", this.StakedNonce)+",\n")
 	s = append(s, "Staked: "+fmt.Sprintf("%#v", this.Staked)+",\n")
@@ -1011,12 +1011,12 @@ func (this *StakedDataV1P0) GoString() string {
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
-func (this *StakedDataV1P1) GoString() string {
+func (this *StakedDataV1_1) GoString() string {
 	if this == nil {
 		return "nil"
 	}
 	s := make([]string, 0, 18)
-	s = append(s, "&systemSmartContracts.StakedDataV1P1{")
+	s = append(s, "&systemSmartContracts.StakedDataV1_1{")
 	s = append(s, "RegisterNonce: "+fmt.Sprintf("%#v", this.RegisterNonce)+",\n")
 	s = append(s, "StakedNonce: "+fmt.Sprintf("%#v", this.StakedNonce)+",\n")
 	s = append(s, "Staked: "+fmt.Sprintf("%#v", this.Staked)+",\n")
@@ -1034,12 +1034,12 @@ func (this *StakedDataV1P1) GoString() string {
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
-func (this *StakedDataV2P0) GoString() string {
+func (this *StakedDataV2_0) GoString() string {
 	if this == nil {
 		return "nil"
 	}
 	s := make([]string, 0, 19)
-	s = append(s, "&systemSmartContracts.StakedDataV2P0{")
+	s = append(s, "&systemSmartContracts.StakedDataV2_0{")
 	s = append(s, "RegisterNonce: "+fmt.Sprintf("%#v", this.RegisterNonce)+",\n")
 	s = append(s, "StakedNonce: "+fmt.Sprintf("%#v", this.StakedNonce)+",\n")
 	s = append(s, "Staked: "+fmt.Sprintf("%#v", this.Staked)+",\n")
@@ -1104,7 +1104,7 @@ func valueToGoStringStaking(v interface{}, typ string) string {
 	pv := reflect.Indirect(rv).Interface()
 	return fmt.Sprintf("func(v %v) *%v { return &v } ( %#v )", typ, typ, pv)
 }
-func (m *StakedDataV1P0) Marshal() (dAtA []byte, err error) {
+func (m *StakedDataV1_0) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1114,12 +1114,12 @@ func (m *StakedDataV1P0) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *StakedDataV1P0) MarshalTo(dAtA []byte) (int, error) {
+func (m *StakedDataV1_0) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *StakedDataV1P0) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *StakedDataV1_0) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -1210,7 +1210,7 @@ func (m *StakedDataV1P0) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *StakedDataV1P1) Marshal() (dAtA []byte, err error) {
+func (m *StakedDataV1_1) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1220,12 +1220,12 @@ func (m *StakedDataV1P1) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *StakedDataV1P1) MarshalTo(dAtA []byte) (int, error) {
+func (m *StakedDataV1_1) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *StakedDataV1P1) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *StakedDataV1_1) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -1332,7 +1332,7 @@ func (m *StakedDataV1P1) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *StakedDataV2P0) Marshal() (dAtA []byte, err error) {
+func (m *StakedDataV2_0) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1342,12 +1342,12 @@ func (m *StakedDataV2P0) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *StakedDataV2P0) MarshalTo(dAtA []byte) (int, error) {
+func (m *StakedDataV2_0) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *StakedDataV2P0) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *StakedDataV2_0) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -1608,7 +1608,7 @@ func encodeVarintStaking(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-func (m *StakedDataV1P0) Size() (n int) {
+func (m *StakedDataV1_0) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1656,7 +1656,7 @@ func (m *StakedDataV1P0) Size() (n int) {
 	return n
 }
 
-func (m *StakedDataV1P1) Size() (n int) {
+func (m *StakedDataV1_1) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1712,7 +1712,7 @@ func (m *StakedDataV1P1) Size() (n int) {
 	return n
 }
 
-func (m *StakedDataV2P0) Size() (n int) {
+func (m *StakedDataV2_0) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1844,11 +1844,11 @@ func sovStaking(x uint64) (n int) {
 func sozStaking(x uint64) (n int) {
 	return sovStaking(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-func (this *StakedDataV1P0) String() string {
+func (this *StakedDataV1_0) String() string {
 	if this == nil {
 		return "nil"
 	}
-	s := strings.Join([]string{`&StakedDataV1P0{`,
+	s := strings.Join([]string{`&StakedDataV1_0{`,
 		`RegisterNonce:` + fmt.Sprintf("%v", this.RegisterNonce) + `,`,
 		`StakedNonce:` + fmt.Sprintf("%v", this.StakedNonce) + `,`,
 		`Staked:` + fmt.Sprintf("%v", this.Staked) + `,`,
@@ -1865,11 +1865,11 @@ func (this *StakedDataV1P0) String() string {
 	}, "")
 	return s
 }
-func (this *StakedDataV1P1) String() string {
+func (this *StakedDataV1_1) String() string {
 	if this == nil {
 		return "nil"
 	}
-	s := strings.Join([]string{`&StakedDataV1P1{`,
+	s := strings.Join([]string{`&StakedDataV1_1{`,
 		`RegisterNonce:` + fmt.Sprintf("%v", this.RegisterNonce) + `,`,
 		`StakedNonce:` + fmt.Sprintf("%v", this.StakedNonce) + `,`,
 		`Staked:` + fmt.Sprintf("%v", this.Staked) + `,`,
@@ -1888,11 +1888,11 @@ func (this *StakedDataV1P1) String() string {
 	}, "")
 	return s
 }
-func (this *StakedDataV2P0) String() string {
+func (this *StakedDataV2_0) String() string {
 	if this == nil {
 		return "nil"
 	}
-	s := strings.Join([]string{`&StakedDataV2P0{`,
+	s := strings.Join([]string{`&StakedDataV2_0{`,
 		`RegisterNonce:` + fmt.Sprintf("%v", this.RegisterNonce) + `,`,
 		`StakedNonce:` + fmt.Sprintf("%v", this.StakedNonce) + `,`,
 		`Staked:` + fmt.Sprintf("%v", this.Staked) + `,`,
@@ -1958,7 +1958,7 @@ func valueToStringStaking(v interface{}) string {
 	pv := reflect.Indirect(rv).Interface()
 	return fmt.Sprintf("*%v", pv)
 }
-func (m *StakedDataV1P0) Unmarshal(dAtA []byte) error {
+func (m *StakedDataV1_0) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1981,10 +1981,10 @@ func (m *StakedDataV1P0) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: StakedDataV1p0: wiretype end group for non-group")
+			return fmt.Errorf("proto: StakedDataV1_0: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: StakedDataV1p0: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: StakedDataV1_0: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -2276,7 +2276,7 @@ func (m *StakedDataV1P0) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *StakedDataV1P1) Unmarshal(dAtA []byte) error {
+func (m *StakedDataV1_1) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2299,10 +2299,10 @@ func (m *StakedDataV1P1) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: StakedDataV1p1: wiretype end group for non-group")
+			return fmt.Errorf("proto: StakedDataV1_1: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: StakedDataV1p1: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: StakedDataV1_1: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -2651,7 +2651,7 @@ func (m *StakedDataV1P1) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *StakedDataV2P0) Unmarshal(dAtA []byte) error {
+func (m *StakedDataV2_0) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2674,10 +2674,10 @@ func (m *StakedDataV2P0) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: StakedDataV2p0: wiretype end group for non-group")
+			return fmt.Errorf("proto: StakedDataV2_0: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: StakedDataV2p0: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: StakedDataV2_0: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:

--- a/vm/systemSmartContracts/stakingSaveLoad.go
+++ b/vm/systemSmartContracts/stakingSaveLoad.go
@@ -1,0 +1,154 @@
+package systemSmartContracts
+
+import (
+	"math"
+	"math/big"
+
+	"github.com/ElrondNetwork/elrond-go/core"
+)
+
+func (r *stakingSC) getConfig() *StakingNodesConfig {
+	stakeConfig := &StakingNodesConfig{
+		MinNumNodes: int64(r.minNumNodes),
+		MaxNumNodes: int64(r.maxNumNodes),
+	}
+	configData := r.eei.GetStorage([]byte(nodesConfigKey))
+	if len(configData) == 0 {
+		return stakeConfig
+	}
+
+	err := r.marshalizer.Unmarshal(stakeConfig, configData)
+	if err != nil {
+		log.Warn("unmarshal error on getConfig function, returning baseConfig",
+			"error", err.Error(),
+		)
+		return &StakingNodesConfig{
+			MinNumNodes: int64(r.minNumNodes),
+			MaxNumNodes: int64(r.maxNumNodes),
+		}
+	}
+
+	return stakeConfig
+}
+
+func (r *stakingSC) setConfig(config *StakingNodesConfig) {
+	configData, err := r.marshalizer.Marshal(config)
+	if err != nil {
+		log.Warn("marshal error on setConfig function",
+			"error", err.Error(),
+		)
+		return
+	}
+
+	r.eei.SetStorage([]byte(nodesConfigKey), configData)
+}
+
+func (r *stakingSC) getOrCreateRegisteredData(key []byte) (*StakedDataV2_0, error) {
+	registrationData := &StakedDataV2_0{
+		RegisterNonce: 0,
+		Staked:        false,
+		UnStakedNonce: 0,
+		UnStakedEpoch: core.DefaultUnstakedEpoch,
+		RewardAddress: nil,
+		StakeValue:    big.NewInt(0),
+		JailedRound:   math.MaxUint64,
+		UnJailedNonce: 0,
+		JailedNonce:   0,
+		StakedNonce:   math.MaxUint64,
+		SlashValue:    big.NewInt(0),
+	}
+
+	data := r.eei.GetStorage(key)
+	if len(data) > 0 {
+		err := r.marshalizer.Unmarshal(registrationData, data)
+		if err != nil {
+			log.Debug("unmarshal error on staking SC stake function",
+				"error", err.Error(),
+			)
+			return nil, err
+		}
+	}
+	if registrationData.SlashValue == nil {
+		registrationData.SlashValue = big.NewInt(0)
+	}
+
+	return registrationData, nil
+}
+
+func (r *stakingSC) saveStakingData(key []byte, stakedData *StakedDataV2_0) error {
+	if !r.flagEnableStaking.IsSet() {
+		return r.saveAsStakingDataV1P0(key, stakedData)
+	}
+	if !r.flagSetOwner.IsSet() {
+		return r.saveAsStakingDataV1P1(key, stakedData)
+	}
+
+	data, err := r.marshalizer.Marshal(stakedData)
+	if err != nil {
+		log.Debug("marshal error in saveStakingData ",
+			"error", err.Error(),
+		)
+		return err
+	}
+
+	r.eei.SetStorage(key, data)
+	return nil
+}
+
+func (r *stakingSC) saveAsStakingDataV1P0(key []byte, stakedData *StakedDataV2_0) error {
+	stakedDataV1 := &StakedDataV1_0{
+		RegisterNonce: stakedData.RegisterNonce,
+		StakedNonce:   stakedData.StakedNonce,
+		Staked:        stakedData.Staked,
+		UnStakedNonce: stakedData.UnStakedNonce,
+		UnStakedEpoch: stakedData.UnStakedEpoch,
+		RewardAddress: stakedData.RewardAddress,
+		StakeValue:    stakedData.StakeValue,
+		JailedRound:   stakedData.JailedRound,
+		JailedNonce:   stakedData.JailedNonce,
+		UnJailedNonce: stakedData.UnJailedNonce,
+		Jailed:        stakedData.Jailed,
+		Waiting:       stakedData.Waiting,
+	}
+
+	data, err := r.marshalizer.Marshal(stakedDataV1)
+	if err != nil {
+		log.Debug("marshal error in saveAsStakingDataV1P0 ",
+			"error", err.Error(),
+		)
+		return err
+	}
+
+	r.eei.SetStorage(key, data)
+	return nil
+}
+
+func (r *stakingSC) saveAsStakingDataV1P1(key []byte, stakedData *StakedDataV2_0) error {
+	stakedDataV1 := &StakedDataV1_1{
+		RegisterNonce: stakedData.RegisterNonce,
+		StakedNonce:   stakedData.StakedNonce,
+		Staked:        stakedData.Staked,
+		UnStakedNonce: stakedData.UnStakedNonce,
+		UnStakedEpoch: stakedData.UnStakedEpoch,
+		RewardAddress: stakedData.RewardAddress,
+		StakeValue:    stakedData.StakeValue,
+		JailedRound:   stakedData.JailedRound,
+		JailedNonce:   stakedData.JailedNonce,
+		UnJailedNonce: stakedData.UnJailedNonce,
+		Jailed:        stakedData.Jailed,
+		Waiting:       stakedData.Waiting,
+		NumJailed:     stakedData.NumJailed,
+		SlashValue:    stakedData.SlashValue,
+	}
+
+	data, err := r.marshalizer.Marshal(stakedDataV1)
+	if err != nil {
+		log.Debug("marshal error in saveAsStakingDataV1P1 ",
+			"error", err.Error(),
+		)
+		return err
+	}
+
+	r.eei.SetStorage(key, data)
+	return nil
+}

--- a/vm/systemSmartContracts/stakingWithWaiting_test.go
+++ b/vm/systemSmartContracts/stakingWithWaiting_test.go
@@ -70,12 +70,12 @@ func TestStakingWaitingSC_ExecuteStakeStakeWaitingUnStake(t *testing.T) {
 
 	eei.SetSCAddress(args.StakingSCAddress)
 	marshaledData := eei.GetStorage(stakerPubKey)
-	stakedData := &StakedDataV2P0{}
+	stakedData := &StakedDataV2_0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.False(t, stakedData.Staked)
 
 	marshaledData = eei.GetStorage(blsKey2)
-	stakedData = &StakedDataV2P0{}
+	stakedData = &StakedDataV2_0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.True(t, stakedData.Staked)
 }
@@ -148,7 +148,7 @@ func TestStakingWaitingSC_ExecuteStakeStakeWaitingUnBondFromWaiting(t *testing.T
 
 	eei.SetSCAddress(args.StakingSCAddress)
 	marshaledData := eei.GetStorage(stakerPubKey)
-	stakedData := &StakedDataV2P0{}
+	stakedData := &StakedDataV2_0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.True(t, stakedData.Staked)
 
@@ -219,12 +219,12 @@ func TestStakingWaitingSC_ExecuteStakeStakeUnStakeStakeUnstake(t *testing.T) {
 	assert.Equal(t, vmcommon.Ok, retCode)
 
 	marshaledData := eei.GetStorageFromAddress(args.StakingSCAddress, stakerPubKey)
-	stakedData := &StakedDataV2P0{}
+	stakedData := &StakedDataV2_0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.False(t, stakedData.Staked)
 
 	marshaledData = eei.GetStorageFromAddress(args.StakingSCAddress, blsKey2)
-	stakedData = &StakedDataV2P0{}
+	stakedData = &StakedDataV2_0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.True(t, stakedData.Staked)
 
@@ -236,7 +236,7 @@ func TestStakingWaitingSC_ExecuteStakeStakeUnStakeStakeUnstake(t *testing.T) {
 	assert.Equal(t, vmcommon.Ok, retCode)
 
 	marshaledData = eei.GetStorageFromAddress(args.StakingSCAddress, blsKey3)
-	stakedData = &StakedDataV2P0{}
+	stakedData = &StakedDataV2_0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.False(t, stakedData.Staked)
 	assert.True(t, stakedData.Waiting)
@@ -248,7 +248,7 @@ func TestStakingWaitingSC_ExecuteStakeStakeUnStakeStakeUnstake(t *testing.T) {
 	assert.Equal(t, vmcommon.Ok, retCode)
 
 	marshaledData = eei.GetStorageFromAddress(args.StakingSCAddress, blsKey2)
-	stakedData = &StakedDataV2P0{}
+	stakedData = &StakedDataV2_0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.False(t, stakedData.Staked)
 	assert.False(t, stakedData.Waiting)

--- a/vm/systemSmartContracts/stakingWithWaiting_test.go
+++ b/vm/systemSmartContracts/stakingWithWaiting_test.go
@@ -70,12 +70,12 @@ func TestStakingWaitingSC_ExecuteStakeStakeWaitingUnStake(t *testing.T) {
 
 	eei.SetSCAddress(args.StakingSCAddress)
 	marshaledData := eei.GetStorage(stakerPubKey)
-	stakedData := &StakedDataV2{}
+	stakedData := &StakedDataV2P0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.False(t, stakedData.Staked)
 
 	marshaledData = eei.GetStorage(blsKey2)
-	stakedData = &StakedDataV2{}
+	stakedData = &StakedDataV2P0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.True(t, stakedData.Staked)
 }
@@ -148,7 +148,7 @@ func TestStakingWaitingSC_ExecuteStakeStakeWaitingUnBondFromWaiting(t *testing.T
 
 	eei.SetSCAddress(args.StakingSCAddress)
 	marshaledData := eei.GetStorage(stakerPubKey)
-	stakedData := &StakedDataV2{}
+	stakedData := &StakedDataV2P0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.True(t, stakedData.Staked)
 
@@ -219,12 +219,12 @@ func TestStakingWaitingSC_ExecuteStakeStakeUnStakeStakeUnstake(t *testing.T) {
 	assert.Equal(t, vmcommon.Ok, retCode)
 
 	marshaledData := eei.GetStorageFromAddress(args.StakingSCAddress, stakerPubKey)
-	stakedData := &StakedDataV2{}
+	stakedData := &StakedDataV2P0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.False(t, stakedData.Staked)
 
 	marshaledData = eei.GetStorageFromAddress(args.StakingSCAddress, blsKey2)
-	stakedData = &StakedDataV2{}
+	stakedData = &StakedDataV2P0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.True(t, stakedData.Staked)
 
@@ -236,7 +236,7 @@ func TestStakingWaitingSC_ExecuteStakeStakeUnStakeStakeUnstake(t *testing.T) {
 	assert.Equal(t, vmcommon.Ok, retCode)
 
 	marshaledData = eei.GetStorageFromAddress(args.StakingSCAddress, blsKey3)
-	stakedData = &StakedDataV2{}
+	stakedData = &StakedDataV2P0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.False(t, stakedData.Staked)
 	assert.True(t, stakedData.Waiting)
@@ -248,7 +248,7 @@ func TestStakingWaitingSC_ExecuteStakeStakeUnStakeStakeUnstake(t *testing.T) {
 	assert.Equal(t, vmcommon.Ok, retCode)
 
 	marshaledData = eei.GetStorageFromAddress(args.StakingSCAddress, blsKey2)
-	stakedData = &StakedDataV2{}
+	stakedData = &StakedDataV2P0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.False(t, stakedData.Staked)
 	assert.False(t, stakedData.Waiting)

--- a/vm/systemSmartContracts/staking_test.go
+++ b/vm/systemSmartContracts/staking_test.go
@@ -210,7 +210,7 @@ func TestStakingSC_ExecuteStakeRegistrationDataStakedShouldErr(t *testing.T) {
 	eei := &mock.SystemEIStub{}
 	eei.GetStorageCalled = func(key []byte) []byte {
 		registrationDataMarshalized, _ := json.Marshal(
-			&StakedDataV2P0{
+			&StakedDataV2_0{
 				Staked: true,
 			})
 		return registrationDataMarshalized
@@ -233,7 +233,7 @@ func TestStakingSC_ExecuteStakeNotEnoughArgsShouldErr(t *testing.T) {
 	stakeValue := big.NewInt(100)
 	eei := &mock.SystemEIStub{}
 	eei.GetStorageCalled = func(key []byte) []byte {
-		registrationDataMarshalized, _ := json.Marshal(&StakedDataV2P0{})
+		registrationDataMarshalized, _ := json.Marshal(&StakedDataV2_0{})
 		return registrationDataMarshalized
 	}
 	args := createMockStakingScArguments()
@@ -254,7 +254,7 @@ func TestStakingSC_ExecuteStake(t *testing.T) {
 	stakeValue := big.NewInt(100)
 	stakerAddress := big.NewInt(100)
 	stakerPubKey := big.NewInt(100)
-	expectedRegistrationData := StakedDataV2P0{
+	expectedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        true,
 		UnStakedNonce: 0,
@@ -287,7 +287,7 @@ func TestStakingSC_ExecuteStake(t *testing.T) {
 	retCode := stakingSmartContract.Execute(arguments)
 	assert.Equal(t, vmcommon.Ok, retCode)
 
-	var registrationData StakedDataV2P0
+	var registrationData StakedDataV2_0
 	data := stakingSmartContract.eei.GetStorage(stakerPubKey.Bytes())
 	err := json.Unmarshal(data, &registrationData)
 	assert.Nil(t, err)
@@ -334,7 +334,7 @@ func TestStakingSC_ExecuteUnStakeUnmarshalErr(t *testing.T) {
 func TestStakingSC_ExecuteUnStakeAlreadyUnStakedAddrShouldErr(t *testing.T) {
 	t.Parallel()
 
-	stakedRegistrationData := StakedDataV2P0{
+	stakedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        false,
 		UnStakedNonce: 0,
@@ -367,7 +367,7 @@ func TestStakingSC_ExecuteUnStakeFailsWithWrongCaller(t *testing.T) {
 	expectedCallerAddress := []byte("caller")
 	wrongCallerAddress := []byte("wrongCaller")
 
-	stakedRegistrationData := StakedDataV2P0{
+	stakedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        true,
 		UnStakedNonce: 0,
@@ -399,7 +399,7 @@ func TestStakingSC_ExecuteUnStakeShouldErrorNotEnoughNodes(t *testing.T) {
 
 	callerAddress := []byte("caller")
 
-	expectedRegistrationData := StakedDataV2P0{
+	expectedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        false,
 		UnStakedNonce: 0,
@@ -409,7 +409,7 @@ func TestStakingSC_ExecuteUnStakeShouldErrorNotEnoughNodes(t *testing.T) {
 		SlashValue:    big.NewInt(0),
 	}
 
-	stakedRegistrationData := StakedDataV2P0{
+	stakedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        true,
 		UnStakedNonce: 0,
@@ -439,7 +439,7 @@ func TestStakingSC_ExecuteUnStakeShouldErrorNotEnoughNodes(t *testing.T) {
 	retCode := stakingSmartContract.Execute(arguments)
 	assert.Equal(t, vmcommon.Ok, retCode)
 
-	var registrationData StakedDataV2P0
+	var registrationData StakedDataV2_0
 	data := stakingSmartContract.eei.GetStorage(arguments.Arguments[0])
 	err := json.Unmarshal(data, &registrationData)
 	assert.Nil(t, err)
@@ -451,7 +451,7 @@ func TestStakingSC_ExecuteUnStake(t *testing.T) {
 
 	callerAddress := []byte("caller")
 
-	expectedRegistrationData := StakedDataV2P0{
+	expectedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        false,
 		UnStakedNonce: 0,
@@ -461,7 +461,7 @@ func TestStakingSC_ExecuteUnStake(t *testing.T) {
 		SlashValue:    big.NewInt(0),
 	}
 
-	stakedRegistrationData := StakedDataV2P0{
+	stakedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        true,
 		UnStakedNonce: 0,
@@ -490,7 +490,7 @@ func TestStakingSC_ExecuteUnStake(t *testing.T) {
 	retCode := stakingSmartContract.Execute(arguments)
 	assert.Equal(t, vmcommon.Ok, retCode)
 
-	var registrationData StakedDataV2P0
+	var registrationData StakedDataV2_0
 	data := stakingSmartContract.eei.GetStorage(arguments.Arguments[0])
 	err := json.Unmarshal(data, &registrationData)
 	assert.Nil(t, err)
@@ -530,7 +530,7 @@ func TestStakingSC_ExecuteUnBoundValidatorNotUnStakeShouldErr(t *testing.T) {
 			return []byte("data")
 		default:
 			registrationDataMarshalized, _ := json.Marshal(
-				&StakedDataV2P0{
+				&StakedDataV2_0{
 					UnStakedNonce: 0,
 				})
 			return registrationDataMarshalized
@@ -559,7 +559,7 @@ func TestStakingSC_ExecuteFinalizeUnBoundBeforePeriodEnds(t *testing.T) {
 	t.Parallel()
 
 	unstakedNonce := uint64(10)
-	registrationData := StakedDataV2P0{
+	registrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        true,
 		UnStakedNonce: unstakedNonce,
@@ -596,7 +596,7 @@ func TestStakingSC_ExecuteUnBoundStillValidator(t *testing.T) {
 
 	unBondPeriod := uint64(100)
 	unstakedNonce := uint64(10)
-	registrationData := StakedDataV2P0{
+	registrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        false,
 		UnStakedNonce: unstakedNonce,
@@ -648,7 +648,7 @@ func TestStakingSC_ExecuteUnBound(t *testing.T) {
 
 	unBondPeriod := uint64(100)
 	unstakedNonce := uint64(10)
-	registrationData := StakedDataV2P0{
+	registrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        false,
 		UnStakedNonce: unstakedNonce,
@@ -759,7 +759,7 @@ func TestStakingSC_ExecuteSlashNotStake(t *testing.T) {
 			return []byte("data")
 		default:
 			registrationDataMarshalized, _ := json.Marshal(
-				&StakedDataV2P0{
+				&StakedDataV2_0{
 					StakeValue: big.NewInt(100),
 				})
 			return registrationDataMarshalized
@@ -791,7 +791,7 @@ func TestStakingSC_ExecuteSlashStaked(t *testing.T) {
 			return []byte("data")
 		default:
 			registrationDataMarshalized, _ := json.Marshal(
-				&StakedDataV2P0{
+				&StakedDataV2_0{
 					StakeValue:    big.NewInt(100),
 					Staked:        true,
 					RewardAddress: []byte("reward"),
@@ -842,7 +842,7 @@ func TestStakingSC_ExecuteUnStakeAndUnBoundStake(t *testing.T) {
 	arguments.Arguments = [][]byte{stakerPubKey, stakerAddress}
 	arguments.CallerAddr = []byte("auction")
 
-	stakedRegistrationData := StakedDataV2P0{
+	stakedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        true,
 		UnStakedNonce: 0,
@@ -863,12 +863,12 @@ func TestStakingSC_ExecuteUnStakeAndUnBoundStake(t *testing.T) {
 	retCode := stakingSmartContract.Execute(arguments)
 	assert.Equal(t, vmcommon.Ok, retCode)
 
-	var registrationData StakedDataV2P0
+	var registrationData StakedDataV2_0
 	data := stakingSmartContract.eei.GetStorage(arguments.Arguments[0])
 	err := json.Unmarshal(data, &registrationData)
 	assert.Nil(t, err)
 
-	expectedRegistrationData := StakedDataV2P0{
+	expectedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 0,
 		Staked:        false,
 		UnStakedNonce: unStakeNonce,
@@ -929,7 +929,7 @@ func TestStakingSc_ExecuteSlashTwoTime(t *testing.T) {
 	stakeValue := big.NewInt(100)
 	eei, _ := NewVMContext(&mock.BlockChainHookStub{}, hooks.NewVMCryptoHook(), &mock.ArgumentParserMock{}, &mock.AccountsStub{}, &mock.RaterMock{})
 
-	stakedRegistrationData := StakedDataV2P0{
+	stakedRegistrationData := StakedDataV2_0{
 		RegisterNonce: 50,
 		Staked:        true,
 		UnStakedNonce: 0,
@@ -957,7 +957,7 @@ func TestStakingSc_ExecuteSlashTwoTime(t *testing.T) {
 	assert.Equal(t, vmcommon.Ok, retCode)
 
 	dataBytes := stakingSmartContract.eei.GetStorage(arguments.CallerAddr)
-	var registrationData StakedDataV2P0
+	var registrationData StakedDataV2_0
 	err := json.Unmarshal(dataBytes, &registrationData)
 	assert.Nil(t, err)
 
@@ -1185,7 +1185,7 @@ func TestStakingSc_ExecuteStakeStakeJailAndSwitch(t *testing.T) {
 	assert.Equal(t, retCode, vmcommon.Ok)
 
 	marshaledData := args.Eei.GetStorage([]byte("secondKey"))
-	stakedData := &StakedDataV2P0{}
+	stakedData := &StakedDataV2_0{}
 	_ = json.Unmarshal(marshaledData, stakedData)
 	assert.True(t, stakedData.Jailed)
 	assert.True(t, stakedData.Staked)

--- a/vm/systemSmartContracts/staking_test.go
+++ b/vm/systemSmartContracts/staking_test.go
@@ -281,7 +281,7 @@ func TestStakingSC_ExecuteStake(t *testing.T) {
 	arguments := CreateVmContractCallInput()
 	arguments.Function = "stake"
 	arguments.CallerAddr = []byte("auction")
-	arguments.Arguments = [][]byte{stakerPubKey.Bytes(), stakerAddress.Bytes()}
+	arguments.Arguments = [][]byte{stakerPubKey.Bytes(), stakerAddress.Bytes(), stakerAddress.Bytes()}
 	arguments.CallValue = big.NewInt(100)
 
 	retCode := stakingSmartContract.Execute(arguments)
@@ -1723,7 +1723,7 @@ func doStake(t *testing.T, sc *stakingSC, callerAddr, stakerAddr, stakerPubKey [
 	arguments := CreateVmContractCallInput()
 	arguments.Function = "stake"
 	arguments.CallerAddr = callerAddr
-	arguments.Arguments = [][]byte{stakerPubKey, stakerAddr}
+	arguments.Arguments = [][]byte{stakerPubKey, stakerAddr, stakerAddr}
 
 	retCode := sc.Execute(arguments)
 	assert.Equal(t, vmcommon.Ok, retCode)


### PR DESCRIPTION
- added `setOwner` functionality in staking SC and `updateStakingV2` in auction SC
- added a new stakingData structure that can hold the owner of the BLS key
- previous `stakingDataV2` becomes `stakingDataV1P1` in order to match data structure versions with the activation flag name
- added unit tests for the new functionality