### PR TITLE
fix epoch-root hash storer config

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -214,7 +214,8 @@
     [TrieEpochRootHashStorage.Cache]
         Name = "TrieEpochRootHashCache"
         Capacity = 1000
-        Type = "LRU"
+        Type = "SizeLRU"
+        SizeInBytes = 314572800 #300MB
     [TrieEpochRootHashStorage.DB]
         FilePath = "TrieEpochRootHashStorageDB"
         Type = "LvlDBSerial"

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -213,14 +213,13 @@
 [TrieEpochRootHashStorage]
     [TrieEpochRootHashStorage.Cache]
         Name = "TrieEpochRootHashCache"
-        Capacity = 10
-        Type = "SizeLRU"
-        SizeInBytes = 5242 #5MB
+        Capacity = 1000
+        Type = "LRU"
     [TrieEpochRootHashStorage.DB]
         FilePath = "TrieEpochRootHashStorageDB"
         Type = "LvlDBSerial"
         BatchDelaySeconds = 2
-        MaxBatchSize = 20000
+        MaxBatchSize = 500
         MaxOpenFiles = 10
 
 [ShardHdrNonceHashStorage]


### PR DESCRIPTION
Fixed the configuration for the `TrieEpochRootHashStorage`. The previous config would have caused the node to stop with the error `cache size is lower than batch size`