### PR TITLE
Resolver fixes

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -353,20 +353,6 @@ VERSION:
 			"and will have a full history over epochs.",
 	}
 
-	numEpochsToSave = cli.Uint64Flag{
-		Name: "num-epochs-to-keep",
-		Usage: "This flag represents the number of epochs which will kept in the databases. It is relevant only if " +
-			"the full archive flag is not set.",
-		Value: uint64(2),
-	}
-
-	numActivePersisters = cli.Uint64Flag{
-		Name: "num-active-persisters",
-		Usage: "This flag represents the number of databases (1 database = 1 epoch) which are kept open at a moment. " +
-			"It is relevant even if the node is full archive or not.",
-		Value: uint64(2),
-	}
-
 	startInEpoch = cli.BoolFlag{
 		Name: "start-in-epoch",
 		Usage: "Boolean option for enabling a node the fast bootstrap mechanism from the network." +
@@ -449,8 +435,6 @@ func main() {
 		workingDirectory,
 		destinationShardAsObserver,
 		keepOldEpochsData,
-		numEpochsToSave,
-		numActivePersisters,
 		startInEpoch,
 		importDbDirectory,
 		importDbNoSigCheck,
@@ -1084,12 +1068,6 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 	log.Trace("creating nodes coordinator")
 	if ctx.IsSet(keepOldEpochsData.Name) {
 		generalConfig.StoragePruning.CleanOldEpochsData = !ctx.GlobalBool(keepOldEpochsData.Name)
-	}
-	if ctx.IsSet(numEpochsToSave.Name) {
-		generalConfig.StoragePruning.NumEpochsToKeep = ctx.GlobalUint64(numEpochsToSave.Name)
-	}
-	if ctx.IsSet(numActivePersisters.Name) {
-		generalConfig.StoragePruning.NumActivePersisters = ctx.GlobalUint64(numActivePersisters.Name)
 	}
 	log.Info("Bootstrap", "epoch", bootstrapParameters.Epoch)
 	if bootstrapParameters.NodesConfig != nil {

--- a/dataRetriever/resolvers/miniblockResolver_test.go
+++ b/dataRetriever/resolvers/miniblockResolver_test.go
@@ -307,7 +307,7 @@ func TestMiniblockResolver_ProcessReceivedMessageNotFoundInPoolShouldRetFromStor
 	}
 
 	store := &mock.StorerStub{}
-	store.GetCalled = func(key []byte) (i []byte, e error) {
+	store.SearchFirstCalled = func(key []byte) (i []byte, e error) {
 		wasResolved = true
 		mb, _ := marshalizer.Marshal(&block.MiniBlock{})
 		return mb, nil
@@ -353,7 +353,7 @@ func TestMiniblockResolver_ProcessReceivedMessageMissingDataShouldNotSend(t *tes
 	}
 
 	store := &mock.StorerStub{}
-	store.GetCalled = func(key []byte) (i []byte, e error) {
+	store.SearchFirstCalled = func(key []byte) (i []byte, e error) {
 		return nil, errors.New("key not found")
 	}
 

--- a/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
+++ b/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/core/random"
@@ -20,6 +21,7 @@ const topicRequestSuffix = "_REQUEST"
 const minPeersToQuery = 2
 
 var _ dataRetriever.TopicResolverSender = (*topicResolverSender)(nil)
+var log = logger.GetOrCreate("dataretriever/resolverstopicresolversender")
 
 // ArgTopicResolverSender is the argument structure used to create new TopicResolverSender instance
 type ArgTopicResolverSender struct {
@@ -107,9 +109,21 @@ func (trs *topicResolverSender) SendOnRequestTopic(rd *dataRetriever.RequestData
 
 	crossPeers := trs.peerListCreator.PeerList()
 	numSentCross := trs.sendOnTopic(crossPeers, topicToSendRequest, buff, trs.numCrossShardPeers)
+	data := make([]interface{}, 0)
+	for _, peer := range crossPeers {
+		data = append(data, "cross peer")
+		data = append(data, peer.Pretty())
+	}
 
 	intraPeers := trs.peerListCreator.IntraShardPeerList()
 	numSentIntra := trs.sendOnTopic(intraPeers, topicToSendRequest, buff, trs.numIntraShardPeers)
+	for _, peer := range intraPeers {
+		data = append(data, "intra peer")
+		data = append(data, peer.Pretty())
+	}
+
+	//TODO remove this
+	log.Warn("requests are sent to", data...)
 
 	trs.callDebugHandler(originalHashes, numSentIntra, numSentCross)
 

--- a/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
+++ b/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
@@ -152,8 +152,8 @@ func (trs *topicResolverSender) sendOnTopic(peerList []core.PeerID, topicToSendR
 
 	logData := make([]interface{}, 0)
 	msgSentCounter := 0
-	for idx := range shuffledIndexes {
-		peer := peerList[idx]
+	for _, shuffledIndex := range shuffledIndexes {
+		peer := peerList[shuffledIndex]
 
 		err := trs.sendToConnectedPeer(topicToSendRequest, buff, peer)
 		if err != nil {
@@ -167,8 +167,7 @@ func (trs *topicResolverSender) sendOnTopic(peerList []core.PeerID, topicToSendR
 			break
 		}
 	}
-	//TODO remove this
-	log.Warn("requests are sent to", logData...)
+	log.Trace("requests are sent to", logData...)
 
 	return msgSentCounter
 }

--- a/dataRetriever/resolvers/transactionResolver.go
+++ b/dataRetriever/resolvers/transactionResolver.go
@@ -146,11 +146,13 @@ func (txRes *TxResolver) fetchTxAsByteSlice(hash []byte) ([]byte, error) {
 			hash,
 			err,
 		)
+
+		return nil, err
 	}
 
 	txRes.ResolverDebugHandler().LogSucceededToResolveData(txRes.topic, hash)
 
-	return buff, err
+	return buff, nil
 }
 
 func (txRes *TxResolver) resolveTxRequestByHashArray(hashesBuff []byte, pid core.PeerID) error {

--- a/integrationTests/resolvers/metablock/metablock_test.go
+++ b/integrationTests/resolvers/metablock/metablock_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
@@ -20,8 +19,6 @@ func TestRequestResolveMetaHeadersByHashRequestingShardResolvingShard(t *testing
 	if testing.Short() {
 		t.Skip("this is not a short test")
 	}
-
-	_ = logger.SetLogLevel("*:TRACE")
 
 	rm := resolvers.NewReceiverMonitor(t)
 	shardId := uint32(0)


### PR DESCRIPTION
- fixed the following resolver-requester issues:
    - fixed reporting of missing transactions and miniblocks in resolvers to the debugging component
    - replaced function that gets the data from persister in miniblock resolver from `Get` to `SearchFirst` as to align with the rest of the resolvers.
- removed unused flags in main.go
- fixed a wrong iteration on an int slice

Testing:
Launch a normal testnet with #AllIn, things should go pretty smooth and no node should be left behind especially at the epoch change event. 