### PR TITLE
En 7776/delegation fund protection

### DIFF
--- a/vm/interface.go
+++ b/vm/interface.go
@@ -47,6 +47,7 @@ type SystemEI interface {
 	BlockChainHook() vmcommon.BlockchainHook
 	CryptoHook() vmcommon.CryptoHook
 	IsValidator(blsKey []byte) bool
+	StatusFromValidatorStatistics(blsKey []byte) string
 	CanUnJail(blsKey []byte) bool
 	IsBadRating(blsKey []byte) bool
 

--- a/vm/mock/systemEIStub.go
+++ b/vm/mock/systemEIStub.go
@@ -10,29 +10,30 @@ import (
 
 // SystemEIStub -
 type SystemEIStub struct {
-	TransferCalled                  func(destination []byte, sender []byte, value *big.Int, input []byte) error
-	GetBalanceCalled                func(addr []byte) *big.Int
-	SetStorageCalled                func(key []byte, value []byte)
-	AddReturnMessageCalled          func(msg string)
-	GetStorageCalled                func(key []byte) []byte
-	SelfDestructCalled              func(beneficiary []byte)
-	CreateVMOutputCalled            func() *vmcommon.VMOutput
-	CleanCacheCalled                func()
-	FinishCalled                    func(value []byte)
-	AddCodeCalled                   func(addr []byte, code []byte)
-	AddTxValueToSmartContractCalled func(value *big.Int, scAddress []byte)
-	BlockChainHookCalled            func() vmcommon.BlockchainHook
-	CryptoHookCalled                func() vmcommon.CryptoHook
-	UseGasCalled                    func(gas uint64) error
-	IsValidatorCalled               func(blsKey []byte) bool
-	ExecuteOnDestContextCalled      func(destination, sender []byte, value *big.Int, input []byte) (*vmcommon.VMOutput, error)
-	DeploySystemSCCalled            func(baseContract []byte, newAddress []byte, caller []byte, value *big.Int, args [][]byte) (vmcommon.ReturnCode, error)
-	GetStorageFromAddressCalled     func(address []byte, key []byte) []byte
-	SetStorageForAddressCalled      func(address []byte, key []byte, value []byte)
-	CanUnJailCalled                 func(blsKey []byte) bool
-	IsBadRatingCalled               func(blsKey []byte) bool
-	SendGlobalSettingToAllCalled    func(sender []byte, input []byte)
-	ReturnMessage                   string
+	TransferCalled                      func(destination []byte, sender []byte, value *big.Int, input []byte) error
+	GetBalanceCalled                    func(addr []byte) *big.Int
+	SetStorageCalled                    func(key []byte, value []byte)
+	AddReturnMessageCalled              func(msg string)
+	GetStorageCalled                    func(key []byte) []byte
+	SelfDestructCalled                  func(beneficiary []byte)
+	CreateVMOutputCalled                func() *vmcommon.VMOutput
+	CleanCacheCalled                    func()
+	FinishCalled                        func(value []byte)
+	AddCodeCalled                       func(addr []byte, code []byte)
+	AddTxValueToSmartContractCalled     func(value *big.Int, scAddress []byte)
+	BlockChainHookCalled                func() vmcommon.BlockchainHook
+	CryptoHookCalled                    func() vmcommon.CryptoHook
+	UseGasCalled                        func(gas uint64) error
+	IsValidatorCalled                   func(blsKey []byte) bool
+	StatusFromValidatorStatisticsCalled func(blsKey []byte) string
+	ExecuteOnDestContextCalled          func(destination, sender []byte, value *big.Int, input []byte) (*vmcommon.VMOutput, error)
+	DeploySystemSCCalled                func(baseContract []byte, newAddress []byte, caller []byte, value *big.Int, args [][]byte) (vmcommon.ReturnCode, error)
+	GetStorageFromAddressCalled         func(address []byte, key []byte) []byte
+	SetStorageForAddressCalled          func(address []byte, key []byte, value []byte)
+	CanUnJailCalled                     func(blsKey []byte) bool
+	IsBadRatingCalled                   func(blsKey []byte) bool
+	SendGlobalSettingToAllCalled        func(sender []byte, input []byte)
+	ReturnMessage                       string
 }
 
 // CanUnJail -
@@ -57,6 +58,14 @@ func (s *SystemEIStub) IsValidator(blsKey []byte) bool {
 		return s.IsValidatorCalled(blsKey)
 	}
 	return false
+}
+
+// StatusFromValidatorStatistics -
+func (s *SystemEIStub) StatusFromValidatorStatistics(blsKey []byte) string {
+	if s.StatusFromValidatorStatisticsCalled != nil {
+		return s.StatusFromValidatorStatisticsCalled(blsKey)
+	}
+	return ""
 }
 
 // UseGas -

--- a/vm/systemSmartContracts/auction_test.go
+++ b/vm/systemSmartContracts/auction_test.go
@@ -2839,50 +2839,6 @@ func TestAuctionStakingSC_ChangeRewardAddress(t *testing.T) {
 	changeRewardAddress(t, sc, stakerAddress, newRewardAddr, vmcommon.Ok)
 }
 
-func TestAuctionStakingSC_ChangeValidatorKeys(t *testing.T) {
-	t.Skip("function is disabled for now as it is not fully tested")
-	t.Parallel()
-
-	receiverAddr := []byte("receiverAddress")
-	stakerAddress := []byte("stakerA")
-	stakerPubKey := []byte("stakerP")
-	minStakeValue := big.NewInt(1000)
-	unboundPeriod := uint64(10)
-	nodesToRunBytes := big.NewInt(1).Bytes()
-	blockChainHook := &mock.BlockChainHookStub{}
-	args := createMockArgumentsForAuction()
-	args.Eei = createVmContextWithStakingSc(minStakeValue, unboundPeriod, blockChainHook)
-
-	sc, _ := NewStakingAuctionSmartContract(args)
-
-	// changeValidatorKeys should err not enough arguments
-	newKey := []byte("newKey")
-	changeValidatorKeys(t, sc, nodesToRunBytes, stakerAddress, stakerPubKey, newKey, nil, vmcommon.UserError)
-	// changeValidatorKeys should error because address is not belongs to any validator
-	changeValidatorKeys(t, sc, nodesToRunBytes, stakerAddress, stakerPubKey, newKey, []byte("signed"), vmcommon.UserError)
-	//do stake
-	nodePrice, _ := big.NewInt(0).SetString(args.StakingSCConfig.GenesisNodePrice, 10)
-	stake(t, sc, nodePrice, receiverAddr, stakerAddress, stakerPubKey, nodesToRunBytes)
-	// changeValidatorKeys should error not enough arguments
-	nodesToRunBytes = big.NewInt(2).Bytes()
-	changeValidatorKeys(t, sc, nodesToRunBytes, stakerAddress, stakerPubKey, newKey, []byte("signed"), vmcommon.UserError)
-	// changeValidatorKeys should error verify sig will return error
-	nodesToRunBytes = big.NewInt(1).Bytes()
-	args.SigVerifier = &mock.MessageSignVerifierMock{
-		VerifyCalled: func(message []byte, signedMessage []byte, pubKey []byte) error {
-			return errors.New("new")
-		},
-	}
-	changeValidatorKeys(t, sc, nodesToRunBytes, stakerAddress, stakerPubKey, newKey, []byte("signed"), vmcommon.UserError)
-	// changeValidatorKeys should error wrong old key
-	args.SigVerifier = &mock.MessageSignVerifierMock{}
-	changeValidatorKeys(t, sc, nodesToRunBytes, stakerAddress, []byte("wrong"), newKey, []byte("signed"), vmcommon.UserError)
-
-	// changeValidatorKeys should work
-	newKey = []byte("newKey1")
-	changeValidatorKeys(t, sc, nodesToRunBytes, stakerAddress, stakerPubKey, newKey, []byte("signed"), vmcommon.Ok)
-}
-
 func TestStakingAuctionSC_UnstakeTokensNotEnabledShouldError(t *testing.T) {
 	t.Parallel()
 
@@ -2913,6 +2869,9 @@ func TestStakingAuctionSC_UnstakeTokensInvalidArgumentsShouldError(t *testing.T)
 	caller := []byte("caller")
 	sc, _ := NewStakingAuctionSmartContract(args)
 
+	registrationData := &AuctionDataV2{RewardAddress: caller}
+	marshaledData, _ := args.Marshalizer.Marshal(registrationData)
+	eei.SetStorage(caller, marshaledData)
 	unstakeTokens(t, sc, caller, nil, zero, vmcommon.UserError)
 	vmOutput := eei.CreateVMOutput()
 	assert.Equal(t, "should have specified one argument containing the unstake value", vmOutput.ReturnMessage)
@@ -2922,6 +2881,7 @@ func TestStakingAuctionSC_UnstakeTokensInvalidArgumentsShouldError(t *testing.T)
 	caller = []byte("caller")
 	sc, _ = NewStakingAuctionSmartContract(args)
 
+	eei.SetStorage(caller, marshaledData)
 	unstakeTokens(t, sc, caller, [][]byte{[]byte("a"), []byte("b")}, zero, vmcommon.UserError)
 	vmOutput = eei.CreateVMOutput()
 	assert.Equal(t, "should have specified one argument containing the unstake value", vmOutput.ReturnMessage)
@@ -3253,6 +3213,9 @@ func TestStakingAuctionSC_UnbondTokensOneArgumentShouldError(t *testing.T) {
 	caller := []byte("caller")
 	sc, _ := NewStakingAuctionSmartContract(args)
 
+	registrationData := &AuctionDataV2{RewardAddress: caller}
+	marshaledData, _ := args.Marshalizer.Marshal(registrationData)
+	eei.SetStorage(caller, marshaledData)
 	unbondTokens(t, sc, caller, [][]byte{[]byte("argument")}, zero, vmcommon.UserError)
 	vmOutput := eei.CreateVMOutput()
 	assert.Equal(t, "should have not specified any arguments", vmOutput.ReturnMessage)
@@ -3610,20 +3573,6 @@ func stake(t *testing.T, asc *stakingAuctionSC, stakeValue *big.Int, receiverAdd
 
 	retCode := asc.Execute(arguments)
 	assert.Equal(t, vmcommon.Ok, retCode)
-}
-
-func changeValidatorKeys(t *testing.T, asc *stakingAuctionSC, numNodes, stakedAddr, oldKey, newKey, signedMessage []byte, expectedCode vmcommon.ReturnCode) {
-	arguments := CreateVmContractCallInput()
-	arguments.Function = "changeValidatorKeys"
-	arguments.CallerAddr = stakedAddr
-	if signedMessage == nil {
-		arguments.Arguments = nil
-	} else {
-		arguments.Arguments = [][]byte{numNodes, oldKey, newKey, signedMessage}
-	}
-
-	retCode := asc.Execute(arguments)
-	assert.Equal(t, expectedCode, retCode)
 }
 
 func changeRewardAddress(t *testing.T, asc *stakingAuctionSC, callerAddr, newRewardAddr []byte, expectedCode vmcommon.ReturnCode) {

--- a/vm/systemSmartContracts/delegation.go
+++ b/vm/systemSmartContracts/delegation.go
@@ -207,14 +207,14 @@ func (d *delegation) init(args *vmcommon.ContractCallInput) vmcommon.ReturnCode 
 		return vmcommon.UserError
 	}
 
-	dStatus := &DelegationContractStatus{
+	status := &DelegationContractStatus{
 		NumDelegators: 1,
 		Delegators:    [][]byte{ownerAddress},
 		StakedKeys:    make([]*NodesData, 0),
 		NotStakedKeys: make([]*NodesData, 0),
 		UnStakedKeys:  make([]*NodesData, 0),
 	}
-	err = d.saveDelegationStatus(dStatus)
+	err = d.saveDelegationStatus(status)
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
@@ -418,13 +418,13 @@ func (d *delegation) addNodes(args *vmcommon.ContractCallInput) vmcommon.ReturnC
 		return vmcommon.UserError
 	}
 
-	dStatus, err := d.getDelegationStatus()
+	status, err := d.getDelegationStatus()
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
 	}
-	listToVerify := append(dStatus.StakedKeys, dStatus.NotStakedKeys...)
-	listToVerify = append(listToVerify, dStatus.UnStakedKeys...)
+	listToVerify := append(status.StakedKeys, status.NotStakedKeys...)
+	listToVerify = append(listToVerify, status.UnStakedKeys...)
 	foundOne := verifyIfBLSPubKeysExist(listToVerify, blsKeys)
 	if foundOne {
 		d.eei.AddReturnMessage(vm.ErrBLSPublicKeyMismatch.Error())
@@ -436,9 +436,9 @@ func (d *delegation) addNodes(args *vmcommon.ContractCallInput) vmcommon.ReturnC
 			BLSKey:    args.Arguments[i],
 			SignedMsg: args.Arguments[i+1],
 		}
-		dStatus.NotStakedKeys = append(dStatus.NotStakedKeys, nodesData)
+		status.NotStakedKeys = append(status.NotStakedKeys, nodesData)
 	}
-	err = d.saveDelegationStatus(dStatus)
+	err = d.saveDelegationStatus(status)
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
@@ -483,7 +483,7 @@ func (d *delegation) removeNodes(args *vmcommon.ContractCallInput) vmcommon.Retu
 		return vmcommon.OutOfGas
 	}
 
