### PR TITLE
Backwards compatibility fix on transaction routes

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1059,7 +1059,7 @@ func (n *Node) CreateTransaction(
 	if version == 0 {
 		return nil, nil, ErrInvalidTransactionVersion
 	}
-	if chainID == "" || len(chainID) != len(string(n.chainID)) {
+	if chainID == "" || len(chainID) > len(string(n.chainID)) {
 		return nil, nil, ErrInvalidChainIDInTransaction
 	}
 	if check.IfNil(n.addressPubkeyConverter) {
@@ -1068,7 +1068,7 @@ func (n *Node) CreateTransaction(
 	if check.IfNil(n.accounts) {
 		return nil, nil, ErrNilAccountsAdapter
 	}
-	if len(signatureHex) != n.addressSignatureHexSize {
+	if len(signatureHex) > n.addressSignatureHexSize {
 		return nil, nil, ErrInvalidSignatureLength
 	}
 	if len(receiver) != n.encodedAddressLength {

--- a/node/node.go
+++ b/node/node.go
@@ -1071,10 +1071,10 @@ func (n *Node) CreateTransaction(
 	if len(signatureHex) > n.addressSignatureHexSize {
 		return nil, nil, ErrInvalidSignatureLength
 	}
-	if len(receiver) != n.encodedAddressLength {
+	if len(receiver) > n.encodedAddressLength {
 		return nil, nil, fmt.Errorf("%w for receiver", ErrInvalidAddressLength)
 	}
-	if len(sender) != n.encodedAddressLength {
+	if len(sender) > n.encodedAddressLength {
 		return nil, nil, fmt.Errorf("%w for sender", ErrInvalidAddressLength)
 	}
 	if len(senderUsername) > core.MaxUserNameLength {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -612,9 +612,10 @@ func TestCreateTransaction_InvalidSignatureShouldErr(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestCreateTransaction_InvalidChainIDShouldErr(t *testing.T) {
+func TestCreateTransaction_ChainIDFieldChecks(t *testing.T) {
 	t.Parallel()
 
+	chainID := "chain id"
 	expectedHash := []byte("expected hash")
 	n, _ := node.NewNode(
 		node.WithInternalMarshalizer(getMarshalizer(), testSizeCheckDelta),
@@ -632,8 +633,17 @@ func TestCreateTransaction_InvalidChainIDShouldErr(t *testing.T) {
 				DecodeCalled: func(hexAddress string) ([]byte, error) {
 					return []byte(hexAddress), nil
 				},
+				EncodeCalled: func(pkBytes []byte) string {
+					return string(pkBytes)
+				},
+				LenCalled: func() int {
+					return 3
+				},
 			}),
+		node.WithTxFeeHandler(&mock.FeeHandlerStub{}),
 		node.WithAccountsAdapter(&mock.AccountsStub{}),
+		node.WithChainID([]byte(chainID)),
+		node.WithAddressSignatureSize(10),
 	)
 
 	nonce := uint64(0)
@@ -643,8 +653,20 @@ func TestCreateTransaction_InvalidChainIDShouldErr(t *testing.T) {
 	gasPrice := uint64(10)
 	gasLimit := uint64(20)
 	txData := []byte("-")
-	signature := "617eff4f"
-	_, _, err := n.CreateTransaction(nonce, value.String(), receiver, nil, sender, nil, gasPrice, gasLimit, txData, signature, "", 1, 0)
+	signature := hex.EncodeToString([]byte(strings.Repeat("s", 10)))
+
+	emptyChainID := ""
+	_, _, err := n.CreateTransaction(nonce, value.String(), receiver, nil, sender, nil, gasPrice, gasLimit, txData, signature, emptyChainID, 1, 0)
+	assert.Equal(t, node.ErrInvalidChainIDInTransaction, err)
+
+	for i := 1; i < len(chainID); i++ {
+		newChainID := strings.Repeat("c", i)
+		_, _, err := n.CreateTransaction(nonce, value.String(), receiver, nil, sender, nil, gasPrice, gasLimit, txData, signature, newChainID, 1, 0)
+		assert.NoError(t, err)
+	}
+
+	newChainID := chainID + "additional text"
+	_, _, err = n.CreateTransaction(nonce, value.String(), receiver, nil, sender, nil, gasPrice, gasLimit, txData, signature, newChainID, 1, 0)
 	assert.Equal(t, node.ErrInvalidChainIDInTransaction, err)
 }
 
@@ -667,6 +689,12 @@ func TestCreateTransaction_InvalidTxVersionShouldErr(t *testing.T) {
 			&mock.PubkeyConverterStub{
 				DecodeCalled: func(hexAddress string) ([]byte, error) {
 					return []byte(hexAddress), nil
+				},
+				EncodeCalled: func(pkBytes []byte) string {
+					return string(pkBytes)
+				},
+				LenCalled: func() int {
+					return 3
 				},
 			}),
 		node.WithAccountsAdapter(&mock.AccountsStub{}),
@@ -756,10 +784,11 @@ func TestCreateTransaction_SenderShardIdIsInDifferentShardShouldNotValidate(t *t
 	assert.True(t, errors.Is(err, node.ErrDifferentSenderShardId))
 }
 
-func TestCreateTransaction_InvalidSignatureLengthShouldErr(t *testing.T) {
+func TestCreateTransaction_SignatureLengthChecks(t *testing.T) {
 	t.Parallel()
 
-	maxLength := 7
+	maxValueLength := 7
+	signatureLength := 10
 	chainID := "chain id"
 	n, _ := node.NewNode(
 		node.WithAddressPubkeyConverter(
@@ -778,29 +807,39 @@ func TestCreateTransaction_InvalidSignatureLengthShouldErr(t *testing.T) {
 		node.WithTxFeeHandler(
 			&mock.FeeHandlerStub{
 				GenesisTotalSupplyCalled: func() *big.Int {
-					str := strings.Repeat("1", maxLength)
+					str := strings.Repeat("1", maxValueLength)
 					bi := big.NewInt(0)
 					bi.SetString(str, 10)
 					return bi
 				},
 			}),
 		node.WithChainID([]byte(chainID)),
-		node.WithAddressSignatureSize(10),
+		node.WithAddressSignatureSize(signatureLength),
+		node.WithInternalMarshalizer(&mock.MarshalizerFake{}, 0),
+		node.WithHasher(&mock.HasherMock{}),
 	)
 
 	nonce := uint64(0)
-	value := "1" + strings.Repeat("0", maxLength+1)
+	value := "1" + strings.Repeat("0", maxValueLength)
 	receiver := "rcv"
 	sender := "snd"
 	gasPrice := uint64(10)
 	gasLimit := uint64(20)
 	txData := []byte("-")
-	signature := "wrong sized signature"
 
+	for i := 0; i <= signatureLength; i++ {
+		signatureBytes := []byte(strings.Repeat("a", i))
+		signatureHex := hex.EncodeToString(signatureBytes)
+		tx, _, err := n.CreateTransaction(nonce, value, receiver, []byte("rcvrUsername"), sender, []byte("sndrUsername"), gasPrice, gasLimit, txData, signatureHex, chainID, 1, 0)
+		assert.NotNil(t, tx)
+		assert.NoError(t, err)
+		assert.Equal(t, signatureBytes, tx.Signature)
+	}
+
+	signature := hex.EncodeToString([]byte(strings.Repeat("a", signatureLength+1)))
 	tx, txHash, err := n.CreateTransaction(nonce, value, receiver, []byte("rcvrUsername"), sender, []byte("sndrUsername"), gasPrice, gasLimit, txData, signature, chainID, 1, 0)
 	assert.Nil(t, tx)
 	assert.Empty(t, txHash)
-	assert.Error(t, err)
 	assert.Equal(t, node.ErrInvalidSignatureLength, err)
 }
 


### PR DESCRIPTION
- backwards compatibility fix on create transaction in node.go. Relaxed the limits as to allow empty fields to work on gasCost computation route.

Pending: add integration tests with real payload