### PR TITLE
Mainnet like configs

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -33,9 +33,9 @@
    # also (minimum) hysteresis nodes for the minimum number of nodes
    SwitchHysteresisForMinNodesEnableEpoch = 2
 
-    # TransactionSignedWithTxHashEnableEpoch represents the epoch when the node will also accept transactions that are
-    # signed with the hash of transaction
-    TransactionSignedWithTxHashEnableEpoch = 3
+   # TransactionSignedWithTxHashEnableEpoch represents the epoch when the node will also accept transactions that are
+   # signed with the hash of transaction
+   TransactionSignedWithTxHashEnableEpoch = 4
 
    # MetaProtectionEnableEpoch represents the epoch when the transactions to the metachain are checked to have enough gas
    MetaProtectionEnableEpoch = 3
@@ -50,7 +50,7 @@
    # MaxNodesChangeEnableEpoch holds configuration for changing the maximum number of nodes and the enabling epoch
    MaxNodesChangeEnableEpoch = [
         { EpochEnable = 0, MaxNumNodes = 36, NodesToShufflePerShard = 4 },
-        { EpochEnable = 3, MaxNumNodes = 56, NodesToShufflePerShard = 2 }
+        { EpochEnable = 4, MaxNumNodes = 56, NodesToShufflePerShard = 2 }
    ]
 
    # GenesisString represents the encoded string for the genesis block

--- a/cmd/node/config/systemSmartContractsConfig.toml
+++ b/cmd/node/config/systemSmartContractsConfig.toml
@@ -5,7 +5,7 @@
     UnBondPeriod = 250
     MinStepValue = "100000000000000000000"
     StakeEnableEpoch = 2
-    StakingV2Epoch = 3
+    StakingV2Epoch = 4
     DoubleKeyProtectionEnableEpoch = 3
     NumRoundsWithoutBleed = 100
     MaximumPercentageToBleed = 0.5
@@ -17,7 +17,7 @@
 [ESDTSystemSCConfig]
     BaseIssuingCost = "5000000000000000000" #5 eGLD
     OwnerAddress = "erd1fpkcgel4gcmh8zqqdt043yfcn5tyx8373kg6q2qmkxzu4dqamc0swts65c"
-    EnabledEpoch = 3
+    EnabledEpoch = 4
 
 [GovernanceSystemSCConfig]
     ProposalCost = "5000000000000000000" #5 eGLD
@@ -25,15 +25,15 @@
     MinQuorum    = 400
     MinPassThreshold = 300
     MinVetoThreshold = 50
-    EnabledEpoch = 3
+    EnabledEpoch = 4
 
 [DelegationManagerSystemSCConfig]
     BaseIssuingCost = "0" #0 eGLD
     MinCreationDeposit = "1250000000000000000000" #1.25K eGLD
-    EnabledEpoch = 3 #enable epoch should not be 0
+    EnabledEpoch = 4 #enable epoch should not be 0
 
 [DelegationSystemSCConfig]
     MinStakeAmount = "10000000000000000000" #10 eGLD
-    EnabledEpoch   = 3 #enable epoch should not be 0
+    EnabledEpoch   = 4 #enable epoch should not be 0
     MinServiceFee  = 0
     MaxServiceFee  = 10000


### PR DESCRIPTION
- changed the configuration flags as to better emulate mainnet transitions

All flags should be disabled during epoch 0 while running the v1.1.10 variant. During epoch 1 the upgrade process will complete, compiling a derived branch from `development`. Now, some flags will have the enable epoch 2. Those flags should be the already activated flags on mainnet. The Maiar-dependent flags will get activated at epoch 3. The rest, at the start of the epoch 4.