### PR TITLE
Fix variables.sh

### DIFF
--- a/scripts/testnet/variables.sh
+++ b/scripts/testnet/variables.sh
@@ -47,6 +47,7 @@ export HARDFORK_DELAY=900 #15 minutes enough to take export and gracefully close
 export NODE_DELAY=60
 
 export GENESIS_STAKE_TYPE="delegated" #'delegated' or 'direct' as in direct stake
+export HYSTERESIS=0.2
 
 #if set to 1, each observer will turn off the antiflooding capability, allowing spam in our network
 export OBSERVERS_ANTIFLOOD_DISABLE=0


### PR DESCRIPTION
Other scripts expect this variable to be defined, best is to define and initialize it with the default value of 0.2
Without this, ./config.sh won't work without manually setting that variable