### PR TITLE
Fix the modifyTotalDelegationCap for infinity amount

### DIFF
--- a/vm/systemSmartContracts/delegation.go
+++ b/vm/systemSmartContracts/delegation.go
@@ -491,7 +491,7 @@ func (d *delegation) modifyTotalDelegationCap(args *vmcommon.ContractCallInput) 
 		return vmcommon.UserError
 	}
 
-	if newTotalDelegationCap.Cmp(globalFund.TotalActive) < 0 {
+	if newTotalDelegationCap.Cmp(globalFund.TotalActive) < 0 && newTotalDelegationCap.Cmp(zero) != 0 {
 		d.eei.AddReturnMessage("cannot make total delegation cap smaller than active")
 		return vmcommon.UserError
 	}

--- a/vm/systemSmartContracts/delegation_test.go
+++ b/vm/systemSmartContracts/delegation_test.go
@@ -2190,6 +2190,14 @@ func TestDelegationSystemSC_ExecuteModifyTotalDelegationCap(t *testing.T) {
 
 	dConfig, _ := d.getDelegationContractConfig()
 	assert.Equal(t, big.NewInt(1500), dConfig.MaxDelegationCap)
+
+
+	vmInput.Arguments = [][]byte{big.NewInt(0).Bytes()}
+	output = d.Execute(vmInput)
+	assert.Equal(t, vmcommon.Ok, output)
+
+	dConfig, _ = d.getDelegationContractConfig()
+	assert.Equal(t, big.NewInt(0), dConfig.MaxDelegationCap)
 }
 
 func TestDelegation_getSuccessAndUnSuccessKeysAllUnSuccess(t *testing.T) {


### PR DESCRIPTION
## Why 

The agency SC can be initiated with an infinity delegation cap. 
Once we change the delegation cap to a higher value and later one we try to set it back to infinity the SC is throwing ```cannot make total delegation cap smaller than active``` [TX](https://testnet-explorer.elrond.com/transactions/e247a401609144ece061abf1e890d50e1b91e3313e0a839d8c962502d56f5846)

## Changes
Modified the ```if``` condition to check if the new value is not equal to ```0``` before returning the error.
A new unit test was added testing the flow where the infinity max cap is used again after a higher value.
