### PR TITLE
Fix epoch start trigger when epoch start previous header is missing

### DIFF
--- a/epochStart/shardchain/trigger.go
+++ b/epochStart/shardchain/trigger.go
@@ -456,11 +456,14 @@ func (t *trigger) receivedMetaBlock(headerHandler data.HeaderHandler, metaBlockH
 		return
 	}
 
-	_, ok = t.mapFinalizedEpochs[metaHdr.Epoch]
-	if t.metaEpoch == headerHandler.GetEpoch() && ok {
-		t.changeEpochFinalityAttestingRoundIfNeeded(metaHdr, metaBlockHash)
-		return
+	if !t.isPreviousEpochStartMetaBlock(metaHdr, metaBlockHash) {
+		_, ok = t.mapFinalizedEpochs[metaHdr.Epoch]
+		if t.metaEpoch == headerHandler.GetEpoch() && ok {
+			t.changeEpochFinalityAttestingRoundIfNeeded(metaHdr, metaBlockHash)
+			return
+		}
 	}
+
 	if !t.newEpochHdrReceived && !metaHdr.IsStartOfEpochBlock() {
 		return
 	}
@@ -494,6 +497,24 @@ func (t *trigger) receivedMetaBlock(headerHandler data.HeaderHandler, metaBlockH
 	t.mapNonceHashes[metaHdr.Nonce] = append(t.mapNonceHashes[metaHdr.Nonce], string(metaBlockHash))
 
 	t.updateTriggerFromMeta()
+}
+
+// call only if mutex is locked before
+func (t *trigger) isPreviousEpochStartMetaBlock(metaBlock *block.MetaBlock, metaBlockHash []byte) bool {
+	metaHdrHashesWithNonce := t.mapNonceHashes[metaBlock.Nonce+1]
+	for _, hash := range metaHdrHashesWithNonce {
+		epochStartMetaBlock, ok := t.mapEpochStartHdrs[hash]
+		if !ok {
+			continue
+		}
+		if !bytes.Equal(metaBlockHash, epochStartMetaBlock.PrevHash) {
+			continue
+		}
+
+		return true
+	}
+
+	return false
 }
 
 // call only if mutex is locked before

--- a/process/track/baseBlockTrack.go
+++ b/process/track/baseBlockTrack.go
@@ -547,6 +547,10 @@ func (bbt *baseBlockTrack) SortHeadersFromNonce(shardID uint32, nonce uint64) ([
 
 	if len(sortedHeadersInfo) > 1 {
 		sort.Slice(sortedHeadersInfo, func(i, j int) bool {
+			if sortedHeadersInfo[i].Header.GetNonce() == sortedHeadersInfo[j].Header.GetNonce() {
+				return sortedHeadersInfo[i].Header.GetRound() < sortedHeadersInfo[j].Header.GetRound()
+			}
+
 			return sortedHeadersInfo[i].Header.GetNonce() < sortedHeadersInfo[j].Header.GetNonce()
 		})
 	}


### PR DESCRIPTION
* Fixed situation when previous epoch start meta block is missing and trigger was not activated
* Fixed a sort situation when more headers have the same nonce in block tracker component