### PR TITLE
view-func-inactive-with-bad-rating

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -388,6 +388,7 @@ func ProcessComponentsFactory(args *processComponentsFactoryArgs) (*Process, err
 		ValidatorStatistics:               validatorStatisticsProcessor,
 		MaxRating:                         args.maxRating,
 		PubKeyConverter:                   args.validatorPubkeyConverter,
+		ChanceComputer:                    args.nodesCoordinator,
 	}
 
 	validatorsProvider, err := peer.NewValidatorsProvider(argVSP)

--- a/process/errors.go
+++ b/process/errors.go
@@ -907,3 +907,6 @@ var ErrFailedExecutionAfterBuiltInFunc = errors.New("failed execution after buil
 
 // ErrNilFallbackHeaderValidator signals that a nil fallback header validator has been provided
 var ErrNilFallbackHeaderValidator = errors.New("nil fallback header validator")
+
+// ErrNilChanceComputer signals that nil chance computer has been provided
+var ErrNilChanceComputer = errors.New("nil chance computer")

--- a/process/peer/validatorsProvider_test.go
+++ b/process/peer/validatorsProvider_test.go
@@ -656,5 +656,6 @@ func createDefaultValidatorsProviderArg() ArgValidatorsProvider {
 		},
 		MaxRating:       100,
 		PubKeyConverter: mock.NewPubkeyConverterMock(32),
+		ChanceComputer:  &mock.NodesCoordinatorMock{},
 	}
 }

--- a/process/peer/validatorsProvider_test.go
+++ b/process/peer/validatorsProvider_test.go
@@ -210,6 +210,7 @@ func TestValidatorsProvider_UpdateCache_WithError(t *testing.T) {
 		refreshCache:                 nil,
 		lock:                         sync.RWMutex{},
 		pubkeyConverter:              mock.NewPubkeyConverterMock(32),
+		chanceComputer:               arg.ChanceComputer,
 	}
 
 	vsp.updateCache()
@@ -229,6 +230,7 @@ func TestValidatorsProvider_Cancel_startRefreshProcess(t *testing.T) {
 		cacheRefreshIntervalDuration: arg.CacheRefreshIntervalDurationInSec,
 		refreshCache:                 make(chan uint32),
 		lock:                         sync.RWMutex{},
+		chanceComputer:               arg.ChanceComputer,
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -286,6 +288,7 @@ func TestValidatorsProvider_UpdateCache(t *testing.T) {
 		refreshCache:                 nil,
 		pubkeyConverter:              mock.NewPubkeyConverterMock(32),
 		lock:                         sync.RWMutex{},
+		chanceComputer:               arg.ChanceComputer,
 	}
 
 	vsp.updateCache()
@@ -405,6 +408,7 @@ func TestValidatorsProvider_createCache(t *testing.T) {
 		cacheRefreshIntervalDuration: arg.CacheRefreshIntervalDurationInSec,
 		pubkeyConverter:              pubKeyConverter,
 		lock:                         sync.RWMutex{},
+		chanceComputer:               arg.ChanceComputer,
 	}
 
 	cache := vsp.createNewCache(0, validatorsMap)
@@ -483,6 +487,7 @@ func TestValidatorsProvider_createCache_combined(t *testing.T) {
 		cache:                        nil,
 		cacheRefreshIntervalDuration: arg.CacheRefreshIntervalDurationInSec,
 		lock:                         sync.RWMutex{},
+		chanceComputer:               arg.ChanceComputer,
 	}
 
 	cache := vsp.createNewCache(0, validatorsMap)

--- a/vm/systemSmartContracts/staking.go
+++ b/vm/systemSmartContracts/staking.go
@@ -1331,7 +1331,7 @@ func (r *stakingSC) getBLSKeyStatus(args *vmcommon.ContractCallInput) vmcommon.R
 		return returnCode
 	}
 
-	if stakedData.Jailed || r.eei.CanUnJail(args.Arguments[0]) {
+	if stakedData.Jailed || r.eei.CanUnJail(args.Arguments[0]) || r.eei.IsBadRating(args.Arguments[0]) {
 		r.eei.Finish([]byte("jailed"))
 		return vmcommon.Ok
 	}

--- a/vm/systemSmartContracts/staking.go
+++ b/vm/systemSmartContracts/staking.go
@@ -378,7 +378,8 @@ func (r *stakingSC) unJail(args *vmcommon.ContractCallInput) vmcommon.ReturnCode
 		r.eei.AddReturnMessage("cannot unJail a key that is not registered")
 		return vmcommon.UserError
 	}
-	if !stakedData.Jailed && !r.eei.CanUnJail(args.Arguments[0]) {
+	isInactiveWithBadRating := r.eei.IsBadRating(args.Arguments[0]) && !r.eei.IsValidator(args.Arguments[0])
+	if !stakedData.Jailed && !r.eei.CanUnJail(args.Arguments[0]) && !isInactiveWithBadRating {
 		r.eei.AddReturnMessage("cannot unJail a node which is not jailed")
 		return vmcommon.UserError
 	}


### PR DESCRIPTION
fixed edge case on view function when a node can be inactive, still  lose some rating and have a bad rating, thus will not be able to unbond before another unjail.