### PR TITLE
fix/getBlockHash-from-current-epoch-only

### DIFF
--- a/process/errors.go
+++ b/process/errors.go
@@ -497,6 +497,9 @@ var ErrInvalidInflationPercentages = errors.New("invalid inflation percentages")
 // ErrInvalidNonceRequest signals that invalid nonce was requested
 var ErrInvalidNonceRequest = errors.New("invalid nonce request")
 
+// ErrInvalidBlockRequestOldEpoch signals that invalid block was requested from old epoch
+var ErrInvalidBlockRequestOldEpoch = errors.New("invalid block request from old epoch")
+
 // ErrNilBlockChainHook signals that nil blockchain hook has been provided
 var ErrNilBlockChainHook = errors.New("nil blockchain hook")
 

--- a/process/smartContract/hooks/blockChainHook.go
+++ b/process/smartContract/hooks/blockChainHook.go
@@ -208,16 +208,19 @@ func (bh *BlockChainHookImpl) GetBlockhash(nonce uint64) ([]byte, error) {
 		return bh.blockChain.GetCurrentBlockHeaderHash(), nil
 	}
 
-	_, hash, err := process.GetHeaderFromStorageWithNonce(
+	header, hash, err := process.GetHeaderFromStorageWithNonce(
 		nonce,
 		bh.shardCoordinator.SelfId(),
 		bh.storageService,
 		bh.uint64Converter,
 		bh.marshalizer,
 	)
-
 	if err != nil {
 		return nil, err
+	}
+
+	if header.GetEpoch() != hdr.GetEpoch() {
+		return nil, process.ErrInvalidBlockRequestOldEpoch
 	}
 
 	return hash, nil


### PR DESCRIPTION
implemented fix for blockchain hook to return blocks from current epoch only. Otherwise different nodes might have different response and roothash in case some smart contracts use this API.