### PR TITLE
Fix/compute unqualified nodes

### DIFF
--- a/cmd/node/config/gasSchedules/gasScheduleV1.toml
+++ b/cmd/node/config/gasSchedules/gasScheduleV1.toml
@@ -26,6 +26,7 @@
     UnstakeTokens       = 5000000
     UnbondTokens        = 5000000
     DelegationMgrOps    = 50000000
+    GetAllNodeStates    = 100000000
 
 [BaseOperationCost]
     StorePerByte      = 50000

--- a/cmd/node/config/gasSchedules/gasScheduleV2.toml
+++ b/cmd/node/config/gasSchedules/gasScheduleV2.toml
@@ -24,6 +24,7 @@
     DelegateVote        = 1000000
     RevokeVote          = 500000
     CloseProposal       = 1000000
+    GetAllNodeStates    = 100000000
 
 [BaseOperationCost]
     StorePerByte      = 50000

--- a/epochStart/errors.go
+++ b/epochStart/errors.go
@@ -281,9 +281,6 @@ var ErrInvalidSystemSCReturn = errors.New("invalid system sc return")
 // ErrUnStakeExecuteError signals that unstaked returned with error
 var ErrUnStakeExecuteError = errors.New("unstake execution error")
 
-// ErrInvalidNumOfKeysToUnStake signals that invalid number of keys were selected to unstake
-var ErrInvalidNumOfKeysToUnStake = errors.New("invalid number of keys to unstake")
-
 // ErrSystemValidatorSCCall signals that system validator sc call failed
 var ErrSystemValidatorSCCall = errors.New("system validator sc call failed")
 

--- a/epochStart/metachain/stakingDataProvider.go
+++ b/epochStart/metachain/stakingDataProvider.go
@@ -231,14 +231,14 @@ func (sdp *stakingDataProvider) getValidatorData(validatorAddress string) (*owne
 }
 
 func (sdp *stakingDataProvider) getValidatorDataFromStakingSC(validatorAddress string) (*ownerStats, error) {
-	topUpValue, totalStakedValue, numRegistered, blsKeys, err := sdp.getValidatorInfoFromSC(validatorAddress)
+	topUpValue, totalStakedValue, numStakedWaiting, blsKeys, err := sdp.getValidatorInfoFromSC(validatorAddress)
 	if err != nil {
 		return nil, err
 	}
 
 	ownerData := &ownerStats{
 		numEligible:    0,
-		numStakedNodes: int(numRegistered.Int64()),
+		numStakedNodes: int(numStakedWaiting.Int64()),
 		topUpValue:     topUpValue,
 		totalStaked:    totalStakedValue,
 	}
@@ -278,9 +278,9 @@ func (sdp *stakingDataProvider) getValidatorInfoFromSC(validatorAddress string) 
 
 	topUpValue := big.NewInt(0).SetBytes(vmOutput.ReturnData[0])
 	totalStakedValue := big.NewInt(0).SetBytes(vmOutput.ReturnData[1])
-	numRegisteredNodes := big.NewInt(0).SetBytes(vmOutput.ReturnData[2])
+	numStakedWaiting := big.NewInt(0).SetBytes(vmOutput.ReturnData[2])
 
-	return topUpValue, totalStakedValue, numRegisteredNodes, vmOutput.ReturnData[3:], nil
+	return topUpValue, totalStakedValue, numStakedWaiting, vmOutput.ReturnData[3:], nil
 }
 
 // ComputeUnQualifiedNodes will compute which nodes are not qualified - do not have enough tokens to be validators

