### PR TITLE
fix/compute-move-balance-fee

### DIFF
--- a/process/block/postprocess/feeHandler.go
+++ b/process/block/postprocess/feeHandler.go
@@ -14,6 +14,8 @@ type feeData struct {
 	devFee *big.Int
 }
 
+var zero = big.NewInt(0)
+
 type feeHandler struct {
 	mut             sync.RWMutex
 	mapHashFee      map[string]*feeData
@@ -60,7 +62,11 @@ func (f *feeHandler) GetDeveloperFees() *big.Int {
 // ProcessTransactionFee adds the tx cost to the accumulated amount
 func (f *feeHandler) ProcessTransactionFee(cost *big.Int, devFee *big.Int, txHash []byte) {
 	if cost == nil {
-		log.Debug("nil cost in ProcessTransactionFee", "error", process.ErrNilValue.Error())
+		log.Error("nil cost in ProcessTransactionFee", "error", process.ErrNilValue.Error())
+		return
+	}
+	if cost.Cmp(zero) < 0 {
+		log.Error("negative cost in ProcessTransactionFee", "error", process.ErrNegativeValue.Error())
 		return
 	}
 

--- a/process/economics/economicsData.go
+++ b/process/economics/economicsData.go
@@ -232,7 +232,7 @@ func (ed *economicsData) GasPerDataByte() uint64 {
 // ComputeMoveBalanceFee computes the provided transaction's fee
 func (ed *economicsData) ComputeMoveBalanceFee(tx process.TransactionWithFeeHandler) *big.Int {
 	if isSmartContractResult(tx) {
-		return ed.ComputeFeeForProcessing(tx, ed.ComputeGasLimit(tx))
+		return big.NewInt(0)
 	}
 
 	return core.SafeMul(tx.GetGasPrice(), ed.ComputeGasLimit(tx))

--- a/process/economics/economicsData.go
+++ b/process/economics/economicsData.go
@@ -231,6 +231,10 @@ func (ed *economicsData) GasPerDataByte() uint64 {
 
 // ComputeMoveBalanceFee computes the provided transaction's fee
 func (ed *economicsData) ComputeMoveBalanceFee(tx process.TransactionWithFeeHandler) *big.Int {
+	if isSmartContractResult(tx) {
+		return ed.ComputeFeeForProcessing(tx, ed.ComputeGasLimit(tx))
+	}
+
 	return core.SafeMul(tx.GetGasPrice(), ed.ComputeGasLimit(tx))
 }
 

--- a/process/economics/economicsData_test.go
+++ b/process/economics/economicsData_test.go
@@ -421,4 +421,7 @@ func TestEconomicsData_SCRWithNotEnoughMoveBalanceShouldNotError(t *testing.T) {
 	scr.GasLimit = 1
 	err = economicsData.CheckValidityTxValues(scr)
 	assert.Nil(t, err)
+
+	moveBalanceFee := economicsData.ComputeMoveBalanceFee(scr)
+	assert.Equal(t, moveBalanceFee, big.NewInt(0))
 }

--- a/process/transaction/shardProcess.go
+++ b/process/transaction/shardProcess.go
@@ -830,7 +830,9 @@ func (txProc *txProcessor) executeFailedRelayedTransaction(
 	totalFee := txProc.economicsFee.ComputeFeeForProcessing(userTx, userTx.GasLimit)
 	senderShardID := txProc.shardCoordinator.ComputeId(userTx.SndAddr)
 	if senderShardID != txProc.shardCoordinator.SelfId() {
-		totalFee.Sub(totalFee, txProc.economicsFee.ComputeMoveBalanceFee(userTx))
+		moveBalanceGasLimit := txProc.economicsFee.ComputeGasLimit(userTx)
+		moveBalanceUserFee := txProc.economicsFee.ComputeFeeForProcessing(userTx, moveBalanceGasLimit)
+		totalFee.Sub(totalFee, moveBalanceUserFee)
 	}
 
 	txProc.txFeeHandler.ProcessTransactionFee(totalFee, big.NewInt(0), originalTxHash)


### PR DESCRIPTION
small little fixes of gas used in scr and user tx
Make moveBalanceCost take into consideration SCR vs TX. SCR does not consume moveBalance