### PR TITLE
EN-8728: gas price modifier metric update

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -842,6 +842,11 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		return err
 	}
 
+	err = economicsData.SetStatusHandler(coreComponents.StatusHandler)
+	if err != nil {
+		log.Debug("cannot set status handler to economicsData", "error", err)
+	}
+
 	log.Trace("creating ratings data components")
 
 	ratingDataArgs := rating.RatingsDataArg{

--- a/core/partitioning/sizeDataPacker_test.go
+++ b/core/partitioning/sizeDataPacker_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func checkExpectedElements(buffer []byte, marshalizer marshal.Marshalizer, expectedElements [][]byte) error {
@@ -143,38 +142,4 @@ func TestSliceSplitter_SendDataInChunksWithOnlyOneLargeElementShouldWork(t *test
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(buffSent))
 	assert.Nil(t, checkExpectedElements(buffSent[0], marshalizer, [][]byte{elemLarge}))
-}
-
-type testStruct struct {
-	Name   string `json:"name"`
-	Number int    `json:"number"`
-}
-
-func TestSliceSplitter_SendAJsonMarshaledSlice(t *testing.T) {
-	sliceOfStruct := make([]testStruct, 0)
-	numElements := 100
-
-	for i := 0; i < numElements; i++ {
-		elem := make([]byte, 20)
-		_, _ = rand.Read(elem)
-		name := string(elem)
-		sliceOfStruct = append(sliceOfStruct, testStruct{
-			Name:   name,
-			Number: 10,
-		})
-	}
-
-	marshalizer := &marshal.JsonMarshalizer{}
-	marshaledSlice, err := marshalizer.Marshal(sliceOfStruct)
-	require.NoError(t, err)
-
-	sdp, err := partitioning.NewSizeDataPacker(marshalizer)
-	require.NoError(t, err)
-
-	res, err := sdp.PackDataInChunks([][]byte{marshaledSlice}, 10)
-	require.NoError(t, err)
-	for _, r := range res {
-		fmt.Println(string(r))
-	}
-	//fmt.Println(res)
 }

--- a/core/partitioning/sizeDataPacker_test.go
+++ b/core/partitioning/sizeDataPacker_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/marshal"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func checkExpectedElements(buffer []byte, marshalizer marshal.Marshalizer, expectedElements [][]byte) error {
@@ -142,4 +143,38 @@ func TestSliceSplitter_SendDataInChunksWithOnlyOneLargeElementShouldWork(t *test
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(buffSent))
 	assert.Nil(t, checkExpectedElements(buffSent[0], marshalizer, [][]byte{elemLarge}))
+}
+
+type testStruct struct {
+	Name   string `json:"name"`
+	Number int    `json:"number"`
+}
+
+func TestSliceSplitter_SendAJsonMarshaledSlice(t *testing.T) {
+	sliceOfStruct := make([]testStruct, 0)
+	numElements := 100
+
+	for i := 0; i < numElements; i++ {
+		elem := make([]byte, 20)
+		_, _ = rand.Read(elem)
+		name := string(elem)
+		sliceOfStruct = append(sliceOfStruct, testStruct{
+			Name:   name,
+			Number: 10,
+		})
+	}
+
+	marshalizer := &marshal.JsonMarshalizer{}
+	marshaledSlice, err := marshalizer.Marshal(sliceOfStruct)
+	require.NoError(t, err)
+
+	sdp, err := partitioning.NewSizeDataPacker(marshalizer)
+	require.NoError(t, err)
+
+	res, err := sdp.PackDataInChunks([][]byte{marshaledSlice}, 10)
+	require.NoError(t, err)
+	for _, r := range res {
+		fmt.Println(string(r))
+	}
+	//fmt.Println(res)
 }

--- a/process/economics/economicsData.go
+++ b/process/economics/economicsData.go
@@ -450,10 +450,6 @@ func (ed *economicsData) EpochConfirmed(epoch uint32) {
 }
 
 func (ed *economicsData) setGasPriceModifierMetric() {
-	if check.IfNil(ed.statusHandler) {
-		log.Debug("cannot set GasPriceModifier metric - nil status handler")
-	}
-
 	if ed.flagGasPriceModifier.IsSet() {
 		ed.statusHandler.SetStringValue(core.MetricGasPriceModifier, fmt.Sprintf("%g", ed.gasPriceModifier))
 	}

--- a/process/economics/economicsData.go
+++ b/process/economics/economicsData.go
@@ -454,7 +454,9 @@ func (ed *economicsData) setGasPriceModifierMetric() {
 		log.Debug("cannot set GasPriceModifier metric - nil status handler")
 	}
 
-	ed.statusHandler.SetStringValue(core.MetricGasPriceModifier, fmt.Sprintf("%g", ed.gasPriceModifier))
+	if ed.flagGasPriceModifier.IsSet() {
+		ed.statusHandler.SetStringValue(core.MetricGasPriceModifier, fmt.Sprintf("%g", ed.gasPriceModifier))
+	}
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/process/economics/economicsData.go
+++ b/process/economics/economicsData.go
@@ -446,13 +446,7 @@ func (ed *economicsData) EpochConfirmed(epoch uint32) {
 
 	ed.flagGasPriceModifier.Toggle(epoch >= ed.gasPriceModifierEnableEpoch)
 	log.Debug("economics: gas price modifier", "enabled", ed.flagGasPriceModifier.IsSet())
-	ed.setGasPriceModifierMetric()
-}
-
-func (ed *economicsData) setGasPriceModifierMetric() {
-	if ed.flagGasPriceModifier.IsSet() {
-		ed.statusHandler.SetStringValue(core.MetricGasPriceModifier, fmt.Sprintf("%g", ed.gasPriceModifier))
-	}
+	ed.statusHandler.SetStringValue(core.MetricGasPriceModifier, fmt.Sprintf("%g", ed.GasPriceModifier()))
 }
 
 // IsInterfaceNil returns true if there is no value under the interface


### PR DESCRIPTION
Made the `gas price modifier` metric to update when the flag is set.
Passed the `app status handler` to `economics data` using `null object design pattern` in order to avoid constructor/arguments changes. This way, the `app status handler` is initialized as a `nil implementation` on the constructor and can be changed using a `setter`.

Testing procedure:
-after starting a node check the endpoint `node-url:port/network/config` and look after the `erd_gas_price_modifier` metric (`1` for current configuration)
-after a number of epochs equal to `GasPriceModifierEnableEpoch` from `config.toml` check the endpoint again. The value should be updated to the one from `economics.toml` (`0.01` for current configuration) 