### PR TITLE
- fix: let echo command to add the new line character

### DIFF
--- a/scripts/testnet/include/config.sh
+++ b/scripts/testnet/include/config.sh
@@ -167,10 +167,10 @@ generateProxyObserverList() {
     for _ in $(seq $SHARD_OBSERVERCOUNT); do
       (( PORT=$PORT_ORIGIN_OBSERVER_REST+$OBSERVER_INDEX))
 
-      echo -n "[[Observers]]" >> config_edit.toml
-      echo -n "   ShardId = $SHARD" >> config_edit.toml
-      echo -n "   Address = \"http://127.0.0.1:$PORT\"" >> config_edit.toml
-      echo -n ""$'\n' >> config_edit.toml
+      echo "[[Observers]]" >> config_edit.toml
+      echo "   ShardId = $SHARD" >> config_edit.toml
+      echo "   Address = \"http://127.0.0.1:$PORT\"" >> config_edit.toml
+      echo ""$'\n' >> config_edit.toml
 
       (( OBSERVER_INDEX++ ))
     done
@@ -179,10 +179,10 @@ generateProxyObserverList() {
   for META_OBSERVER in $(seq $META_OBSERVERCOUNT); do
     (( PORT=$PORT_ORIGIN_OBSERVER_REST+$OBSERVER_INDEX ))
 
-      echo -n "[[Observers]]" >> config_edit.toml
-      echo -n "   ShardId = $METASHARD_ID" >> config_edit.toml
-      echo -n "   Address = \"http://127.0.0.1:$PORT\"" >> config_edit.toml
-      echo -n ""$'\n' >> config_edit.toml
+      echo "[[Observers]]" >> config_edit.toml
+      echo "   ShardId = $METASHARD_ID" >> config_edit.toml
+      echo "   Address = \"http://127.0.0.1:$PORT\"" >> config_edit.toml
+      echo ""$'\n' >> config_edit.toml
 
       (( OBSERVER_INDEX++ ))
     done


### PR DESCRIPTION
go toml parser will fail to parse proxy config file because of the
incompatible right value in Observers config parameters

Signed-off-by: Claudiu Ion Lataretu <claudiu.lataretu@gmail.com>