### PR TITLE
sharding: make the math right for ComputeIdFromBytes

### DIFF
--- a/sharding/multiShardCoordinator.go
+++ b/sharding/multiShardCoordinator.go
@@ -52,7 +52,18 @@ func (msc *multiShardCoordinator) ComputeId(address []byte) uint32 {
 
 // ComputeIdFromBytes calculates the shard for a given address
 func (msc *multiShardCoordinator) ComputeIdFromBytes(address []byte) uint32 {
-	bytesNeed := int(msc.numberOfShards/core.MaxNumShards) + 1
+
+	var bytesNeed int
+	if msc.numberOfShards <= 256 {
+		bytesNeed = 1
+	} else if msc.numberOfShards <= 65536 {
+		bytesNeed = 2
+	} else if msc.numberOfShards <= 16777216 {
+		bytesNeed = 3
+	} else {
+		bytesNeed = 4
+	}
+
 	startingIndex := 0
 	if len(address) > bytesNeed {
 		startingIndex = len(address) - bytesNeed


### PR DESCRIPTION
The correct `numberOfShards` -> `bytesNeed` mapping should be:

```
1~2**8 : 1
2**8+1~2**16 : 2
2**16+1~2**24 : 3
2**24+1~2**32 : 4
```

(`numberOfShards` is guaranteed `>=1` in constructor)

For example, if `numberOfShards` is 256*4, the `bytesNeed` should be 2 instead of 5.