### PR TITLE
Fixed the OriginalSender encoding in nodeTransactions.go

### DIFF
--- a/node/nodeTransactions.go
+++ b/node/nodeTransactions.go
@@ -325,7 +325,7 @@ func (n *Node) prepareRewardTx(tx *rewardTxData.RewardTx) (*transaction.ApiTrans
 }
 
 func (n *Node) prepareUnsignedTx(tx *smartContractResult.SmartContractResult) (*transaction.ApiTransactionResult, error) {
-	return &transaction.ApiTransactionResult{
+	txResult := &transaction.ApiTransactionResult{
 		Tx:                      tx,
 		Type:                    string(transaction.TxTypeUnsigned),
 		Nonce:                   tx.GetNonce(),
@@ -339,7 +339,11 @@ func (n *Node) prepareUnsignedTx(tx *smartContractResult.SmartContractResult) (*
 		CodeMetadata:            tx.GetCodeMetadata(),
 		PreviousTransactionHash: hex.EncodeToString(tx.GetPrevTxHash()),
 		OriginalTransactionHash: hex.EncodeToString(tx.GetOriginalTxHash()),
-		OriginalSender:          n.addressPubkeyConverter.Encode(tx.GetOriginalSender()),
 		ReturnMessage:           string(tx.GetReturnMessage()),
-	}, nil
+	}
+	if len(tx.GetOriginalSender()) == n.addressPubkeyConverter.Len() {
+		txResult.OriginalSender = n.addressPubkeyConverter.Encode(tx.GetOriginalSender())
+	}
+
+	return txResult, nil
 }

--- a/node/nodeTransactions_test.go
+++ b/node/nodeTransactions_test.go
@@ -484,12 +484,13 @@ func TestPrepareUnsignedTx(t *testing.T) {
 	scrResult1, err := n.prepareUnsignedTx(scr1)
 	assert.Nil(t, err)
 	expectedScr1 := &transaction.ApiTransactionResult{
-		Tx:       scr1,
-		Nonce:    1,
-		Type:     string(transaction.TxTypeUnsigned),
-		Value:    "2",
-		Receiver: "erd1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsl6e0p7",
-		Sender:   "erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu",
+		Tx:             scr1,
+		Nonce:          1,
+		Type:           string(transaction.TxTypeUnsigned),
+		Value:          "2",
+		Receiver:       "erd1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsl6e0p7",
+		Sender:         "erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu",
+		OriginalSender: "",
 	}
 	assert.Equal(t, scrResult1, expectedScr1)
 
@@ -513,5 +514,4 @@ func TestPrepareUnsignedTx(t *testing.T) {
 		OriginalSender: "erd1qurswpc8qurswpc8qurswpc8qurswpc8qurswpc8qurswpc8qurstywtnm",
 	}
 	assert.Equal(t, scrResult2, expectedScr2)
-
 }


### PR DESCRIPTION
- fixed original sender encoding in nodeTransactions.go, `prepareUnsignedTx` function