### PR TITLE
Bug fix gas used field 

### DIFF
--- a/core/indexer/common.go
+++ b/core/indexer/common.go
@@ -433,7 +433,7 @@ func prepareSerializedDataForATransaction(
 	}
 
 	var serializedData []byte
-	if tx.GasUsed == tx.GasLimit {
+	if tx.GasUsed == tx.GasLimit && !hasScrWithRefund(tx) {
 		// do not update gasUsed because it is the same with gasUsed when transaction was saved first time in database
 		serializedData =
 			[]byte(fmt.Sprintf(`{"script":{"source":"`+
@@ -462,6 +462,16 @@ func prepareSerializedDataForATransaction(
 	log.Trace("indexer tx is on destination shard", "metaData", string(metaData), "serializedData", string(serializedData))
 
 	return metaData, serializedData, nil
+}
+
+func hasScrWithRefund(tx *Transaction) bool {
+	for _, sc := range tx.SmartContractResults {
+		if isSCRForSenderWithGasUsed(sc, tx) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func prepareSerializedAccountInfo(address string, account *AccountInfo) ([]byte, []byte, error) {

--- a/core/indexer/common_test.go
+++ b/core/indexer/common_test.go
@@ -159,3 +159,32 @@ func TestPrepareBufferMiniblocks(t *testing.T) {
 
 	require.Equal(t, expectedBuff, buff)
 }
+
+func TestHasScrWithRefund(t *testing.T) {
+	t.Parallel()
+
+	sc := ScResult{
+		PreTxHash:      "dad46ed504695598d1e95781e77f224bf4fd829a63f2b05170f1b7f4e5bcd329",
+		Nonce:          12,
+		Value:          "0",
+		Receiver:       "erd1xa7lf3kux3ujrzc6ul0t7tq2x0zdph99pcg0zdj8jctftsk7krus3luq53",
+		Data:           []byte("@6f6b@"),
+		OriginalTxHash: "dad46ed504695598d1e95781e77f224bf4fd829a63f2b05170f1b7f4e5bcd329",
+		ReturnMessage:  "too much gas provided: gas needed = 109013, gas remained = 18609087",
+	}
+
+	tx := &Transaction{
+		Hash:     "dad46ed504695598d1e95781e77f224bf4fd829a63f2b05170f1b7f4e5bcd329",
+		Nonce:    11,
+		GasLimit: 40000000,
+		GasPrice: 1000000000,
+		Status:   "success",
+		Sender:   "erd1xa7lf3kux3ujrzc6ul0t7tq2x0zdph99pcg0zdj8jctftsk7krus3luq53",
+		SmartContractResults: []ScResult{
+			sc,
+		},
+	}
+
+	require.True(t, hasScrWithRefund(tx))
+	require.False(t, hasScrWithRefund(&Transaction{}))
+}

--- a/core/indexer/processTransactions_test.go
+++ b/core/indexer/processTransactions_test.go
@@ -518,3 +518,28 @@ func TestComputeTxGasUsedField(t *testing.T) {
 	expectedGasUsed := uint64(200)
 	require.Equal(t, expectedGasUsed, computeTxGasUsedField(sc, tx))
 }
+
+func TestCheckGasUsedTooMuchGasProvidedCase(t *testing.T) {
+	t.Parallel()
+
+	tx := &Transaction{
+		Hash:     "dad46ed504695598d1e95781e77f224bf4fd829a63f2b05170f1b7f4e5bcd329",
+		Nonce:    11,
+		GasLimit: 40000000,
+		GasPrice: 1000000000,
+		Status:   "success",
+		Sender:   "erd1xa7lf3kux3ujrzc6ul0t7tq2x0zdph99pcg0zdj8jctftsk7krus3luq53",
+	}
+	sc := ScResult{
+		PreTxHash:      "dad46ed504695598d1e95781e77f224bf4fd829a63f2b05170f1b7f4e5bcd329",
+		Nonce:          12,
+		Value:          "0",
+		Receiver:       "erd1xa7lf3kux3ujrzc6ul0t7tq2x0zdph99pcg0zdj8jctftsk7krus3luq53",
+		Data:           []byte("@6f6b@"),
+		OriginalTxHash: "dad46ed504695598d1e95781e77f224bf4fd829a63f2b05170f1b7f4e5bcd329",
+		ReturnMessage:  "too much gas provided: gas needed = 109013, gas remained = 18609087",
+	}
+
+	require.True(t, isSCRForSenderWithGasUsed(sc, tx))
+	require.Equal(t, uint64(40000000), computeTxGasUsedField(sc, tx))
+}


### PR DESCRIPTION
**Bugfix**: fixed problem when we have a cross-shard smart contract call with too much gas provided. The value of gasUsed field was wrong because on destination shard when the transaction is indexed in elasticsearch gasUsed field was not updated.
