### PR TITLE
SC query service dispatcher

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -629,7 +629,7 @@
         [VirtualMachine.Querying.OutOfProcessConfig]
             LogsMarshalizer = "json"
             MessagesMarshalizer = "json"
-            MaxLoopTime = 5000
+            MaxLoopTime = 10000
 
 [Hardfork]
     EnableTrigger = true

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -625,7 +625,7 @@
             MessagesMarshalizer = "json"
             MaxLoopTime = 1000
     [VirtualMachine.Querying]
-        [VirtualMachine.Execution.OutOfProcessConfig]
+        [VirtualMachine.Querying.OutOfProcessConfig]
             LogsMarshalizer = "json"
             MessagesMarshalizer = "json"
             MaxLoopTime = 1000

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -625,7 +625,10 @@
             MessagesMarshalizer = "json"
             MaxLoopTime = 1000
     [VirtualMachine.Querying]
-        OutOfProcessEnabled = true
+        [VirtualMachine.Execution.OutOfProcessConfig]
+            LogsMarshalizer = "json"
+            MessagesMarshalizer = "json"
+            MaxLoopTime = 1000
         NumConcurrentVms = 20
 
 [Hardfork]

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -625,7 +625,8 @@
             MessagesMarshalizer = "json"
             MaxLoopTime = 1000
     [VirtualMachine.Querying]
-        OutOfProcessEnabled = false
+        OutOfProcessEnabled = true
+        NumConcurrentVms = 20
 
 [Hardfork]
     EnableTrigger = true

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -625,11 +625,11 @@
             MessagesMarshalizer = "json"
             MaxLoopTime = 1000
     [VirtualMachine.Querying]
+        NumConcurrentVMs = 20
         [VirtualMachine.Querying.OutOfProcessConfig]
             LogsMarshalizer = "json"
             MessagesMarshalizer = "json"
             MaxLoopTime = 1000
-        NumConcurrentVms = 20
 
 [Hardfork]
     EnableTrigger = true

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -629,7 +629,7 @@
         [VirtualMachine.Querying.OutOfProcessConfig]
             LogsMarshalizer = "json"
             MessagesMarshalizer = "json"
-            MaxLoopTime = 1000
+            MaxLoopTime = 5000
 
 [Hardfork]
     EnableTrigger = true

--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -89,6 +89,8 @@ const (
 	DefaultStaticDbString = "Static"
 	// DefaultShardString is the default Shard string when creating DB path
 	DefaultShardString = "Shard"
+	// TemporaryPath is the default temporary path directory
+	TemporaryPath = "temp"
 )
 
 //TODO remove this
