### PR TITLE
Refactor bootstrapper injection

### DIFF
--- a/epochStart/bootstrap/syncEpochStartMeta.go
+++ b/epochStart/bootstrap/syncEpochStartMeta.go
@@ -41,11 +41,8 @@ type ArgsNewEpochStartMetaSyncer struct {
 	StartInEpochConfig      config.EpochStartConfig
 	ArgsParser              process.ArgumentsParser
 	HeaderIntegrityVerifier process.HeaderIntegrityVerifier
+	MetaBlockProcessor      EpochStartMetaBlockInterceptorProcessor
 }
-
-// thresholdForConsideringMetaBlockCorrect represents the percentage (between 0 and 100) of connected peers to send
-// the same meta block in order to consider it correct
-const thresholdForConsideringMetaBlockCorrect = 67
 
 // NewEpochStartMetaSyncer will return a new instance of epochStartMetaSyncer
 func NewEpochStartMetaSyncer(args ArgsNewEpochStartMetaSyncer) (*epochStartMetaSyncer, error) {
@@ -61,27 +58,17 @@ func NewEpochStartMetaSyncer(args ArgsNewEpochStartMetaSyncer) (*epochStartMetaS
 	if check.IfNil(args.HeaderIntegrityVerifier) {
 		return nil, epochStart.ErrNilHeaderIntegrityVerifier
 	}
+	if check.IfNil(args.MetaBlockProcessor) {
+		return nil, epochStart.ErrNilMetablockProcessor
+	}
 
 	e := &epochStartMetaSyncer{
-		requestHandler: args.RequestHandler,
-		messenger:      args.Messenger,
-		marshalizer:    args.CoreComponentsHolder.InternalMarshalizer(),
-		hasher:         args.CoreComponentsHolder.Hasher(),
+		requestHandler:     args.RequestHandler,
+		messenger:          args.Messenger,
+		marshalizer:        args.CoreComponentsHolder.InternalMarshalizer(),
+		hasher:             args.CoreComponentsHolder.Hasher(),
+		metaBlockProcessor: args.MetaBlockProcessor,
 	}
-
-	processor, err := NewEpochStartMetaBlockProcessor(
-		args.Messenger,
-		args.RequestHandler,
-		args.CoreComponentsHolder.InternalMarshalizer(),
-		args.CoreComponentsHolder.Hasher(),
-		thresholdForConsideringMetaBlockCorrect,
-		args.StartInEpochConfig.MinNumConnectedPeersToStart,
-		args.StartInEpochConfig.MinNumOfPeersToConsiderBlockValid,
-	)
-	if err != nil {
-		return nil, err
-	}
-	e.metaBlockProcessor = processor
 
 	argsInterceptedDataFactory := interceptorsFactory.ArgInterceptedDataFactory{
 		CoreComponents:          args.CoreComponentsHolder,
@@ -105,7 +92,7 @@ func NewEpochStartMetaSyncer(args ArgsNewEpochStartMetaSyncer) (*epochStartMetaS
 		interceptors.ArgSingleDataInterceptor{
 			Topic:            factory.MetachainBlocksTopic,
 			DataFactory:      interceptedMetaHdrDataFactory,
-			Processor:        processor,
+			Processor:        args.MetaBlockProcessor,
 			Throttler:        disabled.NewThrottler(),
 			AntifloodHandler: disabled.NewAntiFloodHandler(),
 			WhiteListRequest: args.WhitelistHandler,

--- a/epochStart/bootstrap/syncEpochStartMeta_test.go
+++ b/epochStart/bootstrap/syncEpochStartMeta_test.go
@@ -9,11 +9,41 @@ import (
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/data/block"
+	"github.com/ElrondNetwork/elrond-go/epochStart"
 	"github.com/ElrondNetwork/elrond-go/epochStart/mock"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 	"github.com/ElrondNetwork/elrond-go/process/economics"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewEpochStartMetaSyncer_NilsShouldError(t *testing.T) {
+	t.Parallel()
+
+	args := getEpochStartSyncerArgs()
+	args.CoreComponentsHolder = nil
+	ess, err := NewEpochStartMetaSyncer(args)
+	assert.True(t, check.IfNil(ess))
+	assert.Equal(t, epochStart.ErrNilCoreComponentsHolder, err)
+
+	args = getEpochStartSyncerArgs()
+	args.CryptoComponentsHolder = nil
+	ess, err = NewEpochStartMetaSyncer(args)
+	assert.True(t, check.IfNil(ess))
+	assert.Equal(t, epochStart.ErrNilCryptoComponentsHolder, err)
+
+	args = getEpochStartSyncerArgs()
+	args.HeaderIntegrityVerifier = nil
+	ess, err = NewEpochStartMetaSyncer(args)
+	assert.True(t, check.IfNil(ess))
+	assert.Equal(t, epochStart.ErrNilHeaderIntegrityVerifier, err)
+
+	args = getEpochStartSyncerArgs()
+	args.MetaBlockProcessor = nil
+	ess, err = NewEpochStartMetaSyncer(args)
+	assert.True(t, check.IfNil(ess))
+	assert.Equal(t, epochStart.ErrNilMetablockProcessor, err)
+}
 
 func TestNewEpochStartMetaSyncer_ShouldWork(t *testing.T) {
 	t.Parallel()
@@ -125,5 +155,6 @@ func getEpochStartSyncerArgs() ArgsNewEpochStartMetaSyncer {
 			MinNumOfPeersToConsiderBlockValid: 2,
 		},
 		HeaderIntegrityVerifier: &mock.HeaderIntegrityVerifierStub{},
+		MetaBlockProcessor:      &mock.EpochStartMetaBlockProcessorStub{},
 	}
 }

--- a/epochStart/errors.go
+++ b/epochStart/errors.go
@@ -232,3 +232,6 @@ var ErrNilChanceComputer = errors.New("nil chance computer")
 
 // ErrInvalidMinNumberOfNodes signals that the minimum number of nodes is invalid
 var ErrInvalidMinNumberOfNodes = errors.New("minimum number of nodes invalid")
+
+// ErrNilMetablockProcessor signals that a nil metablock processor was provided
+var ErrNilMetablockProcessor = errors.New("nil metablock processor")

--- a/epochStart/mock/epochStartMetaBlockProcessorStub.go
+++ b/epochStart/mock/epochStartMetaBlockProcessorStub.go
@@ -1,0 +1,56 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/ElrondNetwork/elrond-go/core"
+	"github.com/ElrondNetwork/elrond-go/data/block"
+	"github.com/ElrondNetwork/elrond-go/process"
+)
+
+// EpochStartMetaBlockProcessorStub -
+type EpochStartMetaBlockProcessorStub struct {
+	ValidateCalled               func(data process.InterceptedData, fromConnectedPeer core.PeerID) error
+	SaveCalled                   func(data process.InterceptedData, fromConnectedPeer core.PeerID, topic string) error
+	RegisterHandlerCalled        func(handler func(topic string, hash []byte, data interface{}))
+	GetEpochStartMetaBlockCalled func(ctx context.Context) (*block.MetaBlock, error)
+}
+
+// Validate -
+func (esmbps *EpochStartMetaBlockProcessorStub) Validate(data process.InterceptedData, fromConnectedPeer core.PeerID) error {
+	if esmbps.ValidateCalled != nil {
+		return esmbps.ValidateCalled(data, fromConnectedPeer)
+	}
+
+	return nil
+}
+
+// Save -
+func (esmbps *EpochStartMetaBlockProcessorStub) Save(data process.InterceptedData, fromConnectedPeer core.PeerID, topic string) error {
+	if esmbps.SaveCalled != nil {
+		return esmbps.SaveCalled(data, fromConnectedPeer, topic)
+	}
+
+	return nil
+}
+
+// RegisterHandler -
+func (esmbps *EpochStartMetaBlockProcessorStub) RegisterHandler(handler func(topic string, hash []byte, data interface{})) {
+	if esmbps.RegisterHandlerCalled != nil {
+		esmbps.RegisterHandlerCalled(handler)
+	}
+}
+
+// IsInterfaceNil -
+func (esmbps *EpochStartMetaBlockProcessorStub) IsInterfaceNil() bool {
+	return esmbps == nil
+}
+
+// GetEpochStartMetaBlock -
+func (esmbps *EpochStartMetaBlockProcessorStub) GetEpochStartMetaBlock(ctx context.Context) (*block.MetaBlock, error) {
+	if esmbps.GetEpochStartMetaBlockCalled != nil {
+		return esmbps.GetEpochStartMetaBlockCalled(ctx)
+	}
+
+	return nil, nil
+}


### PR DESCRIPTION
- refactored epochStartMetaSyncer struct as to use an injected EpochStartMetaBlockInterceptorProcessor rather than a constructed one