-	dStatus, err := d.getDelegationStatus()
+	status, err := d.getDelegationStatus()
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
@@ -491,12 +491,12 @@ func (d *delegation) removeNodes(args *vmcommon.ContractCallInput) vmcommon.Retu
 
 	for _, blsKey := range args.Arguments {
 		found := false
-		for i, nodeData := range dStatus.NotStakedKeys {
+		for i, nodeData := range status.NotStakedKeys {
 			if bytes.Equal(blsKey, nodeData.BLSKey) {
-				copy(dStatus.NotStakedKeys[i:], dStatus.NotStakedKeys[i+1:])
-				lenKeys := len(dStatus.NotStakedKeys)
-				dStatus.NotStakedKeys[lenKeys-1] = nil
-				dStatus.NotStakedKeys = dStatus.NotStakedKeys[:lenKeys-1]
+				copy(status.NotStakedKeys[i:], status.NotStakedKeys[i+1:])
+				lenKeys := len(status.NotStakedKeys)
+				status.NotStakedKeys[lenKeys-1] = nil
+				status.NotStakedKeys = status.NotStakedKeys[:lenKeys-1]
 				found = true
 				break
 			}
@@ -508,7 +508,7 @@ func (d *delegation) removeNodes(args *vmcommon.ContractCallInput) vmcommon.Retu
 		}
 	}
 
-	err = d.saveDelegationStatus(dStatus)
+	err = d.saveDelegationStatus(status)
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
@@ -526,12 +526,12 @@ func (d *delegation) stakeNodes(args *vmcommon.ContractCallInput) vmcommon.Retur
 		d.eei.AddReturnMessage("not enough arguments")
 		return vmcommon.FunctionWrongSignature
 	}
