### PR TITLE
Fix waiting all signatures edge case after NTP sync

### DIFF
--- a/consensus/spos/bls/subroundSignature.go
+++ b/consensus/spos/bls/subroundSignature.go
@@ -216,9 +216,8 @@ func (sr *subroundSignature) doSignatureConsensusCheck() bool {
 
 	areSignaturesCollected, numSigs := sr.areSignaturesCollected(threshold)
 	areAllSignaturesCollected := numSigs == sr.ConsensusGroupSize()
-	isTimeOut := sr.remainingTime() <= 0
 
-	isJobDoneByLeader := isSelfLeader && (areAllSignaturesCollected || (areSignaturesCollected && isTimeOut))
+	isJobDoneByLeader := isSelfLeader && (areAllSignaturesCollected || (areSignaturesCollected && sr.WaitingAllSignaturesTimeOut))
 	isJobDoneByConsensusNode := !isSelfLeader && isSelfInConsensusGroup && sr.IsSelfJobDone(sr.Current())
 
 	isSubroundFinished := !isSelfInConsensusGroup || isJobDoneByConsensusNode || isJobDoneByLeader
@@ -279,6 +278,8 @@ func (sr *subroundSignature) waitAllSignatures() {
 	if sr.IsSubroundFinished(sr.Current()) {
 		return
 	}
+
+	sr.WaitingAllSignaturesTimeOut = true
 
 	select {
 	case sr.ConsensusChannel() <- true:

--- a/consensus/spos/bls/subroundSignature_test.go
+++ b/consensus/spos/bls/subroundSignature_test.go
@@ -2,7 +2,6 @@ package bls_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/ElrondNetwork/elrond-go/consensus"
 	"github.com/ElrondNetwork/elrond-go/consensus/mock"
@@ -411,12 +410,8 @@ func TestSubroundSignature_DoSignatureConsensusCheckShouldReturnFalseWhenNotAllS
 	t.Parallel()
 
 	container := mock.InitConsensusCore()
-	container.SetRounder(&mock.RounderMock{
-		RemainingTimeCalled: func(startTime time.Time, maxTime time.Duration) time.Duration {
-			return 1
-		},
-	})
 	sr := *initSubroundSignatureWithContainer(container)
+	sr.WaitingAllSignaturesTimeOut = false
 
 	sr.SetSelfPubKey(sr.ConsensusGroup()[0])
 
@@ -431,12 +426,8 @@ func TestSubroundSignature_DoSignatureConsensusCheckShouldReturnTrueWhenAllSigna
 	t.Parallel()
 
 	container := mock.InitConsensusCore()
-	container.SetRounder(&mock.RounderMock{
-		RemainingTimeCalled: func(startTime time.Time, maxTime time.Duration) time.Duration {
-			return 1
-		},
-	})
 	sr := *initSubroundSignatureWithContainer(container)
+	sr.WaitingAllSignaturesTimeOut = false
 
 	sr.SetSelfPubKey(sr.ConsensusGroup()[0])
 
@@ -451,12 +442,8 @@ func TestSubroundSignature_DoSignatureConsensusCheckShouldReturnTrueWhenEnoughBu
 	t.Parallel()
 
 	container := mock.InitConsensusCore()
-	container.SetRounder(&mock.RounderMock{
-		RemainingTimeCalled: func(startTime time.Time, maxTime time.Duration) time.Duration {
-			return -1
-		},
-	})
 	sr := *initSubroundSignatureWithContainer(container)
+	sr.WaitingAllSignaturesTimeOut = true
 
 	sr.SetSelfPubKey(sr.ConsensusGroup()[0])
 
@@ -471,17 +458,13 @@ func TestSubroundSignature_DoSignatureConsensusCheckShouldReturnFalseWhenFallbac
 	t.Parallel()
 
 	container := mock.InitConsensusCore()
-	container.SetRounder(&mock.RounderMock{
-		RemainingTimeCalled: func(startTime time.Time, maxTime time.Duration) time.Duration {
-			return -1
-		},
-	})
 	container.SetFallbackHeaderValidator(&testscommon.FallBackHeaderValidatorStub{
 		ShouldApplyFallbackValidationCalled: func(headerHandler data.HeaderHandler) bool {
 			return false
 		},
 	})
 	sr := *initSubroundSignatureWithContainer(container)
+	sr.WaitingAllSignaturesTimeOut = false
 
 	sr.SetSelfPubKey(sr.ConsensusGroup()[0])
 
@@ -496,17 +479,13 @@ func TestSubroundSignature_DoSignatureConsensusCheckShouldReturnTrueWhenFallback
 	t.Parallel()
 
 	container := mock.InitConsensusCore()
-	container.SetRounder(&mock.RounderMock{
-		RemainingTimeCalled: func(startTime time.Time, maxTime time.Duration) time.Duration {
-			return -1
-		},
-	})
 	container.SetFallbackHeaderValidator(&testscommon.FallBackHeaderValidatorStub{
 		ShouldApplyFallbackValidationCalled: func(headerHandler data.HeaderHandler) bool {
 			return true
 		},
 	})
 	sr := *initSubroundSignatureWithContainer(container)
+	sr.WaitingAllSignaturesTimeOut = true
 
 	sr.SetSelfPubKey(sr.ConsensusGroup()[0])
 

--- a/consensus/spos/consensusState.go
+++ b/consensus/spos/consensusState.go
@@ -24,10 +24,11 @@ type ConsensusState struct {
 	receivedHeaders    []data.HeaderHandler
 	mutReceivedHeaders sync.RWMutex
 
-	RoundIndex     int64
-	RoundTimeStamp time.Time
-	RoundCanceled  bool
-	ExtendedCalled bool
+	RoundIndex                  int64
+	RoundTimeStamp              time.Time
+	RoundCanceled               bool
+	ExtendedCalled              bool
+	WaitingAllSignaturesTimeOut bool
 
 	processingBlock    bool
 	mutProcessingBlock sync.RWMutex
@@ -65,6 +66,7 @@ func (cns *ConsensusState) ResetConsensusState() {
 
 	cns.RoundCanceled = false
 	cns.ExtendedCalled = false
+	cns.WaitingAllSignaturesTimeOut = false
 
 	cns.ResetRoundStatus()
 	cns.ResetRoundState()

--- a/consensus/spos/consensusState_test.go
+++ b/consensus/spos/consensusState_test.go
@@ -60,8 +60,12 @@ func TestConsensusState_ResetConsensusStateShouldWork(t *testing.T) {
 
 	cns := internalInitConsensusState()
 	cns.RoundCanceled = true
+	cns.ExtendedCalled = true
+	cns.WaitingAllSignaturesTimeOut = true
 	cns.ResetConsensusState()
 	assert.False(t, cns.RoundCanceled)
+	assert.False(t, cns.ExtendedCalled)
+	assert.False(t, cns.WaitingAllSignaturesTimeOut)
 }
 
 func TestConsensusState_IsNodeLeaderInCurrentRoundShouldReturnFalseWhenGetLeaderErr(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ElrondNetwork/concurrent-map v0.1.3
 	github.com/ElrondNetwork/elrond-go-logger v1.0.4
 	github.com/ElrondNetwork/elrond-vm-common v0.3.0
-	github.com/beevik/ntp v0.2.0
+	github.com/beevik/ntp v0.3.0
 	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -40,10 +40,10 @@ github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrU
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/aws/aws-sdk-go v1.33.5 h1:p2fr1ryvNTU6avUWLI+/H7FGv0TBIjzVM5WDgXBBv4U=
-github.com/aws/aws-sdk-go v1.33.5/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beevik/ntp v0.2.0 h1:sGsd+kAXzT0bfVfzJfce04g+dSRfrs+tbQW8lweuYgw=
 github.com/beevik/ntp v0.2.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
+github.com/beevik/ntp v0.3.0 h1:xzVrPrE4ziasFXgBVBZJDP0Wg/KpMwk2KHJ4Ba8GrDw=
+github.com/beevik/ntp v0.3.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
 github.com/benbjohnson/clock v1.0.2/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.0.3 h1:vkLuvpK4fmtSCuo60+yC63p7y0BmQ8gm5ZXGuBCJyXg=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
@@ -130,7 +130,6 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.2.0 h1:KgJ0snyC2R9VXYN2rneOtQcw5aHQB1Vv0sFl1UcHBOY=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
-github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -260,8 +259,6 @@ github.com/jbenet/goprocess v0.1.4/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZl
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
-github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -767,7 +764,6 @@ golang.org/x/net v0.0.0-20190313220215-9f648a60d977/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200519113804-d87ec0cfa476 h1:E7ct1C6/33eOdrGZKMoyntcEvs2dwZnDe30crG5vpYU=
 golang.org/x/net v0.0.0-20200519113804-d87ec0cfa476/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/ntp/syncTime.go
+++ b/ntp/syncTime.go
@@ -201,6 +201,11 @@ func (s *syncTime) sync() {
 		"num clock offsets", len(clockOffsets),
 		"num clock offsets without edges", len(clockOffsetsWithoutEdges),
 		"clock offset harmonic mean", clockOffsetHarmonicMean)
+
+	if clockOffsetHarmonicMean < -time.Second || clockOffsetHarmonicMean > time.Second {
+		log.Warn("syncTime.sync: clock offset is out of expected bounds",
+			"clock offset harmonic mean", clockOffsetHarmonicMean)
+	}
 }
 
 func (s *syncTime) getClockOffsetsWithoutEdges(clockOffsets []time.Duration) []time.Duration {


### PR DESCRIPTION
* Fixed an edge case in signature round when proposer is waiting after all sigs and meantime a NTP sync update is done with a negative offset
* Added warn log if NTP sync offset is out of normal bounds
* Updated beevik/ntp library to version v0.3.0

**How to be tested:**

**Start a normal system test with #allin and set in config.toml the value of the SyncPeriodSeconds parameter from [NTPConfig] section to a lower value. Ex: from 3600 to 60 seconds. This will help to have more NTP syncs after 1-2 hours of testing and afterwards we can analyze if the behavior of the updated NTP library is good and also if the edge case found is fixed or not.**