### PR TITLE
EN-8854: get all key-value pairs for an account API endpoint

### DIFF
--- a/api/address/routes_test.go
+++ b/api/address/routes_test.go
@@ -75,6 +75,16 @@ type esdtTokensResponse struct {
 	Code  string
 }
 
+type keyValuePairsResponseData struct {
+	Pairs map[string]string `json:"pairs"`
+}
+
+type keyValuePairsResponse struct {
+	Data  keyValuePairsResponseData `json:"data"`
+	Error string                    `json:"error"`
+	Code  string
+}
+
 type usernameResponseData struct {
 	Username string `json:"username"`
 }
@@ -595,6 +605,55 @@ func TestGetESDTTokens_ShouldWork(t *testing.T) {
 	assert.Equal(t, []string{testValue1, testValue2}, esdtTokenResponseObj.Data.Tokens)
 }
 
+func TestGetKeyValuePairs_NodeFailsShouldError(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		GetKeyValuePairsCalled: func(_ string) (map[string]string, error) {
+			return nil, expectedErr
+		},
+	}
+
+	ws := startNodeServer(&facade)
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/keys", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := &shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(response.Error, expectedErr.Error()))
+}
+
+func TestGetKeyValuePairs_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	pairs := map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	}
+	testAddress := "address"
+	facade := mock.Facade{
+		GetKeyValuePairsCalled: func(_ string) (map[string]string, error) {
+			return pairs, nil
+		},
+	}
+
+	ws := startNodeServer(&facade)
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/keys", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := keyValuePairsResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, pairs, response.Data.Pairs)
+}
+
 func getRoutesConfig() config.ApiRoutesConfig {
 	return config.ApiRoutesConfig{
 		APIPackages: map[string]config.APIPackageConfig{
@@ -603,6 +662,7 @@ func getRoutesConfig() config.ApiRoutesConfig {
 					{Name: "/:address", Open: true},
 					{Name: "/:address/balance", Open: true},
 					{Name: "/:address/username", Open: true},
+					{Name: "/:address/keys", Open: true},
 					{Name: "/:address/key/:key", Open: true},
 					{Name: "/:address/esdt", Open: true},
 					{Name: "/:address/esdt/:tokenIdentifier", Open: true},

--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -25,6 +25,9 @@ var ErrGetUsername = errors.New("get username error")
 // ErrGetValueForKey signals an error in getting the value of a key for an account
 var ErrGetValueForKey = errors.New("get value for key error")
 
+// ErrGetKeyValuePairs signals an error in getting the key-value pairs of a key for an account
+var ErrGetKeyValuePairs = errors.New("get key-value pairs error")
+
 // ErrGetESDTTokens signals an error in getting esdt tokens for a given address
 var ErrGetESDTTokens = errors.New("get esdt tokens for account error")
 

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -42,6 +42,7 @@ type Facade struct {
 	GetPeerInfoCalled                       func(pid string) ([]core.QueryP2PPeerInfo, error)
 	GetThrottlerForEndpointCalled           func(endpoint string) (core.Throttler, bool)
 	GetUsernameCalled                       func(address string) (string, error)
+	GetKeyValuePairsCalled                  func(address string) (map[string]string, error)
 	SimulateTransactionExecutionHandler     func(tx *transaction.Transaction) (*transaction.SimulationResults, error)
 	GetNumCheckpointsFromAccountStateCalled func() uint32
 	GetNumCheckpointsFromPeerStateCalled    func() uint32
@@ -110,6 +111,15 @@ func (f *Facade) GetValueForKey(address string, key string) (string, error) {
 	}
 
 	return "", nil
+}
+
+// GetKeyValuePairs -
+func (f *Facade) GetKeyValuePairs(address string) (map[string]string, error) {
+	if f.GetKeyValuePairsCalled != nil {
+		return f.GetKeyValuePairsCalled(address)
+	}
+
+	return nil, nil
 }
 
 // GetESDTBalance -

--- a/cmd/node/config/api.toml
+++ b/cmd/node/config/api.toml
@@ -36,6 +36,9 @@
         # /address/:address/username will return the username of a given account
         { Name = "/:address/username", Open = true },
 
+        # /address/:address/keys will return all the key-value pairs of a given account
+        { Name = "/:address/keys", Open = true },
+
         # /address/:address/key/:key will return the value of a key for a given account
         { Name = "/:address/key/:key", Open = true },
 

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -28,6 +28,9 @@ type NodeHandler interface {
 	// GetValueForKey returns the value of a key from a given account
 	GetValueForKey(address string, key string) (string, error)
 
+	// GetKeyValuePairs returns the key-value pairs under a given address
+	GetKeyValuePairs(address string) (map[string]string, error)
+
 	// GetESDTBalance returns the esdt balance and properties from a given account
 	GetESDTBalance(address string, key string) (string, string, error)
 

--- a/facade/mock/nodeStub.go
+++ b/facade/mock/nodeStub.go
@@ -56,7 +56,7 @@ func (ns *NodeStub) GetUsername(address string) (string, error) {
 
 // GetKeyValuesPairs -
 func (ns *NodeStub) GetKeyValuePairs(address string) (map[string]string, error) {
-	if ns.GetValueForKeyCalled != nil {
+	if ns.GetKeyValuePairsCalled != nil {
 		return ns.GetKeyValuePairsCalled(address)
 	}
 

--- a/facade/mock/nodeStub.go
+++ b/facade/mock/nodeStub.go
@@ -42,6 +42,7 @@ type NodeStub struct {
 	GetUsernameCalled                              func(address string) (string, error)
 	GetESDTBalanceCalled                           func(address string, key string) (string, string, error)
 	GetAllESDTTokensCalled                         func(address string) ([]string, error)
+	GetKeyValuePairsCalled                         func(address string) (map[string]string, error)
 }
 
 // GetUsername -
@@ -51,6 +52,15 @@ func (ns *NodeStub) GetUsername(address string) (string, error) {
 	}
 
 	return "", nil
+}
+
+// GetKeyValuesPairs -
+func (ns *NodeStub) GetKeyValuePairs(address string) (map[string]string, error) {
+	if ns.GetValueForKeyCalled != nil {
+		return ns.GetKeyValuePairsCalled(address)
+	}
+
+	return nil, nil
 }
 
 // GetValueForKey -

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -275,6 +275,11 @@ func (nf *nodeFacade) GetESDTBalance(address string, key string) (string, string
 	return nf.node.GetESDTBalance(address, key)
 }
 
+// GetKeyValuePairs returns all the key-value pairs under the provided address
+func (nf *nodeFacade) GetKeyValuePairs(address string) (map[string]string, error) {
+	return nf.node.GetKeyValuePairs(address)
+}
+
 // GetAllESDTTokens returns all the esdt tokens for a given address
 func (nf *nodeFacade) GetAllESDTTokens(address string) ([]string, error) {
 	return nf.node.GetAllESDTTokens(address)

--- a/facade/nodeFacade_test.go
+++ b/facade/nodeFacade_test.go
@@ -654,3 +654,21 @@ func TestNodeFacade_GetThrottlerForEndpointShouldFindAndReturn(t *testing.T) {
 	assert.NotNil(t, thr)
 	assert.True(t, ok)
 }
+
+func TestNodeFacade_GetKeyValuePairs(t *testing.T) {
+	t.Parallel()
+
+	expectedPairs := map[string]string{"k": "v"}
+	arg := createMockArguments()
+	arg.Node = &mock.NodeStub{
+		GetKeyValuePairsCalled: func(address string) (map[string]string, error) {
+			return expectedPairs, nil
+		},
+	}
+
+	nf, _ := NewNodeFacade(arg)
+
+	res, err := nf.GetKeyValuePairs("addr")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedPairs, res)
+}

--- a/node/node.go
+++ b/node/node.go
@@ -469,7 +469,7 @@ func (n *Node) GetKeyValuePairs(address string) (map[string]string, error) {
 
 	mapToReturn := make(map[string]string)
 	for leaf := range chLeaves {
-		mapToReturn[string(leaf.Key())] = hex.EncodeToString(leaf.Value())
+		mapToReturn[hex.EncodeToString(leaf.Key())] = hex.EncodeToString(leaf.Value())
 	}
 
 	return mapToReturn, nil

--- a/node/node.go
+++ b/node/node.go
@@ -440,6 +440,41 @@ func (n *Node) GetUsername(address string) (string, error) {
 	return string(username), nil
 }
 
+// GetKeyValuePairs returns all the key-value pairs under the address
+func (n *Node) GetKeyValuePairs(address string) (map[string]string, error) {
+	account, err := n.getAccountHandler(address)
+	if err != nil {
+		return nil, err
+	}
+
+	userAccount, ok := n.castAccountToUserAccount(account)
+	if !ok {
+		return nil, ErrAccountNotFound
+	}
+
+	if check.IfNil(userAccount.DataTrie()) {
+		return map[string]string{}, nil
+	}
+
+	rootHash, err := userAccount.DataTrie().RootHash()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	chLeaves, err := userAccount.DataTrie().GetAllLeavesOnChannel(rootHash, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	mapToReturn := make(map[string]string)
+	for leaf := range chLeaves {
+		mapToReturn[string(leaf.Key())] = hex.EncodeToString(leaf.Value())
+	}
+
+	return mapToReturn, nil
+}
+
 // GetValueForKey will return the value for a key from a given account
 func (n *Node) GetValueForKey(address string, key string) (string, error) {
 	keyBytes, err := hex.DecodeString(key)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -266,6 +266,31 @@ func TestNode_GetKeyValuePairs(t *testing.T) {
 	assert.Equal(t, hex.EncodeToString(v2), resV2)
 }
 
+func TestNode_GetValueForKey(t *testing.T) {
+	acc, _ := state.NewUserAccount([]byte("newaddress"))
+
+	k1, v1 := []byte("key1"), []byte("value1")
+	_ = acc.DataTrieTracker().SaveKeyValue(k1, v1)
+
+	accDB := &mock.AccountsStub{}
+
+	accDB.GetExistingAccountCalled = func(address []byte) (handler state.AccountHandler, e error) {
+		return acc, nil
+	}
+
+	n, _ := node.NewNode(
+		node.WithInternalMarshalizer(getMarshalizer(), testSizeCheckDelta),
+		node.WithVmMarshalizer(getMarshalizer()),
+		node.WithHasher(getHasher()),
+		node.WithAddressPubkeyConverter(createMockPubkeyConverter()),
+		node.WithAccountsAdapter(accDB),
+	)
+
+	value, err := n.GetValueForKey(createDummyHexAddress(64), hex.EncodeToString(k1))
+	assert.NoError(t, err)
+	assert.Equal(t, hex.EncodeToString(v1), value)
+}
+
 func TestNode_GetESDTBalance(t *testing.T) {
 	acc, _ := state.NewUserAccount([]byte("newaddress"))
 	esdtToken := "newToken"

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -257,11 +257,11 @@ func TestNode_GetKeyValuePairs(t *testing.T) {
 
 	pairs, err := n.GetKeyValuePairs(createDummyHexAddress(64))
 	assert.Nil(t, err)
-	resV1, ok := pairs[string(k1)]
+	resV1, ok := pairs[hex.EncodeToString(k1)]
 	assert.True(t, ok)
 	assert.Equal(t, hex.EncodeToString(v1), resV1)
 
-	resV2, ok := pairs[string(k2)]
+	resV2, ok := pairs[hex.EncodeToString(k2)]
 	assert.True(t, ok)
 	assert.Equal(t, hex.EncodeToString(v2), resV2)
 }


### PR DESCRIPTION
Implemented the `address/{address}/keys` endpoint that will return a map containing all keys and their values for an account. The value is represented in hexadecimal encoding.

Testing procedure:
-start a testnet using the corresponding proxy's branch
-find an address that must have saved something inside it's key-value storage (for example, an address that interacted with an ESDT token) and make an API call to `proxy-url/address/erd1.../keys`. it should return a map containing all its keys