### PR TITLE
Staking fixes

### DIFF
--- a/sharding/common.go
+++ b/sharding/common.go
@@ -34,6 +34,10 @@ func computeStartIndexAndNumAppearancesForValidator(expEligibleList []uint32, id
 }
 
 func displayValidatorsForRandomness(validators []Validator, randomness []byte) {
+	if log.GetLevel() != logger.LogTrace {
+		return
+	}
+
 	strValidators := ""
 
 	for _, v := range validators {

--- a/vm/systemSmartContracts/staking.go
+++ b/vm/systemSmartContracts/staking.go
@@ -1499,6 +1499,7 @@ func (s *stakingSC) stakeNodesFromQueue(args *vmcommon.ContractCallInput) vmcomm
 			return vmcommon.UserError
 		}
 
+		stakedNodes++
 		// return the change key
 		s.eei.Finish(blsKey)
 		s.eei.Finish(stakedData.RewardAddress)


### PR DESCRIPTION
- fixed the situation when the waiting queue bls key had to become eligible but the bls key owner was not set
- fixed the situation when more-than-expected waiting queue bls keys became eligible 
- optimized some prints when displayValidatorsForRandomness was called