### PR TITLE
epochStart: rewards computation edgecase fix

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -2054,6 +2054,7 @@ func newMetaBlockProcessor(
 		DataPool:                      data.Datapool,
 		ProtocolSustainabilityAddress: economicsData.ProtocolSustainabilityAddress(),
 		NodesConfigProvider:           nodesCoordinator,
+		RewardsFix1EpochEnable:        generalSettingsConfig.SwitchJailWaitingEnableEpoch,
 	}
 	epochRewards, err := metachainEpochStart.NewEpochStartRewardsCreator(argsEpochRewards)
 	if err != nil {

--- a/epochStart/metachain/rewards.go
+++ b/epochStart/metachain/rewards.go
@@ -39,6 +39,8 @@ type ArgsNewRewardsCreator struct {
 	DataPool                      dataRetriever.PoolsHolder
 	ProtocolSustainabilityAddress string
 	NodesConfigProvider           epochStart.NodesConfigProvider
+	// this fixes the situation where a node has 0 proposed blocks and 0 validator failures
+	// but does not receive rewards.
 	RewardsFix1EpochEnable        uint32
 }
 

--- a/epochStart/metachain/rewards.go
+++ b/epochStart/metachain/rewards.go
@@ -264,7 +264,7 @@ func (rc *rewardsCreator) computeValidatorInfoPerRewardAddress(
 			rewardsPerBlockPerNodeForShard := rc.mapRewardsPerBlockPerValidator[validatorInfo.ShardId]
 			protocolRewardValue := big.NewInt(0).Mul(rewardsPerBlockPerNodeForShard, big.NewInt(0).SetUint64(uint64(validatorInfo.NumSelectedInSuccessBlocks)))
 
-			if validatorInfo.LeaderSuccess == 0 && validatorInfo.ValidatorFailure == 0 {
+			if validatorInfo.LeaderSuccess == 0 && validatorInfo.ValidatorSuccess == 0 {
 				protocolSustainabilityRwd.Value.Add(protocolSustainabilityRwd.Value, protocolRewardValue)
 				continue
 			}

--- a/epochStart/metachain/rewards_test.go
+++ b/epochStart/metachain/rewards_test.go
@@ -1,9 +1,10 @@
 package metachain
 
 import (
-	"github.com/ElrondNetwork/elrond-go/vm"
 	"math/big"
 	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/vm"
 
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
@@ -569,7 +570,7 @@ func TestRewardsCreator_ProtocolRewardsForValidatorFromMultipleShards(t *testing
 	}
 
 	rwdc.fillRewardsPerBlockPerNode(&mb.EpochStart.Economics)
-	rwdInfoData := rwdc.computeValidatorInfoPerRewardAddress(valInfo, &rewardTx.RewardTx{})
+	rwdInfoData := rwdc.computeValidatorInfoPerRewardAddress(valInfo, &rewardTx.RewardTx{}, 0)
 	assert.Equal(t, 1, len(rwdInfoData))
 	rwdInfo := rwdInfoData[pubkey]
 	assert.Equal(t, rwdInfo.address, pubkey)
@@ -692,5 +693,6 @@ func getRewardsArguments() ArgsNewRewardsCreator {
 		DataPool:                      testscommon.NewPoolsHolderStub(),
 		ProtocolSustainabilityAddress: "11", // string hex => 17 decimal
 		NodesConfigProvider:           &mock.NodesCoordinatorStub{},
+		RewardsFix1EpochEnable:        0,
 	}
 }


### PR DESCRIPTION
there is an edge case in rewards distribution which is not treated correctly:
if an eligible node is not selected at all the entire epoch as block producer but participates in signing all the blocks it is assigned in consensus group and all those blocks end up in the canonical blockchain, then the node will not receive any rewards for that particular epoch, although it should have received.

this PR fixes this.
