### PR TITLE
EN-7932: add storer for epoch-root hash in import db mode

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -204,6 +204,19 @@
         MaxBatchSize = 100
         MaxOpenFiles = 10
 
+[TrieEpochRootHashStorage]
+    [TrieEpochRootHashStorage.Cache]
+        Name = "TrieEpochRootHashCache"
+        Capacity = 10
+        Type = "SizeLRU"
+        SizeInBytes = 5242 #5MB
+    [TrieEpochRootHashStorage.DB]
+        FilePath = "TrieEpochRootHashStorageDB"
+        Type = "LvlDBSerial"
+        BatchDelaySeconds = 2
+        MaxBatchSize = 20000
+        MaxOpenFiles = 10
+
 [ShardHdrNonceHashStorage]
     [ShardHdrNonceHashStorage.Cache]
         Name = "ShardHdrNonceHashStorage"

--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -906,6 +906,7 @@ func newStorageResolver(
 		pathManager,
 		manualEpochStartNotifier,
 		currentEpoch,
+		false,
 	)
 	if err != nil {
 		return nil, err

--- a/config/config.go
+++ b/config/config.go
@@ -107,6 +107,7 @@ type Config struct {
 	MetaHdrNonceHashStorage    StorageConfig
 	StatusMetricsStorage       StorageConfig
 	ReceiptsStorage            StorageConfig
+	TrieEpochRootHashStorage   StorageConfig
 
 	BootstrapStorage StorageConfig
 	MetaBlockStorage StorageConfig

--- a/dataRetriever/interface.go
+++ b/dataRetriever/interface.go
@@ -79,10 +79,12 @@ const (
 	MiniblocksMetadataUnit UnitType = 12
 	// EpochByHashUnit is the epoch by hash storage unit identifier
 	EpochByHashUnit UnitType = 13
-	// MiniblocksHashByTxHashUnit is the miniblocks hash by tx hash storage unit identifier
+	// MiniblockHashByTxHashUnit is the miniblocks hash by tx hash storage unit identifier
 	MiniblockHashByTxHashUnit UnitType = 14
 	// ReceiptsUnit is the receipts storage unit identifier
 	ReceiptsUnit UnitType = 15
+	// TrieEpochRootHashUnit is the trie epoch <-> root hash storage unit identifier
+	TrieEpochRootHashUnit UnitType = 16
 
 	// ShardHdrNonceHashDataUnit is the header nonce-hash pair data unit identifier
 	//TODO: Add only unit types lower than 100

--- a/epochStart/bootstrap/metaStorageHandler.go
+++ b/epochStart/bootstrap/metaStorageHandler.go
@@ -43,6 +43,7 @@ func NewMetaStorageHandler(
 		pathManagerHandler,
 		epochStartNotifier,
 		currentEpoch,
+		false,
 	)
 	if err != nil {
 		return nil, err

--- a/epochStart/bootstrap/shardStorageHandler.go
+++ b/epochStart/bootstrap/shardStorageHandler.go
@@ -44,6 +44,7 @@ func NewShardStorageHandler(
 		pathManagerHandler,
 		epochStartNotifier,
 		currentEpoch,
+		false,
 	)
 	if err != nil {
 		return nil, err

--- a/factory/dataComponents.go
+++ b/factory/dataComponents.go
@@ -18,23 +18,25 @@ import (
 
 // DataComponentsFactoryArgs holds the arguments needed for creating a data components factory
 type DataComponentsFactoryArgs struct {
-	Config             config.Config
-	EconomicsData      *economics.EconomicsData
-	ShardCoordinator   sharding.Coordinator
-	Core               *CoreComponents
-	PathManager        storage.PathManagerHandler
-	EpochStartNotifier EpochStartNotifier
-	CurrentEpoch       uint32
+	Config                        config.Config
+	EconomicsData                 *economics.EconomicsData
+	ShardCoordinator              sharding.Coordinator
+	Core                          *CoreComponents
+	PathManager                   storage.PathManagerHandler
+	EpochStartNotifier            EpochStartNotifier
+	CurrentEpoch                  uint32
+	CreateTrieEpochRootHashStorer bool
 }
 
 type dataComponentsFactory struct {
-	config             config.Config
-	economicsData      *economics.EconomicsData
-	shardCoordinator   sharding.Coordinator
-	core               *CoreComponents
-	pathManager        storage.PathManagerHandler
-	epochStartNotifier EpochStartNotifier
-	currentEpoch       uint32
+	config                        config.Config
+	economicsData                 *economics.EconomicsData
+	shardCoordinator              sharding.Coordinator
+	core                          *CoreComponents
+	pathManager                   storage.PathManagerHandler
+	epochStartNotifier            EpochStartNotifier
+	currentEpoch                  uint32
+	createTrieEpochRootHashStorer bool
 }
 
 // NewDataComponentsFactory will return a new instance of dataComponentsFactory
@@ -56,13 +58,14 @@ func NewDataComponentsFactory(args DataComponentsFactoryArgs) (*dataComponentsFa
 	}
 
 	return &dataComponentsFactory{
-		config:             args.Config,
-		economicsData:      args.EconomicsData,
-		shardCoordinator:   args.ShardCoordinator,
-		core:               args.Core,
-		pathManager:        args.PathManager,
-		epochStartNotifier: args.EpochStartNotifier,
-		currentEpoch:       args.CurrentEpoch,
+		config:                        args.Config,
+		economicsData:                 args.EconomicsData,
+		shardCoordinator:              args.ShardCoordinator,
+		core:                          args.Core,
+		pathManager:                   args.PathManager,
+		epochStartNotifier:            args.EpochStartNotifier,
+		currentEpoch:                  args.CurrentEpoch,
+		createTrieEpochRootHashStorer: args.CreateTrieEpochRootHashStorer,
 	}, nil
 }
 
@@ -127,6 +130,7 @@ func (dcf *dataComponentsFactory) createDataStoreFromConfig() (dataRetriever.Sto
 		dcf.pathManager,
 		dcf.epochStartNotifier,
 		dcf.currentEpoch,
+		dcf.createTrieEpochRootHashStorer,
 	)
 	if err != nil {
 		return nil, err

--- a/factory/dataComponents_test.go
+++ b/factory/dataComponents_test.go
@@ -121,12 +121,13 @@ func getDataArgs() factory.DataComponentsFactoryArgs {
 	testEconomics.SetMinGasPrice(200000000000)
 
 	return factory.DataComponentsFactoryArgs{
-		Config:             testscommon.GetGeneralConfig(),
-		EconomicsData:      testEconomics.EconomicsData,
-		ShardCoordinator:   mock.NewMultiShardsCoordinatorMock(2),
-		Core:               getCoreComponents(),
-		PathManager:        &mock.PathManagerStub{},
-		EpochStartNotifier: &mock.EpochStartNotifierStub{},
-		CurrentEpoch:       0,
+		Config:                        testscommon.GetGeneralConfig(),
+		EconomicsData:                 testEconomics.EconomicsData,
+		ShardCoordinator:              mock.NewMultiShardsCoordinatorMock(2),
+		Core:                          getCoreComponents(),
+		PathManager:                   &mock.PathManagerStub{},
+		EpochStartNotifier:            &mock.EpochStartNotifierStub{},
+		CurrentEpoch:                  0,
+		CreateTrieEpochRootHashStorer: false,
 	}
 }

--- a/integrationTests/multiShard/endOfEpoch/startInEpoch/startInEpoch_test.go
+++ b/integrationTests/multiShard/endOfEpoch/startInEpoch/startInEpoch_test.go
@@ -226,7 +226,9 @@ func testNodeStartsInEpoch(t *testing.T, shardID uint32, expectedHighestRound ui
 		shardC,
 		&mock.PathManagerStub{},
 		notifier.NewEpochStartSubscriptionHandler(),
-		0)
+		0,
+		false,
+	)
 	assert.NoError(t, err)
 	storageServiceShard, err := storageFactory.CreateForMeta()
 	assert.NoError(t, err)

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -1262,7 +1262,7 @@ func (bp *baseProcessor) commitTrieEpochRootHashIfNeeded(metaBlock *block.MetaBl
 	if err != nil {
 		return err
 	}
-	var epochBytes []byte
+	epochBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(epochBytes, metaBlock.Epoch)
 
 	err = trieEpochRootHashStorageUnit.Put(epochBytes, currentRootHash)

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/data/rewardTx"
 	"github.com/ElrondNetwork/elrond-go/data/state"
 	"github.com/ElrondNetwork/elrond-go/data/transaction"
+	"github.com/ElrondNetwork/elrond-go/data/typeConverters/uint64ByteSlice"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
@@ -29,6 +30,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func haveTime() time.Duration {
@@ -202,6 +204,7 @@ func initStore() *dataRetriever.ChainStorer {
 	store.AddStorer(dataRetriever.ShardHdrNonceHashDataUnit, generateTestUnit())
 	store.AddStorer(dataRetriever.MetaHdrNonceHashDataUnit, generateTestUnit())
 	store.AddStorer(dataRetriever.ReceiptsUnit, generateTestUnit())
+	store.AddStorer(dataRetriever.TrieEpochRootHashUnit, generateTestUnit())
 	return store
 }
 
@@ -1204,4 +1207,86 @@ func TestAddHeaderIntoTrackerPool_ShouldWork(t *testing.T) {
 	wasCalled = false
 	sp.AddHeaderIntoTrackerPool(nonce, shardID)
 	assert.True(t, wasCalled)
+}
+
+func TestBaseProcessor_commitTrieEpochRootHashIfNeededNilStorerShouldNotErr(t *testing.T) {
+	t.Parallel()
+
+	epoch := uint32(37)
+
+	arguments := CreateMockArguments()
+	store := dataRetriever.NewChainStorer()
+	arguments.Store = store
+	sp, _ := blproc.NewShardProcessor(arguments)
+
+	mb := &block.MetaBlock{Epoch: epoch}
+	err := sp.CommitTrieEpochRootHashIfNeeded(mb)
+	require.NoError(t, err)
+}
+
+func TestBaseProcessor_commitTrieEpochRootHashIfNeededDisabledStorerShouldNotErr(t *testing.T) {
+	t.Parallel()
+
+	epoch := uint32(37)
+
+	arguments := CreateMockArguments()
+	store := dataRetriever.NewChainStorer()
+	store.AddStorer(dataRetriever.TrieEpochRootHashUnit, &storageUnit.NilStorer{})
+	arguments.Store = store
+	sp, _ := blproc.NewShardProcessor(arguments)
+
+	mb := &block.MetaBlock{Epoch: epoch}
+	err := sp.CommitTrieEpochRootHashIfNeeded(mb)
+	require.NoError(t, err)
+}
+
+func TestBaseProcessor_commitTrieEpochRootHashIfNeededCannotFindUserAccountStateShouldErr(t *testing.T) {
+	t.Parallel()
+
+	epoch := uint32(37)
+
+	arguments := CreateMockArguments()
+	arguments.Uint64Converter = uint64ByteSlice.NewBigEndianConverter()
+	arguments.AccountsDB = map[state.AccountsDbIdentifier]state.AccountsAdapter{}
+
+	sp, _ := blproc.NewShardProcessor(arguments)
+
+	mb := &block.MetaBlock{Epoch: epoch}
+	err := sp.CommitTrieEpochRootHashIfNeeded(mb)
+	require.True(t, errors.Is(err, process.ErrNilAccountsAdapter))
+}
+
+func TestBaseProcessor_commitTrieEpochRootHashIfNeededShouldWork(t *testing.T) {
+	t.Parallel()
+
+	epoch := uint32(37)
+	rootHash := []byte("root-hash")
+
+	arguments := CreateMockArguments()
+	arguments.Uint64Converter = uint64ByteSlice.NewBigEndianConverter()
+	arguments.AccountsDB = map[state.AccountsDbIdentifier]state.AccountsAdapter{
+		state.UserAccountsState: &mock.AccountsStub{
+			RootHashCalled: func() ([]byte, error) {
+				return rootHash, nil
+			},
+		},
+	}
+
+	store := dataRetriever.NewChainStorer()
+	store.AddStorer(dataRetriever.TrieEpochRootHashUnit,
+		&mock.StorerStub{
+			PutCalled: func(key, data []byte) error {
+				restoredEpoch, err := arguments.Uint64Converter.ToUint64(key)
+				require.NoError(t, err)
+				require.Equal(t, epoch, uint32(restoredEpoch))
+				return nil
+			},
+		},
+	)
+	arguments.Store = store
+	sp, _ := blproc.NewShardProcessor(arguments)
+
+	mb := &block.MetaBlock{Epoch: epoch}
+	err := sp.CommitTrieEpochRootHashIfNeeded(mb)
+	require.NoError(t, err)
 }

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -40,6 +40,10 @@ func (bp *baseProcessor) RemoveHeadersBehindNonceFromPools(
 	bp.removeHeadersBehindNonceFromPools(shouldRemoveBlockBody, shardId, nonce)
 }
 
+func (bp *baseProcessor) CommitTrieEpochRootHashIfNeeded(metaBlock *block.MetaBlock) error {
+	return bp.commitTrieEpochRootHashIfNeeded(metaBlock)
+}
+
 func (sp *shardProcessor) ReceivedMetaBlock(header data.HeaderHandler, metaBlockHash []byte) {
 	sp.receivedMetaBlock(header, metaBlockHash)
 }

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -1349,6 +1349,12 @@ func (mp *metaProcessor) commitEpochStart(header *block.MetaBlock, body *block.B
 		mp.epochStartTrigger.SetProcessed(header, body)
 		go mp.epochRewardsCreator.SaveTxBlockToStorage(header, body)
 		go mp.validatorInfoCreator.SaveValidatorInfoBlocksToStorage(header, body)
+		go func() {
+			err := mp.commitTrieEpochRootHashIfNeeded(header)
+			if err != nil {
+				log.Warn("couldn't commit trie checkpoint", "epoch", header.Epoch, "error", err)
+			}
+		}()
 	} else {
 		currentHeader := mp.blockChain.GetCurrentBlockHeader()
 		if !check.IfNil(currentHeader) && currentHeader.IsStartOfEpochBlock() {

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -1040,6 +1040,12 @@ func (sp *shardProcessor) snapShotEpochStartFromMeta(header *block.Header) {
 			accounts.SnapshotState(rootHash)
 			saveEpochStartEconomicsMetrics(sp.appStatusHandler, metaHdr)
 		}
+		go func() {
+			err := sp.commitTrieEpochRootHashIfNeeded(metaHdr)
+			if err != nil {
+				log.Warn("couldn't commit trie checkpoint", "epoch", header.Epoch, "error", err)
+			}
+		}()
 	}
 }
 

--- a/storage/factory/pruningStorerFactory.go
+++ b/storage/factory/pruningStorerFactory.go
@@ -38,7 +38,7 @@ func NewStorageServiceFactory(
 	pathManager storage.PathManagerHandler,
 	epochStartNotifier storage.EpochStartNotifier,
 	currentEpoch uint32,
-	createTrieCheckPointsDBs bool,
+	createTrieEpochRootHashStorer bool,
 ) (*StorageServiceFactory, error) {
 	if config == nil {
 		return nil, storage.ErrNilConfig
@@ -65,7 +65,7 @@ func NewStorageServiceFactory(
 		pathManager:                   pathManager,
 		epochStartNotifier:            epochStartNotifier,
 		currentEpoch:                  currentEpoch,
-		createTrieEpochRootHashStorer: createTrieCheckPointsDBs,
+		createTrieEpochRootHashStorer: createTrieEpochRootHashStorer,
 	}, nil
 }
 

--- a/storage/factory/pruningStorerFactory.go
+++ b/storage/factory/pruningStorerFactory.go
@@ -23,11 +23,12 @@ const (
 
 // StorageServiceFactory handles the creation of storage services for both meta and shards
 type StorageServiceFactory struct {
-	generalConfig      *config.Config
-	shardCoordinator   storage.ShardCoordinator
-	pathManager        storage.PathManagerHandler
-	epochStartNotifier storage.EpochStartNotifier
-	currentEpoch       uint32
+	generalConfig                 *config.Config
+	shardCoordinator              storage.ShardCoordinator
+	pathManager                   storage.PathManagerHandler
+	epochStartNotifier            storage.EpochStartNotifier
+	createTrieEpochRootHashStorer bool
+	currentEpoch                  uint32
 }
 
 // NewStorageServiceFactory will return a new instance of StorageServiceFactory
@@ -37,6 +38,7 @@ func NewStorageServiceFactory(
 	pathManager storage.PathManagerHandler,
 	epochStartNotifier storage.EpochStartNotifier,
 	currentEpoch uint32,
+	createTrieCheckPointsDBs bool,
 ) (*StorageServiceFactory, error) {
 	if config == nil {
 		return nil, storage.ErrNilConfig
@@ -58,11 +60,12 @@ func NewStorageServiceFactory(
 	}
 
 	return &StorageServiceFactory{
-		generalConfig:      config,
-		shardCoordinator:   shardCoordinator,
-		pathManager:        pathManager,
-		epochStartNotifier: epochStartNotifier,
-		currentEpoch:       currentEpoch,
+		generalConfig:                 config,
+		shardCoordinator:              shardCoordinator,
+		pathManager:                   pathManager,
+		epochStartNotifier:            epochStartNotifier,
+		currentEpoch:                  currentEpoch,
+		createTrieEpochRootHashStorer: createTrieCheckPointsDBs,
 	}, nil
 }
 
@@ -193,6 +196,12 @@ func (psf *StorageServiceFactory) CreateForShard() (dataRetriever.StorageService
 	}
 	successfullyCreatedStorers = append(successfullyCreatedStorers, statusMetricsStorageUnit)
 
+	trieEpochRootHashStorageUnit, err := psf.createTrieEpochRootHashStorerIfNeeded()
+	if err != nil {
+		return nil, err
+	}
+	successfullyCreatedStorers = append(successfullyCreatedStorers, trieEpochRootHashStorageUnit)
+
 	bootstrapUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.BootstrapStorage)
 	bootstrapUnit, err = pruning.NewPruningStorer(bootstrapUnitArgs)
 	if err != nil {
@@ -230,6 +239,7 @@ func (psf *StorageServiceFactory) CreateForShard() (dataRetriever.StorageService
 	store.AddStorer(dataRetriever.StatusMetricsUnit, statusMetricsStorageUnit)
 	store.AddStorer(dataRetriever.TxLogsUnit, txLogsUnit)
 	store.AddStorer(dataRetriever.ReceiptsUnit, receiptsUnit)
+	store.AddStorer(dataRetriever.TrieEpochRootHashUnit, trieEpochRootHashStorageUnit)
 
 	err = psf.setupDbLookupExtensions(store, &successfullyCreatedStorers)
 	if err != nil {
@@ -335,6 +345,12 @@ func (psf *StorageServiceFactory) CreateForMeta() (dataRetriever.StorageService,
 	}
 	successfullyCreatedStorers = append(successfullyCreatedStorers, statusMetricsStorageUnit)
 
+	trieEpochRootHashStorageUnit, err := psf.createTrieEpochRootHashStorerIfNeeded()
+	if err != nil {
+		return nil, err
+	}
+	successfullyCreatedStorers = append(successfullyCreatedStorers, trieEpochRootHashStorageUnit)
+
 	txUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.TxStorage)
 	txUnit, err = pruning.NewPruningStorer(txUnitArgs)
 	if err != nil {
@@ -401,6 +417,7 @@ func (psf *StorageServiceFactory) CreateForMeta() (dataRetriever.StorageService,
 	store.AddStorer(dataRetriever.StatusMetricsUnit, statusMetricsStorageUnit)
 	store.AddStorer(dataRetriever.TxLogsUnit, txLogsUnit)
 	store.AddStorer(dataRetriever.ReceiptsUnit, receiptsUnit)
+	store.AddStorer(dataRetriever.TrieEpochRootHashUnit, trieEpochRootHashStorageUnit)
 
 	err = psf.setupDbLookupExtensions(store, &successfullyCreatedStorers)
 	if err != nil {
@@ -485,4 +502,24 @@ func (psf *StorageServiceFactory) createPruningStorerArgs(storageConfig config.S
 	}
 
 	return args
+}
+
+func (psf *StorageServiceFactory) createTrieEpochRootHashStorerIfNeeded() (storage.Storer, error) {
+	if !psf.createTrieEpochRootHashStorer {
+		return storageUnit.NewNilStorer(), nil
+	}
+
+	trieEpochRootHashDbConfig := GetDBFromConfig(psf.generalConfig.TrieEpochRootHashStorage.DB)
+	shardId := core.GetShardIDString(psf.shardCoordinator.SelfId())
+	dbPath := psf.pathManager.PathForStatic(shardId, psf.generalConfig.TrieEpochRootHashStorage.DB.FilePath)
+	trieEpochRootHashDbConfig.FilePath = dbPath
+	trieEpochRootHashStorageUnit, err := storageUnit.NewStorageUnitFromConf(
+		GetCacherFromConfig(psf.generalConfig.TrieEpochRootHashStorage.Cache),
+		trieEpochRootHashDbConfig,
+		GetBloomFromConfig(psf.generalConfig.TrieEpochRootHashStorage.Bloom))
+	if err != nil {
+		return nil, err
+	}
+
+	return trieEpochRootHashStorageUnit, nil
 }

--- a/storage/storageUnit/nilStorer.go
+++ b/storage/storageUnit/nilStorer.go
@@ -1,77 +1,78 @@
 package storageUnit
 
-type nilStorer struct {
+// NilStorer resembles a disabled implementation of the Storer interface
+type NilStorer struct {
 }
 
 // NewNilStorer will return a nil storer
-func NewNilStorer() *nilStorer {
-	return new(nilStorer)
+func NewNilStorer() *NilStorer {
+	return new(NilStorer)
 }
 
 // GetFromEpoch will do nothing
-func (ns *nilStorer) GetFromEpoch(_ []byte, _ uint32) ([]byte, error) {
+func (ns *NilStorer) GetFromEpoch(_ []byte, _ uint32) ([]byte, error) {
 	return nil, nil
 }
 
 // GetBulkFromEpoch will do nothing
-func (ns *nilStorer) GetBulkFromEpoch(_ [][]byte, _ uint32) (map[string][]byte, error) {
+func (ns *NilStorer) GetBulkFromEpoch(_ [][]byte, _ uint32) (map[string][]byte, error) {
 	return nil, nil
 }
 
 // HasInEpoch will do nothing
-func (ns *nilStorer) HasInEpoch(_ []byte, _ uint32) error {
+func (ns *NilStorer) HasInEpoch(_ []byte, _ uint32) error {
 	return nil
 }
 
 // SearchFirst will do nothing
-func (ns *nilStorer) SearchFirst(_ []byte) ([]byte, error) {
+func (ns *NilStorer) SearchFirst(_ []byte) ([]byte, error) {
 	return nil, nil
 }
 
 // Put will do nothing
-func (ns *nilStorer) Put(_, _ []byte) error {
+func (ns *NilStorer) Put(_, _ []byte) error {
 	return nil
 }
 
 // PutInEpoch will do nothing
-func (ns *nilStorer) PutInEpoch(key, data []byte, _ uint32) error {
+func (ns *NilStorer) PutInEpoch(_, _ []byte, _ uint32) error {
 	return nil
 }
 
 // Close will do nothing
-func (ns *nilStorer) Close() error {
+func (ns *NilStorer) Close() error {
 	return nil
 }
 
 // Get will do nothing
-func (ns *nilStorer) Get(_ []byte) ([]byte, error) {
+func (ns *NilStorer) Get(_ []byte) ([]byte, error) {
 	return nil, nil
 }
 
 // Has will do nothing
-func (ns *nilStorer) Has(_ []byte) error {
+func (ns *NilStorer) Has(_ []byte) error {
 	return nil
 }
 
 // Remove will do nothing
-func (ns *nilStorer) Remove(_ []byte) error {
+func (ns *NilStorer) Remove(_ []byte) error {
 	return nil
 }
 
 // ClearCache will do nothing
-func (ns *nilStorer) ClearCache() {
+func (ns *NilStorer) ClearCache() {
 }
 
 // DestroyUnit will do nothing
-func (ns *nilStorer) DestroyUnit() error {
+func (ns *NilStorer) DestroyUnit() error {
 	return nil
 }
 
 // RangeKeys does nothing
-func (ns *nilStorer) RangeKeys(_ func(key []byte, val []byte) bool) {
+func (ns *NilStorer) RangeKeys(_ func(key []byte, val []byte) bool) {
 }
 
 // IsInterfaceNil returns true if there is no value under the interface
-func (ns *nilStorer) IsInterfaceNil() bool {
+func (ns *NilStorer) IsInterfaceNil() bool {
 	return ns == nil
 }


### PR DESCRIPTION
Added a new storer for `import-db` mode that will hold the `epoch` - `root hash` pairs related to tries snapshots. Based on this, we will be able to re-load the trie state at each end of epoch