-	dStatus, err := d.getDelegationStatus()
+	status, err := d.getDelegationStatus()
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
 	}
-	listToCheck := append(dStatus.NotStakedKeys, dStatus.UnStakedKeys...)
+	listToCheck := append(status.NotStakedKeys, status.UnStakedKeys...)
 	foundAll := verifyAllBLSKeysExist(listToCheck, args.Arguments)
 	if !foundAll {
 		d.eei.AddReturnMessage(vm.ErrBLSPublicKeyMismatch.Error())
@@ -573,11 +573,11 @@ func (d *delegation) stakeNodes(args *vmcommon.ContractCallInput) vmcommon.Retur
 
 	successKeys, _ := getSuccessAndUnSuccessKeys(vmOutput.ReturnData, args.Arguments)
 	for _, successKey := range successKeys {
-		dStatus.NotStakedKeys, dStatus.StakedKeys = moveNodeFromList(dStatus.NotStakedKeys, dStatus.StakedKeys, successKey)
-		dStatus.UnStakedKeys, dStatus.StakedKeys = moveNodeFromList(dStatus.UnStakedKeys, dStatus.StakedKeys, successKey)
+		status.NotStakedKeys, status.StakedKeys = moveNodeFromList(status.NotStakedKeys, status.StakedKeys, successKey)
+		status.UnStakedKeys, status.StakedKeys = moveNodeFromList(status.UnStakedKeys, status.StakedKeys, successKey)
 	}
 
-	err = d.saveDelegationStatus(dStatus)
+	err = d.saveDelegationStatus(status)
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
@@ -595,12 +595,12 @@ func (d *delegation) unStakeNodes(args *vmcommon.ContractCallInput) vmcommon.Ret
 		d.eei.AddReturnMessage("not enough arguments")
 		return vmcommon.FunctionWrongSignature
 	}
