### PR TITLE
process: add some unit tests for devFee and accumulatedFee

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -2107,7 +2107,7 @@ func newMetaBlockProcessor(
 		GenesisEpoch:          genesisHdr.GetEpoch(),
 		GenesisTotalSupply:    economicsData.GenesisTotalSupply(),
 		EconomicsDataNotified: economicsDataProvider,
-		EpochEnableV2:         systemSCConfig.StakingSystemSCConfig.StakingV2Epoch,
+		StakingV2EnableEpoch:  systemSCConfig.StakingSystemSCConfig.StakingV2Epoch,
 	}
 	epochEconomics, err := metachainEpochStart.NewEndOfEpochEconomicsDataCreator(argsEpochEconomics)
 	if err != nil {

--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -2107,6 +2107,7 @@ func newMetaBlockProcessor(
 		GenesisEpoch:          genesisHdr.GetEpoch(),
 		GenesisTotalSupply:    economicsData.GenesisTotalSupply(),
 		EconomicsDataNotified: economicsDataProvider,
+		EpochEnableV2:         systemSCConfig.StakingSystemSCConfig.StakingV2Epoch,
 	}
 	epochEconomics, err := metachainEpochStart.NewEndOfEpochEconomicsDataCreator(argsEpochEconomics)
 	if err != nil {

--- a/epochStart/metachain/economics.go
+++ b/epochStart/metachain/economics.go
@@ -34,7 +34,7 @@ type economics struct {
 	genesisNonce          uint64
 	genesisTotalSupply    *big.Int
 	economicsDataNotified epochStart.EpochEconomicsDataProvider
-	epochEnableV2         uint32
+	stakingV2EnableEpoch  uint32
 }
 
 // ArgsNewEpochEconomics is the argument for the economics constructor
@@ -49,7 +49,7 @@ type ArgsNewEpochEconomics struct {
 	GenesisNonce          uint64
 	GenesisTotalSupply    *big.Int
 	EconomicsDataNotified epochStart.EpochEconomicsDataProvider
-	EpochEnableV2         uint32
+	StakingV2EnableEpoch  uint32
 }
 
 // NewEndOfEpochEconomicsDataCreator creates a new end of epoch economics data creator object
@@ -90,7 +90,7 @@ func NewEndOfEpochEconomicsDataCreator(args ArgsNewEpochEconomics) (*economics, 
 		genesisNonce:          args.GenesisNonce,
 		genesisTotalSupply:    big.NewInt(0).Set(args.GenesisTotalSupply),
 		economicsDataNotified: args.EconomicsDataNotified,
-		epochEnableV2:         args.EpochEnableV2,
+		stakingV2EnableEpoch:  args.StakingV2EnableEpoch,
 	}
 
 	return e, nil
@@ -286,7 +286,7 @@ func (e *economics) adjustRewardsPerBlockWithLeaderPercentage(
 	epoch uint32,
 ) *big.Int {
 	accumulatedFeesForValidators := big.NewInt(0).Set(accumulatedFees)
-	if epoch > e.epochEnableV2 {
+	if epoch > e.stakingV2EnableEpoch {
 		accumulatedFeesForValidators.Sub(accumulatedFeesForValidators, developerFees)
 	}
 	rewardsForLeaders := core.GetPercentageOfValue(accumulatedFeesForValidators, e.rewardsHandler.LeaderPercentage())

--- a/epochStart/metachain/economics.go
+++ b/epochStart/metachain/economics.go
@@ -34,6 +34,7 @@ type economics struct {
 	genesisNonce          uint64
 	genesisTotalSupply    *big.Int
 	economicsDataNotified epochStart.EpochEconomicsDataProvider
+	epochEnableV2         uint32
 }
 
 // ArgsNewEpochEconomics is the argument for the economics constructor
@@ -48,6 +49,7 @@ type ArgsNewEpochEconomics struct {
 	GenesisNonce          uint64
 	GenesisTotalSupply    *big.Int
 	EconomicsDataNotified epochStart.EpochEconomicsDataProvider
+	EpochEnableV2         uint32
 }
 
 // NewEndOfEpochEconomicsDataCreator creates a new end of epoch economics data creator object
@@ -88,6 +90,7 @@ func NewEndOfEpochEconomicsDataCreator(args ArgsNewEpochEconomics) (*economics, 
 		genesisNonce:          args.GenesisNonce,
 		genesisTotalSupply:    big.NewInt(0).Set(args.GenesisTotalSupply),
 		economicsDataNotified: args.EconomicsDataNotified,
+		epochEnableV2:         args.EpochEnableV2,
 	}
 
 	return e, nil
@@ -138,7 +141,7 @@ func (e *economics) ComputeEndOfEpochEconomics(
 
 	remainingToBeDistributed := big.NewInt(0).Sub(totalRewardsToBeDistributed, metaBlock.DevFeesInEpoch)
 	e.adjustRewardsPerBlockWithDeveloperFees(rwdPerBlock, metaBlock.DevFeesInEpoch, totalNumBlocksInEpoch)
-	rewardsForLeaders := e.adjustRewardsPerBlockWithLeaderPercentage(rwdPerBlock, metaBlock.AccumulatedFeesInEpoch, totalNumBlocksInEpoch)
+	rewardsForLeaders := e.adjustRewardsPerBlockWithLeaderPercentage(rwdPerBlock, metaBlock.AccumulatedFeesInEpoch, metaBlock.DevFeesInEpoch, totalNumBlocksInEpoch, metaBlock.Epoch)
 	remainingToBeDistributed = big.NewInt(0).Sub(remainingToBeDistributed, rewardsForLeaders)
 	rewardsForProtocolSustainability := e.computeRewardsForProtocolSustainability(totalRewardsToBeDistributed)
 	remainingToBeDistributed = big.NewInt(0).Sub(remainingToBeDistributed, rewardsForProtocolSustainability)
@@ -278,9 +281,15 @@ func (e *economics) adjustRewardsPerBlockWithDeveloperFees(
 func (e *economics) adjustRewardsPerBlockWithLeaderPercentage(
 	rwdPerBlock *big.Int,
 	accumulatedFees *big.Int,
+	developerFees *big.Int,
 	blocksInEpoch uint64,
+	epoch uint32,
 ) *big.Int {
-	rewardsForLeaders := core.GetPercentageOfValue(accumulatedFees, e.rewardsHandler.LeaderPercentage())
+	accumulatedFeesForValidators := big.NewInt(0).Set(accumulatedFees)
+	if epoch > e.epochEnableV2 {
+		accumulatedFeesForValidators.Sub(accumulatedFeesForValidators, developerFees)
+	}
+	rewardsForLeaders := core.GetPercentageOfValue(accumulatedFeesForValidators, e.rewardsHandler.LeaderPercentage())
 	averageLeaderRewardPerBlock := big.NewInt(0).Div(rewardsForLeaders, big.NewInt(0).SetUint64(blocksInEpoch))
 	rwdPerBlock.Sub(rwdPerBlock, averageLeaderRewardPerBlock)
 	return rewardsForLeaders

--- a/process/smartContract/process_test.go
+++ b/process/smartContract/process_test.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/parsers"
 	"github.com/ElrondNetwork/elrond-go/core/vmcommon"
@@ -16,6 +17,8 @@ import (
 	"github.com/ElrondNetwork/elrond-go/data/state"
 	"github.com/ElrondNetwork/elrond-go/data/transaction"
 	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/process/block/postprocess"
+	"github.com/ElrondNetwork/elrond-go/process/economics"
 	"github.com/ElrondNetwork/elrond-go/process/mock"
 	"github.com/ElrondNetwork/elrond-go/process/smartContract/builtInFunctions"
 	"github.com/ElrondNetwork/elrond-go/testscommon/economicsmocks"
@@ -2402,6 +2405,141 @@ func TestSmartContractProcessor_computeTotalConsumedFeeAndDevRwd(t *testing.T) {
 	assert.Equal(t, devFees.Int64(), int64(10))
 }
 
+func TestSmartContractProcessor_computeTotalConsumedFeeAndDevRwdWithDifferentSCCallPrice(t *testing.T) {
+	t.Parallel()
+
+	scAccountAddress := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x1e, 0x2e, 0x61, 0x1a, 0x9c, 0xe1, 0xe0, 0xc8, 0xe3, 0x28, 0x3c, 0xcc, 0x7c, 0x1b, 0x0f, 0x46, 0x61, 0x91, 0x70, 0x79, 0xa7, 0x5c}
+	acc, err := state.NewUserAccount(scAccountAddress)
+	require.Nil(t, err)
+	require.NotNil(t, acc)
+
+	arguments := createMockSmartContractProcessorArguments()
+	arguments.ArgsParser = NewArgumentParser()
+	shardCoordinator := &mock.CoordinatorStub{ComputeIdCalled: func(address []byte) uint32 {
+		return 0
+	}}
+
+	// use a real fee handler
+	args := createRealEconomicsDataArgs()
+	feeHandler, err := economics.NewEconomicsData(*args)
+	require.Nil(t, err)
+	require.NotNil(t, feeHandler)
+	arguments.TxFeeHandler, err = postprocess.NewFeeAccumulator()
+
+	arguments.EconomicsFee = feeHandler
+	arguments.Coordinator = shardCoordinator
+	arguments.AccountsDB = &mock.AccountsStub{
+		RevertToSnapshotCalled: func(snapshot int) error {
+			return nil
+		},
+		LoadAccountCalled: func(address []byte) (state.AccountHandler, error) {
+			return acc, nil
+		},
+	}
+
+	sc, err := NewSmartContractProcessor(arguments)
+	require.Nil(t, err)
+	require.NotNil(t, sc)
+
+	tx := &transaction.Transaction{
+		RcvAddr:  scAccountAddress,
+		GasPrice: 1000000000,
+		GasLimit: 30000000,
+		Data:     make([]byte, 100),
+	}
+	vmoutput := &vmcommon.VMOutput{
+		GasRemaining: 10000000,
+		GasRefund:    big.NewInt(0),
+	}
+	builtInGasUsed := uint64(1000000)
+
+	totalFee, devFees := sc.computeTotalConsumedFeeAndDevRwd(tx, vmoutput, builtInGasUsed)
+	expectedTotalFee, expectedDevFees := computeExpectedResults(args, tx, builtInGasUsed, vmoutput)
+	require.Equal(t, expectedTotalFee, totalFee)
+	require.Equal(t, expectedDevFees, devFees)
+}
+
+func TestSmartContractProcessor_finishSCExecutionV2(t *testing.T) {
+	scAccountAddress := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x1e, 0x2e, 0x61, 0x1a, 0x9c, 0xe1, 0xe0, 0xc8, 0xe3, 0x28, 0x3c, 0xcc, 0x7c, 0x1b, 0x0f, 0x46, 0x61, 0x91, 0x70, 0x79, 0xa7, 0x5c}
+	tests := []struct {
+		name           string
+		tx             *transaction.Transaction
+		vmOutput       *vmcommon.VMOutput
+		builtInGasUsed uint64
+	}{
+		{
+			name:           "intra shard smart contract execution with builtin gas and remaining gas",
+			tx:             &transaction.Transaction{RcvAddr: scAccountAddress, GasPrice: 1000000000, GasLimit: 30000000, Data: make([]byte, 100)},
+			vmOutput:       &vmcommon.VMOutput{GasRemaining: 10000000, GasRefund: big.NewInt(0)},
+			builtInGasUsed: uint64(1000000),
+		},
+		{
+			name:           "intra shard smart contract execution with no builtin gas and remaining gas",
+			tx:             &transaction.Transaction{RcvAddr: scAccountAddress, GasPrice: 1000000000, GasLimit: 30000000, Data: make([]byte, 100)},
+			vmOutput:       &vmcommon.VMOutput{GasRemaining: 10000000, GasRefund: big.NewInt(0)},
+			builtInGasUsed: uint64(1000000),
+		},
+		{
+			name:           "intra shard smart contract execution with builtin gas and no remaining gas",
+			tx:             &transaction.Transaction{RcvAddr: scAccountAddress, GasPrice: 2000000000, GasLimit: 20000000, Data: make([]byte, 100)},
+			vmOutput:       &vmcommon.VMOutput{GasRemaining: 0, GasRefund: big.NewInt(0)},
+			builtInGasUsed: uint64(1000000),
+		},
+		{
+			name:           "intra shard smart contract execution with no builtin gas and no remaining gas",
+			tx:             &transaction.Transaction{RcvAddr: scAccountAddress, GasPrice: 2000000000, GasLimit: 20000000, Data: make([]byte, 100)},
+			vmOutput:       &vmcommon.VMOutput{GasRemaining: 0, GasRefund: big.NewInt(0)},
+			builtInGasUsed: uint64(0),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			acc, err := state.NewUserAccount(scAccountAddress)
+			require.Nil(t, err)
+			require.NotNil(t, acc)
+
+			arguments := createMockSmartContractProcessorArguments()
+			arguments.ArgsParser = NewArgumentParser()
+			shardCoordinator := &mock.CoordinatorStub{ComputeIdCalled: func(address []byte) uint32 {
+				return 0
+			}}
+
+			// use a real fee handler
+			args := createRealEconomicsDataArgs()
+			arguments.EconomicsFee, err = economics.NewEconomicsData(*args)
+			require.Nil(t, err)
+
+			arguments.TxFeeHandler, err = postprocess.NewFeeAccumulator()
+			require.Nil(t, err)
+
+			arguments.Coordinator = shardCoordinator
+			arguments.AccountsDB = &mock.AccountsStub{
+				RevertToSnapshotCalled: func(snapshot int) error {
+					return nil
+				},
+				LoadAccountCalled: func(address []byte) (state.AccountHandler, error) {
+					return acc, nil
+				},
+			}
+
+			sc, err := NewSmartContractProcessor(arguments)
+			require.Nil(t, err)
+			require.NotNil(t, sc)
+
+			expectedTotalFee, expectedDevFees := computeExpectedResults(args, test.tx, test.builtInGasUsed, test.vmOutput)
+
+			retcode, err := sc.finishSCExecution(nil, []byte("txhash"), test.tx, test.vmOutput, test.builtInGasUsed)
+			require.Nil(t, err)
+			require.Equal(t, retcode, vmcommon.Ok)
+			require.Nil(t, err)
+			require.Equal(t, expectedDevFees, acc.DeveloperReward)
+			require.Equal(t, expectedTotalFee, sc.txFeeHandler.GetAccumulatedFees())
+			require.Equal(t, expectedDevFees, sc.txFeeHandler.GetDeveloperFees())
+		})
+	}
+}
+
 func TestScProcessor_CreateRefundForRelayerFromAnotherShard(t *testing.T) {
 	arguments := createMockSmartContractProcessorArguments()
 	sndAddress := []byte("sender11")
@@ -2525,4 +2663,61 @@ func TestProcessIfErrorCheckBackwardsCompatibilityProcessTransactionFeeCalledSho
 	err := sc.ProcessIfError(nil, []byte("txHash"), tx, "0", []byte("message"), 1, 100)
 	require.Nil(t, err)
 	require.False(t, called)
+}
+
+func createRealEconomicsDataArgs() *economics.ArgsNewEconomicsData {
+	return &economics.ArgsNewEconomicsData{
+		Economics: &config.EconomicsConfig{
+			GlobalSettings: config.GlobalSettings{
+				GenesisTotalSupply: "20000000000000000000000000",
+				MinimumInflation:   0.0,
+				YearSettings: []*config.YearSetting{
+					{Year: 1, MaximumInflation: 0.10845130},
+				},
+				Denomination: 18,
+			},
+			RewardsSettings: config.RewardsSettings{
+				LeaderPercentage:                 0.1,
+				DeveloperPercentage:              0.3,
+				ProtocolSustainabilityPercentage: 0.1,
+				ProtocolSustainabilityAddress:    "erd1j25xk97yf820rgdp3mj5scavhjkn6tjyn0t63pmv5qyjj7wxlcfqqe2rw5",
+				TopUpGradientPoint:               "3000000000000000000000000",
+				TopUpFactor:                      0.25,
+			},
+			FeeSettings: config.FeeSettings{
+				MaxGasLimitPerBlock:     "1500000000",
+				MaxGasLimitPerMetaBlock: "15000000000",
+				GasPerDataByte:          "1500",
+				MinGasPrice:             "1000000000",
+				MinGasLimit:             "50000",
+				GasPriceModifier:        0.01,
+			},
+		},
+		EpochNotifier:                  &mock.EpochNotifierStub{},
+		PenalizedTooMuchGasEnableEpoch: 0,
+		GasPriceModifierEnableEpoch:    0,
+	}
+}
+
+func computeExpectedResults(args *economics.ArgsNewEconomicsData, tx *transaction.Transaction, builtInGasUsed uint64, vmoutput *vmcommon.VMOutput) (*big.Int, *big.Int) {
+	minGasLimitBigInt, _ := big.NewInt(0).SetString(args.Economics.FeeSettings.MinGasLimit, 10)
+	gasPerByteBigInt, _ := big.NewInt(0).SetString(args.Economics.FeeSettings.GasPerDataByte, 10)
+	minGasLimit := minGasLimitBigInt.Uint64()
+	gasPerByte := gasPerByteBigInt.Uint64()
+
+	moveGas := uint64(len(tx.Data))*gasPerByte + minGasLimit
+	moveFee := big.NewInt(0).SetUint64(moveGas)
+	moveFee = big.NewInt(0).Mul(moveFee, big.NewInt(0).SetUint64(tx.GasPrice))
+
+	processGas := tx.GasLimit - builtInGasUsed - moveGas - vmoutput.GasRemaining
+	processPrice := big.NewInt(0).SetUint64(uint64(float64(tx.GasPrice) * args.Economics.FeeSettings.GasPriceModifier))
+	processFee := big.NewInt(0).SetUint64(processGas)
+	processFee = big.NewInt(0).Mul(processFee, processPrice)
+
+	builtInFee := big.NewInt(0).Mul(big.NewInt(0).SetUint64(builtInGasUsed), processPrice)
+
+	expectedTotalFee := big.NewInt(0).Add(moveFee, processFee)
+	expectedTotalFee.Add(expectedTotalFee, builtInFee)
+	expectedDevFees := core.GetPercentageOfValue(processFee, args.Economics.RewardsSettings.DeveloperPercentage)
+	return expectedTotalFee, expectedDevFees
 }


### PR DESCRIPTION
Fixed a mismatch between validator statistics accumulation of block proposer fees and end of epoch economics computation.
In validator statistics, the block proposer fees was accumulated considering 10% out of (feesPerBlock - devFees) while the end of epoch economics was considering the fee as 10% out of feesPerBlock. 

The effect was that in the end of epoch metachain block there were a bit more tokens reported as distributed for rewards than actually distributed.

Added also several tests for the computation of developer fees out of the transaction fees.