### PR TITLE
process/track: rm redundant check

### DIFF
--- a/process/track/baseBlockTrack.go
+++ b/process/track/baseBlockTrack.go
@@ -619,7 +619,7 @@ func (bbt *baseBlockTrack) IsShardStuck(shardID uint32) bool {
 	lastShardProcessedMetaNonce := bbt.blockBalancer.GetLastShardProcessedMetaNonce(shardID)
 
 	isMetaDifferenceTooLarge := false
-	shouldCheckLastMetaNonceProcessed := shardID != core.MetachainShardId && lastShardProcessedMetaNonce > 0
+	shouldCheckLastMetaNonceProcessed := lastShardProcessedMetaNonce > 0
 	if shouldCheckLastMetaNonceProcessed {
 		metaHeaders, _ := bbt.GetTrackedHeaders(core.MetachainShardId)
 		numMetaHeaders := len(metaHeaders)


### PR DESCRIPTION
`shardID != core.MetachainShardId` is already guaranteed by Line 614.