-	dStatus, err := d.getDelegationStatus()
+	status, err := d.getDelegationStatus()
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
 	}
-	foundAll := verifyAllBLSKeysExist(dStatus.StakedKeys, args.Arguments)
+	foundAll := verifyAllBLSKeysExist(status.StakedKeys, args.Arguments)
 	if !foundAll {
 		d.eei.AddReturnMessage(vm.ErrBLSPublicKeyMismatch.Error())
 		return vmcommon.UserError
@@ -617,10 +617,10 @@ func (d *delegation) unStakeNodes(args *vmcommon.ContractCallInput) vmcommon.Ret
 
 	successKeys, _ := getSuccessAndUnSuccessKeys(vmOutput.ReturnData, args.Arguments)
 	for _, successKey := range successKeys {
-		dStatus.StakedKeys, dStatus.UnStakedKeys = moveNodeFromList(dStatus.StakedKeys, dStatus.UnStakedKeys, successKey)
+		status.StakedKeys, status.UnStakedKeys = moveNodeFromList(status.StakedKeys, status.UnStakedKeys, successKey)
 	}
 
-	err = d.saveDelegationStatus(dStatus)
+	err = d.saveDelegationStatus(status)
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
@@ -652,13 +652,13 @@ func (d *delegation) unBondNodes(args *vmcommon.ContractCallInput) vmcommon.Retu
 		d.eei.AddReturnMessage("not enough arguments")
 		return vmcommon.FunctionWrongSignature
 	}
