### PR TITLE
[Import DB] change the way the root hash is fetched

### DIFF
--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -1257,7 +1257,7 @@ func (bp *baseProcessor) addHeaderIntoTrackerPool(nonce uint64, shardID uint32) 
 	}
 }
 
-func (bp *baseProcessor) commitTrieEpochRootHashIfNeeded(metaBlock *block.MetaBlock) error {
+func (bp *baseProcessor) commitTrieEpochRootHashIfNeeded(metaBlock *block.MetaBlock, rootHash []byte) error {
 	trieEpochRootHashStorageUnit := bp.store.GetStorer(dataRetriever.TrieEpochRootHashUnit)
 	if check.IfNil(trieEpochRootHashStorageUnit) {
 		return nil
@@ -1272,20 +1272,15 @@ func (bp *baseProcessor) commitTrieEpochRootHashIfNeeded(metaBlock *block.MetaBl
 		return fmt.Errorf("%w for user accounts state", process.ErrNilAccountsAdapter)
 	}
 
-	currentRootHash, err := userAccountsDb.RootHash()
-	if err != nil {
-		return err
-	}
-
 	epochBytes := bp.uint64Converter.ToByteSlice(uint64(metaBlock.Epoch))
 
-	err = trieEpochRootHashStorageUnit.Put(epochBytes, currentRootHash)
+	err := trieEpochRootHashStorageUnit.Put(epochBytes, rootHash)
 	if err != nil {
 		return err
 	}
 
 	ctx := context.Background()
-	allLeavesChan, err := userAccountsDb.GetAllLeaves(currentRootHash, ctx)
+	allLeavesChan, err := userAccountsDb.GetAllLeaves(rootHash, ctx)
 	if err != nil {
 		return err
 	}

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -1249,7 +1249,7 @@ func TestBaseProcessor_commitTrieEpochRootHashIfNeededNilStorerShouldNotErr(t *t
 	sp, _ := blproc.NewShardProcessor(arguments)
 
 	mb := &block.MetaBlock{Epoch: epoch}
-	err := sp.CommitTrieEpochRootHashIfNeeded(mb)
+	err := sp.CommitTrieEpochRootHashIfNeeded(mb, []byte("root"))
 	require.NoError(t, err)
 }
 
@@ -1265,7 +1265,7 @@ func TestBaseProcessor_commitTrieEpochRootHashIfNeededDisabledStorerShouldNotErr
 	sp, _ := blproc.NewShardProcessor(arguments)
 
 	mb := &block.MetaBlock{Epoch: epoch}
-	err := sp.CommitTrieEpochRootHashIfNeeded(mb)
+	err := sp.CommitTrieEpochRootHashIfNeeded(mb, []byte("root"))
 	require.NoError(t, err)
 }
 
@@ -1281,7 +1281,7 @@ func TestBaseProcessor_commitTrieEpochRootHashIfNeededCannotFindUserAccountState
 	sp, _ := blproc.NewShardProcessor(arguments)
 
 	mb := &block.MetaBlock{Epoch: epoch}
-	err := sp.CommitTrieEpochRootHashIfNeeded(mb)
+	err := sp.CommitTrieEpochRootHashIfNeeded(mb, []byte("root"))
 	require.True(t, errors.Is(err, process.ErrNilAccountsAdapter))
 }
 
@@ -1318,6 +1318,6 @@ func TestBaseProcessor_commitTrieEpochRootHashIfNeededShouldWork(t *testing.T) {
 	sp, _ := blproc.NewShardProcessor(arguments)
 
 	mb := &block.MetaBlock{Epoch: epoch}
-	err := sp.CommitTrieEpochRootHashIfNeeded(mb)
+	err := sp.CommitTrieEpochRootHashIfNeeded(mb, []byte("root"))
 	require.NoError(t, err)
 }

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -40,8 +40,8 @@ func (bp *baseProcessor) RemoveHeadersBehindNonceFromPools(
 	bp.removeHeadersBehindNonceFromPools(shouldRemoveBlockBody, shardId, nonce)
 }
 
-func (bp *baseProcessor) CommitTrieEpochRootHashIfNeeded(metaBlock *block.MetaBlock) error {
-	return bp.commitTrieEpochRootHashIfNeeded(metaBlock)
+func (bp *baseProcessor) CommitTrieEpochRootHashIfNeeded(metaBlock *block.MetaBlock, rootHash []byte) error {
+	return bp.commitTrieEpochRootHashIfNeeded(metaBlock, rootHash)
 }
 
 func (sp *shardProcessor) ReceivedMetaBlock(header data.HeaderHandler, metaBlockHash []byte) {

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -1260,6 +1260,17 @@ func (mp *metaProcessor) updateState(lastMetaBlock data.HeaderHandler) {
 		ctx := context.Background()
 		mp.accountsDB[state.UserAccountsState].SnapshotState(lastMetaBlock.GetRootHash(), ctx)
 		mp.accountsDB[state.PeerAccountsState].SnapshotState(lastMetaBlock.GetValidatorStatsRootHash(), ctx)
+		go func() {
+			metaBlock, ok := lastMetaBlock.(*block.MetaBlock)
+			if !ok {
+				log.Warn("cannot commit Trie Epoch Root Hash: lastMetaBlock is not *block.MetaBlock")
+				return
+			}
+			err := mp.commitTrieEpochRootHashIfNeeded(metaBlock, lastMetaBlock.GetRootHash())
+			if err != nil {
+				log.Warn("couldn't commit trie checkpoint", "epoch", metaBlock.Epoch, "error", err)
+			}
+		}()
 	}
 
 	mp.updateStateStorage(
@@ -1369,12 +1380,6 @@ func (mp *metaProcessor) commitEpochStart(header *block.MetaBlock, body *block.B
 		mp.epochStartTrigger.SetProcessed(header, body)
 		go mp.epochRewardsCreator.SaveTxBlockToStorage(header, body)
 		go mp.validatorInfoCreator.SaveValidatorInfoBlocksToStorage(header, body)
-		go func() {
-			err := mp.commitTrieEpochRootHashIfNeeded(header)
-			if err != nil {
-				log.Warn("couldn't commit trie checkpoint", "epoch", header.Epoch, "error", err)
-			}
-		}()
 	} else {
 		currentHeader := mp.blockChain.GetCurrentBlockHeader()
 		if !check.IfNil(currentHeader) && currentHeader.IsStartOfEpochBlock() {

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -1056,13 +1056,13 @@ func (sp *shardProcessor) snapShotEpochStartFromMeta(header *block.Header) {
 			ctx := context.Background()
 			accounts.SnapshotState(rootHash, ctx)
 			saveEpochStartEconomicsMetrics(sp.appStatusHandler, metaHdr)
+			go func() {
+				err := sp.commitTrieEpochRootHashIfNeeded(metaHdr, rootHash)
+				if err != nil {
+					log.Warn("couldn't commit trie checkpoint", "epoch", header.Epoch, "error", err)
+				}
+			}()
 		}
-		go func() {
-			err := sp.commitTrieEpochRootHashIfNeeded(metaHdr)
-			if err != nil {
-				log.Warn("couldn't commit trie checkpoint", "epoch", header.Epoch, "error", err)
-			}
-		}()
 	}
 }
 


### PR DESCRIPTION
fix so that the root hash when storing into EpochRootHashStorer is exactly the same as the snapshot's root hash. Before this, there were some inconsistencies and the test was not relevant.