### PR TITLE
added trace log for invalid transaction

### DIFF
--- a/process/transaction/shardProcess.go
+++ b/process/transaction/shardProcess.go
@@ -266,6 +266,8 @@ func (txProc *txProcessor) executingFailedTransaction(
 		return err
 	}
 
+	log.Trace("executingFailedTransaction", "fail reason(error)", txError, "tx hash", txHash)
+
 	rpt := &receipt.Receipt{
 		Value:   big.NewInt(0).Set(txFee),
 		SndAddr: tx.SndAddr,


### PR DESCRIPTION
Added a log that displays the fail reason (which is the error that caused the transaction to be invalid). Useful when debugging relayed transactions processing for example