-	dStatus, err := d.getDelegationStatus()
+	status, err := d.getDelegationStatus()
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
 	}
 
-	foundAll := verifyAllBLSKeysExist(dStatus.UnStakedKeys, args.Arguments)
+	foundAll := verifyAllBLSKeysExist(status.UnStakedKeys, args.Arguments)
 	if !foundAll {
 		d.eei.AddReturnMessage(vm.ErrBLSPublicKeyMismatch.Error())
 		return vmcommon.UserError
@@ -675,10 +675,10 @@ func (d *delegation) unBondNodes(args *vmcommon.ContractCallInput) vmcommon.Retu
 
 	successKeys, _ := getSuccessAndUnSuccessKeys(vmOutput.ReturnData, args.Arguments)
 	for _, successKey := range successKeys {
-		dStatus.UnStakedKeys, dStatus.NotStakedKeys = moveNodeFromList(dStatus.UnStakedKeys, dStatus.NotStakedKeys, successKey)
+		status.UnStakedKeys, status.NotStakedKeys = moveNodeFromList(status.UnStakedKeys, status.NotStakedKeys, successKey)
 	}
 
-	err = d.saveDelegationStatus(dStatus)
+	err = d.saveDelegationStatus(status)
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
@@ -711,7 +711,7 @@ func (d *delegation) unJailNodes(args *vmcommon.ContractCallInput) vmcommon.Retu
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.OutOfGas
 	}
-	dStatus, err := d.getDelegationStatus()
+	status, err := d.getDelegationStatus()
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
@@ -722,14 +722,14 @@ func (d *delegation) unJailNodes(args *vmcommon.ContractCallInput) vmcommon.Retu
 		return vmcommon.UserError
 	}
 
-	listToCheck := append(dStatus.StakedKeys, dStatus.UnStakedKeys...)
+	listToCheck := append(status.StakedKeys, status.UnStakedKeys...)
 	foundAll := verifyAllBLSKeysExist(listToCheck, args.Arguments)
 	if !foundAll {
 		d.eei.AddReturnMessage(vm.ErrBLSPublicKeyMismatch.Error())
 		return vmcommon.UserError
 	}
 
-	isDelegator := d.checkIfDelegator(dStatus, args.CallerAddr)
+	isDelegator := d.checkIfDelegator(status, args.CallerAddr)
 	if !isDelegator {
 		d.eei.AddReturnMessage("not a delegator")
 		return vmcommon.UserError
@@ -756,8 +756,8 @@ func (d *delegation) unJailNodes(args *vmcommon.ContractCallInput) vmcommon.Retu
 	return vmcommon.Ok
 }
 
