### PR TITLE
[soft restart] fixed issue when checking core subcomponents

### DIFF
--- a/factory/coreComponents.go
+++ b/factory/coreComponents.go
@@ -70,7 +70,7 @@ type coreComponents struct {
 	statusHandlersUtils           factory.StatusHandlersUtils
 	pathHandler                   storage.PathManagerHandler
 	syncTimer                     ntp.SyncTimer
-	RoundHandler                  consensus.RoundHandler
+	roundHandler                  consensus.RoundHandler
 	alarmScheduler                core.TimersScheduler
 	watchdog                      core.WatchdogTimer
 	nodesSetupHandler             sharding.GenesisNodesSetupHandler
@@ -263,7 +263,7 @@ func (ccf *coreComponentsFactory) Create() (*coreComponents, error) {
 		statusHandlersUtils:           statusHandlersInfo,
 		pathHandler:                   pathHandler,
 		syncTimer:                     syncer,
-		RoundHandler:                  roundHandler,
+		roundHandler:                  roundHandler,
 		alarmScheduler:                alarmScheduler,
 		watchdog:                      watchdogTimer,
 		nodesSetupHandler:             genesisNodesConfig,

--- a/factory/coreComponentsHandler.go
+++ b/factory/coreComponentsHandler.go
@@ -123,7 +123,7 @@ func (mcc *managedCoreComponents) CheckSubcomponents() error {
 	if check.IfNil(mcc.syncTimer) {
 		return errors.ErrNilSyncTimer
 	}
-	if check.IfNil(mcc.RoundHandler()) {
+	if check.IfNil(mcc.coreComponents.RoundHandler) {
 		return errors.ErrNilRoundHandler
 	}
 	if check.IfNil(mcc.economicsData) {

--- a/factory/coreComponentsHandler.go
+++ b/factory/coreComponentsHandler.go
@@ -123,7 +123,7 @@ func (mcc *managedCoreComponents) CheckSubcomponents() error {
 	if check.IfNil(mcc.syncTimer) {
 		return errors.ErrNilSyncTimer
 	}
-	if check.IfNil(mcc.coreComponents.RoundHandler) {
+	if check.IfNil(mcc.roundHandler) {
 		return errors.ErrNilRoundHandler
 	}
 	if check.IfNil(mcc.economicsData) {
@@ -438,7 +438,7 @@ func (mcc *managedCoreComponents) RoundHandler() consensus.RoundHandler {
 		return nil
 	}
 
-	return mcc.coreComponents.RoundHandler
+	return mcc.coreComponents.roundHandler
 }
 
 // NodesShuffler returns the nodes shuffler


### PR DESCRIPTION
fixed the deadlock situation when a method that was mutex-protected was called inside a function that was already protected by the same mutex