### PR TITLE
Fix import-DB for the testnet edge case

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -1520,12 +1520,14 @@ func applyCompatibleConfigs(isInImportMode bool, importDbNoSigCheckFlag bool, lo
 		log.Warn("the node is in import mode! Will auto-set some config values",
 			"GeneralSettings.StartInEpochEnabled", "false",
 			"StateTriesConfig.CheckpointRoundsModulus", importCheckpointRoundsModulus,
+			"StoragePruning.NumActivePersisters", config.StoragePruning.NumEpochsToKeep,
 			"p2p.ThresholdMinConnectedPeers", 0,
 			"no sig check", importDbNoSigCheckFlag,
 			"heartbeat sender", "off",
 		)
 		config.GeneralSettings.StartInEpochEnabled = false
 		config.StateTriesConfig.CheckpointRoundsModulus = importCheckpointRoundsModulus
+		config.StoragePruning.NumActivePersisters = config.StoragePruning.NumEpochsToKeep
 		p2pConfig.Node.ThresholdMinConnectedPeers = 0
 		config.Heartbeat.DurationToConsiderUnresponsiveInSec = math.MaxInt32
 		config.Heartbeat.MinTimeToWaitBetweenBroadcastsInSec = math.MaxInt32 - 2

--- a/dataRetriever/storageResolvers/headerResolver.go
+++ b/dataRetriever/storageResolvers/headerResolver.go
@@ -79,7 +79,7 @@ func (hdrRes *headerResolver) RequestDataFromHash(hash []byte, _ uint32) error {
 	metaEpoch := hdrRes.epochHandler.MetaEpoch()
 	hdrRes.mutEpochHandler.RUnlock()
 
-	hdrRes.manualEpochStartNotifier.NewEpoch(metaEpoch + 1)
+	hdrRes.manualEpochStartNotifier.NewEpoch(metaEpoch + 2)
 
 	buff, err := hdrRes.hdrStorage.SearchFirst(hash)
 	if err != nil {


### PR DESCRIPTION
This PR fixes the edge case found in testnet when a shard stopped including metaheaders for 2 epochs

- made the storage resolvers open 2 epochs in advance. Also, the maximum active persisters value is set to the maximum value it can hold (config.StoragePruning.NumEpochsToKeep) in import-db mode