### PR TITLE
Elastic search will not index sender transactions in import db mode

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -1204,7 +1204,8 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		epochStartNotifier,
 		addressPubkeyConverter,
 		validatorPubkeyConverter,
-		shardCoordinator.SelfId(),
+		shardCoordinator,
+		isInImportMode,
 	)
 	if err != nil {
 		return err
@@ -1995,7 +1996,8 @@ func createElasticIndexer(
 	startNotifier notifier.EpochStartNotifier,
 	addressPubkeyConverter core.PubkeyConverter,
 	validatorPubkeyConverter core.PubkeyConverter,
-	shardId uint32,
+	shardCoordinator storage.ShardCoordinator,
+	isInImportDB bool,
 ) (indexer.Indexer, error) {
 
 	if !elasticSearchConfig.Enabled {
@@ -2015,7 +2017,8 @@ func createElasticIndexer(
 		EpochStartNotifier:       startNotifier,
 		AddressPubkeyConverter:   addressPubkeyConverter,
 		ValidatorPubkeyConverter: validatorPubkeyConverter,
-		ShardId:                  shardId,
+		ShardCoordinator:         shardCoordinator,
+		IsInImportDBMode:         isInImportDB,
 	}
 
 	return indexer.NewElasticIndexer(arguments)

--- a/core/errors.go
+++ b/core/errors.go
@@ -79,3 +79,6 @@ var ErrInvalidLogFileMinLifeSpan = errors.New("minimum log file life span is inv
 
 // ErrFileLoggingProcessIsClosed signals that the file logging process is closed
 var ErrFileLoggingProcessIsClosed = errors.New("file logging process is closed")
+
+// ErrNilShardCoordinator signals that a nil shard coordinator was provided
+var ErrNilShardCoordinator = errors.New("nil shard coordinator")

--- a/core/indexer/common.go
+++ b/core/indexer/common.go
@@ -55,6 +55,9 @@ func checkElasticSearchParams(arguments ElasticIndexerArgs) error {
 	if arguments.EpochStartNotifier == nil {
 		return core.ErrNilEpochStartNotifier
 	}
+	if check.IfNil(arguments.ShardCoordinator) {
+		return core.ErrNilShardCoordinator
+	}
 
 	return nil
 }

--- a/core/indexer/elasticsearch.go
+++ b/core/indexer/elasticsearch.go
@@ -26,7 +26,6 @@ type Options struct {
 
 //ElasticIndexerArgs is struct that is used to store all components that are needed to create a indexer
 type ElasticIndexerArgs struct {
-	ShardId                  uint32
 	Url                      string
 	UserName                 string
 	Password                 string
@@ -37,6 +36,8 @@ type ElasticIndexerArgs struct {
 	AddressPubkeyConverter   core.PubkeyConverter
 	ValidatorPubkeyConverter core.PubkeyConverter
 	Options                  *Options
+	ShardCoordinator         sharding.Coordinator
+	IsInImportDBMode         bool
 }
 
 type elasticIndexer struct {
@@ -63,6 +64,8 @@ func NewElasticIndexer(arguments ElasticIndexerArgs) (Indexer, error) {
 		Password:                 arguments.Password,
 		Marshalizer:              arguments.Marshalizer,
 		Hasher:                   arguments.Hasher,
+		IsInImportDBMode:         arguments.IsInImportDBMode,
+		ShardCoordinator:         arguments.ShardCoordinator,
 	}
 	client, err := NewElasticSearchDatabase(databaseArguments)
 	if err != nil {
@@ -77,7 +80,7 @@ func NewElasticIndexer(arguments ElasticIndexerArgs) (Indexer, error) {
 		isNilIndexer: false,
 	}
 
-	if arguments.ShardId == core.MetachainShardId {
+	if arguments.ShardCoordinator.SelfId() == core.MetachainShardId {
 		arguments.EpochStartNotifier.RegisterHandler(indexer.epochStartEventHandler())
 	}
 

--- a/core/indexer/elasticsearchDatabase.go
+++ b/core/indexer/elasticsearchDatabase.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/sharding"
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 )
@@ -28,14 +29,18 @@ type ElasticSearchDatabaseArgs struct {
 	Hasher                   hashing.Hasher
 	AddressPubkeyConverter   core.PubkeyConverter
 	ValidatorPubkeyConverter core.PubkeyConverter
+	IsInImportDBMode         bool
+	ShardCoordinator         sharding.Coordinator
 }
 
 // elasticSearchDatabase object it contains business logic built over databaseWriterHandler glue code wrapper
 type elasticSearchDatabase struct {
 	*txDatabaseProcessor
-	dbClient    databaseClientHandler
-	marshalizer marshal.Marshalizer
-	hasher      hashing.Hasher
+	dbClient         databaseClientHandler
+	marshalizer      marshal.Marshalizer
+	hasher           hashing.Hasher
+	isInImportDBMode bool
+	shardCoordinator sharding.Coordinator
 }
 
 // NewElasticSearchDatabase is method that will create a new elastic search dbClient
@@ -60,6 +65,8 @@ func NewElasticSearchDatabase(arguments ElasticSearchDatabaseArgs) (*elasticSear
 		arguments.Marshalizer,
 		arguments.AddressPubkeyConverter,
 		arguments.ValidatorPubkeyConverter,
+		arguments.ShardCoordinator,
+		arguments.IsInImportDBMode,
 	)
 
 	err = esdb.createIndexes()
@@ -464,4 +471,3 @@ func (esd *elasticSearchDatabase) computeBlockSearchOrder(header data.HeaderHand
 
 	return uint32(order)
 }
-

--- a/core/indexer/elasticsearchDatabase_test.go
+++ b/core/indexer/elasticsearchDatabase_test.go
@@ -37,6 +37,8 @@ func newTestElasticSearchDatabase(elasticsearchWriter databaseClientHandler, arg
 			arguments.Marshalizer,
 			arguments.AddressPubkeyConverter,
 			arguments.ValidatorPubkeyConverter,
+			nil,
+			false,
 		),
 		dbClient:    elasticsearchWriter,
 		marshalizer: arguments.Marshalizer,

--- a/core/indexer/elasticsearch_test.go
+++ b/core/indexer/elasticsearch_test.go
@@ -46,6 +46,8 @@ func NewElasticIndexerArguments() indexer.ElasticIndexerArgs {
 		EpochStartNotifier:       &mock.EpochStartNotifierStub{},
 		AddressPubkeyConverter:   mock.NewPubkeyConverterMock(32),
 		ValidatorPubkeyConverter: mock.NewPubkeyConverterMock(96),
+		ShardCoordinator:         &mock.ShardCoordinatorMock{},
+		IsInImportDBMode:         false,
 	}
 }
 
@@ -266,7 +268,9 @@ func TestElasticIndexer_EpochChange(t *testing.T) {
 	arguments := NewElasticIndexerArguments()
 	arguments.Url = ts.URL
 	arguments.Marshalizer = &mock.MarshalizerMock{Fail: true}
-	arguments.ShardId = core.MetachainShardId
+	scm := &mock.ShardCoordinatorMock{}
+	scm.SetSelfId(core.MetachainShardId)
+	arguments.ShardCoordinator = scm
 	epochChangeNotifier := &mock.EpochStartNotifierStub{}
 	arguments.EpochStartNotifier = epochChangeNotifier
 
@@ -303,7 +307,9 @@ func TestElasticIndexer_EpochChangeValidators(t *testing.T) {
 	arguments := NewElasticIndexerArguments()
 	arguments.Url = ts.URL
 	arguments.Marshalizer = &mock.MarshalizerMock{Fail: true}
-	arguments.ShardId = core.MetachainShardId
+	scm := &mock.ShardCoordinatorMock{}
+	scm.SetSelfId(core.MetachainShardId)
+	arguments.ShardCoordinator = scm
 	epochChangeNotifier := &mock.EpochStartNotifierStub{}
 	arguments.EpochStartNotifier = epochChangeNotifier
 

--- a/core/indexer/processTransactions_test.go
+++ b/core/indexer/processTransactions_test.go
@@ -123,6 +123,8 @@ func TestPrepareTransactionsForDatabase(t *testing.T) {
 		&mock.MarshalizerMock{},
 		&mock.PubkeyConverterMock{},
 		&mock.PubkeyConverterMock{},
+		nil,
+		false,
 	)
 
 	transactions := txDbProc.prepareTransactionsForDatabase(body, header, txPool, 0)
@@ -138,6 +140,8 @@ func TestPrepareTxLog(t *testing.T) {
 		&mock.MarshalizerMock{},
 		&mock.PubkeyConverterMock{},
 		&mock.PubkeyConverterMock{},
+		nil,
+		false,
 	)
 
 	scAddr := []byte("addr")
@@ -226,6 +230,8 @@ func TestRelayedTransactions(t *testing.T) {
 		&mock.MarshalizerMock{},
 		&mock.PubkeyConverterMock{},
 		&mock.PubkeyConverterMock{},
+		nil,
+		false,
 	)
 
 	transactions := txDbProc.prepareTransactionsForDatabase(body, header, txPool, 0)
@@ -252,6 +258,8 @@ func TestSetTransactionSearchOrder(t *testing.T) {
 		&mock.MarshalizerMock{},
 		&mock.PubkeyConverterMock{},
 		&mock.PubkeyConverterMock{},
+		nil,
+		false,
 	)
 
 	transactions := txDbProc.setTransactionSearchOrder(txPool, 0)

--- a/core/mock/shardCoordinatorMock.go
+++ b/core/mock/shardCoordinatorMock.go
@@ -6,35 +6,36 @@ import (
 
 // ShardCoordinatorMock -
 type ShardCoordinatorMock struct {
+	selfId uint32
 }
 
 // NumberOfShards -
-func (scm ShardCoordinatorMock) NumberOfShards() uint32 {
+func (scm *ShardCoordinatorMock) NumberOfShards() uint32 {
 	panic("implement me")
 }
 
 // ComputeId -
-func (scm ShardCoordinatorMock) ComputeId(_ []byte) uint32 {
+func (scm *ShardCoordinatorMock) ComputeId(_ []byte) uint32 {
 	panic("implement me")
 }
 
 // SetSelfId -
-func (scm ShardCoordinatorMock) SetSelfId(_ uint32) error {
-	panic("implement me")
+func (scm *ShardCoordinatorMock) SetSelfId(selfId uint32) {
+	scm.selfId = selfId
 }
 
 // SelfId -
-func (scm ShardCoordinatorMock) SelfId() uint32 {
-	return 0
+func (scm *ShardCoordinatorMock) SelfId() uint32 {
+	return scm.selfId
 }
 
 // SameShard -
-func (scm ShardCoordinatorMock) SameShard(_, _ []byte) bool {
+func (scm *ShardCoordinatorMock) SameShard(_, _ []byte) bool {
 	return true
 }
 
 // CommunicationIdentifier -
-func (scm ShardCoordinatorMock) CommunicationIdentifier(destShardID uint32) string {
+func (scm *ShardCoordinatorMock) CommunicationIdentifier(destShardID uint32) string {
 	if destShardID == core.MetachainShardId {
 		return "_0_META"
 	}
@@ -43,6 +44,6 @@ func (scm ShardCoordinatorMock) CommunicationIdentifier(destShardID uint32) stri
 }
 
 // IsInterfaceNil returns true if there is no value under the interface
-func (scm ShardCoordinatorMock) IsInterfaceNil() bool {
-	return false
+func (scm *ShardCoordinatorMock) IsInterfaceNil() bool {
+	return scm == nil
 }


### PR DESCRIPTION
- made the elastic search not index transactions if the node is node in the destination shard when running in import-db