### PR TITLE
max number of shards for genesis config

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -46,6 +46,9 @@
    # GenesisString represents the encoded string for the genesis block
    GenesisString = "67656E65736973"
 
+   # GenesisMaxNumberOfShards represents the maximum number of shards to be created at genesis (excluding metaChain shard)
+   GenesisMaxNumberOfShards  = 3
+
 [Versions]
    DefaultVersion = "default"
    VersionsByEpochs = [

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -635,6 +635,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		nodesSetupPath,
 		addressPubkeyConverter,
 		validatorPubkeyConverter,
+		generalConfig.GeneralSettings.GenesisMaxNumberOfShards,
 	)
 	if err != nil {
 		return err

--- a/cmd/storer2elastic/main.go
+++ b/cmd/storer2elastic/main.go
@@ -185,6 +185,7 @@ func startStorer2Elastic(ctx *cli.Context) error {
 		flagsValues.nodesSetupFilePath,
 		addressPubKeyConverter,
 		validatorPubKeyConverter,
+		nodeConfig.GeneralSettings.GenesisMaxNumberOfShards,
 	)
 	if err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -221,6 +221,7 @@ type GeneralSettingsConfig struct {
 	MetaProtectionEnableEpoch              uint32
 	AheadOfTimeGasUsageEnableEpoch         uint32
 	GenesisString                          string
+	GenesisMaxNumberOfShards               uint32
 }
 
 // FacadeConfig will hold different configuration option that will be passed to the main ElrondFacade

--- a/sharding/errors.go
+++ b/sharding/errors.go
@@ -37,6 +37,9 @@ var ErrNilShardCoordinator = errors.New("trying to set nil shard coordinator")
 // ErrNilPubkeyConverter signals that a nil public key converter has been provided
 var ErrNilPubkeyConverter = errors.New("trying to set nil pubkey converter")
 
+// ErrInvalidMaximumNumberOfShards signals that an invalid maximum number of shards has been provided
+var ErrInvalidMaximumNumberOfShards = errors.New("trying to set an invalid maximum number of shards")
+
 // ErrCouldNotParsePubKey signals that a given public key could not be parsed
 var ErrCouldNotParsePubKey = errors.New("could not parse node's public key")
 

--- a/sharding/nodesSetup.go
+++ b/sharding/nodesSetup.go
@@ -71,6 +71,7 @@ type NodesSetup struct {
 
 	InitialNodes []*InitialNode `json:"initialNodes"`
 
+	genesisMaxNumShards      uint32
 	nrOfShards               uint32
 	nrOfNodes                uint32
 	nrOfMetaChainNodes       uint32
@@ -85,6 +86,7 @@ func NewNodesSetup(
 	nodesFilePath string,
 	addressPubkeyConverter core.PubkeyConverter,
 	validatorPubkeyConverter core.PubkeyConverter,
+	genesisMaxNumShards uint32,
 ) (*NodesSetup, error) {
 
 	if check.IfNil(addressPubkeyConverter) {
@@ -93,10 +95,14 @@ func NewNodesSetup(
 	if check.IfNil(validatorPubkeyConverter) {
 		return nil, fmt.Errorf("%w for validatorPubkeyConverter", ErrNilPubkeyConverter)
 	}
+	if genesisMaxNumShards < 1 {
+		return nil, fmt.Errorf("%w for genesisMaxNumShards", ErrInvalidMaximumNumberOfShards)
+	}
 
 	nodes := &NodesSetup{
 		addressPubkeyConverter:   addressPubkeyConverter,
 		validatorPubkeyConverter: validatorPubkeyConverter,
+		genesisMaxNumShards:      genesisMaxNumShards,
 	}
 
 	err := core.LoadJsonFile(nodes, nodesFilePath)
@@ -200,6 +206,10 @@ func (ns *NodesSetup) processMetaChainAssigment() {
 	hystShard := uint32(float32(ns.MinNodesPerShard) * ns.Hysteresis)
 
 	ns.nrOfShards = (ns.nrOfNodes - ns.nrOfMetaChainNodes - hystMeta) / (ns.MinNodesPerShard + hystShard)
+
+	if ns.nrOfShards > ns.genesisMaxNumShards {
+		ns.nrOfShards = ns.genesisMaxNumShards
+	}
 }
 
 func (ns *NodesSetup) processShardAssignment() {

--- a/sharding/nodesSetup_test.go
+++ b/sharding/nodesSetup_test.go
@@ -646,7 +646,7 @@ func TestNodesSetup_IfNodesWithinMaxShardLimitEquivalentDistribution(t *testing.
 		Adaptivity:                  false,
 		addressPubkeyConverter:      mock.NewPubkeyConverterMock(32),
 		validatorPubkeyConverter:    mock.NewPubkeyConverterMock(96),
-		genesisMaxNumShards:         3,
+		genesisMaxNumShards:         100,
 	}
 
 	ns = createAndAssignNodes(*ns, 2169)

--- a/testscommon/generalConfig.go
+++ b/testscommon/generalConfig.go
@@ -8,7 +8,8 @@ import (
 func GetGeneralConfig() config.Config {
 	return config.Config{
 		GeneralSettings: config.GeneralSettingsConfig{
-			StartInEpochEnabled: true,
+			StartInEpochEnabled:      true,
+			GenesisMaxNumberOfShards: 100,
 		},
 		EpochStartConfig: config.EpochStartConfig{
 			MinRoundsBetweenEpochs:            5,


### PR DESCRIPTION
Add maximum number of shards for genesis nodes config

This will allow more flexible initial test-net nodes config.
Should be backwards compatible, as long as the set maximum number of shards >=  with the legacy end result (3 shards without MetaChain)

Legacy implementation would have split the nodes into maximum number of shards allowed by the constraints (number of eligible nodes per shard + minimum hysteresis for waiting nodes), now even if more shards could be created, the given maximum number of shards is kept as a hard limit, the remaining nodes being distributed to the shards waiting lists.
