### PR TITLE
Add claimRewards value to TotalCumulatedRewards

### DIFF
--- a/vm/systemSmartContracts/delegation.go
+++ b/vm/systemSmartContracts/delegation.go
@@ -1013,6 +1013,7 @@ func (d *delegation) reDelegateRewards(args *vmcommon.ContractCallInput) vmcommo
 		return vmcommon.UserError
 	}
 
+	delegator.TotalCumulatedRewards.Add(delegator.TotalCumulatedRewards, delegator.UnClaimedRewards)
 	delegateValue := big.NewInt(0).Set(delegator.UnClaimedRewards)
 	delegator.UnClaimedRewards.SetUint64(0)
 

--- a/vm/systemSmartContracts/delegation_test.go
+++ b/vm/systemSmartContracts/delegation_test.go
@@ -2605,6 +2605,7 @@ func TestDelegation_ExecuteReDelegateRewards(t *testing.T) {
 	_, delegatorData, _ := d.getOrCreateDelegatorData(vmInput.CallerAddr)
 	assert.Equal(t, uint32(3), delegatorData.RewardsCheckpoint)
 	assert.Equal(t, uint64(0), delegatorData.UnClaimedRewards.Uint64())
+	assert.Equal(t, uint64(155), delegatorData.TotalCumulatedRewards.Uint64())
 
 	activeFund, _ := d.getFund(delegatorData.ActiveFund)
 	assert.Equal(t, big.NewInt(155+1000), activeFund.Value)


### PR DESCRIPTION
- Fixed the situation when the TotalCumulatedRewards rewards did not contain the `claimRewards` value