### PR TITLE
added rounds per epoch in network config

### DIFF
--- a/statusHandler/statusMetricsProvider.go
+++ b/statusHandler/statusMetricsProvider.go
@@ -178,6 +178,7 @@ func (sm *statusMetrics) ConfigMetrics() map[string]interface{} {
 	configMetrics[core.MetricMinTransactionVersion] = sm.loadUint64Metric(core.MetricMinTransactionVersion)
 	configMetrics[core.MetricTopUpFactor] = sm.loadStringMetric(core.MetricTopUpFactor)
 	configMetrics[core.MetricGasPriceModifier] = sm.loadStringMetric(core.MetricGasPriceModifier)
+	configMetrics[core.MetricRoundsPerEpoch] = sm.loadUint64Metric(core.MetricRoundsPerEpoch)
 
 	return configMetrics
 }

--- a/statusHandler/statusMetricsProvider_test.go
+++ b/statusHandler/statusMetricsProvider_test.go
@@ -166,6 +166,7 @@ func TestStatusMetrics_NetworkConfig(t *testing.T) {
 	sm.SetUInt64Value(core.MetricMinTransactionVersion, 2)
 	sm.SetStringValue(core.MetricTopUpFactor, fmt.Sprintf("%g", 12.134))
 	sm.SetStringValue(core.MetricGasPriceModifier, fmt.Sprintf("%g", 0.5))
+	sm.SetUInt64Value(core.MetricRoundsPerEpoch, uint64(144))
 
 	expectedConfig := map[string]interface{}{
 		"erd_chain_id":                      "local-id",
@@ -185,6 +186,7 @@ func TestStatusMetrics_NetworkConfig(t *testing.T) {
 		"erd_start_time":                    uint64(9999),
 		"erd_top_up_factor":                 "12.134",
 		"erd_gas_price_modifier":            "0.5",
+		"erd_rounds_per_epoch":              uint64(144),
 	}
 
 	configMetrics := sm.ConfigMetrics()


### PR DESCRIPTION
Added metric rounds per epoch in the API route /network/config