### PR TITLE
Hardfork: execute pending txs in correct order

### DIFF
--- a/update/common.go
+++ b/update/common.go
@@ -1,0 +1,124 @@
+package update
+
+import (
+	"github.com/ElrondNetwork/elrond-go/data"
+	"github.com/ElrondNetwork/elrond-go/data/block"
+)
+
+// TxInfo defines the structure which hold the tx info
+type TxInfo struct {
+	TxHash []byte
+	Tx     data.TransactionHandler
+}
+
+// GetPendingMiniBlocks get all the pending miniBlocks from epoch start metaBlock and unFinished metaBlocks
+func GetPendingMiniBlocks(
+	epochStartMetaBlock *block.MetaBlock,
+	unFinishedMetaBlocksMap map[string]*block.MetaBlock,
+) ([]block.MiniBlockHeader, error) {
+
+	if epochStartMetaBlock == nil {
+		return nil, ErrNilEpochStartMetaBlock
+	}
+	if unFinishedMetaBlocksMap == nil {
+		return nil, ErrNilUnFinishedMetaBlocksMap
+	}
+
+	pendingMiniBlocks := make([]block.MiniBlockHeader, 0)
+	nonceToHashMap := CreateNonceToHashMap(unFinishedMetaBlocksMap)
+
+	for _, shardData := range epochStartMetaBlock.EpochStart.LastFinalizedHeaders {
+		computedPending, err := ComputePendingMiniBlocksFromUnFinished(
+			shardData,
+			unFinishedMetaBlocksMap,
+			nonceToHashMap,
+			epochStartMetaBlock.GetNonce(),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		pendingMiniBlocks = append(pendingMiniBlocks, computedPending...)
+	}
+
+	//TODO: These pendingMiniBlocks are already added in method ComputePendingMiniBlocksFromUnFinished called above
+	//when nonce == epochStartMetaBlockNonce in "for" done there, by calling method GetAllMiniBlocksWithDst inside it.
+	//The below commented code should be removed, otherwise it would duplicate these miniblocks
+	//(especially the rewards miniblocks) which would be executed twice!
+	//for _, mbHdr := range epochStartMetaBlock.MiniBlockHeaders {
+	//	if mbHdr.SenderShardID != core.MetachainShardId || mbHdr.Type == block.PeerBlock {
+	//		continue
+	//	}
+	//	pendingMiniBlocks = append(pendingMiniBlocks, mbHdr)
+	//}
+
+	return pendingMiniBlocks, nil
+}
+
+// CreateNonceToHashMap creates a map of nonce to hash from all the given metaBlocks
+func CreateNonceToHashMap(unFinishedMetaBlocks map[string]*block.MetaBlock) map[uint64]string {
+	nonceToHashMap := make(map[uint64]string, len(unFinishedMetaBlocks))
+	for metaBlockHash, metaBlock := range unFinishedMetaBlocks {
+		nonceToHashMap[metaBlock.GetNonce()] = metaBlockHash
+	}
+
+	return nonceToHashMap
+}
+
+// ComputePendingMiniBlocksFromUnFinished computes all the pending miniBlocks from unFinished metaBlocks
+func ComputePendingMiniBlocksFromUnFinished(
+	epochStartShardData block.EpochStartShardData,
+	unFinishedMetaBlocks map[string]*block.MetaBlock,
+	nonceToHashMap map[uint64]string,
+	epochStartMetaBlockNonce uint64,
+) ([]block.MiniBlockHeader, error) {
+	pendingMiniBlocks := make([]block.MiniBlockHeader, 0)
+	pendingMiniBlocks = append(pendingMiniBlocks, epochStartShardData.PendingMiniBlockHeaders...)
+
+	firstPendingMetaBlock, ok := unFinishedMetaBlocks[string(epochStartShardData.FirstPendingMetaBlock)]
+	if !ok {
+		return nil, ErrWrongUnFinishedMetaHdrsMap
+	}
+
+	firstUnFinishedMetaBlockNonce := firstPendingMetaBlock.GetNonce()
+	for nonce := firstUnFinishedMetaBlockNonce + 1; nonce <= epochStartMetaBlockNonce; nonce++ {
+		metaBlockHash, exists := nonceToHashMap[nonce]
+		if !exists {
+			return nil, ErrWrongUnFinishedMetaHdrsMap
+		}
+
+		metaBlock, exists := unFinishedMetaBlocks[metaBlockHash]
+		if !exists {
+			return nil, ErrWrongUnFinishedMetaHdrsMap
+		}
+
+		pendingMiniBlocksFromMetaBlock := GetAllMiniBlocksWithDst(metaBlock, epochStartShardData.ShardID)
+		pendingMiniBlocks = append(pendingMiniBlocks, pendingMiniBlocksFromMetaBlock...)
+	}
+
+	return pendingMiniBlocks, nil
+}
+
+// GetAllMiniBlocksWithDst returns all miniBlock headers with the given destination from the given metaBlock
+func GetAllMiniBlocksWithDst(metaBlock *block.MetaBlock, destShardID uint32) []block.MiniBlockHeader {
+	mbHdrs := make([]block.MiniBlockHeader, 0)
+	for i := 0; i < len(metaBlock.ShardInfo); i++ {
+		if metaBlock.ShardInfo[i].ShardID == destShardID {
+			continue
+		}
+
+		for _, mbHdr := range metaBlock.ShardInfo[i].ShardMiniBlockHeaders {
+			if mbHdr.ReceiverShardID == destShardID && mbHdr.SenderShardID != destShardID {
+				mbHdrs = append(mbHdrs, mbHdr)
+			}
+		}
+	}
+
+	for _, mbHdr := range metaBlock.MiniBlockHeaders {
+		if mbHdr.ReceiverShardID == destShardID && mbHdr.SenderShardID != destShardID {
+			mbHdrs = append(mbHdrs, mbHdr)
+		}
+	}
+
+	return mbHdrs
+}

--- a/update/errors.go
+++ b/update/errors.go
@@ -253,3 +253,6 @@ var ErrNilEpochStartMetaBlock = errors.New("nil epoch start metaBlock was provid
 
 //ErrNilUnFinishedMetaBlocksMap signals that a nil unFinished metaBlocks map was provided
 var ErrNilUnFinishedMetaBlocksMap = errors.New("nil unFinished metaBlocks map was provided")
+
+//ErrDuplicatedMiniBlocksFound signals that duplicated miniBlocks were found
+var ErrDuplicatedMiniBlocksFound = errors.New("duplicated miniBlocks were found")

--- a/update/errors.go
+++ b/update/errors.go
@@ -14,9 +14,6 @@ var ErrInvalidFolderName = errors.New("invalid folder name")
 // ErrNilStorage signals that storage is nil
 var ErrNilStorage = errors.New("nil storage")
 
-// ErrNilDataTrieContainer signals that data trie container is nil
-var ErrNilDataTrieContainer = errors.New("nil data trie container")
-
 // ErrNotSynced signals that syncing has not been finished yet
 var ErrNotSynced = errors.New("not synced")
 
@@ -95,8 +92,8 @@ var ErrNilMiniBlocksSyncHandler = errors.New("nil miniblocks sync handler")
 // ErrNilTransactionsSyncHandler signals that nil transactions sync handler was provided
 var ErrNilTransactionsSyncHandler = errors.New("nil transaction sync handler")
 
-// ErrWrongUnfinishedMetaHdrsMap signals that wrong unfinished meta headers map was provided
-var ErrWrongUnfinishedMetaHdrsMap = errors.New("wrong unfinished meta headers map")
+// ErrWrongUnFinishedMetaHdrsMap signals that wrong unFinished meta headers map was provided
+var ErrWrongUnFinishedMetaHdrsMap = errors.New("wrong unFinished meta headers map")
 
 // ErrNilAccounts signals that nil accounts was provided
 var ErrNilAccounts = errors.New("nil accounts")
@@ -221,8 +218,8 @@ var ErrNilTimeCache = errors.New("nil time cache")
 // ErrNilHardforkStorer signals that a nil hardfork storer has been provided
 var ErrNilHardforkStorer = errors.New("nil hardfork storer")
 
-// ErrExpectedOneMetablock signals that exactly one metablock should have been used
-var ErrExpectedOneMetablock = errors.New("expected one metablock")
+// ErrExpectedOneStartOfEpochMetaBlock signals that exactly one start of epoch metaBlock should have been used
+var ErrExpectedOneStartOfEpochMetaBlock = errors.New("expected one start of epoch metaBlock")
 
 // ErrImportingData signals that an import error occurred
 var ErrImportingData = errors.New("error importing data")
@@ -238,3 +235,21 @@ var ErrEmptyExportFolderPath = errors.New("empty export folder path")
 
 // ErrNilGenesisNodesSetupHandler signals that a nil genesis nodes setup handler has been provided
 var ErrNilGenesisNodesSetupHandler = errors.New("nil genesis nodes setup handler")
+
+// ErrWrongImportedMiniBlocksMap signals that wrong imported miniBlocks map was provided
+var ErrWrongImportedMiniBlocksMap = errors.New("wrong imported miniBlocks map was provided")
+
+// ErrWrongImportedTransactionsMap signals that wrong imported transactions map was provided
+var ErrWrongImportedTransactionsMap = errors.New("wrong imported transactions map was provided")
+
+// ErrMiniBlockNotFoundInImportedMap signals that the given miniBlock was not found in imported map
+var ErrMiniBlockNotFoundInImportedMap = errors.New("miniBlock was not found in imported map")
+
+// ErrTransactionNotFoundInImportedMap signals that the given transaction was not found in imported map
+var ErrTransactionNotFoundInImportedMap = errors.New("transaction was not found in imported map")
+
+// ErrNilEpochStartMetaBlock signals that a nil epoch start metaBlock was provided
+var ErrNilEpochStartMetaBlock = errors.New("nil epoch start metaBlock was provided")
+
+//ErrNilUnFinishedMetaBlocksMap signals that a nil unFinished metaBlocks map was provided
+var ErrNilUnFinishedMetaBlocksMap = errors.New("nil unFinished metaBlocks map was provided")

--- a/update/genesis/base.go
+++ b/update/genesis/base.go
@@ -15,8 +15,11 @@ import (
 	"github.com/ElrondNetwork/elrond-go/update"
 )
 
-// MetaBlockIdentifier is the constant which defines the export/import identifier for metaBlock
-const MetaBlockIdentifier = "metaBlock"
+// EpochStartMetaBlockIdentifier is the constant which defines the export/import identifier for epoch start metaBlock
+const EpochStartMetaBlockIdentifier = "epochStartMetaBlock"
+
+// UnFinishedMetaBlocksIdentifier is the constant which defines the export/import identifier for unFinished metaBlocks
+const UnFinishedMetaBlocksIdentifier = "unFinishedMetaBlocks"
 
 // TransactionsIdentifier is the constant which defines the export/import identifier for transactions
 const TransactionsIdentifier = "transactions"

--- a/update/genesis/import_test.go
+++ b/update/genesis/import_test.go
@@ -1,14 +1,19 @@
 package genesis
 
 import (
+	"encoding/hex"
+	"fmt"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/data"
+	"github.com/ElrondNetwork/elrond-go/data/block"
 	"github.com/ElrondNetwork/elrond-go/data/trie/factory"
 	"github.com/ElrondNetwork/elrond-go/update"
 	"github.com/ElrondNetwork/elrond-go/update/mock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -92,4 +97,43 @@ func TestImportAll(t *testing.T) {
 
 	err := importState.ImportAll()
 	require.Nil(t, err)
+}
+
+func TestStateImport_ImportUnFinishedMetaBlocksShouldWork(t *testing.T) {
+	t.Parallel()
+
+	trieStorageManagers := make(map[string]data.StorageManager)
+	trieStorageManagers[factory.UserAccountTrie] = &mock.StorageManagerStub{}
+
+	hasher := &mock.HasherMock{}
+	marshahlizer := &mock.MarshalizerMock{}
+	metaBlock := &block.MetaBlock{
+		Round:   1,
+		ChainID: []byte("chainId"),
+	}
+	metaBlockHash, _ := core.CalculateHash(marshahlizer, hasher, metaBlock)
+
+	args := ArgsNewStateImport{
+		HardforkStorer: &mock.HardforkStorerStub{
+			GetCalled: func(identifier string, key []byte) ([]byte, error) {
+				return marshahlizer.Marshal(metaBlock)
+			},
+		},
+		Hasher:              hasher,
+		Marshalizer:         marshahlizer,
+		TrieStorageManagers: trieStorageManagers,
+		ShardID:             0,
+		StorageConfig:       config.StorageConfig{},
+	}
+
+	importState, _ := NewStateImport(args)
+	require.False(t, check.IfNil(importState))
+
+	key := fmt.Sprintf("meta@chainId@%s", hex.EncodeToString(metaBlockHash))
+	err := importState.importUnFinishedMetaBlocks(UnFinishedMetaBlocksIdentifier, [][]byte{
+		[]byte(key),
+	})
+
+	require.Nil(t, err)
+	assert.Equal(t, importState.importedUnFinishedMetaBlocks[string(metaBlockHash)], metaBlock)
 }

--- a/update/interface.go
+++ b/update/interface.go
@@ -14,7 +14,7 @@ import (
 // StateSyncer interface defines the methods needed to sync and get all states
 type StateSyncer interface {
 	GetEpochStartMetaBlock() (*block.MetaBlock, error)
-	GetUnfinishedMetaBlocks() (map[string]*block.MetaBlock, error)
+	GetUnFinishedMetaBlocks() (map[string]*block.MetaBlock, error)
 	SyncAllState(epoch uint32) error
 	GetAllTries() (map[string]data.Trie, error)
 	GetAllTransactions() (map[string]data.TransactionHandler, error)
@@ -93,6 +93,7 @@ type ImportHandler interface {
 	GetValidatorAccountsDB() state.AccountsAdapter
 	GetMiniBlocks() map[string]*block.MiniBlock
 	GetHardForkMetaBlock() *block.MetaBlock
+	GetUnFinishedMetaBlocks() map[string]*block.MetaBlock
 	GetTransactions() map[string]data.TransactionHandler
 	GetAccountsDBForShard(shardID uint32) state.AccountsAdapter
 	IsInterfaceNil() bool
@@ -106,7 +107,7 @@ type HardForkBlockProcessor interface {
 
 // PendingTransactionProcessor defines the methods to process a transaction destination me
 type PendingTransactionProcessor interface {
-	ProcessTransactionsDstMe(mapTxs map[string]data.TransactionHandler) (block.MiniBlockSlice, error)
+	ProcessTransactionsDstMe(txsInfo []*TxInfo) (block.MiniBlockSlice, error)
 	RootHash() ([]byte, error)
 	IsInterfaceNil() bool
 }
@@ -115,7 +116,7 @@ type PendingTransactionProcessor interface {
 type HeaderSyncHandler interface {
 	SyncUnFinishedMetaHeaders(epoch uint32) error
 	GetEpochStartMetaBlock() (*block.MetaBlock, error)
-	GetUnfinishedMetaBlocks() (map[string]*block.MetaBlock, error)
+	GetUnFinishedMetaBlocks() (map[string]*block.MetaBlock, error)
 	IsInterfaceNil() bool
 }
 

--- a/update/mock/headerSyncHandlerStub.go
+++ b/update/mock/headerSyncHandlerStub.go
@@ -8,7 +8,7 @@ import (
 type HeaderSyncHandlerStub struct {
 	SyncUnFinishedMetaHeadersCalled func(epoch uint32) error
 	GetEpochStartMetaBlockCalled    func() (*block.MetaBlock, error)
-	GetUnfinishedMetaBlocksCalled   func() (map[string]*block.MetaBlock, error)
+	GetUnFinishedMetaBlocksCalled   func() (map[string]*block.MetaBlock, error)
 }
 
 // SyncUnFinishedMetaHeaders -
@@ -27,10 +27,10 @@ func (hsh *HeaderSyncHandlerStub) GetEpochStartMetaBlock() (*block.MetaBlock, er
 	return nil, nil
 }
 
-// GetUnfinishedMetaBlocks -
-func (hsh *HeaderSyncHandlerStub) GetUnfinishedMetaBlocks() (map[string]*block.MetaBlock, error) {
-	if hsh.GetUnfinishedMetaBlocksCalled != nil {
-		return hsh.GetUnfinishedMetaBlocksCalled()
+// GetUnFinishedMetaBlocks -
+func (hsh *HeaderSyncHandlerStub) GetUnFinishedMetaBlocks() (map[string]*block.MetaBlock, error) {
+	if hsh.GetUnFinishedMetaBlocksCalled != nil {
+		return hsh.GetUnFinishedMetaBlocksCalled()
 	}
 	return nil, nil
 }

--- a/update/mock/importHandlerStub.go
+++ b/update/mock/importHandlerStub.go
@@ -8,12 +8,13 @@ import (
 
 // ImportHandlerStub -
 type ImportHandlerStub struct {
-	ImportAllCalled              func() error
-	GetValidatorAccountsDBCalled func() state.AccountsAdapter
-	GetMiniBlocksCalled          func() map[string]*block.MiniBlock
-	GetHardForkMetaBlockCalled   func() *block.MetaBlock
-	GetTransactionsCalled        func() map[string]data.TransactionHandler
-	GetAccountsDBForShardCalled  func(shardID uint32) state.AccountsAdapter
+	ImportAllCalled               func() error
+	GetValidatorAccountsDBCalled  func() state.AccountsAdapter
+	GetMiniBlocksCalled           func() map[string]*block.MiniBlock
+	GetHardForkMetaBlockCalled    func() *block.MetaBlock
+	GetUnFinishedMetaBlocksCalled func() map[string]*block.MetaBlock
+	GetTransactionsCalled         func() map[string]data.TransactionHandler
+	GetAccountsDBForShardCalled   func(shardID uint32) state.AccountsAdapter
 }
 
 // ImportAll -
@@ -44,6 +45,14 @@ func (ihs *ImportHandlerStub) GetMiniBlocks() map[string]*block.MiniBlock {
 func (ihs *ImportHandlerStub) GetHardForkMetaBlock() *block.MetaBlock {
 	if ihs.GetHardForkMetaBlockCalled != nil {
 		return ihs.GetHardForkMetaBlockCalled()
+	}
+	return nil
+}
+
+// GetUnFinishedMetaBlocks -
+func (ihs *ImportHandlerStub) GetUnFinishedMetaBlocks() map[string]*block.MetaBlock {
+	if ihs.GetUnFinishedMetaBlocksCalled != nil {
+		return ihs.GetUnFinishedMetaBlocksCalled()
 	}
 	return nil
 }

--- a/update/mock/pendingTransactionProcessorStub.go
+++ b/update/mock/pendingTransactionProcessorStub.go
@@ -1,20 +1,20 @@
 package mock
 
 import (
-	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/block"
+	"github.com/ElrondNetwork/elrond-go/update"
 )
 
 // PendingTransactionProcessorStub -
 type PendingTransactionProcessorStub struct {
-	ProcessTransactionsDstMeCalled func(mapTxs map[string]data.TransactionHandler) (block.MiniBlockSlice, error)
+	ProcessTransactionsDstMeCalled func(txsInfo []*update.TxInfo) (block.MiniBlockSlice, error)
 	RootHashCalled                 func() ([]byte, error)
 }
 
 // ProcessTransactionsDstMe -
-func (ptps *PendingTransactionProcessorStub) ProcessTransactionsDstMe(mapTxs map[string]data.TransactionHandler) (block.MiniBlockSlice, error) {
+func (ptps *PendingTransactionProcessorStub) ProcessTransactionsDstMe(txsInfo []*update.TxInfo) (block.MiniBlockSlice, error) {
 	if ptps.ProcessTransactionsDstMeCalled != nil {
-		return ptps.ProcessTransactionsDstMeCalled(mapTxs)
+		return ptps.ProcessTransactionsDstMeCalled(txsInfo)
 	}
 	return nil, nil
 }

--- a/update/mock/syncStateStub.go
+++ b/update/mock/syncStateStub.go
@@ -8,7 +8,7 @@ import (
 // SyncStateStub -
 type SyncStateStub struct {
 	GetEpochStartMetaBlockCalled  func() (*block.MetaBlock, error)
-	GetUnfinishedMetaBlocksCalled func() (map[string]*block.MetaBlock, error)
+	GetUnFinishedMetaBlocksCalled func() (map[string]*block.MetaBlock, error)
 	SyncAllStateCalled            func(epoch uint32) error
 	GetAllTriesCalled             func() (map[string]data.Trie, error)
 	GetAllTransactionsCalled      func() (map[string]data.TransactionHandler, error)
@@ -23,10 +23,10 @@ func (sss *SyncStateStub) GetEpochStartMetaBlock() (*block.MetaBlock, error) {
 	return nil, nil
 }
 
-// GetUnfinishedMetaBlocks -
-func (sss *SyncStateStub) GetUnfinishedMetaBlocks() (map[string]*block.MetaBlock, error) {
-	if sss.GetUnfinishedMetaBlocksCalled != nil {
-		return sss.GetUnfinishedMetaBlocksCalled()
+// GetUnFinishedMetaBlocks -
+func (sss *SyncStateStub) GetUnFinishedMetaBlocks() (map[string]*block.MetaBlock, error) {
+	if sss.GetUnFinishedMetaBlocksCalled != nil {
+		return sss.GetUnFinishedMetaBlocksCalled()
 	}
 	return nil, nil
 }

--- a/update/process/processPending_test.go
+++ b/update/process/processPending_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go/core/check"
-	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/block"
 	"github.com/ElrondNetwork/elrond-go/data/transaction"
+	"github.com/ElrondNetwork/elrond-go/update"
 	"github.com/ElrondNetwork/elrond-go/update/mock"
-	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	"github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -75,11 +75,11 @@ func TestPendingTransactionProcessor_ProcessTransactionsDstMe(t *testing.T) {
 
 	pendingTxProcessor, _ := NewPendingTransactionProcessor(args)
 
-	hash1 := "hash1"
-	hash2 := "hash2"
-	hash3 := "hash3"
-	hash4 := "hash4"
-	hash5 := "hash5"
+	hash1 := []byte("hash1")
+	hash2 := []byte("hash2")
+	hash3 := []byte("hash3")
+	hash4 := []byte("hash4")
+	hash5 := []byte("hash5")
 
 	tx1 := &transaction.Transaction{RcvAddr: addr1}
 	tx2 := &transaction.Transaction{SndAddr: addr2}
@@ -87,15 +87,15 @@ func TestPendingTransactionProcessor_ProcessTransactionsDstMe(t *testing.T) {
 	tx4 := &transaction.Transaction{SndAddr: addr4}
 	tx5 := &transaction.Transaction{SndAddr: addr5}
 
-	mapTxs := map[string]data.TransactionHandler{
-		hash1: tx1,
-		hash2: tx2,
-		hash3: tx3,
-		hash4: tx4,
-		hash5: tx5,
+	txsInfo := []*update.TxInfo{
+		{TxHash: hash1, Tx: tx1},
+		{TxHash: hash2, Tx: tx2},
+		{TxHash: hash3, Tx: tx3},
+		{TxHash: hash4, Tx: tx4},
+		{TxHash: hash5, Tx: tx5},
 	}
 
-	mbSlice, err := pendingTxProcessor.ProcessTransactionsDstMe(mapTxs)
+	mbSlice, err := pendingTxProcessor.ProcessTransactionsDstMe(txsInfo)
 	assert.True(t, called)
 	assert.NotNil(t, mbSlice)
 	assert.NoError(t, err)

--- a/update/process/shardBlock_test.go
+++ b/update/process/shardBlock_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
+	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/block"
+	"github.com/ElrondNetwork/elrond-go/data/transaction"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/ElrondNetwork/elrond-go/storage/memorydb"
@@ -15,6 +17,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/update"
 	"github.com/ElrondNetwork/elrond-go/update/mock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func generateTestCache() storage.Cacher {
@@ -69,7 +72,6 @@ func TestNewShardBlockCreatorAfterHardFork(t *testing.T) {
 }
 
 func TestCreateBody(t *testing.T) {
-	t.Skip("fix this test")
 	t.Parallel()
 
 	mb1, mb2 := &block.MiniBlock{SenderShardID: 0}, &block.MiniBlock{SenderShardID: 1}
@@ -92,8 +94,11 @@ func TestCreateBody(t *testing.T) {
 		EpochStart: block.EpochStart{
 			LastFinalizedHeaders: []block.EpochStartShardData{
 				{
+					FirstPendingMetaBlock: []byte("metaBlock_hash"),
 					PendingMiniBlockHeaders: []block.MiniBlockHeader{
-						{},
+						{
+							Hash: []byte("miniBlock_hash"),
+						},
 					},
 				},
 			},
@@ -101,7 +106,7 @@ func TestCreateBody(t *testing.T) {
 	}
 
 	unFinishedMetaBlocks := map[string]*block.MetaBlock{
-		"hash": {Round: 1},
+		"metaBlock_hash": {Round: 1},
 	}
 	args.ImportHandler = &mock.ImportHandlerStub{
 		GetHardForkMetaBlockCalled: func() *block.MetaBlock {
@@ -109,6 +114,11 @@ func TestCreateBody(t *testing.T) {
 		},
 		GetUnFinishedMetaBlocksCalled: func() map[string]*block.MetaBlock {
 			return unFinishedMetaBlocks
+		},
+		GetMiniBlocksCalled: func() map[string]*block.MiniBlock {
+			return map[string]*block.MiniBlock{
+				"miniBlock_hash": {},
+			}
 		},
 	}
 
@@ -161,7 +171,6 @@ func TestCreateMiniBlockHeader(t *testing.T) {
 }
 
 func TestCreateNewBlock(t *testing.T) {
-	t.Skip("fix this test")
 	t.Parallel()
 
 	rootHash := []byte("rotHash")
@@ -183,10 +192,24 @@ func TestCreateNewBlock(t *testing.T) {
 		},
 	}
 
-	metaBlock := &block.MetaBlock{Round: 2}
+	metaBlock := &block.MetaBlock{
+		Round: 2,
+		EpochStart: block.EpochStart{
+			LastFinalizedHeaders: []block.EpochStartShardData{
+				{
+					FirstPendingMetaBlock: []byte("metaBlock_hash"),
+					PendingMiniBlockHeaders: []block.MiniBlockHeader{
+						{
+							Hash: []byte("miniBlock_hash"),
+						},
+					},
+				},
+			},
+		},
+	}
 	metaHash, _ := core.CalculateHash(args.Marshalizer, args.Hasher, metaBlock)
 	unFinishedMetaBlocks := map[string]*block.MetaBlock{
-		"hash": {Round: 1},
+		"metaBlock_hash": {Round: 1},
 	}
 	args.ImportHandler = &mock.ImportHandlerStub{
 		GetHardForkMetaBlockCalled: func() *block.MetaBlock {
@@ -194,6 +217,11 @@ func TestCreateNewBlock(t *testing.T) {
 		},
 		GetUnFinishedMetaBlocksCalled: func() map[string]*block.MetaBlock {
 			return unFinishedMetaBlocks
+		},
+		GetMiniBlocksCalled: func() map[string]*block.MiniBlock {
+			return map[string]*block.MiniBlock{
+				"miniBlock_hash": {},
+			}
 		},
 	}
 
@@ -240,4 +268,258 @@ func TestCreateNewBlock(t *testing.T) {
 	assert.Equal(t, expectedHeader, header)
 }
 
-//TODO: Add an unit test for method getPendingTxsInCorrectOrder
+func TestGetPendingMbsAndTxsInCorrectOrder_ShouldErrWhenGetPendingMiniBlocksFails(t *testing.T) {
+	t.Parallel()
+
+	args := createMockArgsNewShardBlockCreatorAfterHardFork()
+	shardBlockCreator, _ := NewShardBlockCreatorAfterHardFork(args)
+
+	_, _, err := shardBlockCreator.getPendingMbsAndTxsInCorrectOrder()
+	assert.Equal(t, update.ErrNilEpochStartMetaBlock, err)
+}
+
+func TestGetPendingMbsAndTxsInCorrectOrder_ShouldErrWrongImportedMiniBlocksMap(t *testing.T) {
+	t.Parallel()
+
+	args := createMockArgsNewShardBlockCreatorAfterHardFork()
+
+	metaBlock := &block.MetaBlock{
+		Round: 2,
+		EpochStart: block.EpochStart{
+			LastFinalizedHeaders: []block.EpochStartShardData{
+				{
+					FirstPendingMetaBlock: []byte("metaBlock_hash"),
+					PendingMiniBlockHeaders: []block.MiniBlockHeader{
+						{
+							Hash: []byte("miniBlock_hash"),
+						},
+					},
+				},
+			},
+		},
+	}
+	unFinishedMetaBlocks := map[string]*block.MetaBlock{
+		"metaBlock_hash": {Round: 1},
+	}
+	args.ImportHandler = &mock.ImportHandlerStub{
+		GetHardForkMetaBlockCalled: func() *block.MetaBlock {
+			return metaBlock
+		},
+		GetUnFinishedMetaBlocksCalled: func() map[string]*block.MetaBlock {
+			return unFinishedMetaBlocks
+		},
+	}
+
+	shardBlockCreator, _ := NewShardBlockCreatorAfterHardFork(args)
+
+	_, _, err := shardBlockCreator.getPendingMbsAndTxsInCorrectOrder()
+	assert.Equal(t, update.ErrWrongImportedMiniBlocksMap, err)
+}
+
+func TestGetPendingMbsAndTxsInCorrectOrder_ShouldErrMiniBlockNotFoundInImportedMap(t *testing.T) {
+	t.Parallel()
+
+	args := createMockArgsNewShardBlockCreatorAfterHardFork()
+
+	metaBlock := &block.MetaBlock{
+		Round: 2,
+		EpochStart: block.EpochStart{
+			LastFinalizedHeaders: []block.EpochStartShardData{
+				{
+					FirstPendingMetaBlock: []byte("metaBlock_hash"),
+					PendingMiniBlockHeaders: []block.MiniBlockHeader{
+						{
+							Hash: []byte("miniBlock_hash1"),
+						},
+					},
+				},
+			},
+		},
+	}
+	unFinishedMetaBlocks := map[string]*block.MetaBlock{
+		"metaBlock_hash": {Round: 1},
+	}
+	args.ImportHandler = &mock.ImportHandlerStub{
+		GetHardForkMetaBlockCalled: func() *block.MetaBlock {
+			return metaBlock
+		},
+		GetUnFinishedMetaBlocksCalled: func() map[string]*block.MetaBlock {
+			return unFinishedMetaBlocks
+		},
+		GetMiniBlocksCalled: func() map[string]*block.MiniBlock {
+			return map[string]*block.MiniBlock{
+				"miniBlock_hash2": {},
+			}
+		},
+	}
+
+	shardBlockCreator, _ := NewShardBlockCreatorAfterHardFork(args)
+
+	_, _, err := shardBlockCreator.getPendingMbsAndTxsInCorrectOrder()
+	assert.Equal(t, update.ErrMiniBlockNotFoundInImportedMap, err)
+}
+
+func TestGetPendingMbsAndTxsInCorrectOrder_ShouldErrTransactionNotFoundInImportedMap(t *testing.T) {
+	t.Parallel()
+
+	args := createMockArgsNewShardBlockCreatorAfterHardFork()
+
+	metaBlock := &block.MetaBlock{
+		Round: 2,
+		EpochStart: block.EpochStart{
+			LastFinalizedHeaders: []block.EpochStartShardData{
+				{
+					FirstPendingMetaBlock: []byte("metaBlock_hash"),
+					PendingMiniBlockHeaders: []block.MiniBlockHeader{
+						{
+							Hash: []byte("miniBlock_hash"),
+						},
+					},
+				},
+			},
+		},
+	}
+	unFinishedMetaBlocks := map[string]*block.MetaBlock{
+		"metaBlock_hash": {Round: 1},
+	}
+	args.ImportHandler = &mock.ImportHandlerStub{
+		GetHardForkMetaBlockCalled: func() *block.MetaBlock {
+			return metaBlock
+		},
+		GetUnFinishedMetaBlocksCalled: func() map[string]*block.MetaBlock {
+			return unFinishedMetaBlocks
+		},
+		GetMiniBlocksCalled: func() map[string]*block.MiniBlock {
+			return map[string]*block.MiniBlock{
+				"miniBlock_hash": {
+					TxHashes: [][]byte{
+						[]byte("tx_hash1"),
+						[]byte("tx_hash2"),
+					},
+				},
+			}
+		},
+	}
+
+	shardBlockCreator, _ := NewShardBlockCreatorAfterHardFork(args)
+
+	_, _, err := shardBlockCreator.getPendingMbsAndTxsInCorrectOrder()
+	assert.Equal(t, update.ErrTransactionNotFoundInImportedMap, err)
+}
+
+func TestGetPendingMbsAndTxsInCorrectOrder_ShouldErrWrongImportedTransactionsMap(t *testing.T) {
+	t.Parallel()
+
+	args := createMockArgsNewShardBlockCreatorAfterHardFork()
+
+	metaBlock := &block.MetaBlock{
+		Round: 2,
+		EpochStart: block.EpochStart{
+			LastFinalizedHeaders: []block.EpochStartShardData{
+				{
+					FirstPendingMetaBlock: []byte("metaBlock_hash"),
+					PendingMiniBlockHeaders: []block.MiniBlockHeader{
+						{
+							Hash: []byte("miniBlock_hash"),
+						},
+					},
+				},
+			},
+		},
+	}
+	unFinishedMetaBlocks := map[string]*block.MetaBlock{
+		"metaBlock_hash": {Round: 1},
+	}
+	args.ImportHandler = &mock.ImportHandlerStub{
+		GetHardForkMetaBlockCalled: func() *block.MetaBlock {
+			return metaBlock
+		},
+		GetUnFinishedMetaBlocksCalled: func() map[string]*block.MetaBlock {
+			return unFinishedMetaBlocks
+		},
+		GetMiniBlocksCalled: func() map[string]*block.MiniBlock {
+			return map[string]*block.MiniBlock{
+				"miniBlock_hash": {
+					TxHashes: [][]byte{
+						[]byte("tx_hash1"),
+						[]byte("tx_hash2"),
+					},
+				},
+			}
+		},
+		GetTransactionsCalled: func() map[string]data.TransactionHandler {
+			return map[string]data.TransactionHandler{
+				"tx_hash1": &transaction.Transaction{Nonce: 0},
+				"tx_hash2": &transaction.Transaction{Nonce: 1},
+				"tx_hash3": &transaction.Transaction{Nonce: 2},
+			}
+		},
+	}
+
+	shardBlockCreator, _ := NewShardBlockCreatorAfterHardFork(args)
+
+	_, _, err := shardBlockCreator.getPendingMbsAndTxsInCorrectOrder()
+	assert.Equal(t, update.ErrWrongImportedTransactionsMap, err)
+}
+
+func TestGetPendingMbsAndTxsInCorrectOrder_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	args := createMockArgsNewShardBlockCreatorAfterHardFork()
+
+	metaBlock := &block.MetaBlock{
+		Round: 2,
+		EpochStart: block.EpochStart{
+			LastFinalizedHeaders: []block.EpochStartShardData{
+				{
+					FirstPendingMetaBlock: []byte("metaBlock_hash"),
+					PendingMiniBlockHeaders: []block.MiniBlockHeader{
+						{
+							Hash: []byte("miniBlock_hash"),
+						},
+					},
+				},
+			},
+		},
+	}
+	unFinishedMetaBlocks := map[string]*block.MetaBlock{
+		"metaBlock_hash": {Round: 1},
+	}
+	args.ImportHandler = &mock.ImportHandlerStub{
+		GetHardForkMetaBlockCalled: func() *block.MetaBlock {
+			return metaBlock
+		},
+		GetUnFinishedMetaBlocksCalled: func() map[string]*block.MetaBlock {
+			return unFinishedMetaBlocks
+		},
+		GetMiniBlocksCalled: func() map[string]*block.MiniBlock {
+			return map[string]*block.MiniBlock{
+				"miniBlock_hash": {
+					TxHashes: [][]byte{
+						[]byte("tx_hash1"),
+						[]byte("tx_hash2"),
+					},
+				},
+			}
+		},
+		GetTransactionsCalled: func() map[string]data.TransactionHandler {
+			return map[string]data.TransactionHandler{
+				"tx_hash1": &transaction.Transaction{Nonce: 0},
+				"tx_hash2": &transaction.Transaction{Nonce: 1},
+			}
+		},
+	}
+
+	shardBlockCreator, _ := NewShardBlockCreatorAfterHardFork(args)
+
+	pendingMiniBlocks, txsInfoPerPendingMiniBlock, err := shardBlockCreator.getPendingMbsAndTxsInCorrectOrder()
+	assert.Nil(t, err)
+	require.Equal(t, 1, len(pendingMiniBlocks))
+	require.Equal(t, 1, len(txsInfoPerPendingMiniBlock))
+	require.Equal(t, 2, len(txsInfoPerPendingMiniBlock[0]))
+	assert.Equal(t, []byte("miniBlock_hash"), pendingMiniBlocks[0].Hash)
+	assert.Equal(t, []byte("tx_hash1"), txsInfoPerPendingMiniBlock[0][0].TxHash)
+	assert.Equal(t, []byte("miniBlock_hash"), txsInfoPerPendingMiniBlock[0][0].MbHash)
+	assert.Equal(t, []byte("tx_hash2"), txsInfoPerPendingMiniBlock[0][1].TxHash)
+	assert.Equal(t, []byte("miniBlock_hash"), txsInfoPerPendingMiniBlock[0][1].MbHash)
+}

--- a/update/process/shardBlock_test.go
+++ b/update/process/shardBlock_test.go
@@ -69,6 +69,7 @@ func TestNewShardBlockCreatorAfterHardFork(t *testing.T) {
 }
 
 func TestCreateBody(t *testing.T) {
+	t.Skip("fix this test")
 	t.Parallel()
 
 	mb1, mb2 := &block.MiniBlock{SenderShardID: 0}, &block.MiniBlock{SenderShardID: 1}
@@ -86,7 +87,19 @@ func TestCreateBody(t *testing.T) {
 		},
 	}
 
-	metaBlock := &block.MetaBlock{Round: 2}
+	metaBlock := &block.MetaBlock{
+		Round: 2,
+		EpochStart: block.EpochStart{
+			LastFinalizedHeaders: []block.EpochStartShardData{
+				{
+					PendingMiniBlockHeaders: []block.MiniBlockHeader{
+						{},
+					},
+				},
+			},
+		},
+	}
+
 	unFinishedMetaBlocks := map[string]*block.MetaBlock{
 		"hash": {Round: 1},
 	}
@@ -148,6 +161,7 @@ func TestCreateMiniBlockHeader(t *testing.T) {
 }
 
 func TestCreateNewBlock(t *testing.T) {
+	t.Skip("fix this test")
 	t.Parallel()
 
 	rootHash := []byte("rotHash")

--- a/update/sync/coordinator.go
+++ b/update/sync/coordinator.go
@@ -75,7 +75,7 @@ func (ss *syncState) SyncAllState(epoch uint32) error {
 
 	ss.printMetablockInfo(meta)
 
-	unFinished, err := ss.headers.GetUnfinishedMetaBlocks()
+	unFinished, err := ss.headers.GetUnFinishedMetaBlocks()
 	if err != nil {
 		return err
 	}
@@ -157,9 +157,9 @@ func (ss *syncState) GetEpochStartMetaBlock() (*block.MetaBlock, error) {
 	return ss.headers.GetEpochStartMetaBlock()
 }
 
-// GetUnfinishedMetaBlocks returns the synced unfinished metablocks
-func (ss *syncState) GetUnfinishedMetaBlocks() (map[string]*block.MetaBlock, error) {
-	return ss.headers.GetUnfinishedMetaBlocks()
+// GetUnFinishedMetaBlocks returns the synced unFinished metablocks
+func (ss *syncState) GetUnFinishedMetaBlocks() (map[string]*block.MetaBlock, error) {
+	return ss.headers.GetUnFinishedMetaBlocks()
 }
 
 // GetAllTries returns the synced tries

--- a/update/sync/syncHeaders.go
+++ b/update/sync/syncHeaders.go
@@ -180,7 +180,7 @@ func (h *headersToSync) receivedUnFinishedMetaBlocks(headerHandler data.HeaderHa
 	h.chReceivedAll <- true
 }
 
-// SyncUnFinishedMetaHeaders syncs and validates all the unfinished metaHeaders for each shard
+// SyncUnFinishedMetaHeaders syncs and validates all the unFinished metaHeaders for each shard
 func (h *headersToSync) SyncUnFinishedMetaHeaders(epoch uint32) error {
 	// TODO: do this with context.Context
 	err := h.syncEpochStartMetaHeader(epoch, waitTimeForHeaders)
@@ -335,7 +335,7 @@ func (h *headersToSync) syncAllNeededMetaHeaders(waitTime time.Duration) error {
 	if requested {
 		err := WaitFor(h.chReceivedAll, waitTime)
 		if err != nil {
-			log.Warn("timeOut for requesting all unfinished metaBlocks")
+			log.Warn("timeOut for requesting all unFinished metaBlocks")
 			return err
 		}
 	}
@@ -414,8 +414,8 @@ func (h *headersToSync) GetEpochStartMetaBlock() (*block.MetaBlock, error) {
 	return nil, update.ErrNotSynced
 }
 
-// GetUnfinishedMetaBlocks returns the synced metablock
-func (h *headersToSync) GetUnfinishedMetaBlocks() (map[string]*block.MetaBlock, error) {
+// GetUnFinishedMetaBlocks returns the synced metablock
+func (h *headersToSync) GetUnFinishedMetaBlocks() (map[string]*block.MetaBlock, error) {
 	h.mutMeta.Lock()
 	unFinished := make(map[string]*block.MetaBlock)
 	for hash, meta := range h.unFinishedMetaBlocks {

--- a/update/sync/syncMiniBlocks_test.go
+++ b/update/sync/syncMiniBlocks_test.go
@@ -138,7 +138,11 @@ func TestSyncPendingMiniBlocksFromMeta_MiniBlocksInPoolWithRewards(t *testing.T)
 	mbHash := []byte("mbHash")
 	rwdMBHash := []byte("rwdMBHash")
 	mb := &block.MiniBlock{}
-	rwdMB := &block.MiniBlock{Type: block.RewardsBlock}
+	rwdMB := &block.MiniBlock{
+		SenderShardID:   core.MetachainShardId,
+		ReceiverShardID: 0,
+		Type:            block.RewardsBlock,
+	}
 	args := ArgsNewPendingMiniBlocksSyncer{
 		Storage: &mock.StorerStub{},
 		Cache: &testscommon.CacherStub{
@@ -166,10 +170,13 @@ func TestSyncPendingMiniBlocksFromMeta_MiniBlocksInPoolWithRewards(t *testing.T)
 		EpochStart: block.EpochStart{
 			LastFinalizedHeaders: []block.EpochStartShardData{
 				{
-					ShardID:                 0,
-					RootHash:                []byte("shardDataRootHash"),
-					PendingMiniBlockHeaders: []block.MiniBlockHeader{{Hash: mbHash}},
-					FirstPendingMetaBlock:   []byte("firstPending"),
+					ShardID:  0,
+					RootHash: []byte("shardDataRootHash"),
+					PendingMiniBlockHeaders: []block.MiniBlockHeader{
+						{Hash: mbHash},
+						{Hash: rwdMBHash},
+					},
+					FirstPendingMetaBlock: []byte("firstPending"),
 				},
 			},
 		},


### PR DESCRIPTION
* Implemented a fix in Hardfork mechanism, which would execute all pending transactions in the correct order
* Exported/Imported unFinished metaBlocks as well, as they are needed for execution of pending transactions in the correct order
* Extracted common used code in a new file
* Refactored some prints and some methods names