--- a/epochStart/metachain/stakingDataProvider.go
+++ b/epochStart/metachain/stakingDataProvider.go
@@ -315,8 +315,8 @@ func (sdp *stakingDataProvider) ComputeUnQualifiedNodes(validatorInfos map[uint3
 
 		numKeysToUnStake := totalActive - maxQualified.Int64()
 		selectedKeys := selectKeysToUnStake(sortedKeys, numKeysToUnStake)
-		if int64(len(selectedKeys)) != numKeysToUnStake {
-			return nil, nil, epochStart.ErrInvalidNumOfKeysToUnStake
+		if len(selectedKeys) == 0 {
+			continue
 		}
 
 		keysToUnStake = append(keysToUnStake, selectedKeys...)
@@ -340,7 +340,7 @@ func createMapBLSKeyStatus(validatorInfos map[uint32][]*state.ValidatorInfo) map
 }
 
 func selectKeysToUnStake(sortedKeys map[string][][]byte, numToSelect int64) [][]byte {
-	selectedKeys := make([][]byte, 0, numToSelect)
+	selectedKeys := make([][]byte, 0)
 	newKeys := sortedKeys[string(core.NewList)]
 	if len(newKeys) > 0 {
 		selectedKeys = append(selectedKeys, newKeys...)
@@ -364,7 +364,11 @@ func selectKeysToUnStake(sortedKeys map[string][][]byte, numToSelect int64) [][]
 		selectedKeys = append(selectedKeys, eligibleKeys...)
 	}
 
-	return selectedKeys[:numToSelect]
+	if int64(len(selectedKeys)) >= numToSelect {
+		return selectedKeys[:numToSelect]
+	}
+
+	return selectedKeys
 }
 
 func arrangeBlsKeysByStatus(mapBlsKeyStatus map[string]string, blsKeys [][]byte) (map[string][][]byte, int64) {

--- a/epochStart/metachain/stakingDataProvider.go
+++ b/epochStart/metachain/stakingDataProvider.go
@@ -273,7 +273,7 @@ func (sdp *stakingDataProvider) getValidatorInfoFromSC(validatorAddress string) 
 	}
 
 	if len(vmOutput.ReturnData) < 3 {
-		return nil, nil, nil, nil, fmt.Errorf("%w, getTotalStakedTopUpBlsKeys function should have at least two values", epochStart.ErrExecutingSystemScCode)
+		return nil, nil, nil, nil, fmt.Errorf("%w, getTotalStakedTopUpBlsKeys function should have at least tree values", epochStart.ErrExecutingSystemScCode)
 	}
 
 	topUpValue := big.NewInt(0).SetBytes(vmOutput.ReturnData[0])

--- a/epochStart/metachain/stakingDataProvider.go
+++ b/epochStart/metachain/stakingDataProvider.go
@@ -15,8 +15,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/vm"
 )
 
-const conversionBase = 10
-
 type ownerStats struct {
 	numEligible        int
 	numStakedNodes     int
@@ -280,15 +278,8 @@ func (sdp *stakingDataProvider) getValidatorInfoFromSC(validatorAddress string) 
 		return nil, nil, nil, fmt.Errorf("%w, getTotalStakedTopUpBlsKeys function should have at least two values", epochStart.ErrExecutingSystemScCode)
 	}
 
-	topUpValue, ok := big.NewInt(0).SetString(string(vmOutput.ReturnData[0]), conversionBase)
-	if !ok {
-		return nil, nil, nil, fmt.Errorf("%w, error: topUp string returned is not a number", epochStart.ErrExecutingSystemScCode)
-	}
-
-	totalStakedValue, ok := big.NewInt(0).SetString(string(vmOutput.ReturnData[1]), conversionBase)
-	if !ok {
-		return nil, nil, nil, fmt.Errorf("%w, error: totalStaked string returned is not a number", epochStart.ErrExecutingSystemScCode)
-	}
+	topUpValue := big.NewInt(0).SetBytes(vmOutput.ReturnData[0])
+	totalStakedValue := big.NewInt(0).SetBytes(vmOutput.ReturnData[1])
 
 	return topUpValue, totalStakedValue, vmOutput.ReturnData[2:], nil
 }

