### PR TITLE
Keygenerator refactor

### DIFF
--- a/cmd/keygenerator/main.go
+++ b/cmd/keygenerator/main.go
@@ -92,8 +92,8 @@ VERSION:
 
 	argsConfig = &cfg{}
 
-	walletKeyFileNameTemplate    = "walletKey%s.pem"
-	validatorKeyFileNameTemplate = "validatorKey%s.pem"
+	walletKeyFilenameTemplate    = "walletKey%s.pem"
+	validatorKeyFilenameTemplate = "validatorKey%s.pem"
 
 	log = logger.GetOrCreate("keygenerator")
 
@@ -280,13 +280,13 @@ func saveKeys(validatorKeys []key, walletKeys []key, noSplit bool) error {
 
 	var errFound error
 	if len(validatorKeys) > 0 {
-		err := saveSliceKeys(validatorKeyFileNameTemplate, validatorKeys, validatorPubKeyConverter, noSplit)
+		err := saveSliceKeys(validatorKeyFilenameTemplate, validatorKeys, validatorPubKeyConverter, noSplit)
 		if err != nil {
 			errFound = err
 		}
 	}
 	if len(walletKeys) > 0 {
-		err := saveSliceKeys(walletKeyFileNameTemplate, walletKeys, walletPubKeyConverter, noSplit)
+		err := saveSliceKeys(walletKeyFilenameTemplate, walletKeys, walletPubKeyConverter, noSplit)
 		if err != nil {
 			errFound = err
 		}

--- a/cmd/keygenerator/main.go
+++ b/cmd/keygenerator/main.go
@@ -1,26 +1,41 @@
 package main
 
 import (
+	"bytes"
 	"encoding/hex"
+	"encoding/pem"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	logger "github.com/ElrondNetwork/elrond-go-logger"
-	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/core"
+	"github.com/ElrondNetwork/elrond-go/core/check"
+	"github.com/ElrondNetwork/elrond-go/core/pubkeyConverter"
 	"github.com/ElrondNetwork/elrond-go/crypto"
 	"github.com/ElrondNetwork/elrond-go/crypto/signing"
 	"github.com/ElrondNetwork/elrond-go/crypto/signing/ed25519"
 	"github.com/ElrondNetwork/elrond-go/crypto/signing/mcl"
-	"github.com/ElrondNetwork/elrond-go/data/state/factory"
 	"github.com/urfave/cli"
 )
 
 type cfg struct {
-	numKeys int
-	keyType string
+	numKeys    int
+	keyType    string
+	consoleOut bool
+	noSplit    bool
+}
+
+const validatorType = "validator"
+const walletType = "wallet"
+const bothType = "both"
+
+type key struct {
+	skBytes []byte
+	pkBytes []byte
 }
 
 const keysFolderPattern = "node-%d"
@@ -51,13 +66,28 @@ VERSION:
 		Value:       1,
 		Destination: &argsConfig.numKeys,
 	}
-
 	// keyType defines a flag for setting what keys should generate
 	keyType = cli.StringFlag{
-		Name:        "key-type",
-		Usage:       "What king of keys should generate. Available options: validator, wallet, both",
+		Name: "key-type",
+		Usage: fmt.Sprintf(
+			"What king of keys should generate. Available options: %s, %s, %s",
+			validatorType,
+			walletType,
+			bothType),
 		Value:       "validator",
 		Destination: &argsConfig.keyType,
+	}
+	// consoleOut is the flag that, if active, will print everything on the console, not on a physical file
+	consoleOut = cli.BoolFlag{
+		Name:        "console-out",
+		Usage:       "Boolean option that will enable printing the generated keys directly on the console",
+		Destination: &argsConfig.consoleOut,
+	}
+	// noSplit is the flag that, if active, will generate the keys in the same file
+	noSplit = cli.BoolFlag{
+		Name:        "no-split",
+		Usage:       "Boolean option that will make each generated key added in the same file",
+		Destination: &argsConfig.noSplit,
 	}
 
 	argsConfig = &cfg{}
@@ -66,6 +96,9 @@ VERSION:
 	validatorKeyFileName = "validatorKey.pem"
 
 	log = logger.GetOrCreate("keygenerator")
+
+	validatorPubKeyConverter, _ = pubkeyConverter.NewHexPubkeyConverter(blsPubkeyLen)
+	walletPubKeyConverter, _    = pubkeyConverter.NewBech32PubkeyConverter(txSignPubkeyLen)
 )
 
 func main() {
@@ -83,10 +116,12 @@ func main() {
 	app.Flags = []cli.Flag{
 		numKeys,
 		keyType,
+		consoleOut,
+		noSplit,
 	}
 
 	app.Action = func(_ *cli.Context) error {
-		return generateAllFiles()
+		return process()
 	}
 
 	err := app.Run(os.Args)
@@ -95,6 +130,216 @@ func main() {
 
 		os.Exit(1)
 	}
+}
+
+func process() error {
+	validatorKeys, walletKeys, err := generateKeys(argsConfig.keyType, argsConfig.numKeys)
+	if err != nil {
+		return err
+	}
+
+	return outputKeys(validatorKeys, walletKeys, argsConfig.consoleOut, argsConfig.noSplit)
+}
+
+func generateKeys(typeKey string, numKeys int) ([]key, []key, error) {
+	if numKeys < 1 {
+		return nil, nil, fmt.Errorf("number of keys should be a number greater or equal to 1")
+	}
+
+	validatorKeys := make([]key, 0)
+	walletKeys := make([]key, 0)
+	var err error
+
+	blockSigningGenerator := signing.NewKeyGenerator(mcl.NewSuiteBLS12())
+	txSigningGenerator := signing.NewKeyGenerator(ed25519.NewEd25519())
+
+	for i := 0; i < numKeys; i++ {
+		switch typeKey {
+		case validatorType:
+			validatorKeys, err = generateKey(blockSigningGenerator, validatorKeys)
+			if err != nil {
+				return nil, nil, err
+			}
+		case walletType:
+			walletKeys, err = generateKey(txSigningGenerator, walletKeys)
+			if err != nil {
+				return nil, nil, err
+			}
+		case bothType:
+			validatorKeys, err = generateKey(blockSigningGenerator, validatorKeys)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			walletKeys, err = generateKey(txSigningGenerator, walletKeys)
+			if err != nil {
+				return nil, nil, err
+			}
+		default:
+			return nil, nil, fmt.Errorf("unknown key type %s", argsConfig.keyType)
+		}
+	}
+
+	return validatorKeys, walletKeys, nil
+}
+
+func generateKey(keyGen crypto.KeyGenerator, list []key) ([]key, error) {
+	sk, pk := keyGen.GeneratePair()
+	skBytes, err := sk.ToByteArray()
+	if err != nil {
+		return nil, err
+	}
+
+	pkBytes, err := pk.ToByteArray()
+	if err != nil {
+		return nil, err
+	}
+
+	list = append(
+		list,
+		key{
+			skBytes: skBytes,
+			pkBytes: pkBytes,
+		},
+	)
+
+	return list, nil
+}
+
+func outputKeys(
+	validatorKeys []key,
+	walletKeys []key,
+	consoleOut bool,
+	noSplit bool,
+) error {
+	if consoleOut {
+		return printKeys(validatorKeys, walletKeys)
+	}
+
+	return saveKeys(validatorKeys, walletKeys, noSplit)
+}
+
+func printKeys(validatorKeys []key, walletKeys []key) error {
+	if len(validatorKeys)+len(walletKeys) == 0 {
+		return fmt.Errorf("internal error: no keys to print")
+	}
+
+	var errFound error
+	if len(validatorKeys) > 0 {
+		err := printSliceKeys("Validator keys:", validatorKeys, validatorPubKeyConverter)
+		if err != nil {
+			errFound = err
+		}
+	}
+	if len(walletKeys) > 0 {
+		err := printSliceKeys("Wallet keys:", walletKeys, walletPubKeyConverter)
+		if err != nil {
+			errFound = err
+		}
+	}
+
+	return errFound
+}
+
+func printSliceKeys(message string, sliceKeys []key, converter core.PubkeyConverter) error {
+	data := []string{message + "\n"}
+
+	for _, k := range sliceKeys {
+		buf := bytes.NewBuffer(make([]byte, 0))
+		err := writeKeyToStream(buf, k, converter)
+		if err != nil {
+			return err
+		}
+
+		data = append(data, string(buf.Bytes()))
+	}
+
+	log.Info(strings.Join(data, ""))
+	return nil
+}
+
+func writeKeyToStream(writer io.Writer, key key, pubkeyConverter core.PubkeyConverter) error {
+	if check.IfNilReflect(writer) {
+		return fmt.Errorf("nil writer")
+	}
+
+	pkString := pubkeyConverter.Encode(key.pkBytes)
+
+	blk := pem.Block{
+		Type:  "PRIVATE KEY for " + pkString,
+		Bytes: []byte(hex.EncodeToString(key.skBytes)),
+	}
+
+	return pem.Encode(writer, &blk)
+}
+
+func saveKeys(validatorKeys []key, walletKeys []key, noSplit bool) error {
+	if len(validatorKeys)+len(walletKeys) == 0 {
+		return fmt.Errorf("internal error: no keys to save")
+	}
+
+	var errFound error
+	if len(validatorKeys) > 0 {
+		err := saveSliceKeys(validatorKeyFileName, validatorKeys, validatorPubKeyConverter, noSplit)
+		if err != nil {
+			errFound = err
+		}
+	}
+	if len(walletKeys) > 0 {
+		err := saveSliceKeys(walletKeyFileName, walletKeys, walletPubKeyConverter, noSplit)
+		if err != nil {
+			errFound = err
+		}
+	}
+
+	return errFound
+}
+
+func saveSliceKeys(baseFilename string, keys []key, pubkeyConverter core.PubkeyConverter, noSplit bool) error {
+	var file *os.File
+	var err error
+	for i, k := range keys {
+		shouldCreateFile := !noSplit || i == 0
+		if shouldCreateFile {
+			file, err = generateFile(i, len(keys), baseFilename)
+			if err != nil {
+				return err
+			}
+		}
+
+		err = writeKeyToStream(file, k, pubkeyConverter)
+		if err != nil {
+			return err
+		}
+		if !noSplit {
+			err = file.Close()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if noSplit {
+		return file.Close()
+	}
+
+	return nil
+}
+
+func generateFile(index int, numKeys int, baseFilename string) (*os.File, error) {
+	folder, err := generateFolder(index, numKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	filename := filepath.Join(folder, baseFilename)
+	backupFileIfExists(filename)
+	err = os.Remove(filename)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	return os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, core.FileModeUserReadWrite)
 }
 
 func generateFolder(index int, numKeys int) (string, error) {
@@ -117,21 +362,6 @@ func generateFolder(index int, numKeys int) (string, error) {
 	return absPath, nil
 }
 
-func generateKeys(keyGen crypto.KeyGenerator) ([]byte, []byte, error) {
-	sk, pk := keyGen.GeneratePair()
-	skBytes, err := sk.ToByteArray()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	pkBytes, err := pk.ToByteArray()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return skBytes, pkBytes, nil
-}
-
 func backupFileIfExists(filename string) {
 	if _, err := os.Stat(filename); err != nil {
 		if os.IsNotExist(err) {
@@ -142,96 +372,98 @@ func backupFileIfExists(filename string) {
 	_ = os.Rename(filename, filename+"."+fmt.Sprintf("%d", time.Now().Unix()))
 }
 
-func generateAllFiles() error {
-	for i := 0; i < argsConfig.numKeys; i++ {
-		err := generateOneSetOfFiles(i, argsConfig.numKeys)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func generateOneSetOfFiles(index int, numKeys int) error {
-	switch argsConfig.keyType {
-	case "validator":
-		return generateBlockKey(index, numKeys)
-	case "wallet":
-		return generateTxKey(index, numKeys)
-	case "both":
-		err := generateBlockKey(index, numKeys)
-		if err != nil {
-			return err
-		}
-
-		return generateTxKey(index, numKeys)
-	default:
-		return fmt.Errorf("unknown key type %s", argsConfig.keyType)
-	}
-}
-
-func generateBlockKey(index int, numKeys int) error {
-	pubkeyConverter, err := factory.NewPubkeyConverter(
-		config.PubkeyConfig{
-			Length: blsPubkeyLen,
-			Type:   factory.HexFormat,
-		},
-	)
-	if err != nil {
-		return err
-	}
-
-	genForBlockSigningSk := signing.NewKeyGenerator(mcl.NewSuiteBLS12())
-
-	return generateAndSave(index, numKeys, validatorKeyFileName, genForBlockSigningSk, pubkeyConverter)
-}
-
-func generateTxKey(index int, numKeys int) error {
-	pubkeyConverter, err := factory.NewPubkeyConverter(
-		config.PubkeyConfig{
-			Length: txSignPubkeyLen,
-			Type:   factory.Bech32Format,
-		},
-	)
-	if err != nil {
-		return err
-	}
-
-	genForBlockSigningSk := signing.NewKeyGenerator(ed25519.NewEd25519())
-
-	return generateAndSave(index, numKeys, walletKeyFileName, genForBlockSigningSk, pubkeyConverter)
-}
-
-func generateAndSave(index int, numKeys int, baseFilename string, genForBlockSigningSk crypto.KeyGenerator, pubkeyConverter core.PubkeyConverter) error {
-	folder, err := generateFolder(index, numKeys)
-	if err != nil {
-		return err
-	}
-
-	filename := filepath.Join(folder, baseFilename)
-	backupFileIfExists(filename)
-
-	err = os.Remove(filename)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, core.FileModeUserReadWrite)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		_ = file.Close()
-	}()
-
-	sk, pk, err := generateKeys(genForBlockSigningSk)
-	if err != nil {
-		return err
-	}
-
-	pkString := pubkeyConverter.Encode(pk)
-
-	return core.SaveSkToPemFile(file, pkString, []byte(hex.EncodeToString(sk)))
-}
+//
+//func generateAllFiles() error {
+//	for i := 0; i < argsConfig.numKeys; i++ {
+//		err := generateOneSetOfFiles(i)
+//		if err != nil {
+//			return err
+//		}
+//	}
+//
+//	return nil
+//}
+//
+//func generateOneSetOfFiles(index int) error {
+//	switch argsConfig.keyType {
+//	case "validator":
+//		return generateBlockKey(index, argsConfig.numKeys, argsConfig.consoleOut)
+//	case "wallet":
+//		return generateTxKey(index, argsConfig.numKeys, argsConfig.consoleOut)
+//	case "both":
+//		err := generateBlockKey(index, argsConfig.numKeys, argsConfig.consoleOut)
+//		if err != nil {
+//			return err
+//		}
+//
+//		return generateTxKey(index, argsConfig.numKeys, argsConfig.consoleOut)
+//	default:
+//		return fmt.Errorf("unknown key type %s", argsConfig.keyType)
+//	}
+//}
+//
+//func generateBlockKey(index int, numKeys int, consoleOut bool) error {
+//	pubkeyConverter, err := factory.NewPubkeyConverter(
+//		config.PubkeyConfig{
+//			Length: blsPubkeyLen,
+//			Type:   factory.HexFormat,
+//		},
+//	)
+//	if err != nil {
+//		return err
+//	}
+//
+//
+//
+//	return generateAndSave(index, numKeys, consoleOut, validatorKeyFileName, genForBlockSigningSk, pubkeyConverter)
+//}
+//
+//func generateTxKey(index int, numKeys int, consoleOut bool) error {
+//	pubkeyConverter, err := factory.NewPubkeyConverter(
+//		config.PubkeyConfig{
+//			Length: txSignPubkeyLen,
+//			Type:   factory.Bech32Format,
+//		},
+//	)
+//	if err != nil {
+//		return err
+//	}
+//
+//
+//
+//	return generateAndSave(index, numKeys, consoleOut, walletKeyFileName, genForBlockSigningSk, pubkeyConverter)
+//}
+//
+//func generateAndSave(index int, numKeys int, baseFilename string, genForBlockSigningSk crypto.KeyGenerator, pubkeyConverter core.PubkeyConverter) error {
+//	folder, err := generateFolder(index, numKeys)
+//	if err != nil {
+//		return err
+//	}
+//
+//	filename := filepath.Join(folder, baseFilename)
+//	backupFileIfExists(filename)
+//
+//	err = os.Remove(filename)
+//	if err != nil && !os.IsNotExist(err) {
+//		return err
+//	}
+//
+//	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, core.FileModeUserReadWrite)
+//	if err != nil {
+//		return err
+//	}
+//
+//	defer func() {
+//		_ = file.Close()
+//	}()
+//
+//	sk, pk, err := generateKeys(genForBlockSigningSk)
+//	if err != nil {
+//		return err
+//	}
+//
+//	pkString := pubkeyConverter.Encode(pk)
+//
+//	return core.SaveSkToPemFile(file, pkString, []byte(hex.EncodeToString(sk)))
+//}
+//


### PR DESCRIPTION
- refactored keygenerator app: 
1. added the possibility to output data on the console (through the extra `-console-out` flag)
2. create a single file with all the generated keys (based on type) (through the extra `no-split` flag)

This will also solve issue #1982