-func (d *delegation) checkIfDelegator(dStatus *DelegationContractStatus, address []byte) bool {
-	for _, delegatorAddress := range dStatus.Delegators {
+func (d *delegation) checkIfDelegator(status *DelegationContractStatus, address []byte) bool {
+	for _, delegatorAddress := range status.Delegators {
 		if bytes.Equal(delegatorAddress, address) {
 			return true
 		}
@@ -776,7 +776,7 @@ func (d *delegation) delegate(args *vmcommon.ContractCallInput) vmcommon.ReturnC
 		return vmcommon.OutOfGas
 	}
 
-	dStatus, err := d.getDelegationStatus()
+	status, err := d.getDelegationStatus()
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
@@ -820,8 +820,8 @@ func (d *delegation) delegate(args *vmcommon.ContractCallInput) vmcommon.ReturnC
 			return vmcommon.UserError
 		}
 
-		dStatus.Delegators = append(dStatus.Delegators, args.CallerAddr)
-		err = d.saveDelegationStatus(dStatus)
+		status.Delegators = append(status.Delegators, args.CallerAddr)
+		err = d.saveDelegationStatus(status)
 		if err != nil {
 			d.eei.AddReturnMessage(err.Error())
 			return vmcommon.UserError
@@ -894,20 +894,20 @@ func (d *delegation) resolveUnStakedUnBondResponse(
 		return actualUserVal, remainingVal, nil
 	}
 
-	dStatus, err := d.getDelegationStatus()
+	status, err := d.getDelegationStatus()
 	if err != nil {
 		return nil, nil, err
 	}
 
 	for i := 0; i < lenReturnData-1; i++ {
 		if unStake {
-			dStatus.StakedKeys, dStatus.UnStakedKeys = moveNodeFromList(dStatus.StakedKeys, dStatus.UnStakedKeys, returnData[i])
+			status.StakedKeys, status.UnStakedKeys = moveNodeFromList(status.StakedKeys, status.UnStakedKeys, returnData[i])
 		} else {
-			dStatus.UnStakedKeys, dStatus.NotStakedKeys = moveNodeFromList(dStatus.UnStakedKeys, dStatus.NotStakedKeys, returnData[i])
+			status.UnStakedKeys, status.NotStakedKeys = moveNodeFromList(status.UnStakedKeys, status.NotStakedKeys, returnData[i])
 		}
 	}
 
-	err = d.saveDelegationStatus(dStatus)
+	err = d.saveDelegationStatus(status)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1224,22 +1224,22 @@ func (d *delegation) saveDelegationContractConfig(dConfig *DelegationConfig) err
 }
 
 func (d *delegation) getDelegationStatus() (*DelegationContractStatus, error) {
-	dStatus := &DelegationContractStatus{}
+	status := &DelegationContractStatus{}
 	marshaledData := d.eei.GetStorage([]byte(delegationStatusKey))
 	if len(marshaledData) == 0 {
 		return nil, fmt.Errorf("%w delegation status", vm.ErrDataNotFoundUnderKey)
 	}
 
-	err := d.marshalizer.Unmarshal(dStatus, marshaledData)
+	err := d.marshalizer.Unmarshal(status, marshaledData)
 	if err != nil {
 		return nil, err
 	}
 
-	return dStatus, nil
+	return status, nil
 }
 
-func (d *delegation) saveDelegationStatus(dStatus *DelegationContractStatus) error {
-	marshaledData, err := d.marshalizer.Marshal(dStatus)
+func (d *delegation) saveDelegationStatus(status *DelegationContractStatus) error {
+	marshaledData, err := d.marshalizer.Marshal(status)
 	if err != nil {
 		return err
 	}

--- a/vm/systemSmartContracts/eei.go
+++ b/vm/systemSmartContracts/eei.go
@@ -536,6 +536,21 @@ func (host *vmContext) IsValidator(blsKey []byte) bool {
 	return isValidator
 }
 
+// StatusFromValidatorStatistics returns the list in which the validator is present
+func (host *vmContext) StatusFromValidatorStatistics(blsKey []byte) string {
+	acc, err := host.validatorAccountsDB.GetExistingAccount(blsKey)
+	if err != nil {
+		return string(core.InactiveList)
+	}
+
+	validatorAccount, castOk := acc.(state.PeerAccountHandler)
+	if !castOk {
+		return string(core.InactiveList)
+	}
+
+	return validatorAccount.GetList()
+}
+
 // CanUnJail returns true if the validator is jailed in the validator statistics
 func (host *vmContext) CanUnJail(blsKey []byte) bool {
 	acc, err := host.validatorAccountsDB.GetExistingAccount(blsKey)


### PR DESCRIPTION
When a user stakes - those values must be sent to the auction smart contract to make a topup of the existing values.
When a user unDelegates -the auction smart contract has to be announced as well, with the required amount. If the required amount if bigger than the top-up value, the nodes must be unstaked as well.
When a user withdraws, the required amount must be undelegated from the auction smart contract, if the required amount is bigger than the available unstaked funds, nodes must be undonded as well.