--- a/epochStart/metachain/stakingDataProvider.go
+++ b/epochStart/metachain/stakingDataProvider.go
@@ -17,7 +17,7 @@ import (
 
 type ownerStats struct {
 	numEligible        int
-	numStakedNodes     int
+	numStakedNodes     int64
 	topUpValue         *big.Int
 	totalStaked        *big.Int
 	eligibleBaseStake  *big.Int
@@ -136,7 +136,7 @@ func (sdp *stakingDataProvider) processStakingData() {
 		if owner.numStakedNodes == 0 {
 			ownerStakePerNode.Set(sdp.minNodePrice)
 		} else {
-			ownerStakePerNode.Div(owner.totalStaked, big.NewInt(int64(owner.numStakedNodes)))
+			ownerStakePerNode.Div(owner.totalStaked, big.NewInt(owner.numStakedNodes))
 		}
 
 		ownerEligibleStake := big.NewInt(0).Mul(ownerStakePerNode, ownerEligibleNodes)
@@ -238,7 +238,7 @@ func (sdp *stakingDataProvider) getValidatorDataFromStakingSC(validatorAddress s
 
 	ownerData := &ownerStats{
 		numEligible:    0,
-		numStakedNodes: int(numStakedWaiting.Int64()),
+		numStakedNodes: numStakedWaiting.Int64(),
 		topUpValue:     topUpValue,
 		totalStaked:    totalStakedValue,
 	}
@@ -292,9 +292,8 @@ func (sdp *stakingDataProvider) ComputeUnQualifiedNodes(validatorInfos map[uint3
 	keysToUnStake := make([][]byte, 0)
 	mapBLSKeyStatus := createMapBLSKeyStatus(validatorInfos)
 	for ownerAddress, stakingInfo := range sdp.cache {
-		numRegisteredKeys := int64(len(stakingInfo.blsKeys))
 		maxQualified := big.NewInt(0).Div(stakingInfo.totalStaked, sdp.minNodePrice)
-		if maxQualified.Int64() >= numRegisteredKeys {
+		if maxQualified.Int64() >= stakingInfo.numStakedNodes {
 			continue
 		}
 

--- a/epochStart/metachain/stakingDataProvider.go
+++ b/epochStart/metachain/stakingDataProvider.go
@@ -273,7 +273,7 @@ func (sdp *stakingDataProvider) getValidatorInfoFromSC(validatorAddress string) 
 	}
 
 	if len(vmOutput.ReturnData) < 3 {
-		return nil, nil, nil, nil, fmt.Errorf("%w, getTotalStakedTopUpBlsKeys function should have at least tree values", epochStart.ErrExecutingSystemScCode)
+		return nil, nil, nil, nil, fmt.Errorf("%w, getTotalStakedTopUpBlsKeys function should have at least three values", epochStart.ErrExecutingSystemScCode)
 	}
 
 	topUpValue := big.NewInt(0).SetBytes(vmOutput.ReturnData[0])

--- a/epochStart/metachain/stakingDataProvider_test.go
+++ b/epochStart/metachain/stakingDataProvider_test.go
@@ -121,7 +121,7 @@ func TestStakingDataProvider_PrepareDataForBlsKeyLoadOwnerDataErrorsShouldErr(t 
 	err = sdp.loadDataForBlsKey([]byte("bls key"))
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), epochStart.ErrExecutingSystemScCode.Error()))
-	assert.True(t, strings.Contains(err.Error(), "getTotalStakedTopUpBlsKeys function should have at least two values"))
+	assert.True(t, strings.Contains(err.Error(), "getTotalStakedTopUpBlsKeys function should have at least tree values"))
 }
 
 func TestStakingDataProvider_PrepareDataForBlsKeyFromSCShouldWork(t *testing.T) {

--- a/epochStart/metachain/stakingDataProvider_test.go
+++ b/epochStart/metachain/stakingDataProvider_test.go
@@ -406,7 +406,7 @@ func createStakingDataProviderWithMockArgs(
 				assert.Equal(t, vm.ValidatorSCAddress, input.RecipientAddr)
 
 				return &vmcommon.VMOutput{
-					ReturnData: [][]byte{topUpVal.Bytes(), stakingVal.Bytes()},
+					ReturnData: [][]byte{topUpVal.Bytes(), stakingVal.Bytes(), big.NewInt(3).Bytes()},
 				}, nil
 
 			}

--- a/epochStart/metachain/stakingDataProvider_test.go
+++ b/epochStart/metachain/stakingDataProvider_test.go
@@ -106,19 +106,6 @@ func TestStakingDataProvider_PrepareDataForBlsKeyLoadOwnerDataErrorsShouldErr(t 
 					ReturnCode: vmcommon.Ok,
 				}, nil
 			}
-			if numCall == 4 {
-				return &vmcommon.VMOutput{
-					ReturnCode: vmcommon.Ok,
-					ReturnData: [][]byte{[]byte("not a number"), []byte("1")},
-				}, nil
-			}
-			if numCall == 5 {
-				return &vmcommon.VMOutput{
-					ReturnCode: vmcommon.Ok,
-					ReturnData: [][]byte{[]byte("1"), []byte("not a number")},
-				}, nil
-			}
-
 			return nil, nil
 		},
 	}, "100000")
@@ -135,16 +122,6 @@ func TestStakingDataProvider_PrepareDataForBlsKeyLoadOwnerDataErrorsShouldErr(t 
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), epochStart.ErrExecutingSystemScCode.Error()))
 	assert.True(t, strings.Contains(err.Error(), "getTotalStakedTopUpBlsKeys function should have at least two values"))
