### PR TITLE
Formatted NFT identifier in api response

### DIFF
--- a/api/address/routes.go
+++ b/api/address/routes.go
@@ -438,7 +438,7 @@ func GetESDTNFTData(c *gin.Context) {
 			http.StatusBadRequest,
 			shared.GenericAPIResponse{
 				Data:  nil,
-				Error: fmt.Sprintf("%s: %s", errors.ErrNonceInvalid.Error(), errors.ErrEmptyKey.Error()),
+				Error: errors.ErrNonceInvalid.Error(),
 				Code:  shared.ReturnCodeRequestError,
 			},
 		)

--- a/api/address/routes.go
+++ b/api/address/routes.go
@@ -57,13 +57,13 @@ type esdtTokenData struct {
 type esdtNFTTokenData struct {
 	TokenIdentifier string   `json:"tokenIdentifier"`
 	Balance         string   `json:"balance"`
-	Properties      string   `json:"properties"`
-	Name            string   `json:"name"`
-	Creator         string   `json:"creator"`
-	Royalties       string   `json:"royalties"`
-	Hash            []byte   `json:"hash"`
-	URIs            [][]byte `json:"uris"`
-	Attributes      []byte   `json:"attributes"`
+	Properties      string   `json:"properties,omitempty"`
+	Name            string   `json:"name,omitempty"`
+	Creator         string   `json:"creator,omitempty"`
+	Royalties       string   `json:"royalties,omitempty"`
+	Hash            []byte   `json:"hash,omitempty"`
+	URIs            [][]byte `json:"uris,omitempty"`
+	Attributes      []byte   `json:"attributes,omitempty"`
 }
 
 // Routes defines address related routes

--- a/cmd/node/config/api.toml
+++ b/cmd/node/config/api.toml
@@ -49,10 +49,7 @@
         { Name = "/:address/esdt/:tokenIdentifier", Open = true },
 
         # /address/:address/nft/:tokenIdentifier/nonce/:nonce will return data of an nft esdt token for a given account, tokenID and nonce
-        { Name = "/:address/nft/:tokenIdentifier/nonce/:nonce", Open = true },
-
-        # /address/:address/completeEsdts will return the list of esdt tokens and all the underlying data for a given account
-        { Name = "/:address/completeEsdts", Open = true }
+        { Name = "/:address/nft/:tokenIdentifier/nonce/:nonce", Open = true }
 	]
 
 [APIPackages.hardfork]

--- a/node/node.go
+++ b/node/node.go
@@ -60,6 +60,8 @@ import (
 // SendTransactionsPipe is the pipe used for sending new transactions
 const SendTransactionsPipe = "send transactions pipe"
 
+const esdtTickerNumChars = 6
+
 var log = logger.GetOrCreate("node")
 var numSecondsBetweenPrints = 20
 
@@ -592,12 +594,32 @@ func (n *Node) GetAllESDTTokens(address string) (map[string]*esdt.ESDigitalToken
 
 		if esdtToken.TokenMetaData != nil {
 			esdtToken.TokenMetaData.Creator = []byte(n.addressPubkeyConverter.Encode(esdtToken.TokenMetaData.Creator))
+			tokenName = adjustNftTokenIdentifier(tokenName, esdtToken.TokenMetaData.Nonce)
 		}
 
 		allESDTs[tokenName] = esdtToken
 	}
 
 	return allESDTs, nil
+}
+
+func adjustNftTokenIdentifier(token string, nonce uint64) string {
+	splitToken := strings.Split(token, "-")
+	if len(splitToken) < 2 {
+		return token
+	}
+
+	if len(splitToken[1]) < esdtTickerNumChars {
+		return token
+	}
+
+	nonceBytes := big.NewInt(0).SetUint64(nonce).Bytes()
+	formattedTokenIdentifier := fmt.Sprintf("%s-%s-%s",
+		splitToken[0],
+		splitToken[1][:esdtTickerNumChars],
+		hex.EncodeToString(nonceBytes))
+
+	return formattedTokenIdentifier
 }
 
 func (n *Node) getAccountHandler(address string) (state.AccountHandler, error) {

--- a/node/node.go
+++ b/node/node.go
@@ -57,10 +57,13 @@ import (
 	"github.com/ElrondNetwork/elrond-go/update"
 )
 
-// SendTransactionsPipe is the pipe used for sending new transactions
-const SendTransactionsPipe = "send transactions pipe"
+const (
+	// SendTransactionsPipe is the pipe used for sending new transactions
+	SendTransactionsPipe = "send transactions pipe"
 
-const esdtTickerNumChars = 6
+	// esdtTickerNumChars represents the number of hex-encoded characters of a ticker
+	esdtTickerNumChars = 6
+)
 
 var log = logger.GetOrCreate("node")
 var numSecondsBetweenPrints = 20


### PR DESCRIPTION
Formatted the NFT identifier in `/address/:address/esdt` endpoint. 
Now, if a token is regular esdt, the key for it would follow the syntax `TICKER-3e3e3e` and if it the token is a NFT, then it would follow the syntax `TICKER-3e3e3e-02` where `02` is the hex encoded nonce.

Before this PR, the token identifier for NFTs would have resulted in non readable characters