### PR TITLE
changed log level when requesting trie nodes from network

### DIFF
--- a/dataRetriever/requestHandlers/requestHandler.go
+++ b/dataRetriever/requestHandlers/requestHandler.go
@@ -377,7 +377,7 @@ func (rrh *resolverRequestHandler) RequestTrieNodes(destShardID uint32, hashes [
 		return
 	}
 
-	log.Debug("requesting trie nodes from network",
+	log.Trace("requesting trie nodes from network",
 		"topic", topic,
 		"shard", destShardID,
 		"num nodes", len(rrh.trieHashesAccumulator),


### PR DESCRIPTION
Change log level to `trace` when requesting trie nodes from network. Otherwise, when syncing using epoch bootstrapper, this log would have appeared way to many times and the node was prone to remain unsynced.