-
-	err = sdp.loadDataForBlsKey([]byte("bls key"))
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), epochStart.ErrExecutingSystemScCode.Error()))
-	assert.True(t, strings.Contains(err.Error(), "topUp string returned is not a number"))
-
-	err = sdp.loadDataForBlsKey([]byte("bls key"))
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), epochStart.ErrExecutingSystemScCode.Error()))
-	assert.True(t, strings.Contains(err.Error(), "totalStaked string returned is not a number"))
 }
 
 func TestStakingDataProvider_PrepareDataForBlsKeyFromSCShouldWork(t *testing.T) {
@@ -429,7 +406,7 @@ func createStakingDataProviderWithMockArgs(
 				assert.Equal(t, vm.ValidatorSCAddress, input.RecipientAddr)
 
 				return &vmcommon.VMOutput{
-					ReturnData: [][]byte{[]byte(topUpVal.String()), []byte(stakingVal.String())},
+					ReturnData: [][]byte{topUpVal.Bytes(), stakingVal.Bytes()},
 				}, nil
 
 			}

--- a/epochStart/metachain/stakingDataProvider_test.go
+++ b/epochStart/metachain/stakingDataProvider_test.go
@@ -121,7 +121,7 @@ func TestStakingDataProvider_PrepareDataForBlsKeyLoadOwnerDataErrorsShouldErr(t 
 	err = sdp.loadDataForBlsKey([]byte("bls key"))
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), epochStart.ErrExecutingSystemScCode.Error()))
-	assert.True(t, strings.Contains(err.Error(), "getTotalStakedTopUpBlsKeys function should have at least three values"))
+	assert.True(t, strings.Contains(err.Error(), "getTotalStakedTopUpStakedBlsKeys function should have at least three values"))
 }
 
 func TestStakingDataProvider_PrepareDataForBlsKeyFromSCShouldWork(t *testing.T) {
@@ -401,7 +401,7 @@ func createStakingDataProviderWithMockArgs(
 				return &vmcommon.VMOutput{
 					ReturnData: [][]byte{owner},
 				}, nil
-			case "getTotalStakedTopUpBlsKeys":
+			case "getTotalStakedTopUpStakedBlsKeys":
 				assert.Equal(t, owner, input.VMInput.CallerAddr)
 				assert.Equal(t, vm.ValidatorSCAddress, input.RecipientAddr)
 

--- a/epochStart/metachain/stakingDataProvider_test.go
+++ b/epochStart/metachain/stakingDataProvider_test.go
@@ -121,7 +121,7 @@ func TestStakingDataProvider_PrepareDataForBlsKeyLoadOwnerDataErrorsShouldErr(t 
 	err = sdp.loadDataForBlsKey([]byte("bls key"))
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), epochStart.ErrExecutingSystemScCode.Error()))
-	assert.True(t, strings.Contains(err.Error(), "getTotalStakedTopUpBlsKeys function should have at least tree values"))
+	assert.True(t, strings.Contains(err.Error(), "getTotalStakedTopUpBlsKeys function should have at least three values"))
 }
 
 func TestStakingDataProvider_PrepareDataForBlsKeyFromSCShouldWork(t *testing.T) {

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -246,7 +246,7 @@ func TestSystemSCProcessor_NobodyToSwapWithStakingV2(t *testing.T) {
 	}
 
 	doStake(t, s.systemVM, s.userAccountsDB, owner1, big.NewInt(1000), blsKeys...)
-	doUnStake(t, s.systemVM, s.userAccountsDB, owner1, blsKeys...)
+	doUnStake(t, s.systemVM, s.userAccountsDB, owner1, blsKeys[:3]...)
 	validatorsInfo := make(map[uint32][]*state.ValidatorInfo)
 	jailed := &state.ValidatorInfo{
 		PublicKey:       blsKeys[0],

--- a/process/factory/metachain/vmContainerFactory_test.go
+++ b/process/factory/metachain/vmContainerFactory_test.go
@@ -245,6 +245,7 @@ func FillGasMapMetaChainSystemSCsCosts(value uint64) map[string]uint64 {
 	gasMap["UnStakeTokens"] = value
 	gasMap["UnBondTokens"] = value
 	gasMap["DelegationMgrOps"] = value
+	gasMap["GetAllNodeStates"] = value
 
 	return gasMap
 }

--- a/vm/gasCost.go
+++ b/vm/gasCost.go
@@ -31,6 +31,7 @@ type MetaChainSystemSCsCost struct {
 	UnStakeTokens       uint64
 	UnBondTokens        uint64
 	DelegationMgrOps    uint64
+	GetAllNodeStates    uint64
 }
 
 // BuiltInCost defines cost for built-in methods

--- a/vm/systemSmartContracts/defaults/gasMap.go
+++ b/vm/systemSmartContracts/defaults/gasMap.go
@@ -59,6 +59,7 @@ func FillGasMapMetaChainSystemSCsCosts(value uint64) map[string]uint64 {
 	gasMap["UnStakeTokens"] = value
 	gasMap["UnBondTokens"] = value
 	gasMap["DelegationMgrOps"] = value
+	gasMap["GetAllNodeStates"] = value
 
 	return gasMap
 }

--- a/vm/systemSmartContracts/delegation.go
+++ b/vm/systemSmartContracts/delegation.go
@@ -349,7 +349,7 @@ func (d *delegation) makeStakeArgsIfAutomaticActivation(
 	}
 
 	maxNodesToStake := big.NewInt(0).Div(globalFund.TotalActive, d.nodePrice).Uint64()
-	numStakedNodes := uint64(len(status.StakedKeys))
+	numStakedNodes := uint64(len(status.StakedKeys) + len(status.UnStakedKeys))
 	if maxNodesToStake <= numStakedNodes {
 		return nil
 	}

--- a/vm/systemSmartContracts/staking.go
+++ b/vm/systemSmartContracts/staking.go
@@ -573,6 +573,13 @@ func (s *stakingSC) unStakeAtEndOfEpoch(args *vmcommon.ContractCallInput) vmcomm
 	if registrationData.Staked {
 		s.removeFromStakedNodes()
 	}
+	if registrationData.Waiting {
+		err = s.removeFromWaitingList(args.Arguments[0])
+		if err != nil {
+			s.eei.AddReturnMessage(err.Error())
+			return vmcommon.UserError
+		}
+	}
 
 	registrationData.Staked = false
 	registrationData.UnStakedEpoch = s.eei.BlockChainHook().CurrentEpoch()

--- a/vm/systemSmartContracts/staking.go
+++ b/vm/systemSmartContracts/staking.go
@@ -565,12 +565,15 @@ func (s *stakingSC) unStakeAtEndOfEpoch(args *vmcommon.ContractCallInput) vmcomm
 		return vmcommon.Ok
 	}
 
-	if !registrationData.Staked {
-		log.Debug("stakingSC.unStakeAtEndOfEpoch: cannot unStake node which was already unStaked")
+	if !registrationData.Staked && !registrationData.Waiting {
+		log.Debug("stakingSC.unStakeAtEndOfEpoch: cannot unStake node which was already unStaked", "blsKey", hex.EncodeToString(args.Arguments[0]))
 		return vmcommon.Ok
 	}
 
-	s.removeFromStakedNodes()
+	if registrationData.Staked {
+		s.removeFromStakedNodes()
+	}
+
 	registrationData.Staked = false
 	registrationData.UnStakedEpoch = s.eei.BlockChainHook().CurrentEpoch()
 	registrationData.UnStakedNonce = s.eei.BlockChainHook().CurrentNonce()

--- a/vm/systemSmartContracts/validator.go
+++ b/vm/systemSmartContracts/validator.go
@@ -1685,8 +1685,8 @@ func (v *validatorSC) getTotalStakedTopUpBlsKeys(args *vmcommon.ContractCallInpu
 		return vmcommon.UserError
 	}
 
-	v.eei.Finish([]byte(topUp.String()))
-	v.eei.Finish([]byte(registrationData.TotalStakeValue.String()))
+	v.eei.Finish(topUp.Bytes())
+	v.eei.Finish(registrationData.TotalStakeValue.Bytes())
 
 	for _, blsKey := range registrationData.BlsPubKeys {
 		v.eei.Finish(blsKey)

--- a/vm/systemSmartContracts/validator.go
+++ b/vm/systemSmartContracts/validator.go
@@ -1676,6 +1676,9 @@ func (v *validatorSC) getTotalStakedTopUpBlsKeys(args *vmcommon.ContractCallInpu
 
 	topUp := big.NewInt(0).Set(registrationData.TotalStakeValue)
 	topUp.Sub(topUp, stakeForNodes)
+	if topUp.Cmp(zero) < 0 {
+		topUp.Set(zero)
+	}
 
 	if registrationData.TotalStakeValue.Cmp(zero) < 0 {
 		v.eei.AddReturnMessage("contract error on getTopUp function, total stake < locked stake value")

--- a/vm/systemSmartContracts/validator.go
+++ b/vm/systemSmartContracts/validator.go
@@ -183,8 +183,8 @@ func (v *validatorSC) Execute(args *vmcommon.ContractCallInput) vmcommon.ReturnC
 		return v.unJail(args)
 	case "getTotalStaked":
 		return v.getTotalStaked(args)
-	case "getTotalStakedTopUpBlsKeys":
-		return v.getTotalStakedTopUpBlsKeys(args)
+	case "getTotalStakedTopUpStakedBlsKeys":
+		return v.getTotalStakedTopUpStakedBlsKeys(args)
 	case "getBlsKeysStatus":
 		return v.getBlsKeysStatus(args)
 	case "cleanRegisteredData":
@@ -734,7 +734,7 @@ func (v *validatorSC) reStakeUnStakedNodes(args *vmcommon.ContractCallInput) vmc
 		return vmcommon.UserError
 	}
 
-	numStakedAndWaiting, err := v.getNumStakedAndWaitingNodes(registrationData, mapNodesToReStake, true)
+	numStakedAndWaiting, _, err := v.getNumStakedAndWaitingNodes(registrationData, mapNodesToReStake, true)
 	if err != nil {
 		v.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
@@ -756,12 +756,13 @@ func (v *validatorSC) getNumStakedAndWaitingNodes(
 	registrationData *ValidatorDataV2,
 	mapCheckedKeys map[string]struct{},
 	checkJailed bool,
-) (uint64, error) {
+) (uint64, [][]byte, error) {
 	errUseGas := v.eei.UseGas(v.gasCost.MetaChainSystemSCsCost.GetAllNodeStates)
 	if errUseGas != nil {
-		return 0, errUseGas
+		return 0, nil, errUseGas
 	}
 
+	listActiveNodes := make([][]byte, 0)
 	numActiveNodes := uint64(0)
 	for _, blsKey := range registrationData.BlsPubKeys {
 		_, exists := mapCheckedKeys[string(blsKey)]
@@ -771,19 +772,23 @@ func (v *validatorSC) getNumStakedAndWaitingNodes(
 
 		stakedData, err := v.getStakedData(blsKey)
 		if err != nil {
-			return 0, err
+			return 0, nil, err
 		}
 
 		if checkJailed && stakedData.Jailed {
-			return 0, vm.ErrBLSPublicKeyAlreadyJailed
+			return 0, nil, vm.ErrBLSPublicKeyAlreadyJailed
 		}
 
 		if stakedData.Staked || stakedData.Waiting || stakedData.Jailed {
 			numActiveNodes++
 		}
+
+		if stakedData.Staked || stakedData.Waiting {
+			listActiveNodes = append(listActiveNodes, blsKey)
+		}
 	}
 
-	return numActiveNodes, nil
+	return numActiveNodes, listActiveNodes, nil
 }
 
 func (v *validatorSC) checkAllGivenKeysAreUnStaked(registrationData *ValidatorDataV2, blsKeys [][]byte) (map[string]struct{}, error) {
@@ -1654,7 +1659,7 @@ func (v *validatorSC) getTotalStaked(args *vmcommon.ContractCallInput) vmcommon.
 	return vmcommon.Ok
 }
 
-func (v *validatorSC) getTotalStakedTopUpBlsKeys(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
+func (v *validatorSC) getTotalStakedTopUpStakedBlsKeys(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
 	if !v.flagEnableTopUp.IsSet() {
 		v.eei.AddReturnMessage("invalid method to call")
 		return vmcommon.UserError
@@ -1682,7 +1687,7 @@ func (v *validatorSC) getTotalStakedTopUpBlsKeys(args *vmcommon.ContractCallInpu
 
 	validatorConfig := v.getConfig(v.eei.BlockChainHook().CurrentEpoch())
 
-	numActive, err := v.getNumStakedAndWaitingNodes(registrationData, make(map[string]struct{}), false)
+	numActive, listActiveNodes, err := v.getNumStakedAndWaitingNodes(registrationData, make(map[string]struct{}), false)
 	if err != nil {
 		v.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
@@ -1706,7 +1711,7 @@ func (v *validatorSC) getTotalStakedTopUpBlsKeys(args *vmcommon.ContractCallInpu
 	v.eei.Finish(registrationData.TotalStakeValue.Bytes())
 	v.eei.Finish(big.NewInt(0).SetUint64(numActive).Bytes())
 
-	for _, blsKey := range registrationData.BlsPubKeys {
+	for _, blsKey := range listActiveNodes {
 		v.eei.Finish(blsKey)
 	}
 

--- a/vm/systemSmartContracts/validator.go
+++ b/vm/systemSmartContracts/validator.go
@@ -757,6 +757,11 @@ func (v *validatorSC) getNumStakedAndWaitingNodes(
 	mapCheckedKeys map[string]struct{},
 	checkJailed bool,
 ) (uint64, error) {
+	errUseGas := v.eei.UseGas(v.gasCost.MetaChainSystemSCsCost.GetAllNodeStates)
+	if errUseGas != nil {
+		return 0, errUseGas
+	}
+
 	numActiveNodes := uint64(0)
 	for _, blsKey := range registrationData.BlsPubKeys {
 		_, exists := mapCheckedKeys[string(blsKey)]
@@ -1688,6 +1693,7 @@ func (v *validatorSC) getTotalStakedTopUpBlsKeys(args *vmcommon.ContractCallInpu
 	topUp := big.NewInt(0).Set(registrationData.TotalStakeValue)
 	topUp.Sub(topUp, stakeForNodes)
 	if topUp.Cmp(zero) < 0 {
+		log.Warn("topup value is less than 0")
 		topUp.Set(zero)
 	}
 

--- a/vm/systemSmartContracts/validator.go
+++ b/vm/systemSmartContracts/validator.go
@@ -1687,6 +1687,7 @@ func (v *validatorSC) getTotalStakedTopUpBlsKeys(args *vmcommon.ContractCallInpu
 
 	v.eei.Finish(topUp.Bytes())
 	v.eei.Finish(registrationData.TotalStakeValue.Bytes())
+	v.eei.Finish(big.NewInt(int64(registrationData.NumRegistered)).Bytes())
 
 	for _, blsKey := range registrationData.BlsPubKeys {
 		v.eei.Finish(blsKey)

--- a/vm/systemSmartContracts/validator_test.go
+++ b/vm/systemSmartContracts/validator_test.go
@@ -3689,8 +3689,8 @@ func TestStakingValidatorSC_GetTopUpTotalStakedShouldWork(t *testing.T) {
 	vmOutput := eei.CreateVMOutput()
 
 	// nodePrice is 1000 and there is 1 registered node - the rest is topup
-	assert.Equal(t, big.NewInt(32827).String(), string(vmOutput.ReturnData[0]))
-	assert.Equal(t, totalStake.String(), string(vmOutput.ReturnData[1]))
+	assert.Equal(t, big.NewInt(32827).Bytes(), vmOutput.ReturnData[0])
+	assert.Equal(t, totalStake.Bytes(), vmOutput.ReturnData[1])
 }
 
 func TestMarshalingBetweenValidatorV1AndValidatorV2(t *testing.T) {

--- a/vm/systemSmartContracts/validator_test.go
+++ b/vm/systemSmartContracts/validator_test.go
@@ -3612,7 +3612,7 @@ func TestStakingValidatorSC_GetTopUpTotalStakedWithValueShouldError(t *testing.T
 	caller := []byte("caller")
 	sc, _ := NewValidatorSmartContract(args)
 
-	callFunctionAndCheckResult(t, "getTotalStakedTopUpBlsKeys", sc, caller, nil, big.NewInt(1), vmcommon.UserError)
+	callFunctionAndCheckResult(t, "getTotalStakedTopUpStakedBlsKeys", sc, caller, nil, big.NewInt(1), vmcommon.UserError)
 	vmOutput := eei.CreateVMOutput()
 	assert.Equal(t, vm.TransactionValueMustBeZero, vmOutput.ReturnMessage)
 }
@@ -3631,7 +3631,7 @@ func TestStakingValidatorSC_GetTopUpTotalStakedInsufficientGasShouldError(t *tes
 	caller := []byte("caller")
 	sc, _ := NewValidatorSmartContract(args)
 
-	callFunctionAndCheckResult(t, "getTotalStakedTopUpBlsKeys", sc, caller, nil, big.NewInt(0), vmcommon.OutOfGas)
+	callFunctionAndCheckResult(t, "getTotalStakedTopUpStakedBlsKeys", sc, caller, nil, big.NewInt(0), vmcommon.OutOfGas)
 	vmOutput := eei.CreateVMOutput()
 	assert.Equal(t, vm.InsufficientGasLimit, vmOutput.ReturnMessage)
 }
@@ -3649,7 +3649,7 @@ func TestStakingValidatorSC_GetTopUpTotalStakedCallerDoesNotExistShouldError(t *
 	caller := []byte("caller")
 	sc, _ := NewValidatorSmartContract(args)
 
-	callFunctionAndCheckResult(t, "getTotalStakedTopUpBlsKeys", sc, caller, nil, big.NewInt(0), vmcommon.UserError)
+	callFunctionAndCheckResult(t, "getTotalStakedTopUpStakedBlsKeys", sc, caller, nil, big.NewInt(0), vmcommon.UserError)
 	vmOutput := eei.CreateVMOutput()
 	assert.Equal(t, "caller not registered in staking/validator sc", vmOutput.ReturnMessage)
 }
@@ -3685,7 +3685,7 @@ func TestStakingValidatorSC_GetTopUpTotalStakedShouldWork(t *testing.T) {
 		},
 	)
 
-	callFunctionAndCheckResult(t, "getTotalStakedTopUpBlsKeys", sc, caller, nil, big.NewInt(0), vmcommon.Ok)
+	callFunctionAndCheckResult(t, "getTotalStakedTopUpStakedBlsKeys", sc, caller, nil, big.NewInt(0), vmcommon.Ok)
 	vmOutput := eei.CreateVMOutput()
 
 	assert.Equal(t, totalStake.Bytes(), vmOutput.ReturnData[0])

--- a/vm/systemSmartContracts/validator_test.go
+++ b/vm/systemSmartContracts/validator_test.go
@@ -3688,8 +3688,7 @@ func TestStakingValidatorSC_GetTopUpTotalStakedShouldWork(t *testing.T) {
 	callFunctionAndCheckResult(t, "getTotalStakedTopUpBlsKeys", sc, caller, nil, big.NewInt(0), vmcommon.Ok)
 	vmOutput := eei.CreateVMOutput()
 
-	// nodePrice is 1000 and there is 1 registered node - the rest is topup
-	assert.Equal(t, big.NewInt(32827).Bytes(), vmOutput.ReturnData[0])
+	assert.Equal(t, totalStake.Bytes(), vmOutput.ReturnData[0])
 	assert.Equal(t, totalStake.Bytes(), vmOutput.ReturnData[1])
 }
 


### PR DESCRIPTION
fix compute unqualified nodes when there are no nodes to unstake - it can happen when someone unstake tokens but all of its nodes are in jail
optimize get total topup and total stake
fix: set totUp if it is less than 0 to 0