### PR TITLE
fix-log-message-double-stake

### DIFF
--- a/cmd/node/config/systemSmartContractsConfig.toml
+++ b/cmd/node/config/systemSmartContractsConfig.toml
@@ -5,6 +5,7 @@
     MinStepValue = "100000000000000000000"
     AuctionEnableEpoch = 100000
     StakeEnableEpoch = 2
+    DoubleKeyProtectionEnableEpoch = 2
     NumRoundsWithoutBleed = 100
     MaximumPercentageToBleed = 0.5
     BleedPercentagePerRound = 0.00001

--- a/config/systemSmartContractsConfig.go
+++ b/config/systemSmartContractsConfig.go
@@ -16,6 +16,7 @@ type StakingSystemSCConfig struct {
 	UnBondPeriod                         uint64
 	AuctionEnableEpoch                   uint32
 	StakeEnableEpoch                     uint32
+	DoubleKeyProtectionEnableEpoch       uint32
 	NumRoundsWithoutBleed                uint64
 	MaximumPercentageToBleed             float64
 	BleedPercentagePerRound              float64

--- a/process/scToProtocol/stakingToPeer.go
+++ b/process/scToProtocol/stakingToPeer.go
@@ -2,6 +2,7 @@ package scToProtocol
 
 import (
 	"bytes"
+	"encoding/hex"
 	"math"
 
 	"github.com/ElrondNetwork/elrond-go-logger"
@@ -178,7 +179,9 @@ func (stp *stakingToPeer) UpdateProtocol(body *block.Body, nonce uint64) error {
 		// no data under key -> peer can be deleted from trie
 		if len(data) == 0 {
 			err = stp.peerState.RemoveAccount(blsPubKey)
-			log.LogIfError(err, "staking to protocol RemoveAccount blsPubKey", blsPubKey)
+			if err != nil {
+				log.Debug("staking to protocol RemoveAccount", "error", err, "blsPubKey", hex.EncodeToString(blsPubKey))
+			}
 
 			continue
 		}

--- a/vm/systemSmartContracts/auction.go
+++ b/vm/systemSmartContracts/auction.go
@@ -793,7 +793,7 @@ func (s *stakingAuctionSC) stake(args *vmcommon.ContractCallInput) vmcommon.Retu
 	}
 
 	if s.flagDoubleKey.IsSet() && checkDoubleBLSKeys(blsKeys) {
-		s.eei.AddReturnMessage("invalid arguments, same bls key twice")
+		s.eei.AddReturnMessage("invalid arguments, found same bls key twice")
 		return vmcommon.UserError
 	}
 

--- a/vm/systemSmartContracts/auction_test.go
+++ b/vm/systemSmartContracts/auction_test.go
@@ -492,6 +492,56 @@ func TestStakingAuctionSC_ExecuteStakeAddedNewPubKeysShouldWork(t *testing.T) {
 	assert.Equal(t, vmcommon.Ok, errCode)
 }
 
+func TestStakingAuctionSC_ExecuteStakeDoubleKeyAndCleanup(t *testing.T) {
+	t.Parallel()
+
+	arguments := CreateVmContractCallInput()
+
+	key1 := []byte("Key1")
+	args := createMockArgumentsForAuction()
+
+	atArgParser := parsers.NewCallArgsParser()
+	eei, _ := NewVMContext(&mock.BlockChainHookStub{}, hooks.NewVMCryptoHook(), atArgParser, &mock.AccountsStub{}, &mock.RaterMock{})
+
+	argsStaking := createMockStakingScArguments()
+	argsStaking.StakingSCConfig.GenesisNodePrice = "10000000"
+	argsStaking.Eei = eei
+	argsStaking.StakingSCConfig.UnBondPeriod = 100000
+	stakingSC, _ := NewStakingSmartContract(argsStaking)
+
+	eei.SetSCAddress([]byte("auction"))
+	_ = eei.SetSystemSCContainer(&mock.SystemSCContainerStub{GetCalled: func(key []byte) (contract vm.SystemSmartContract, err error) {
+		return stakingSC, nil
+	}})
+
+	args.Eei = eei
+	args.StakingSCConfig = argsStaking.StakingSCConfig
+	args.StakingSCConfig.DoubleKeyProtectionEnableEpoch = 1000
+	auctionSC, _ := NewStakingAuctionSmartContract(args)
+
+	arguments.Function = "stake"
+	arguments.CallValue = big.NewInt(0).Mul(big.NewInt(2), big.NewInt(10000000))
+	arguments.Arguments = [][]byte{big.NewInt(2).Bytes(), key1, []byte("msg1"), key1, []byte("msg1")}
+
+	errCode := auctionSC.Execute(arguments)
+	assert.Equal(t, vmcommon.Ok, errCode)
+
+	registeredData := &AuctionData{}
+	_ = auctionSC.marshalizer.Unmarshal(registeredData, eei.GetStorage(arguments.CallerAddr))
+	assert.Equal(t, 2, len(registeredData.BlsPubKeys))
+
+	auctionSC.flagDoubleKey.Set()
+	arguments.Function = "cleanRegisteredData"
+	arguments.CallValue = big.NewInt(0)
+	arguments.Arguments = [][]byte{}
+
+	errCode = auctionSC.Execute(arguments)
+	assert.Equal(t, vmcommon.Ok, errCode)
+
+	_ = auctionSC.marshalizer.Unmarshal(registeredData, eei.GetStorage(arguments.CallerAddr))
+	assert.Equal(t, 1, len(registeredData.BlsPubKeys))
+}
+
 func TestStakingAuctionSC_ExecuteStakeWithRewardAddress(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
fix log message. added protection against staking same key two times in the same stake call.