### PR TITLE
Backwards compatibility fixes

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -2065,17 +2065,16 @@ func newMetaBlockProcessor(
 	}
 
 	argsStaking := scToProtocol.ArgStakingToPeer{
-		PubkeyConv:            stateComponents.ValidatorPubkeyConverter,
-		Hasher:                core.Hasher,
-		Marshalizer:           core.InternalMarshalizer,
-		PeerState:             stateComponents.PeerAccounts,
-		BaseState:             stateComponents.AccountsAdapter,
-		ArgParser:             argsParser,
-		CurrTxs:               data.Datapool.CurrentBlockTxs(),
-		RatingsData:           ratingsData,
-		EpochNotifier:         epochNotifier,
-		StakeEnableEpoch:      systemSCConfig.StakingSystemSCConfig.StakeEnableEpoch,
-		UnBondCorrectionEpoch: generalConfig.GeneralSettings.SCDeployEnableEpoch,
+		PubkeyConv:       stateComponents.ValidatorPubkeyConverter,
+		Hasher:           core.Hasher,
+		Marshalizer:      core.InternalMarshalizer,
+		PeerState:        stateComponents.PeerAccounts,
+		BaseState:        stateComponents.AccountsAdapter,
+		ArgParser:        argsParser,
+		CurrTxs:          data.Datapool.CurrentBlockTxs(),
+		RatingsData:      ratingsData,
+		EpochNotifier:    epochNotifier,
+		StakeEnableEpoch: systemSCConfig.StakingSystemSCConfig.StakeEnableEpoch,
 	}
 	smartContractToProtocol, err := scToProtocol.NewStakingToPeer(argsStaking)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ElrondNetwork/elrond-go
 go 1.13
 
 require (
-	github.com/ElrondNetwork/arwen-wasm-vm v1.0.6
+	github.com/ElrondNetwork/arwen-wasm-vm v1.0.7-0.20210118103426-7b6037a61b4a
 	github.com/ElrondNetwork/concurrent-map v0.1.3
 	github.com/ElrondNetwork/elrond-go-logger v1.0.4
 	github.com/beevik/ntp v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ElrondNetwork/elrond-go
 go 1.13
 
 require (
-	github.com/ElrondNetwork/arwen-wasm-vm v1.0.7-0.20210118103426-7b6037a61b4a
+	github.com/ElrondNetwork/arwen-wasm-vm v1.0.7
 	github.com/ElrondNetwork/concurrent-map v0.1.3
 	github.com/ElrondNetwork/elrond-go-logger v1.0.4
 	github.com/beevik/ntp v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/ElrondNetwork/arwen-wasm-vm v0.4.5/go.mod h1:KkBYEpvpc72DED4uecEQwWyZ
 github.com/ElrondNetwork/arwen-wasm-vm v0.4.6-0.20201113105541-2d483b749160/go.mod h1:uS9EKt7jtD8IEvENBkYcs2A1EBUcR7fsg7O7DddMnKw=
 github.com/ElrondNetwork/arwen-wasm-vm v1.0.1/go.mod h1:uxQWVuU916waVH/uL7BV7pghsYbvLoFOfG9aK51guuA=
 github.com/ElrondNetwork/arwen-wasm-vm v1.0.2-0.20210114092308-50b1b15f8b64/go.mod h1:AgVp6qutd1y+EPTUoZ/xdT19+drpPTdCAo5v46thfiY=
-github.com/ElrondNetwork/arwen-wasm-vm v1.0.7-0.20210118103426-7b6037a61b4a h1:C7KDvzv6RJ8RghuBkrjhToUmXhY8TePANe8poCYxyXQ=
-github.com/ElrondNetwork/arwen-wasm-vm v1.0.7-0.20210118103426-7b6037a61b4a/go.mod h1:XlB9GmvMG889+apktS9FcvKFmIx7kdjpFNIY7Lxsq9k=
+github.com/ElrondNetwork/arwen-wasm-vm v1.0.7 h1:+R/YBqVyTfOUsFfzGicQ5XGLh1WzX4PsgPBJWX4k5wU=
+github.com/ElrondNetwork/arwen-wasm-vm v1.0.7/go.mod h1:XlB9GmvMG889+apktS9FcvKFmIx7kdjpFNIY7Lxsq9k=
 github.com/ElrondNetwork/big-int-util v0.0.5/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg1IJLPAK6GVHMbC7Aw4=
 github.com/ElrondNetwork/big-int-util v0.1.0 h1:vTMoJ5azhVmr7jhpSD3JUjQdkdyXoEPVkOvhdw1RjV4=
 github.com/ElrondNetwork/big-int-util v0.1.0/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg1IJLPAK6GVHMbC7Aw4=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/ElrondNetwork/arwen-wasm-vm v0.4.5/go.mod h1:KkBYEpvpc72DED4uecEQwWyZ
 github.com/ElrondNetwork/arwen-wasm-vm v0.4.6-0.20201113105541-2d483b749160/go.mod h1:uS9EKt7jtD8IEvENBkYcs2A1EBUcR7fsg7O7DddMnKw=
 github.com/ElrondNetwork/arwen-wasm-vm v1.0.1/go.mod h1:uxQWVuU916waVH/uL7BV7pghsYbvLoFOfG9aK51guuA=
 github.com/ElrondNetwork/arwen-wasm-vm v1.0.2-0.20210114092308-50b1b15f8b64/go.mod h1:AgVp6qutd1y+EPTUoZ/xdT19+drpPTdCAo5v46thfiY=
-github.com/ElrondNetwork/arwen-wasm-vm v1.0.6 h1:ax69dfyISK2Fp7C/mhVkRxvMMWtGAKDLJLKztQ0yRJA=
-github.com/ElrondNetwork/arwen-wasm-vm v1.0.6/go.mod h1:XlB9GmvMG889+apktS9FcvKFmIx7kdjpFNIY7Lxsq9k=
+github.com/ElrondNetwork/arwen-wasm-vm v1.0.7-0.20210118103426-7b6037a61b4a h1:C7KDvzv6RJ8RghuBkrjhToUmXhY8TePANe8poCYxyXQ=
+github.com/ElrondNetwork/arwen-wasm-vm v1.0.7-0.20210118103426-7b6037a61b4a/go.mod h1:XlB9GmvMG889+apktS9FcvKFmIx7kdjpFNIY7Lxsq9k=
 github.com/ElrondNetwork/big-int-util v0.0.5/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg1IJLPAK6GVHMbC7Aw4=
 github.com/ElrondNetwork/big-int-util v0.1.0 h1:vTMoJ5azhVmr7jhpSD3JUjQdkdyXoEPVkOvhdw1RjV4=
 github.com/ElrondNetwork/big-int-util v0.1.0/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg1IJLPAK6GVHMbC7Aw4=

--- a/process/scToProtocol/stakingToPeer.go
+++ b/process/scToProtocol/stakingToPeer.go
@@ -26,17 +26,16 @@ var log = logger.GetOrCreate("process/scToProtocol")
 
 // ArgStakingToPeer is struct that contain all components that are needed to create a new stakingToPeer object
 type ArgStakingToPeer struct {
-	PubkeyConv            core.PubkeyConverter
-	Hasher                hashing.Hasher
-	Marshalizer           marshal.Marshalizer
-	PeerState             state.AccountsAdapter
-	BaseState             state.AccountsAdapter
-	ArgParser             process.ArgumentsParser
-	CurrTxs               dataRetriever.TransactionCacher
-	RatingsData           process.RatingsInfoHandler
-	StakeEnableEpoch      uint32
-	UnBondCorrectionEpoch uint32
-	EpochNotifier         process.EpochNotifier
+	PubkeyConv       core.PubkeyConverter
+	Hasher           hashing.Hasher
+	Marshalizer      marshal.Marshalizer
+	PeerState        state.AccountsAdapter
+	BaseState        state.AccountsAdapter
+	ArgParser        process.ArgumentsParser
+	CurrTxs          dataRetriever.TransactionCacher
+	RatingsData      process.RatingsInfoHandler
+	StakeEnableEpoch uint32
+	EpochNotifier    process.EpochNotifier
 }
 
 // stakingToPeer defines the component which will translate changes from staking SC state
@@ -48,15 +47,13 @@ type stakingToPeer struct {
 	peerState   state.AccountsAdapter
 	baseState   state.AccountsAdapter
 
-	argParser             process.ArgumentsParser
-	currTxs               dataRetriever.TransactionCacher
-	startRating           uint32
-	unJailRating          uint32
-	jailRating            uint32
-	stakeEnableEpoch      uint32
-	unBondCorrectionEpoch uint32
-	flagStaking           atomic.Flag
-	flagUnBondCorrection  atomic.Flag
+	argParser        process.ArgumentsParser
+	currTxs          dataRetriever.TransactionCacher
+	startRating      uint32
+	unJailRating     uint32
+	jailRating       uint32
+	stakeEnableEpoch uint32
+	flagStaking      atomic.Flag
 }
 
 // NewStakingToPeer creates the component which moves from staking sc state to peer state
@@ -67,18 +64,17 @@ func NewStakingToPeer(args ArgStakingToPeer) (*stakingToPeer, error) {
 	}
 
 	st := &stakingToPeer{
-		pubkeyConv:            args.PubkeyConv,
-		hasher:                args.Hasher,
-		marshalizer:           args.Marshalizer,
-		peerState:             args.PeerState,
-		baseState:             args.BaseState,
-		argParser:             args.ArgParser,
-		currTxs:               args.CurrTxs,
-		startRating:           args.RatingsData.StartRating(),
-		unJailRating:          args.RatingsData.StartRating(),
-		jailRating:            args.RatingsData.MinRating(),
-		stakeEnableEpoch:      args.StakeEnableEpoch,
-		unBondCorrectionEpoch: args.UnBondCorrectionEpoch,
+		pubkeyConv:       args.PubkeyConv,
+		hasher:           args.Hasher,
+		marshalizer:      args.Marshalizer,
+		peerState:        args.PeerState,
+		baseState:        args.BaseState,
+		argParser:        args.ArgParser,
+		currTxs:          args.CurrTxs,
+		startRating:      args.RatingsData.StartRating(),
+		unJailRating:     args.RatingsData.StartRating(),
+		jailRating:       args.RatingsData.MinRating(),
+		stakeEnableEpoch: args.StakeEnableEpoch,
 	}
 
 	args.EpochNotifier.RegisterNotifyHandler(st)
@@ -195,7 +191,7 @@ func (stp *stakingToPeer) UpdateProtocol(body *block.Body, nonce uint64) error {
 			continue
 		}
 
-		if len(data) == 0 && stp.flagUnBondCorrection.IsSet() {
+		if len(data) == 0 {
 			continue
 		}
 
@@ -416,9 +412,6 @@ func (stp *stakingToPeer) getAllModifiedStates(body *block.Body) ([]string, erro
 func (stp *stakingToPeer) EpochConfirmed(epoch uint32) {
 	stp.flagStaking.Toggle(epoch >= stp.stakeEnableEpoch)
 	log.Debug("stakingToPeer: stake", "enabled", stp.flagStaking.IsSet())
-
-	stp.flagUnBondCorrection.Toggle(epoch >= stp.unBondCorrectionEpoch)
-	log.Debug("stakingToPeer: unBondCorrection", "enabled", stp.flagUnBondCorrection.IsSet())
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/vm/systemSmartContracts/validator.go
+++ b/vm/systemSmartContracts/validator.go
@@ -1263,12 +1263,6 @@ func (v *validatorSC) unBondNodesFromStakingSC(blsKeys [][]byte) [][]byte {
 }
 
 func (v *validatorSC) unBondV1(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
-	if len(args.Arguments) > 0 {
-		if strings.Contains(hex.EncodeToString(args.Arguments[0]), "cb18fc7dc8996bb52") {
-			log.Debug("DEBUG!!!")
-		}
-	}
-
 	registrationData, returnCode := v.checkUnBondArguments(args)
 	if returnCode != vmcommon.Ok {
 		return returnCode

--- a/vm/systemSmartContracts/validator.go
+++ b/vm/systemSmartContracts/validator.go
@@ -1263,6 +1263,12 @@ func (v *validatorSC) unBondNodesFromStakingSC(blsKeys [][]byte) [][]byte {
 }
 
 func (v *validatorSC) unBondV1(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
+	if len(args.Arguments) > 0 {
+		if strings.Contains(hex.EncodeToString(args.Arguments[0]), "cb18fc7dc8996bb52") {
+			log.Debug("DEBUG!!!")
+		}
+	}
+
 	registrationData, returnCode := v.checkUnBondArguments(args)
 	if returnCode != vmcommon.Ok {
 		return returnCode


### PR DESCRIPTION
- removed unnecessary backwards compatibility flag from stakingToPeer as the v1.1.10 does not change the peer state on unBond operation.