### PR TITLE
Fixes top up rewards

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -2096,7 +2096,7 @@ func newMetaBlockProcessor(
 		TopUpRewardFactor:     economicsData.RewardsTopUpFactor(),
 		TopUpGradientPoint:    economicsData.RewardsTopUpGradientPoint(),
 		EconomicsDataProvider: economicsDataProvider,
-		EpochEnableV2:         10000000, // TODO: change this back when economics v2 is working
+		EpochEnableV2:         systemSCConfig.StakingSystemSCConfig.StakingV2Epoch,
 	}
 
 	epochRewards, err := metachainEpochStart.NewRewardsCreatorProxy(argsEpochRewards)

--- a/epochStart/interface.go
+++ b/epochStart/interface.go
@@ -171,8 +171,12 @@ type EpochEconomicsDataProvider interface {
 
 // EpochStartRewardsCreator defines the functionality for the metachain to create rewards at end of epoch
 type EpochStartRewardsCreator interface {
-	CreateRewardsMiniBlocks(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) (block.MiniBlockSlice, error)
-	VerifyRewardsMiniBlocks(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) error
+	CreateRewardsMiniBlocks(
+		metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics,
+	) (block.MiniBlockSlice, error)
+	VerifyRewardsMiniBlocks(
+		metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics,
+	) error
 	GetProtocolSustainabilityRewards() *big.Int
 	GetLocalTxCache() TransactionCacher
 	CreateMarshalizedData(body *block.Body) map[string][][]byte

--- a/epochStart/metachain/baseRewards.go
+++ b/epochStart/metachain/baseRewards.go
@@ -343,12 +343,13 @@ func (brc *baseRewardsCreator) isSystemDelegationSC(address []byte) bool {
 
 func (brc *baseRewardsCreator) createProtocolSustainabilityRewardTransaction(
 	metaBlock *block.MetaBlock,
+	computedEconomics *block.Economics,
 ) (*rewardTx.RewardTx, uint32, error) {
 
 	shardID := brc.shardCoordinator.ComputeId(brc.protocolSustainabilityAddress)
 	protocolSustainabilityRwdTx := &rewardTx.RewardTx{
 		Round:   metaBlock.GetRound(),
-		Value:   big.NewInt(0).Set(metaBlock.EpochStart.Economics.RewardsForProtocolSustainability),
+		Value:   big.NewInt(0).Set(computedEconomics.RewardsForProtocolSustainability),
 		RcvAddr: brc.protocolSustainabilityAddress,
 		Epoch:   metaBlock.Epoch,
 	}

--- a/epochStart/metachain/baseRewards.go
+++ b/epochStart/metachain/baseRewards.go
@@ -422,17 +422,10 @@ func (brc *baseRewardsCreator) adjustProtocolSustainabilityRewards(protocolSusta
 		protocolSustainabilityRwdTx.Value.SetUint64(0)
 	}
 
-	// TODO: Reject negative values when VerifyRewardsMiniBlocks is refactored
-	// Currently VerifyRewardsMiniBlocks starts its computation (calling CreateRewardsMiniBlocks) based on the
-	// metaBlock produced by a block producer.
-	// That metaBlock already has in Economics the adjusted protocol sustainability rewards as effect of
-	// executing CreateRewardsMiniBlocks, so the proposer and validator start validation with different values,
-	// which makes adjusting protocol rewards with negative values a requirement for validators.
-
-	//if dustRewards.Cmp(big.NewInt(0)) < 0 {
-	//	log.Error("trying to adjust protocol rewards with negative value", "dustRewards", dustRewards.String())
-	//	return
-	//}
+	if dustRewards.Cmp(big.NewInt(0)) < 0 {
+		log.Error("trying to adjust protocol rewards with negative value", "dustRewards", dustRewards.String())
+		return
+	}
 
 	protocolSustainabilityRwdTx.Value.Add(protocolSustainabilityRwdTx.Value, dustRewards)
 

--- a/epochStart/metachain/baseRewards_test.go
+++ b/epochStart/metachain/baseRewards_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
+	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/block"
 	"github.com/ElrondNetwork/elrond-go/data/rewardTx"
 	"github.com/ElrondNetwork/elrond-go/data/state"
@@ -324,11 +325,12 @@ func TestBaseRewardsCreator_CreateMarshalizedDataOnlyRewardsMiniblocksGetMarshal
 	require.Greater(t, len(result), 0)
 
 	readRwTx := &rewardTx.RewardTx{}
-	for _, data := range result {
-		for _, tx := range data {
+	var expectedTx data.TransactionHandler
+	for _, resData := range result {
+		for _, tx := range resData {
 			err = args.Marshalizer.Unmarshal(readRwTx, tx)
 			require.Nil(t, err)
-			expectedTx, err := rwd.currTxs.GetTx(dummyMiniBlock.TxHashes[0])
+			expectedTx, err = rwd.currTxs.GetTx(dummyMiniBlock.TxHashes[0])
 			require.Nil(t, err)
 			require.Equal(t, expectedTx, readRwTx)
 		}
@@ -461,6 +463,7 @@ func TestBaseRewardsCreator_SaveTxBlockToStorageNonRewardsMiniBlocksAreIgnored(t
 		block.ReceiptBlock,
 	}
 
+	var mb, mmb []byte
 	for _, mbType := range miniBlockTypes {
 		dummyMiniBlock.Type = mbType
 
@@ -470,10 +473,10 @@ func TestBaseRewardsCreator_SaveTxBlockToStorageNonRewardsMiniBlocksAreIgnored(t
 			},
 		})
 
-		mmb, err := args.Marshalizer.Marshal(dummyMiniBlock)
+		mmb, err = args.Marshalizer.Marshal(dummyMiniBlock)
 		require.Nil(t, err)
 		mbHash := args.Hasher.Compute(string(mmb))
-		mb, err := args.MiniBlockStorage.Get(mbHash)
+		mb, err = args.MiniBlockStorage.Get(mbHash)
 		require.Nil(t, mb)
 		require.NotNil(t, err)
 	}
@@ -485,10 +488,10 @@ func TestBaseRewardsCreator_SaveTxBlockToStorageNonRewardsMiniBlocksAreIgnored(t
 		},
 	})
 
-	mmb, err := args.Marshalizer.Marshal(dummyMiniBlock)
+	mmb, err = args.Marshalizer.Marshal(dummyMiniBlock)
 	require.Nil(t, err)
 	mbHash := args.Hasher.Compute(string(mmb))
-	mb, err := rwd.miniBlockStorage.Get(mbHash)
+	mb, err = rwd.miniBlockStorage.Get(mbHash)
 	require.Equal(t, mmb, mb)
 	require.Nil(t, err)
 
@@ -580,6 +583,8 @@ func TestBaseRewardsCreator_DeleteTxsFromStorageNonRewardsMiniBlocksIgnored(t *t
 		EpochStart:     getDefaultEpochStart(),
 		DevFeesInEpoch: big.NewInt(0),
 	}
+
+	var tx, mb []byte
 	for _, mbType := range miniBlockTypes {
 		dummyMb := createDummyRewardTxMiniblock(rwd)
 		dummyMb.Type = mbType
@@ -600,11 +605,11 @@ func TestBaseRewardsCreator_DeleteTxsFromStorageNonRewardsMiniBlocksIgnored(t *t
 		_ = rwd.miniBlockStorage.Put(mbHash, dummyMbMarshalled)
 
 		rwd.DeleteTxsFromStorage(metaBlk, &block.Body{MiniBlocks: block.MiniBlockSlice{dummyMb}})
-		tx, err := rwd.rewardsStorage.Get(rwTxHash)
+		tx, err = rwd.rewardsStorage.Get(rwTxHash)
 		require.Nil(t, err)
 		require.NotNil(t, tx)
 
-		mb, err := rwd.miniBlockStorage.Get(mbHash)
+		mb, err = rwd.miniBlockStorage.Get(mbHash)
 		require.Nil(t, err)
 		require.NotNil(t, mb)
 	}
@@ -945,8 +950,6 @@ func TestBaseRewardsCreator_adjustProtocolSustainabilityRewardsPositiveValue(t *
 
 func TestBaseRewardsCreator_adjustProtocolSustainabilityRewardsNegValueNotAccepted(t *testing.T) {
 	t.Parallel()
-	// TODO: enable the test when rewards miniBlocks verification is refactored
-	t.Skip("skip until refactor")
 
 	args := getBaseRewardsArguments()
 	rwd, err := NewBaseRewardsCreator(args)

--- a/epochStart/metachain/baseRewards_test.go
+++ b/epochStart/metachain/baseRewards_test.go
@@ -866,7 +866,7 @@ func TestBaseRewardsCreator_createProtocolSustainabilityRewardTransaction(t *tes
 		DevFeesInEpoch: big.NewInt(0),
 	}
 
-	rwTx, _, err := rwd.createProtocolSustainabilityRewardTransaction(metaBlk)
+	rwTx, _, err := rwd.createProtocolSustainabilityRewardTransaction(metaBlk, &metaBlk.EpochStart.Economics)
 	require.Nil(t, err)
 	require.NotNil(t, rwTx)
 	require.Equal(t, metaBlk.EpochStart.Economics.RewardsForProtocolSustainability, rwTx.Value)

--- a/epochStart/metachain/economics.go
+++ b/epochStart/metachain/economics.go
@@ -321,14 +321,19 @@ func (e *economics) computeNumOfTotalCreatedBlocks(
 	totalNumBlocks := uint64(0)
 	var blocksInShard uint64
 	blocksPerShard := make(map[uint32]uint64)
-	for shardId := uint32(0); shardId < e.shardCoordinator.NumberOfShards(); shardId++ {
+	shardMap := createShardsMap(e.shardCoordinator)
+	for shardId := range shardMap {
 		blocksInShard = mapEndNonce[shardId] - mapStartNonce[shardId]
 		blocksPerShard[shardId] = blocksInShard
 		totalNumBlocks += blocksInShard
+		log.Debug("computeNumOfTotalCreatedBlocks",
+			"shardID", shardId,
+			"prevEpochLastNonce", mapEndNonce[shardId],
+			"epochLastNonce", mapStartNonce[shardId],
+			"nbBlocksEpoch", blocksPerShard[shardId],
+		)
 	}
-	blocksInShard = mapEndNonce[core.MetachainShardId] - mapStartNonce[core.MetachainShardId]
-	blocksPerShard[core.MetachainShardId] = blocksInShard
-	totalNumBlocks += blocksInShard
+
 	e.economicsDataNotified.SetNumberOfBlocks(totalNumBlocks)
 	e.economicsDataNotified.SetNumberOfBlocksPerShard(blocksPerShard)
 
@@ -375,14 +380,18 @@ func (e *economics) startNoncePerShardFromLastCrossNotarized(metaNonce uint64, e
 }
 
 // VerifyRewardsPerBlock checks whether rewards per block value was correctly computed
-func (e *economics) VerifyRewardsPerBlock(metaBlock *block.MetaBlock, correctedProtocolSustainability *big.Int) error {
+func (e *economics) VerifyRewardsPerBlock(
+	metaBlock *block.MetaBlock,
+	correctedProtocolSustainability *big.Int,
+	computedEconomics *block.Economics,
+) error {
+	if computedEconomics == nil {
+		return epochStart.ErrNilEconomicsData
+	}
 	if !metaBlock.IsStartOfEpochBlock() {
 		return nil
 	}
-	computedEconomics, err := e.ComputeEndOfEpochEconomics(metaBlock)
-	if err != nil {
-		return err
-	}
+
 	computedEconomics.RewardsForProtocolSustainability.Set(correctedProtocolSustainability)
 	computedEconomicsHash, err := core.CalculateHash(e.marshalizer, e.hasher, computedEconomics)
 	if err != nil {

--- a/epochStart/metachain/economics_test.go
+++ b/epochStart/metachain/economics_test.go
@@ -467,7 +467,11 @@ func TestEconomics_VerifyRewardsPerBlock_DifferentHitRates(t *testing.T) {
 			DevFeesInEpoch:         devFeesInEpoch,
 		}
 
-		err := ec.VerifyRewardsPerBlock(&mb, expectedProtocolSustainabilityRewards)
+		computedEconomics, err := ec.ComputeEndOfEpochEconomics(&mb)
+		assert.Nil(t, err)
+		assert.NotNil(t, computedEconomics)
+
+		err = ec.VerifyRewardsPerBlock(&mb, expectedProtocolSustainabilityRewards, computedEconomics)
 		assert.Nil(t, err)
 
 		ecos, err := ec.ComputeEndOfEpochEconomics(&mb)

--- a/epochStart/metachain/rewards.go
+++ b/epochStart/metachain/rewards.go
@@ -49,7 +49,7 @@ func NewEpochStartRewardsCreator(args ArgsNewRewardsCreator) (*rewardsCreator, e
 func (rc *rewardsCreator) CreateRewardsMiniBlocks(
 	metaBlock *block.MetaBlock,
 	validatorsInfo map[uint32][]*state.ValidatorInfo,
-	_ *block.Economics,
+	computedEconomics *block.Economics,
 ) (block.MiniBlockSlice, error) {
 	if check.IfNil(metaBlock) {
 		return nil, epochStart.ErrNilHeaderHandler
@@ -70,8 +70,6 @@ func (rc *rewardsCreator) CreateRewardsMiniBlocks(
 
 	miniBlocks := rc.initializeRewardsMiniBlocks()
 
-	// keep the functionality as it was by passing the metaBlock economics
-	computedEconomics := &metaBlock.EpochStart.Economics
 	protSustRwdTx, protSustShardId, err := rc.createProtocolSustainabilityRewardTransaction(metaBlock, computedEconomics)
 	if err != nil {
 		return nil, err

--- a/epochStart/metachain/rewards.go
+++ b/epochStart/metachain/rewards.go
@@ -46,7 +46,11 @@ func NewEpochStartRewardsCreator(args ArgsNewRewardsCreator) (*rewardsCreator, e
 }
 
 // CreateRewardsMiniBlocks creates the rewards miniblocks according to economics data and validator info
-func (rc *rewardsCreator) CreateRewardsMiniBlocks(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) (block.MiniBlockSlice, error) {
+func (rc *rewardsCreator) CreateRewardsMiniBlocks(
+	metaBlock *block.MetaBlock,
+	validatorsInfo map[uint32][]*state.ValidatorInfo,
+	_ *block.Economics,
+) (block.MiniBlockSlice, error) {
 	if check.IfNil(metaBlock) {
 		return nil, epochStart.ErrNilHeaderHandler
 	}
@@ -66,13 +70,15 @@ func (rc *rewardsCreator) CreateRewardsMiniBlocks(metaBlock *block.MetaBlock, va
 
 	miniBlocks := rc.initializeRewardsMiniBlocks()
 
-	protocolSustainabilityRwdTx, protocolSustainabilityShardId, err := rc.createProtocolSustainabilityRewardTransaction(metaBlock)
+	// keep the functionality as it was by passing the metaBlock economics
+	computedEconomics := &metaBlock.EpochStart.Economics
+	protSustRwdTx, protSustShardId, err := rc.createProtocolSustainabilityRewardTransaction(metaBlock, computedEconomics)
 	if err != nil {
 		return nil, err
 	}
 
 	rc.fillBaseRewardsPerBlockPerNode(economicsData.RewardsPerBlock)
-	err = rc.addValidatorRewardsToMiniBlocks(validatorsInfo, metaBlock, miniBlocks, protocolSustainabilityRwdTx)
+	err = rc.addValidatorRewardsToMiniBlocks(validatorsInfo, metaBlock, miniBlocks, protSustRwdTx)
 	if err != nil {
 		return nil, err
 	}
@@ -80,8 +86,8 @@ func (rc *rewardsCreator) CreateRewardsMiniBlocks(metaBlock *block.MetaBlock, va
 	totalWithoutDevelopers := big.NewInt(0).Sub(economicsData.TotalToDistribute, metaBlock.DevFeesInEpoch)
 	difference := big.NewInt(0).Sub(totalWithoutDevelopers, rc.accumulatedRewards)
 	log.Debug("arithmetic difference in end of epoch rewards economics", "value", difference)
-	rc.adjustProtocolSustainabilityRewards(protocolSustainabilityRwdTx, difference)
-	err = rc.addProtocolRewardToMiniBlocks(protocolSustainabilityRwdTx, miniBlocks, protocolSustainabilityShardId)
+	rc.adjustProtocolSustainabilityRewards(protSustRwdTx, difference)
+	err = rc.addProtocolRewardToMiniBlocks(protSustRwdTx, miniBlocks, protSustShardId)
 	if err != nil {
 		return nil, err
 	}
@@ -177,12 +183,16 @@ func (rc *rewardsCreator) computeValidatorInfoPerRewardAddress(
 }
 
 // VerifyRewardsMiniBlocks verifies if received rewards miniblocks are correct
-func (rc *rewardsCreator) VerifyRewardsMiniBlocks(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) error {
+func (rc *rewardsCreator) VerifyRewardsMiniBlocks(
+	metaBlock *block.MetaBlock,
+	validatorsInfo map[uint32][]*state.ValidatorInfo,
+	computedEconomics *block.Economics,
+) error {
 	if check.IfNil(metaBlock) {
 		return epochStart.ErrNilHeaderHandler
 	}
 
-	createdMiniBlocks, err := rc.CreateRewardsMiniBlocks(metaBlock, validatorsInfo)
+	createdMiniBlocks, err := rc.CreateRewardsMiniBlocks(metaBlock, validatorsInfo, computedEconomics)
 	if err != nil {
 		return err
 	}

--- a/epochStart/metachain/rewardsCreatorProxy.go
+++ b/epochStart/metachain/rewardsCreatorProxy.go
@@ -64,21 +64,29 @@ func NewRewardsCreatorProxy(args RewardsCreatorProxyArgs) (*rewardsCreatorProxy,
 }
 
 // CreateRewardsMiniBlocks proxies the CreateRewardsMiniBlocks method of the configured rewardsCreator instance
-func (rcp *rewardsCreatorProxy) CreateRewardsMiniBlocks(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) (block.MiniBlockSlice, error) {
+func (rcp *rewardsCreatorProxy) CreateRewardsMiniBlocks(
+	metaBlock *block.MetaBlock,
+	validatorsInfo map[uint32][]*state.ValidatorInfo,
+	computedEconomics *block.Economics,
+) (block.MiniBlockSlice, error) {
 	err := rcp.changeRewardCreatorIfNeeded(metaBlock.Epoch)
 	if err != nil {
 		return nil, err
 	}
-	return rcp.rc.CreateRewardsMiniBlocks(metaBlock, validatorsInfo)
+	return rcp.rc.CreateRewardsMiniBlocks(metaBlock, validatorsInfo, computedEconomics)
 }
 
 // VerifyRewardsMiniBlocks proxies the same method of the configured rewardsCreator instance
-func (rcp *rewardsCreatorProxy) VerifyRewardsMiniBlocks(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) error {
+func (rcp *rewardsCreatorProxy) VerifyRewardsMiniBlocks(
+	metaBlock *block.MetaBlock,
+	validatorsInfo map[uint32][]*state.ValidatorInfo,
+	computedEconomics *block.Economics,
+) error {
 	err := rcp.changeRewardCreatorIfNeeded(metaBlock.Epoch)
 	if err != nil {
 		return err
 	}
-	return rcp.rc.VerifyRewardsMiniBlocks(metaBlock, validatorsInfo)
+	return rcp.rc.VerifyRewardsMiniBlocks(metaBlock, validatorsInfo, computedEconomics)
 }
 
 // GetProtocolSustainabilityRewards proxies the same method of the configured rewardsCreator instance

--- a/epochStart/metachain/rewardsCreatorProxy.go
+++ b/epochStart/metachain/rewardsCreatorProxy.go
@@ -38,6 +38,7 @@ type rewardsCreatorProxy struct {
 	mutRc         sync.Mutex
 }
 
+// NewRewardsCreatorProxy creates a rewards creator proxy instance
 func NewRewardsCreatorProxy(args RewardsCreatorProxyArgs) (*rewardsCreatorProxy, error) {
 	var err error
 

--- a/epochStart/metachain/rewardsCreatorProxy_test.go
+++ b/epochStart/metachain/rewardsCreatorProxy_test.go
@@ -53,15 +53,16 @@ func TestRewardsCreatorProxy_CreateRewardsMiniBlocksWithError(t *testing.T) {
 
 	rewardCreatorV1 := &mock.RewardsCreatorStub{
 		CreateRewardsMiniBlocksCalled: func(
-			metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo,
+			metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics,
 		) (block.MiniBlockSlice, error) {
 			return nil, expectedErr
 		},
 	}
 
 	rewardsCreatorProxy, vInfo, mb := createTestData(rewardCreatorV1, rCreatorV1)
+	computedEconomics := &mb.EpochStart.Economics
 
-	miniBlocks, err := rewardsCreatorProxy.CreateRewardsMiniBlocks(mb, vInfo)
+	miniBlocks, err := rewardsCreatorProxy.CreateRewardsMiniBlocks(mb, vInfo, computedEconomics)
 	require.Equal(t, expectedErr, err)
 	require.Nil(t, miniBlocks)
 }
@@ -71,15 +72,16 @@ func TestRewardsCreatorProxy_CreateRewardsMiniBlocksOK(t *testing.T) {
 
 	rewardCreatorV1 := &mock.RewardsCreatorStub{
 		CreateRewardsMiniBlocksCalled: func(
-			metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo,
+			metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics,
 		) (block.MiniBlockSlice, error) {
 			return make(block.MiniBlockSlice, 2), nil
 		},
 	}
 
 	rewardsCreatorProxy, vInfo, mb := createTestData(rewardCreatorV1, rCreatorV1)
+	economics := &mb.EpochStart.Economics
 
-	miniBlocks, err := rewardsCreatorProxy.CreateRewardsMiniBlocks(mb, vInfo)
+	miniBlocks, err := rewardsCreatorProxy.CreateRewardsMiniBlocks(mb, vInfo, economics)
 	require.Nil(t, err)
 	require.NotNil(t, miniBlocks)
 }
@@ -89,7 +91,7 @@ func TestRewardsCreatorProxy_CreateRewardsMiniBlocksWithSwitchToRewardsCreatorV2
 
 	rewardCreatorV1 := &mock.RewardsCreatorStub{
 		CreateRewardsMiniBlocksCalled: func(
-			metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo,
+			metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics,
 		) (block.MiniBlockSlice, error) {
 			return make(block.MiniBlockSlice, 2), nil
 		},
@@ -98,8 +100,9 @@ func TestRewardsCreatorProxy_CreateRewardsMiniBlocksWithSwitchToRewardsCreatorV2
 	rewardsCreatorProxy, vInfo, metaBlock := createTestData(rewardCreatorV1, rCreatorV1)
 	rewardsCreatorProxy.epochEnableV2 = 1
 	metaBlock.Epoch = 3
+	economics := &metaBlock.EpochStart.Economics
 
-	miniBlocks, err := rewardsCreatorProxy.CreateRewardsMiniBlocks(metaBlock, vInfo)
+	miniBlocks, err := rewardsCreatorProxy.CreateRewardsMiniBlocks(metaBlock, vInfo, economics)
 	require.Nil(t, err)
 	require.NotNil(t, miniBlocks)
 	require.Equal(t, rewardsCreatorProxy.configuredRC, rCreatorV2)
@@ -114,7 +117,7 @@ func TestRewardsCreatorProxy_CreateRewardsMiniBlocksWithSwitchToRewardsCreatorV1
 
 	rewardCreatorV2 := &mock.RewardsCreatorStub{
 		CreateRewardsMiniBlocksCalled: func(
-			metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo,
+			metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics,
 		) (block.MiniBlockSlice, error) {
 			return make(block.MiniBlockSlice, 2), nil
 		},
@@ -123,8 +126,9 @@ func TestRewardsCreatorProxy_CreateRewardsMiniBlocksWithSwitchToRewardsCreatorV1
 	rewardsCreatorProxy, vInfo, metaBlock := createTestData(rewardCreatorV2, rCreatorV2)
 	rewardsCreatorProxy.epochEnableV2 = 5
 	metaBlock.Epoch = 3
+	economics := &metaBlock.EpochStart.Economics
 
-	miniBlocks, err := rewardsCreatorProxy.CreateRewardsMiniBlocks(metaBlock, vInfo)
+	miniBlocks, err := rewardsCreatorProxy.CreateRewardsMiniBlocks(metaBlock, vInfo, economics)
 	require.Nil(t, err)
 	require.NotNil(t, miniBlocks)
 	require.Equal(t, rewardsCreatorProxy.configuredRC, rCreatorV1)
@@ -139,14 +143,16 @@ func TestRewardsCreatorProxy_VerifyRewardsMiniBlocksWithError(t *testing.T) {
 
 	expectedErr := fmt.Errorf("expectedError")
 	rewardCreatorV1 := &mock.RewardsCreatorStub{
-		VerifyRewardsMiniBlocksCalled: func(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) error {
+		VerifyRewardsMiniBlocksCalled: func(
+			metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics) error {
 			return expectedErr
 		},
 	}
 
 	rewardsCreatorProxy, vInfo, mb := createTestData(rewardCreatorV1, rCreatorV1)
+	economics := &mb.EpochStart.Economics
 
-	err := rewardsCreatorProxy.VerifyRewardsMiniBlocks(mb, vInfo)
+	err := rewardsCreatorProxy.VerifyRewardsMiniBlocks(mb, vInfo, economics)
 	require.Equal(t, expectedErr, err)
 }
 
@@ -154,14 +160,16 @@ func TestRewardsCreatorProxy_VerifyRewardsMiniBlocksOK(t *testing.T) {
 	t.Parallel()
 
 	rewardCreatorV1 := &mock.RewardsCreatorStub{
-		VerifyRewardsMiniBlocksCalled: func(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) error {
+		VerifyRewardsMiniBlocksCalled: func(
+			metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics) error {
 			return nil
 		},
 	}
 
 	rewardsCreatorProxy, vInfo, mb := createTestData(rewardCreatorV1, rCreatorV1)
+	economics := &mb.EpochStart.Economics
 
-	err := rewardsCreatorProxy.VerifyRewardsMiniBlocks(mb, vInfo)
+	err := rewardsCreatorProxy.VerifyRewardsMiniBlocks(mb, vInfo, economics)
 	require.Nil(t, err)
 }
 

--- a/epochStart/metachain/rewardsV2.go
+++ b/epochStart/metachain/rewardsV2.go
@@ -90,11 +90,10 @@ func (rc *rewardsCreatorV2) CreateRewardsMiniBlocks(
 	rc.mutRewardsData.Lock()
 	defer rc.mutRewardsData.Unlock()
 
-	economicsData := *computedEconomics
 	log.Debug("rewardsCreatorV2.CreateRewardsMiniBlocks",
-		"totalToDistribute", economicsData.TotalToDistribute,
-		"rewardsForProtocolSustainability", economicsData.RewardsForProtocolSustainability,
-		"rewardsPerBlock", economicsData.RewardsPerBlock,
+		"totalToDistribute", computedEconomics.TotalToDistribute,
+		"rewardsForProtocolSustainability", computedEconomics.RewardsForProtocolSustainability,
+		"rewardsPerBlock", computedEconomics.RewardsPerBlock,
 		"devFeesInEpoch", metaBlock.DevFeesInEpoch,
 		"rewardsForBlocks no fees", rc.economicsDataProvider.RewardsToBeDistributedForBlocks(),
 		"numberOfBlocks", rc.economicsDataProvider.NumberOfBlocks(),

--- a/epochStart/metachain/rewardsV2.go
+++ b/epochStart/metachain/rewardsV2.go
@@ -24,6 +24,7 @@ type nodeRewardsData struct {
 	valInfo      *state.ValidatorInfo
 }
 
+// RewardsCreatorArgsV2 holds the data required to create end of epoch rewards
 type RewardsCreatorArgsV2 struct {
 	BaseRewardsCreatorArgs
 	StakingDataProvider   epochStart.StakingDataProvider
@@ -40,7 +41,7 @@ type rewardsCreatorV2 struct {
 	topUpGradientPoint    *big.Int
 }
 
-// NewEpochStartRewardsCreator creates a new rewards creator object
+// NewEpochStartRewardsCreatorV2 creates a new rewards creator object
 func NewEpochStartRewardsCreatorV2(args RewardsCreatorArgsV2) (*rewardsCreatorV2, error) {
 	brc, err := NewBaseRewardsCreator(args.BaseRewardsCreatorArgs)
 	if err != nil {
@@ -74,15 +75,22 @@ func NewEpochStartRewardsCreatorV2(args RewardsCreatorArgsV2) (*rewardsCreatorV2
 // CreateRewardsMiniBlocks creates the rewards miniblocks according to economics data and validator info.
 // This method applies the rewards according to the economics version 2 proposal, which takes into consideration
 // stake top-up values per node
-func (rc *rewardsCreatorV2) CreateRewardsMiniBlocks(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) (block.MiniBlockSlice, error) {
+func (rc *rewardsCreatorV2) CreateRewardsMiniBlocks(
+	metaBlock *block.MetaBlock,
+	validatorsInfo map[uint32][]*state.ValidatorInfo,
+	computedEconomics *block.Economics,
+) (block.MiniBlockSlice, error) {
 	if check.IfNil(metaBlock) {
 		return nil, epochStart.ErrNilHeaderHandler
+	}
+	if computedEconomics == nil{
+		return nil, epochStart.ErrNilEconomicsData
 	}
 
 	rc.mutRewardsData.Lock()
 	defer rc.mutRewardsData.Unlock()
 
-	economicsData := metaBlock.EpochStart.Economics
+	economicsData := *computedEconomics
 	log.Debug("rewardsCreatorV2.CreateRewardsMiniBlocks",
 		"totalToDistribute", economicsData.TotalToDistribute,
 		"rewardsForProtocolSustainability", economicsData.RewardsForProtocolSustainability,
@@ -100,7 +108,7 @@ func (rc *rewardsCreatorV2) CreateRewardsMiniBlocks(metaBlock *block.MetaBlock, 
 		return nil, err
 	}
 
-	protRwdTx, protRwdShardId, err := rc.createProtocolSustainabilityRewardTransaction(metaBlock)
+	protRwdTx, protRwdShardId, err := rc.createProtocolSustainabilityRewardTransaction(metaBlock, computedEconomics)
 	if err != nil {
 		return nil, err
 	}
@@ -124,12 +132,16 @@ func (rc *rewardsCreatorV2) CreateRewardsMiniBlocks(metaBlock *block.MetaBlock, 
 }
 
 // VerifyRewardsMiniBlocks verifies if received rewards miniblocks are correct
-func (rc *rewardsCreatorV2) VerifyRewardsMiniBlocks(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) error {
+func (rc *rewardsCreatorV2) VerifyRewardsMiniBlocks(
+	metaBlock *block.MetaBlock,
+	validatorsInfo map[uint32][]*state.ValidatorInfo,
+	computedEconomics *block.Economics,
+) error {
 	if check.IfNil(metaBlock) {
 		return epochStart.ErrNilHeaderHandler
 	}
 
-	createdMiniBlocks, err := rc.CreateRewardsMiniBlocks(metaBlock, validatorsInfo)
+	createdMiniBlocks, err := rc.CreateRewardsMiniBlocks(metaBlock, validatorsInfo, computedEconomics)
 	if err != nil {
 		return err
 	}

--- a/epochStart/metachain/rewardsV2_test.go
+++ b/epochStart/metachain/rewardsV2_test.go
@@ -127,7 +127,7 @@ func TestRewardsCreator_CreateRewardsMiniBlocksV2ComputeErrorsShouldErr(t *testi
 			AccumulatedFees: big.NewInt(100),
 		},
 	}
-	bdy, err := rwd.CreateRewardsMiniBlocks(mb, valInfo)
+	bdy, err := rwd.CreateRewardsMiniBlocks(mb, valInfo, &mb.EpochStart.Economics)
 	require.NotNil(t, err)
 	require.Equal(t, expectedErr, err)
 	require.Nil(t, bdy)
@@ -993,7 +993,7 @@ func TestNewEpochStartRewardsCreatorV2_CreateRewardsMiniBlocks(t *testing.T) {
 		DevFeesInEpoch: big.NewInt(0),
 	}
 
-	miniBlocks, err = rwd.CreateRewardsMiniBlocks(metaBlock, vInfo)
+	miniBlocks, err = rwd.CreateRewardsMiniBlocks(metaBlock, vInfo, &metaBlock.EpochStart.Economics)
 	require.Nil(t, err)
 	require.NotNil(t, miniBlocks)
 
@@ -1034,7 +1034,7 @@ func TestNewEpochStartRewardsCreatorV2_CreateRewardsMiniBlocks(t *testing.T) {
 		}
 	}
 
-	err = rwd.VerifyRewardsMiniBlocks(metaBlock, vInfo)
+	err = rwd.VerifyRewardsMiniBlocks(metaBlock, vInfo, &metaBlock.EpochStart.Economics)
 	require.Nil(t, err)
 }
 

--- a/epochStart/metachain/rewards_test.go
+++ b/epochStart/metachain/rewards_test.go
@@ -141,7 +141,7 @@ func TestRewardsCreator_CreateRewardsMiniBlocks(t *testing.T) {
 			AccumulatedFees: big.NewInt(100),
 		},
 	}
-	bdy, err := rwd.CreateRewardsMiniBlocks(mb, valInfo)
+	bdy, err := rwd.CreateRewardsMiniBlocks(mb, valInfo, &mb.EpochStart.Economics)
 	assert.Nil(t, err)
 	assert.NotNil(t, bdy)
 }
@@ -184,7 +184,7 @@ func TestRewardsCreator_VerifyRewardsMiniBlocksHashDoesNotMatch(t *testing.T) {
 		},
 	}
 
-	err := rwd.VerifyRewardsMiniBlocks(mb, valInfo)
+	err := rwd.VerifyRewardsMiniBlocks(mb, valInfo, &mb.EpochStart.Economics)
 	assert.Equal(t, epochStart.ErrRewardMiniBlockHashDoesNotMatch, err)
 }
 
@@ -243,7 +243,7 @@ func TestRewardsCreator_VerifyRewardsMiniBlocksRewardsMbNumDoesNotMatch(t *testi
 		},
 	}
 
-	err := rwd.VerifyRewardsMiniBlocks(mb, valInfo)
+	err := rwd.VerifyRewardsMiniBlocks(mb, valInfo, &mb.EpochStart.Economics)
 	assert.Equal(t, epochStart.ErrRewardMiniBlocksNumDoesNotMatch, err)
 }
 
@@ -304,7 +304,7 @@ func TestRewardsCreator_VerifyRewardsMiniBlocksShouldWork(t *testing.T) {
 		},
 	}
 
-	err := rwd.VerifyRewardsMiniBlocks(mb, valInfo)
+	err := rwd.VerifyRewardsMiniBlocks(mb, valInfo, &mb.EpochStart.Economics)
 	assert.Nil(t, err)
 }
 
@@ -374,7 +374,7 @@ func TestRewardsCreator_VerifyRewardsMiniBlocksShouldWorkEvenIfNotAllShardsHaveR
 		},
 	}
 
-	err := rwd.VerifyRewardsMiniBlocks(mb, valInfo)
+	err := rwd.VerifyRewardsMiniBlocks(mb, valInfo, &mb.EpochStart.Economics)
 	assert.Nil(t, err)
 }
 
@@ -396,7 +396,7 @@ func TestRewardsCreator_CreateMarshalizedData(t *testing.T) {
 			AccumulatedFees: big.NewInt(100),
 		},
 	}
-	_, _ = rwd.CreateRewardsMiniBlocks(mb, valInfo)
+	_, _ = rwd.CreateRewardsMiniBlocks(mb, valInfo, &mb.EpochStart.Economics)
 
 	rwdTx := rewardTx.RewardTx{
 		Round:   0,
@@ -454,7 +454,7 @@ func TestRewardsCreator_SaveTxBlockToStorage(t *testing.T) {
 			LeaderSuccess:   1,
 		},
 	}
-	_, _ = rwd.CreateRewardsMiniBlocks(mb, valInfo)
+	_, _ = rwd.CreateRewardsMiniBlocks(mb, valInfo, &mb.EpochStart.Economics)
 
 	mb2 := block.MetaBlock{
 		MiniBlockHeaders: []block.MiniBlockHeader{
@@ -596,7 +596,7 @@ func TestRewardsCreator_CreateProtocolSustainabilityRewardTransaction(t *testing
 		Epoch:   0,
 	}
 
-	rwdTx, _, err := rwdc.createProtocolSustainabilityRewardTransaction(mb)
+	rwdTx, _, err := rwdc.createProtocolSustainabilityRewardTransaction(mb, &mb.EpochStart.Economics)
 	assert.Equal(t, expectedRewardTx, rwdTx)
 	assert.Nil(t, err)
 }
@@ -631,7 +631,7 @@ func TestRewardsCreator_AddProtocolSustainabilityRewardToMiniBlocks(t *testing.T
 	metaBlk.EpochStart.Economics.RewardsForProtocolSustainability.Set(expectedRewardTx.Value)
 	metaBlk.EpochStart.Economics.TotalToDistribute.Set(expectedRewardTx.Value)
 
-	miniBlocks, err := rwdc.CreateRewardsMiniBlocks(metaBlk, make(map[uint32][]*state.ValidatorInfo))
+	miniBlocks, err := rwdc.CreateRewardsMiniBlocks(metaBlk, make(map[uint32][]*state.ValidatorInfo), &metaBlk.EpochStart.Economics)
 	assert.Nil(t, err)
 	assert.Equal(t, cloneMb, miniBlocks[0])
 }
@@ -671,7 +671,7 @@ func TestRewardsCreator_ValidatorInfoWithMetaAddressAddedToProtocolSustainabilit
 	_ = userAcc.DataTrieTracker().SaveKeyValue([]byte(core.DelegationSystemSCKey), []byte(core.DelegationSystemSCKey))
 	_ = args.UserAccountsDB.SaveAccount(userAcc)
 
-	miniBlocks, err := rwdc.CreateRewardsMiniBlocks(metaBlk, valInfo)
+	miniBlocks, err := rwdc.CreateRewardsMiniBlocks(metaBlk, valInfo, &metaBlk.EpochStart.Economics)
 	assert.Nil(t, err)
 	assert.Equal(t, len(miniBlocks), 2)
 	assert.Equal(t, len(miniBlocks[0].TxHashes), 1)

--- a/epochStart/mock/rewardsCreatorStub.go
+++ b/epochStart/mock/rewardsCreatorStub.go
@@ -11,8 +11,12 @@ import (
 
 // RewardsCreatorStub -
 type RewardsCreatorStub struct {
-	CreateRewardsMiniBlocksCalled          func(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) (block.MiniBlockSlice, error)
-	VerifyRewardsMiniBlocksCalled          func(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) error
+	CreateRewardsMiniBlocksCalled func(
+		metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics,
+	) (block.MiniBlockSlice, error)
+	VerifyRewardsMiniBlocksCalled func(
+		metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics,
+	) error
 	GetProtocolSustainabilityRewardsCalled func() *big.Int
 	GetLocalTxCacheCalled                  func() epochStart.TransactionCacher
 	CreateMarshalizedDataCalled            func(body *block.Body) map[string][][]byte
@@ -26,18 +30,23 @@ type RewardsCreatorStub struct {
 func (rcs *RewardsCreatorStub) CreateRewardsMiniBlocks(
 	metaBlock *block.MetaBlock,
 	validatorsInfo map[uint32][]*state.ValidatorInfo,
+	computedEconomics *block.Economics,
 ) (block.MiniBlockSlice, error) {
 	if rcs.CreateRewardsMiniBlocksCalled != nil {
-		return rcs.CreateRewardsMiniBlocksCalled(metaBlock, validatorsInfo)
+		return rcs.CreateRewardsMiniBlocksCalled(metaBlock, validatorsInfo, computedEconomics)
 	}
 
 	return nil, nil
 }
 
 // VerifyRewardsMiniBlocks -
-func (rcs *RewardsCreatorStub) VerifyRewardsMiniBlocks(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) error {
+func (rcs *RewardsCreatorStub) VerifyRewardsMiniBlocks(
+	metaBlock *block.MetaBlock,
+	validatorsInfo map[uint32][]*state.ValidatorInfo,
+	computedEconomics *block.Economics,
+) error {
 	if rcs.VerifyRewardsMiniBlocksCalled != nil {
-		return rcs.VerifyRewardsMiniBlocksCalled(metaBlock, validatorsInfo)
+		return rcs.VerifyRewardsMiniBlocksCalled(metaBlock, validatorsInfo, computedEconomics)
 	}
 	return nil
 }
@@ -96,7 +105,7 @@ func (rcs *RewardsCreatorStub) RemoveBlockDataFromPools(metaBlock *block.MetaBlo
 	}
 }
 
-// IsInterfaceNil
+// IsInterfaceNil -
 func (rcs *RewardsCreatorStub) IsInterfaceNil() bool {
 	return rcs == nil
 }

--- a/integrationTests/mock/epochEconomicsStub.go
+++ b/integrationTests/mock/epochEconomicsStub.go
@@ -9,7 +9,9 @@ import (
 // EpochEconomicsStub -
 type EpochEconomicsStub struct {
 	ComputeEndOfEpochEconomicsCalled func(metaBlock *block.MetaBlock) (*block.Economics, error)
-	VerifyRewardsPerBlockCalled      func(metaBlock *block.MetaBlock, correctedProtocolSustainability *big.Int) error
+	VerifyRewardsPerBlockCalled      func(
+		metaBlock *block.MetaBlock, correctedProtocolSustainability *big.Int, computedEconomics *block.Economics,
+	) error
 }
 
 // ComputeEndOfEpochEconomics -
@@ -21,9 +23,13 @@ func (e *EpochEconomicsStub) ComputeEndOfEpochEconomics(metaBlock *block.MetaBlo
 }
 
 // VerifyRewardsPerBlock -
-func (e *EpochEconomicsStub) VerifyRewardsPerBlock(metaBlock *block.MetaBlock, correctedProtocolSustainability *big.Int) error {
+func (e *EpochEconomicsStub) VerifyRewardsPerBlock(
+	metaBlock *block.MetaBlock,
+	correctedProtocolSustainability *big.Int,
+	computedEconomics *block.Economics,
+) error {
 	if e.VerifyRewardsPerBlockCalled != nil {
-		return e.VerifyRewardsPerBlockCalled(metaBlock, correctedProtocolSustainability)
+		return e.VerifyRewardsPerBlockCalled(metaBlock, correctedProtocolSustainability, computedEconomics)
 	}
 	return nil
 }

--- a/integrationTests/mock/epochRewardsCreatorStub.go
+++ b/integrationTests/mock/epochRewardsCreatorStub.go
@@ -11,8 +11,12 @@ import (
 
 // EpochRewardsCreatorStub -
 type EpochRewardsCreatorStub struct {
-	CreateRewardsMiniBlocksCalled  func(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) (block.MiniBlockSlice, error)
-	VerifyRewardsMiniBlocksCalled  func(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) error
+	CreateRewardsMiniBlocksCalled func(
+		metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics,
+	) (block.MiniBlockSlice, error)
+	VerifyRewardsMiniBlocksCalled func(
+		metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics,
+	) error
 	CreateMarshalizedDataCalled    func(body *block.Body) map[string][][]byte
 	SaveTxBlockToStorageCalled     func(metaBlock *block.MetaBlock, body *block.Body)
 	DeleteTxsFromStorageCalled     func(metaBlock *block.MetaBlock, body *block.Body)
@@ -39,9 +43,13 @@ func (e *EpochRewardsCreatorStub) GetLocalTxCache() epochStart.TransactionCacher
 }
 
 // CreateRewardsMiniBlocks -
-func (e *EpochRewardsCreatorStub) CreateRewardsMiniBlocks(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) (block.MiniBlockSlice, error) {
+func (e *EpochRewardsCreatorStub) CreateRewardsMiniBlocks(
+	metaBlock *block.MetaBlock,
+	validatorsInfo map[uint32][]*state.ValidatorInfo,
+	computedEconomics *block.Economics,
+) (block.MiniBlockSlice, error) {
 	if e.CreateRewardsMiniBlocksCalled != nil {
-		return e.CreateRewardsMiniBlocksCalled(metaBlock, validatorsInfo)
+		return e.CreateRewardsMiniBlocksCalled(metaBlock, validatorsInfo, computedEconomics)
 	}
 	return nil, nil
 }
@@ -55,9 +63,13 @@ func (e *EpochRewardsCreatorStub) GetRewardsTxs(body *block.Body) map[string]dat
 }
 
 // VerifyRewardsMiniBlocks -
-func (e *EpochRewardsCreatorStub) VerifyRewardsMiniBlocks(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) error {
+func (e *EpochRewardsCreatorStub) VerifyRewardsMiniBlocks(
+	metaBlock *block.MetaBlock,
+	validatorsInfo map[uint32][]*state.ValidatorInfo,
+	computedEconomics *block.Economics,
+) error {
 	if e.VerifyRewardsMiniBlocksCalled != nil {
-		return e.VerifyRewardsMiniBlocksCalled(metaBlock, validatorsInfo)
+		return e.VerifyRewardsMiniBlocksCalled(metaBlock, validatorsInfo, computedEconomics)
 	}
 	return nil
 }

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -366,7 +366,7 @@ func (mp *metaProcessor) processEpochStartMetaBlock(
 		return err
 	}
 
-	err = mp.epochRewardsCreator.VerifyRewardsMiniBlocks(header, allValidatorsInfo)
+	err = mp.epochRewardsCreator.VerifyRewardsMiniBlocks(header, allValidatorsInfo, computedEconomics)
 	if err != nil {
 		return err
 	}
@@ -763,7 +763,7 @@ func (mp *metaProcessor) createEpochStartBody(metaBlock *block.MetaBlock) (data.
 		return nil, err
 	}
 
-	rewardMiniBlocks, err := mp.epochRewardsCreator.CreateRewardsMiniBlocks(metaBlock, allValidatorsInfo)
+	rewardMiniBlocks, err := mp.epochRewardsCreator.CreateRewardsMiniBlocks(metaBlock, allValidatorsInfo, &metaBlock.EpochStart.Economics)
 	if err != nil {
 		return nil, err
 	}

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -361,6 +361,11 @@ func (mp *metaProcessor) processEpochStartMetaBlock(
 		return err
 	}
 
+	computedEconomics, err := mp.epochEconomics.ComputeEndOfEpochEconomics(header)
+	if err != nil {
+		return err
+	}
+
 	err = mp.epochRewardsCreator.VerifyRewardsMiniBlocks(header, allValidatorsInfo)
 	if err != nil {
 		return err
@@ -381,7 +386,7 @@ func (mp *metaProcessor) processEpochStartMetaBlock(
 		return err
 	}
 
-	err = mp.epochEconomics.VerifyRewardsPerBlock(header, mp.epochRewardsCreator.GetProtocolSustainabilityRewards())
+	err = mp.epochEconomics.VerifyRewardsPerBlock(header, mp.epochRewardsCreator.GetProtocolSustainabilityRewards(), computedEconomics)
 	if err != nil {
 		return err
 	}

--- a/process/interface.go
+++ b/process/interface.go
@@ -547,7 +547,7 @@ type RewardsHandler interface {
 // EndOfEpochEconomics defines the functionality that is needed to compute end of epoch economics data
 type EndOfEpochEconomics interface {
 	ComputeEndOfEpochEconomics(metaBlock *block.MetaBlock) (*block.Economics, error)
-	VerifyRewardsPerBlock(metaBlock *block.MetaBlock, correctedProtocolSustainability *big.Int) error
+	VerifyRewardsPerBlock(metaBlock *block.MetaBlock, correctedProtocolSustainability *big.Int, computedEconomics *block.Economics) error
 	IsInterfaceNil() bool
 }
 

--- a/process/interface.go
+++ b/process/interface.go
@@ -762,8 +762,12 @@ type EpochStartDataCreator interface {
 
 // EpochStartRewardsCreator defines the functionality for the metachain to create rewards at end of epoch
 type EpochStartRewardsCreator interface {
-	CreateRewardsMiniBlocks(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) (block.MiniBlockSlice, error)
-	VerifyRewardsMiniBlocks(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) error
+	CreateRewardsMiniBlocks(
+		metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics,
+	) (block.MiniBlockSlice, error)
+	VerifyRewardsMiniBlocks(
+		metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics,
+	) error
 	GetProtocolSustainabilityRewards() *big.Int
 	GetLocalTxCache() epochStart.TransactionCacher
 	CreateMarshalizedData(body *block.Body) map[string][][]byte

--- a/process/mock/epochEconomicsStub.go
+++ b/process/mock/epochEconomicsStub.go
@@ -9,7 +9,9 @@ import (
 // EpochEconomicsStub -
 type EpochEconomicsStub struct {
 	ComputeEndOfEpochEconomicsCalled func(metaBlock *block.MetaBlock) (*block.Economics, error)
-	VerifyRewardsPerBlockCalled      func(metaBlock *block.MetaBlock, correctedProtocolSustainability *big.Int) error
+	VerifyRewardsPerBlockCalled      func(
+		metaBlock *block.MetaBlock, correctedProtocolSustainability *big.Int, computedEconomics *block.Economics,
+	) error
 }
 
 // ComputeEndOfEpochEconomics -
@@ -21,9 +23,13 @@ func (e *EpochEconomicsStub) ComputeEndOfEpochEconomics(metaBlock *block.MetaBlo
 }
 
 // VerifyRewardsPerBlock -
-func (e *EpochEconomicsStub) VerifyRewardsPerBlock(metaBlock *block.MetaBlock, correctedProtocolSustainability *big.Int) error {
+func (e *EpochEconomicsStub) VerifyRewardsPerBlock(
+	metaBlock *block.MetaBlock,
+	correctedProtocolSustainability *big.Int,
+	computedEconomics *block.Economics,
+) error {
 	if e.VerifyRewardsPerBlockCalled != nil {
-		return e.VerifyRewardsPerBlockCalled(metaBlock, correctedProtocolSustainability)
+		return e.VerifyRewardsPerBlockCalled(metaBlock, correctedProtocolSustainability, computedEconomics)
 	}
 	return nil
 }

--- a/process/mock/epochRewardsCreatorStub.go
+++ b/process/mock/epochRewardsCreatorStub.go
@@ -11,8 +11,12 @@ import (
 
 // EpochRewardsCreatorStub -
 type EpochRewardsCreatorStub struct {
-	CreateRewardsMiniBlocksCalled  func(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) (block.MiniBlockSlice, error)
-	VerifyRewardsMiniBlocksCalled  func(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) error
+	CreateRewardsMiniBlocksCalled func(
+		metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics,
+	) (block.MiniBlockSlice, error)
+	VerifyRewardsMiniBlocksCalled func(
+		metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo, computedEconomics *block.Economics,
+	) error
 	CreateMarshalizedDataCalled    func(body *block.Body) map[string][][]byte
 	SaveTxBlockToStorageCalled     func(metaBlock *block.MetaBlock, body *block.Body)
 	DeleteTxsFromStorageCalled     func(metaBlock *block.MetaBlock, body *block.Body)
@@ -39,17 +43,25 @@ func (e *EpochRewardsCreatorStub) GetLocalTxCache() epochStart.TransactionCacher
 }
 
 // CreateRewardsMiniBlocks -
-func (e *EpochRewardsCreatorStub) CreateRewardsMiniBlocks(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) (block.MiniBlockSlice, error) {
+func (e *EpochRewardsCreatorStub) CreateRewardsMiniBlocks(
+	metaBlock *block.MetaBlock,
+	validatorsInfo map[uint32][]*state.ValidatorInfo,
+	computedEconomics *block.Economics,
+) (block.MiniBlockSlice, error) {
 	if e.CreateRewardsMiniBlocksCalled != nil {
-		return e.CreateRewardsMiniBlocksCalled(metaBlock, validatorsInfo)
+		return e.CreateRewardsMiniBlocksCalled(metaBlock, validatorsInfo, computedEconomics)
 	}
 	return nil, nil
 }
 
 // VerifyRewardsMiniBlocks -
-func (e *EpochRewardsCreatorStub) VerifyRewardsMiniBlocks(metaBlock *block.MetaBlock, validatorsInfo map[uint32][]*state.ValidatorInfo) error {
+func (e *EpochRewardsCreatorStub) VerifyRewardsMiniBlocks(
+	metaBlock *block.MetaBlock,
+	validatorsInfo map[uint32][]*state.ValidatorInfo,
+	computedEconomics *block.Economics,
+) error {
 	if e.VerifyRewardsMiniBlocksCalled != nil {
-		return e.VerifyRewardsMiniBlocksCalled(metaBlock, validatorsInfo)
+		return e.VerifyRewardsMiniBlocksCalled(metaBlock, validatorsInfo, computedEconomics)
 	}
 	return nil
 }


### PR DESCRIPTION
- fix number of blocks considered at the end of epoch for rewards v2 (previously EoE economics was computed after the rewards miniblocks on consensus validators while for block proposer it was computed before)
- use own computed economics for validation instead of the one coming from metablock header
- reject negative adjustments for protocol sustainability