@@ -1412,6 +1414,7 @@ func newBlockProcessor(
 ) (process.BlockProcessor, error) {
 
 	shardCoordinator := processArgs.shardCoordinator
+	workingDir := filepath.Join(processArgs.workingDir, TemporaryPath)
 
 	if shardCoordinator.SelfId() < shardCoordinator.NumberOfShards() {
 		return newShardBlockProcessor(
@@ -1442,7 +1445,7 @@ func newBlockProcessor(
 			processArgs.epochNotifier,
 			txSimulatorProcessorArgs,
 			processArgs.mainConfig,
-			processArgs.workingDir,
+			workingDir,
 		)
 	}
 	if shardCoordinator.SelfId() == core.MetachainShardId {
@@ -1478,7 +1481,7 @@ func newBlockProcessor(
 			processArgs.epochNotifier,
 			txSimulatorProcessorArgs,
 			processArgs.mainConfig,
-			processArgs.workingDir,
+			workingDir,
 			processArgs.rater,
 		)
 	}

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -2514,7 +2514,7 @@ func createScQueryService(
 ) (process.SCQueryService, error) {
 	numConcurrentVms := generalConfig.VirtualMachine.Querying.NumConcurrentVms
 	if numConcurrentVms < 1 {
-		return nil, fmt.Errorf("VirtualMachine.Querying.NumConcurrentVms should be a positive number higher than 1")
+		return nil, fmt.Errorf("VirtualMachine.Querying.NumConcurrentVms should be a positive number more than 1")
 	}
 
 	list := make([]process.SCQueryService, 0, numConcurrentVms)
@@ -2630,8 +2630,10 @@ func createScQueryElement(
 			return nil, err
 		}
 	} else {
+		queryVirtualMachineConfig := generalConfig.VirtualMachine.Querying.VirtualMachineConfig
+		queryVirtualMachineConfig.OutOfProcessEnabled = true
 		vmFactory, err = shard.NewVMContainerFactory(
-			generalConfig.VirtualMachine.Querying.VirtualMachineConfig,
+			queryVirtualMachineConfig,
 			economics.MaxGasLimitPerBlock(shardCoordinator.SelfId()),
 			gasScheduleNotifier,
 			argsHook,

--- a/config/config.go
+++ b/config/config.go
@@ -334,13 +334,19 @@ type IncreaseFactorConfig struct {
 // VirtualMachineServicesConfig holds configuration for the Virtual Machine(s): both querying and execution services.
 type VirtualMachineServicesConfig struct {
 	Execution VirtualMachineConfig
-	Querying  VirtualMachineConfig
+	Querying  QueryVirtualMachineConfig
 }
 
 // VirtualMachineConfig holds configuration for a Virtual Machine service
 type VirtualMachineConfig struct {
 	OutOfProcessConfig  VirtualMachineOutOfProcessConfig
 	OutOfProcessEnabled bool
+}
+
+// QueryVirtualMachineConfig holds the configuration for the virtual machine(s) used in query process
+type QueryVirtualMachineConfig struct {
+	VirtualMachineConfig
+	NumConcurrentVms int
 }
 
 // VirtualMachineOutOfProcessConfig holds configuration for out-of-process virtual machine(s)

--- a/config/config.go
+++ b/config/config.go
@@ -346,7 +346,7 @@ type VirtualMachineConfig struct {
 // QueryVirtualMachineConfig holds the configuration for the virtual machine(s) used in query process
 type QueryVirtualMachineConfig struct {
 	VirtualMachineConfig
-	NumConcurrentVms int
+	NumConcurrentVMs int
 }
 
 // VirtualMachineOutOfProcessConfig holds configuration for out-of-process virtual machine(s)

--- a/process/errors.go
+++ b/process/errors.go
@@ -746,9 +746,6 @@ var ErrCallerIsNotTheDNSAddress = errors.New("not a dns address")
 // ErrUserNameChangeIsDisabled signals the user name change is not allowed
 var ErrUserNameChangeIsDisabled = errors.New("user name change is disabled")
 
-// ErrDestinationNotInSelfShard signals that user is not in self shard
-var ErrDestinationNotInSelfShard = errors.New("destination is not in self shard")
-
 // ErrUserNameDoesNotMatch signals that user name does not match
 var ErrUserNameDoesNotMatch = errors.New("user name does not match")
 
@@ -931,3 +928,9 @@ var ErrNotEnoughGasInUserTx = errors.New("not enough gas provided in user tx")
 
 // ErrNegativeBalanceDeltaOnCrossShardAccount signals that negative balance delta was given on cross shard account
 var ErrNegativeBalanceDeltaOnCrossShardAccount = errors.New("negative balance delta on cross shard account")
+
+// ErrNilOrEmptyList signals that a nil or empty list was provided
+var ErrNilOrEmptyList = errors.New("nil or empty provided list")
+
+// ErrNilScQueryElement signals that a nil sc query service element was provided
+var ErrNilScQueryElement = errors.New("nil SC query service element")

--- a/process/interface.go
+++ b/process/interface.go
@@ -793,6 +793,7 @@ type PeerValidatorMapper interface {
 // SCQueryService defines how data should be get from a SC account
 type SCQueryService interface {
 	ExecuteQuery(query *SCQuery) (*vmcommon.VMOutput, error)
+	ComputeScCallGasLimit(tx *transaction.Transaction) (uint64, error)
 	IsInterfaceNil() bool
 }
 

--- a/process/smartContract/scQueryServiceDispatcher.go
+++ b/process/smartContract/scQueryServiceDispatcher.go
@@ -1,0 +1,74 @@
+package smartContract
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go/core/check"
+	"github.com/ElrondNetwork/elrond-go/core/vmcommon"
+	"github.com/ElrondNetwork/elrond-go/data/transaction"
+	"github.com/ElrondNetwork/elrond-go/process"
+)
+
+type scQueryServiceDispatcher struct {
+	mutList     sync.RWMutex
+	list        []process.SCQueryService
+	mutIndex    sync.Mutex
+	index       int
+	maxListSize int
+}
+
+// NewScQueryServiceDispatcher returns a smart contract query service dispatcher that for each function call
+// will forward the request towards the provided list in a round-robin fashion
+func NewScQueryServiceDispatcher(list []process.SCQueryService) (*scQueryServiceDispatcher, error) {
+	if len(list) == 0 {
+		return nil, fmt.Errorf("%w in NewScQueryServiceDispatcher", process.ErrNilOrEmptyList)
+	}
+	for i := 0; i < len(list); i++ {
+		if check.IfNil(list[i]) {
+			return nil, fmt.Errorf("%w at element %d", process.ErrNilScQueryElement, i)
+		}
+	}
+
+	return &scQueryServiceDispatcher{
+		list:        list,
+		maxListSize: len(list),
+		index:       0,
+	}, nil
+}
+
+// ExecuteQuery will call this method on one of the element from provided list
+func (sqsd *scQueryServiceDispatcher) ExecuteQuery(query *process.SCQuery) (*vmcommon.VMOutput, error) {
+	index := sqsd.getUpdatedIndex()
+
+	sqsd.mutList.RLock()
+	defer sqsd.mutList.RUnlock()
+
+	return sqsd.list[index].ExecuteQuery(query)
+}
+
+// ComputeScCallGasLimit will call this method on one of the element from provided list
+func (sqsd *scQueryServiceDispatcher) ComputeScCallGasLimit(tx *transaction.Transaction) (uint64, error) {
+	index := sqsd.getUpdatedIndex()
+
+	sqsd.mutList.RLock()
+	defer sqsd.mutList.RUnlock()
+
+	return sqsd.list[index].ComputeScCallGasLimit(tx)
+}
+
+func (sqsd *scQueryServiceDispatcher) getUpdatedIndex() int {
+	sqsd.mutIndex.Lock()
+	sqsd.index++
+	sqsd.index = sqsd.index % sqsd.maxListSize
+
+	updatedValue := sqsd.index
+	sqsd.mutIndex.Unlock()
+
+	return updatedValue
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (sqsd *scQueryServiceDispatcher) IsInterfaceNil() bool {
+	return sqsd == nil
+}

--- a/process/smartContract/scQueryServiceDispatcher.go
+++ b/process/smartContract/scQueryServiceDispatcher.go
@@ -39,7 +39,7 @@ func NewScQueryServiceDispatcher(list []process.SCQueryService) (*scQueryService
 
 // ExecuteQuery will call this method on one of the element from provided list
 func (sqsd *scQueryServiceDispatcher) ExecuteQuery(query *process.SCQuery) (*vmcommon.VMOutput, error) {
-	index := sqsd.getUpdatedIndex()
+	index := sqsd.getNewIndex()
 
 	sqsd.mutList.RLock()
 	defer sqsd.mutList.RUnlock()
@@ -49,7 +49,7 @@ func (sqsd *scQueryServiceDispatcher) ExecuteQuery(query *process.SCQuery) (*vmc
 
 // ComputeScCallGasLimit will call this method on one of the element from provided list
 func (sqsd *scQueryServiceDispatcher) ComputeScCallGasLimit(tx *transaction.Transaction) (uint64, error) {
-	index := sqsd.getUpdatedIndex()
+	index := sqsd.getNewIndex()
 
 	sqsd.mutList.RLock()
 	defer sqsd.mutList.RUnlock()
@@ -57,12 +57,12 @@ func (sqsd *scQueryServiceDispatcher) ComputeScCallGasLimit(tx *transaction.Tran
 	return sqsd.list[index].ComputeScCallGasLimit(tx)
 }
 
-func (sqsd *scQueryServiceDispatcher) getUpdatedIndex() int {
+func (sqsd *scQueryServiceDispatcher) getNewIndex() int {
 	sqsd.mutIndex.Lock()
+	updatedValue := sqsd.index
+
 	sqsd.index++
 	sqsd.index = sqsd.index % sqsd.maxListSize
-
-	updatedValue := sqsd.index
 	sqsd.mutIndex.Unlock()
 
 	return updatedValue

--- a/process/smartContract/scQueryServiceDispatcher_test.go
+++ b/process/smartContract/scQueryServiceDispatcher_test.go
@@ -1,0 +1,163 @@
+package smartContract
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/core/check"
+	"github.com/ElrondNetwork/elrond-go/core/vmcommon"
+	"github.com/ElrondNetwork/elrond-go/data/transaction"
+	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/process/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewScQueryServiceDispatcher_NilEmptyListShouldErr(t *testing.T) {
+	t.Parallel()
+
+	sqsd, err := NewScQueryServiceDispatcher(nil)
+	assert.True(t, check.IfNil(sqsd))
+	assert.True(t, errors.Is(err, process.ErrNilOrEmptyList))
+
+	sqsd, err = NewScQueryServiceDispatcher(make([]process.SCQueryService, 0))
+	assert.True(t, check.IfNil(sqsd))
+	assert.True(t, errors.Is(err, process.ErrNilOrEmptyList))
+}
+
+func TestNewScQueryServiceDispatcher_OneElementIsNilShouldErr(t *testing.T) {
+	t.Parallel()
+
+	sqsd, err := NewScQueryServiceDispatcher([]process.SCQueryService{
+		&mock.ScQueryStub{},
+		nil,
+		&mock.ScQueryStub{},
+	})
+	assert.True(t, check.IfNil(sqsd))
+	assert.True(t, errors.Is(err, process.ErrNilScQueryElement))
+}
+
+func TestNewScQueryServiceDispatcher_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	sqsd, err := NewScQueryServiceDispatcher([]process.SCQueryService{
+		&mock.ScQueryStub{},
+		&mock.ScQueryStub{},
+	})
+	assert.False(t, check.IfNil(sqsd))
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(sqsd.list))
+}
+
+func TestScQueryServiceDispatcher_ExecuteQueryShouldCallInRoundRobinFashion(t *testing.T) {
+	t.Parallel()
+
+	calledElement1 := 0
+	calledElement2 := 0
+	sqsd, _ := NewScQueryServiceDispatcher([]process.SCQueryService{
+		&mock.ScQueryStub{
+			ExecuteQueryCalled: func(query *process.SCQuery) (*vmcommon.VMOutput, error) {
+				calledElement1++
+
+				return nil, nil
+			},
+		},
+		&mock.ScQueryStub{
+			ExecuteQueryCalled: func(query *process.SCQuery) (*vmcommon.VMOutput, error) {
+				calledElement2++
+
+				return nil, nil
+			},
+		},
+	})
+
+	_, _ = sqsd.ExecuteQuery(nil)
+	_, _ = sqsd.ExecuteQuery(nil)
+	_, _ = sqsd.ExecuteQuery(nil)
+
+	assert.Equal(t, 1, calledElement1)
+	assert.Equal(t, 2, calledElement2)
+}
+
+func TestScQueryServiceDispatcher_ComputeScCallGasLimitShouldCallInRoundRobinFashion(t *testing.T) {
+	t.Parallel()
+
+	calledElement1 := 0
+	calledElement2 := 0
+	sqsd, _ := NewScQueryServiceDispatcher([]process.SCQueryService{
+		&mock.ScQueryStub{
+			ComputeScCallGasLimitHandler: func(tx *transaction.Transaction) (uint64, error) {
+				calledElement1++
+
+				return 0, nil
+			},
+		},
+		&mock.ScQueryStub{
+			ComputeScCallGasLimitHandler: func(tx *transaction.Transaction) (uint64, error) {
+				calledElement2++
+
+				return 0, nil
+			},
+		},
+	})
+
+	_, _ = sqsd.ComputeScCallGasLimit(nil)
+	_, _ = sqsd.ComputeScCallGasLimit(nil)
+	_, _ = sqsd.ComputeScCallGasLimit(nil)
+
+	assert.Equal(t, 1, calledElement1)
+	assert.Equal(t, 2, calledElement2)
+}
+
+func TestScQueryServiceDispatcher_ShouldWorkInAConcurrentManner(t *testing.T) {
+	t.Parallel()
+
+	calledElement1 := uint32(0)
+	calledElement2 := uint32(0)
+	sqsd, _ := NewScQueryServiceDispatcher([]process.SCQueryService{
+		&mock.ScQueryStub{
+			ExecuteQueryCalled: func(query *process.SCQuery) (*vmcommon.VMOutput, error) {
+				atomic.AddUint32(&calledElement1, 1)
+
+				return nil, nil
+			},
+			ComputeScCallGasLimitHandler: func(tx *transaction.Transaction) (uint64, error) {
+				atomic.AddUint32(&calledElement1, 1)
+
+				return 0, nil
+			},
+		},
+		&mock.ScQueryStub{
+			ExecuteQueryCalled: func(query *process.SCQuery) (*vmcommon.VMOutput, error) {
+				atomic.AddUint32(&calledElement2, 1)
+
+				return nil, nil
+			},
+			ComputeScCallGasLimitHandler: func(tx *transaction.Transaction) (uint64, error) {
+				atomic.AddUint32(&calledElement2, 1)
+
+				return 0, nil
+			},
+		},
+	})
+
+	numCalls := 100
+	wg := &sync.WaitGroup{}
+	wg.Add(numCalls * 2)
+	for i := 0; i < numCalls; i++ {
+		go func() {
+			_, _ = sqsd.ExecuteQuery(nil)
+			wg.Done()
+		}()
+		go func() {
+			_, _ = sqsd.ComputeScCallGasLimit(nil)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, uint32(numCalls), atomic.LoadUint32(&calledElement1))
+	assert.Equal(t, uint32(numCalls), atomic.LoadUint32(&calledElement2))
+}

--- a/process/smartContract/scQueryServiceDispatcher_test.go
+++ b/process/smartContract/scQueryServiceDispatcher_test.go
@@ -76,8 +76,8 @@ func TestScQueryServiceDispatcher_ExecuteQueryShouldCallInRoundRobinFashion(t *t
 	_, _ = sqsd.ExecuteQuery(nil)
 	_, _ = sqsd.ExecuteQuery(nil)
 
-	assert.Equal(t, 1, calledElement1)
-	assert.Equal(t, 2, calledElement2)
+	assert.Equal(t, 2, calledElement1)
+	assert.Equal(t, 1, calledElement2)
 }
 
 func TestScQueryServiceDispatcher_ComputeScCallGasLimitShouldCallInRoundRobinFashion(t *testing.T) {
@@ -106,8 +106,8 @@ func TestScQueryServiceDispatcher_ComputeScCallGasLimitShouldCallInRoundRobinFas
 	_, _ = sqsd.ComputeScCallGasLimit(nil)
 	_, _ = sqsd.ComputeScCallGasLimit(nil)
 
-	assert.Equal(t, 1, calledElement1)
-	assert.Equal(t, 2, calledElement2)
+	assert.Equal(t, 2, calledElement1)
+	assert.Equal(t, 1, calledElement2)
 }
 
 func TestScQueryServiceDispatcher_ShouldWorkInAConcurrentManner(t *testing.T) {


### PR DESCRIPTION
- added scQueryServiceDispatcher functionality that can launch a specified number of VMs used in query service and will route each and every request to such generated SC query service in a round-robin fashion