### PR TITLE
Fix stuck situation created by too many scrs generated in one single mini block

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -1595,6 +1595,7 @@ func newShardBlockProcessor(
 		stateComponents.AddressPubkeyConverter,
 		data.Store,
 		data.Datapool,
+		economics,
 	)
 	if err != nil {
 		return nil, err
@@ -1924,6 +1925,7 @@ func newMetaBlockProcessor(
 		stateComponents.AddressPubkeyConverter,
 		data.Store,
 		data.Datapool,
+		economicsData,
 	)
 	if err != nil {
 		return nil, err
@@ -2306,6 +2308,7 @@ func createShardTxSimulatorProcessor(
 		stateComponents.AddressPubkeyConverter,
 		disabled.NewChainStorer(),
 		data.Datapool,
+		&processDisabled.FeeHandler{},
 	)
 	if err != nil {
 		return err
@@ -2376,6 +2379,7 @@ func createMetaTxSimulatorProcessor(
 		stateComponents.AddressPubkeyConverter,
 		disabled.NewChainStorer(),
 		data.Datapool,
+		&processDisabled.FeeHandler{},
 	)
 	if err != nil {
 		return err

--- a/genesis/process/metaGenesisBlockCreator.go
+++ b/genesis/process/metaGenesisBlockCreator.go
@@ -282,6 +282,7 @@ func createProcessorsForMetaGenesisBlock(arg ArgsGenesisBlockCreator, generalCon
 		return nil, err
 	}
 
+	genesisFeeHandler := &disabled.FeeHandler{}
 	interimProcFactory, err := metachain.NewIntermediateProcessorsContainerFactory(
 		arg.ShardCoordinator,
 		arg.Marshalizer,
@@ -289,6 +290,7 @@ func createProcessorsForMetaGenesisBlock(arg ArgsGenesisBlockCreator, generalCon
 		arg.PubkeyConv,
 		arg.Store,
 		arg.DataPool,
+		genesisFeeHandler,
 	)
 	if err != nil {
 		return nil, err
@@ -326,7 +328,6 @@ func createProcessorsForMetaGenesisBlock(arg ArgsGenesisBlockCreator, generalCon
 	}
 
 	argsParser := smartContract.NewArgumentParser()
-	genesisFeeHandler := &disabled.FeeHandler{}
 	argsNewSCProcessor := smartContract.ArgsNewSmartContractProcessor{
 		VmContainer:                    vmContainer,
 		ArgsParser:                     argsParser,
@@ -351,7 +352,7 @@ func createProcessorsForMetaGenesisBlock(arg ArgsGenesisBlockCreator, generalCon
 		PenalizedTooMuchGasEnableEpoch: generalConfig.PenalizedTooMuchGasEnableEpoch,
 		RepairCallbackEnableEpoch:      generalConfig.RepairCallbackEnableEpoch,
 		IsGenesisProcessing:            true,
-		StakingV2EnableEpoch: arg.SystemSCConfig.StakingSystemSCConfig.StakingV2Epoch,
+		StakingV2EnableEpoch:           arg.SystemSCConfig.StakingSystemSCConfig.StakingV2Epoch,
 	}
 	scProcessor, err := smartContract.NewSmartContractProcessor(argsNewSCProcessor)
 	if err != nil {

--- a/genesis/process/shardGenesisBlockCreator.go
+++ b/genesis/process/shardGenesisBlockCreator.go
@@ -307,6 +307,7 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, generalCo
 		return nil, err
 	}
 
+	genesisFeeHandler := &disabled.FeeHandler{}
 	interimProcFactory, err := shard.NewIntermediateProcessorsContainerFactory(
 		arg.ShardCoordinator,
 		arg.Marshalizer,
@@ -314,6 +315,7 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, generalCo
 		arg.PubkeyConv,
 		arg.Store,
 		arg.DataPool,
+		genesisFeeHandler,
 	)
 	if err != nil {
 		return nil, err
@@ -358,7 +360,6 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, generalCo
 		return nil, err
 	}
 
-	genesisFeeHandler := &disabled.FeeHandler{}
 	argsNewScProcessor := smartContract.ArgsNewSmartContractProcessor{
 		VmContainer:                    vmContainer,
 		ArgsParser:                     smartContract.NewArgumentParser(),

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -1214,6 +1214,7 @@ func (tpn *TestProcessorNode) initInnerProcessors(gasMap map[string]map[string]u
 		TestAddressPubkeyConverter,
 		tpn.Storage,
 		tpn.DataPool,
+		tpn.EconomicsData,
 	)
 
 	tpn.InterimProcContainer, _ = interimProcFactory.Create()
@@ -1225,6 +1226,7 @@ func (tpn *TestProcessorNode) initInnerProcessors(gasMap map[string]map[string]u
 		tpn.Storage,
 		dataBlock.SmartContractResultBlock,
 		tpn.DataPool.CurrentBlockTxs(),
+		tpn.EconomicsData,
 	)
 
 	tpn.InterimProcContainer.Remove(dataBlock.SmartContractResultBlock)
@@ -1406,6 +1408,7 @@ func (tpn *TestProcessorNode) initMetaInnerProcessors() {
 		TestAddressPubkeyConverter,
 		tpn.Storage,
 		tpn.DataPool,
+		tpn.EconomicsData,
 	)
 
 	tpn.InterimProcContainer, _ = interimProcFactory.Create()
@@ -1417,6 +1420,7 @@ func (tpn *TestProcessorNode) initMetaInnerProcessors() {
 		tpn.Storage,
 		dataBlock.SmartContractResultBlock,
 		tpn.DataPool.CurrentBlockTxs(),
+		tpn.EconomicsData,
 	)
 
 	tpn.InterimProcContainer.Remove(dataBlock.SmartContractResultBlock)

--- a/process/block/postprocess/intermediateResults.go
+++ b/process/block/postprocess/intermediateResults.go
@@ -163,15 +163,7 @@ func (irp *intermediateResultsProcessor) CreateAllInterMiniBlocks() []*block.Min
 // VerifyInterMiniBlocks verifies if the smart contract results added to the block are valid
 func (irp *intermediateResultsProcessor) VerifyInterMiniBlocks(body *block.Body) error {
 	scrMbs := irp.CreateAllInterMiniBlocks()
-	createdMapMbs := make(map[uint32][]*block.MiniBlock)
-	for _, mb := range scrMbs {
-		_, ok := createdMapMbs[mb.ReceiverShardID]
-		if !ok {
-			createdMapMbs[mb.ReceiverShardID] = make([]*block.MiniBlock, 0)
-		}
-
-		createdMapMbs[mb.ReceiverShardID] = append(createdMapMbs[mb.ReceiverShardID], mb)
-	}
+	createdMapMbs := createMiniBlocksMap(scrMbs)
 
 	countedCrossShard := 0
 	for i := 0; i < len(body.MiniBlocks); i++ {

--- a/process/block/postprocess/intermediateResults_test.go
+++ b/process/block/postprocess/intermediateResults_test.go
@@ -1020,8 +1020,6 @@ func TestIntermediateResultsProcessor_SplitMiniBlocksIfNeededShouldWork(t *testi
 	)
 
 	irp.mutInterResultsForBlock.Lock()
-	defer irp.mutInterResultsForBlock.Unlock()
-
 	tx1 := transaction.Transaction{Nonce: 0, GasLimit: 100}
 	tx2 := transaction.Transaction{Nonce: 1, GasLimit: 100}
 	tx3 := transaction.Transaction{Nonce: 2, GasLimit: 100}
@@ -1032,6 +1030,7 @@ func TestIntermediateResultsProcessor_SplitMiniBlocksIfNeededShouldWork(t *testi
 	irp.interResultsForBlock["hash3"] = &txInfo{tx: &tx3}
 	irp.interResultsForBlock["hash4"] = &txInfo{tx: &tx4}
 	irp.interResultsForBlock["hash5"] = &txInfo{tx: &tx5}
+	irp.mutInterResultsForBlock.Unlock()
 
 	miniBlocks := make([]*block.MiniBlock, 0)
 
@@ -1048,10 +1047,14 @@ func TestIntermediateResultsProcessor_SplitMiniBlocksIfNeededShouldWork(t *testi
 	miniBlocks = append(miniBlocks, &mb2)
 
 	gasLimit = 300
+	irp.mutInterResultsForBlock.Lock()
 	splitMiniBlocks := irp.splitMiniBlocksIfNeeded(miniBlocks)
+	irp.mutInterResultsForBlock.Unlock()
 	assert.Equal(t, 2, len(splitMiniBlocks))
 
 	gasLimit = 199
+	irp.mutInterResultsForBlock.Lock()
 	splitMiniBlocks = irp.splitMiniBlocksIfNeeded(miniBlocks)
+	irp.mutInterResultsForBlock.Unlock()
 	assert.Equal(t, 5, len(splitMiniBlocks))
 }

--- a/process/block/postprocess/intermediateResults_test.go
+++ b/process/block/postprocess/intermediateResults_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const maxGasLimitPerBlock = uint64(1500000000)
+
 func createMockPubkeyConverter() *mock.PubkeyConverterMock {
 	return mock.NewPubkeyConverterMock(32)
 }
@@ -33,6 +35,7 @@ func TestNewIntermediateResultsProcessor_NilHashes(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.TxBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, irp)
@@ -50,6 +53,7 @@ func TestNewIntermediateResultsProcessor_NilMarshalizer(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.TxBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, irp)
@@ -67,6 +71,7 @@ func TestNewIntermediateResultsProcessor_NilShardCoordinator(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.TxBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, irp)
@@ -84,6 +89,7 @@ func TestNewIntermediateResultsProcessor_NilPubkeyConverter(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.TxBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, irp)
@@ -101,10 +107,47 @@ func TestNewIntermediateResultsProcessor_NilStorer(t *testing.T) {
 		nil,
 		block.TxBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, irp)
 	assert.Equal(t, process.ErrNilStorage, err)
+}
+
+func TestNewIntermediateResultsProcessor_NilTxForCurrentBlockHandler(t *testing.T) {
+	t.Parallel()
+
+	irp, err := NewIntermediateResultsProcessor(
+		&mock.HasherMock{},
+		&mock.MarshalizerMock{},
+		mock.NewMultiShardsCoordinatorMock(5),
+		createMockPubkeyConverter(),
+		&mock.ChainStorerMock{},
+		block.TxBlock,
+		nil,
+		&mock.FeeHandlerStub{},
+	)
+
+	assert.Nil(t, irp)
+	assert.Equal(t, process.ErrNilTxForCurrentBlockHandler, err)
+}
+
+func TestNewIntermediateResultsProcessor_NilEconomicsFeeHandler(t *testing.T) {
+	t.Parallel()
+
+	irp, err := NewIntermediateResultsProcessor(
+		&mock.HasherMock{},
+		&mock.MarshalizerMock{},
+		mock.NewMultiShardsCoordinatorMock(5),
+		createMockPubkeyConverter(),
+		&mock.ChainStorerMock{},
+		block.TxBlock,
+		&mock.TxForCurrentBlockStub{},
+		nil,
+	)
+
+	assert.Nil(t, irp)
+	assert.Equal(t, process.ErrNilEconomicsFeeHandler, err)
 }
 
 func TestNewIntermediateResultsProcessor_Good(t *testing.T) {
@@ -118,6 +161,7 @@ func TestNewIntermediateResultsProcessor_Good(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.TxBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -136,6 +180,7 @@ func TestIntermediateResultsProcessor_getShardIdsFromAddressesGood(t *testing.T)
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -160,6 +205,7 @@ func TestIntermediateResultsProcessor_AddIntermediateTransactions(t *testing.T) 
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -181,6 +227,7 @@ func TestIntermediateResultsProcessor_AddIntermediateTransactionsWrongType(t *te
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -205,6 +252,7 @@ func TestIntermediateResultsProcessor_AddIntermediateTransactionsNilSender(t *te
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -237,6 +285,7 @@ func TestIntermediateResultsProcessor_AddIntermediateTransactionsNilReceiver(t *
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -276,6 +325,7 @@ func TestIntermediateResultsProcessor_AddIntermediateTransactionsShardIdMismatch
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -305,6 +355,7 @@ func TestIntermediateResultsProcessor_AddIntermediateTransactionsNegativeValueIn
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -344,6 +395,7 @@ func TestIntermediateResultsProcessor_AddIntermediateTransactionsAddrGood(t *tes
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -373,6 +425,7 @@ func TestIntermediateResultsProcessor_AddIntermediateTransactionsAddAndRevert(t 
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -411,6 +464,7 @@ func TestIntermediateResultsProcessor_CreateAllInterMiniBlocksNothingInCache(t *
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -432,6 +486,11 @@ func TestIntermediateResultsProcessor_CreateAllInterMiniBlocksNotCrossShard(t *t
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{
+			MaxGasLimitPerBlockCalled: func() uint64 {
+				return maxGasLimitPerBlock
+			},
+		},
 	)
 
 	assert.NotNil(t, irp)
@@ -465,6 +524,11 @@ func TestIntermediateResultsProcessor_CreateAllInterMiniBlocksCrossShard(t *test
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{
+			MaxGasLimitPerBlockCalled: func() uint64 {
+				return maxGasLimitPerBlock
+			},
+		},
 	)
 
 	assert.NotNil(t, irp)
@@ -523,6 +587,7 @@ func TestIntermediateResultsProcessor_GetNumOfCrossInterMbsAndTxsShouldWork(t *t
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	txs := make([]data.TransactionHandler, 0)
@@ -557,6 +622,7 @@ func TestIntermediateResultsProcessor_VerifyInterMiniBlocksNilBody(t *testing.T)
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -580,6 +646,7 @@ func TestIntermediateResultsProcessor_VerifyInterMiniBlocksBodyShouldpassAsNotCr
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -608,6 +675,7 @@ func TestIntermediateResultsProcessor_VerifyInterMiniBlocksBodyMissingMiniblock(
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -634,6 +702,11 @@ func TestIntermediateResultsProcessor_VerifyInterMiniBlocksBodyMiniBlockMissmatc
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{
+			MaxGasLimitPerBlockCalled: func() uint64 {
+				return maxGasLimitPerBlock
+			},
+		},
 	)
 
 	assert.NotNil(t, irp)
@@ -679,6 +752,11 @@ func TestIntermediateResultsProcessor_VerifyInterMiniBlocksBodyShouldPass(t *tes
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{
+			MaxGasLimitPerBlockCalled: func() uint64 {
+				return maxGasLimitPerBlock
+			},
+		},
 	)
 
 	assert.NotNil(t, irp)
@@ -745,6 +823,7 @@ func TestIntermediateResultsProcessor_SaveCurrentIntermediateTxToStorageShouldSa
 		},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -789,6 +868,7 @@ func TestIntermediateResultsProcessor_CreateMarshalizedDataNothingToMarshal(t *t
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -820,6 +900,7 @@ func TestIntermediateResultsProcessor_CreateMarshalizedData(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -887,6 +968,7 @@ func TestIntermediateResultsProcessor_GetAllCurrentUsedTxs(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.SmartContractResultBlock,
 		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.NotNil(t, irp)
@@ -912,4 +994,63 @@ func TestIntermediateResultsProcessor_GetAllCurrentUsedTxs(t *testing.T) {
 
 	usedTxs := irp.GetAllCurrentFinishedTxs()
 	assert.Equal(t, 4, len(usedTxs))
+}
+
+func TestIntermediateResultsProcessor_SplitMiniBlocksIfNeededShouldWork(t *testing.T) {
+	t.Parallel()
+
+	var gasLimit uint64
+	nrShards := 5
+	shardCoordinator := mock.NewMultiShardsCoordinatorMock(uint32(nrShards))
+	hasher := &mock.HasherMock{}
+	marshalizer := &mock.MarshalizerMock{}
+	irp, _ := NewIntermediateResultsProcessor(
+		hasher,
+		marshalizer,
+		shardCoordinator,
+		createMockPubkeyConverter(),
+		&mock.ChainStorerMock{},
+		block.SmartContractResultBlock,
+		&mock.TxForCurrentBlockStub{},
+		&mock.FeeHandlerStub{
+			MaxGasLimitPerBlockCalled: func() uint64 {
+				return gasLimit
+			},
+		},
+	)
+
+	irp.mutInterResultsForBlock.Lock()
+	tx1 := transaction.Transaction{Nonce: 0, GasLimit: 100}
+	tx2 := transaction.Transaction{Nonce: 1, GasLimit: 100}
+	tx3 := transaction.Transaction{Nonce: 2, GasLimit: 100}
+	tx4 := transaction.Transaction{Nonce: 3, GasLimit: 100}
+	tx5 := transaction.Transaction{Nonce: 4, GasLimit: 100}
+	irp.interResultsForBlock["hash1"] = &txInfo{tx: &tx1}
+	irp.interResultsForBlock["hash2"] = &txInfo{tx: &tx2}
+	irp.interResultsForBlock["hash3"] = &txInfo{tx: &tx3}
+	irp.interResultsForBlock["hash4"] = &txInfo{tx: &tx4}
+	irp.interResultsForBlock["hash5"] = &txInfo{tx: &tx5}
+	irp.mutInterResultsForBlock.Unlock()
+
+	miniBlocks := make([]*block.MiniBlock, 0)
+
+	mb1 := block.MiniBlock{
+		ReceiverShardID: 1,
+		TxHashes:        [][]byte{[]byte("hash1"), []byte("hash2")},
+	}
+	miniBlocks = append(miniBlocks, &mb1)
+
+	mb2 := block.MiniBlock{
+		ReceiverShardID: 2,
+		TxHashes:        [][]byte{[]byte("hash3"), []byte("hash4"), []byte("hash5"), []byte("hash6")},
+	}
+	miniBlocks = append(miniBlocks, &mb2)
+
+	gasLimit = 300
+	splitMiniBlocks := irp.splitMiniBlocksIfNeeded(miniBlocks)
+	assert.Equal(t, 2, len(splitMiniBlocks))
+
+	gasLimit = 199
+	splitMiniBlocks = irp.splitMiniBlocksIfNeeded(miniBlocks)
+	assert.Equal(t, 5, len(splitMiniBlocks))
 }

--- a/process/block/postprocess/intermediateResults_test.go
+++ b/process/block/postprocess/intermediateResults_test.go
@@ -1019,7 +1019,6 @@ func TestIntermediateResultsProcessor_SplitMiniBlocksIfNeededShouldWork(t *testi
 		},
 	)
 
-	irp.mutInterResultsForBlock.Lock()
 	tx1 := transaction.Transaction{Nonce: 0, GasLimit: 100}
 	tx2 := transaction.Transaction{Nonce: 1, GasLimit: 100}
 	tx3 := transaction.Transaction{Nonce: 2, GasLimit: 100}
@@ -1030,7 +1029,6 @@ func TestIntermediateResultsProcessor_SplitMiniBlocksIfNeededShouldWork(t *testi
 	irp.interResultsForBlock["hash3"] = &txInfo{tx: &tx3}
 	irp.interResultsForBlock["hash4"] = &txInfo{tx: &tx4}
 	irp.interResultsForBlock["hash5"] = &txInfo{tx: &tx5}
-	irp.mutInterResultsForBlock.Unlock()
 
 	miniBlocks := make([]*block.MiniBlock, 0)
 
@@ -1047,14 +1045,10 @@ func TestIntermediateResultsProcessor_SplitMiniBlocksIfNeededShouldWork(t *testi
 	miniBlocks = append(miniBlocks, &mb2)
 
 	gasLimit = 300
-	irp.mutInterResultsForBlock.Lock()
 	splitMiniBlocks := irp.splitMiniBlocksIfNeeded(miniBlocks)
-	irp.mutInterResultsForBlock.Unlock()
 	assert.Equal(t, 2, len(splitMiniBlocks))
 
 	gasLimit = 199
-	irp.mutInterResultsForBlock.Lock()
 	splitMiniBlocks = irp.splitMiniBlocksIfNeeded(miniBlocks)
-	irp.mutInterResultsForBlock.Unlock()
 	assert.Equal(t, 5, len(splitMiniBlocks))
 }

--- a/process/block/postprocess/intermediateResults_test.go
+++ b/process/block/postprocess/intermediateResults_test.go
@@ -1020,6 +1020,8 @@ func TestIntermediateResultsProcessor_SplitMiniBlocksIfNeededShouldWork(t *testi
 	)
 
 	irp.mutInterResultsForBlock.Lock()
+	defer irp.mutInterResultsForBlock.Unlock()
+
 	tx1 := transaction.Transaction{Nonce: 0, GasLimit: 100}
 	tx2 := transaction.Transaction{Nonce: 1, GasLimit: 100}
 	tx3 := transaction.Transaction{Nonce: 2, GasLimit: 100}
@@ -1030,7 +1032,6 @@ func TestIntermediateResultsProcessor_SplitMiniBlocksIfNeededShouldWork(t *testi
 	irp.interResultsForBlock["hash3"] = &txInfo{tx: &tx3}
 	irp.interResultsForBlock["hash4"] = &txInfo{tx: &tx4}
 	irp.interResultsForBlock["hash5"] = &txInfo{tx: &tx5}
-	irp.mutInterResultsForBlock.Unlock()
 
 	miniBlocks := make([]*block.MiniBlock, 0)
 

--- a/process/block/postprocess/oneMBPostProcessor.go
+++ b/process/block/postprocess/oneMBPostProcessor.go
@@ -30,6 +30,7 @@ func NewOneMiniBlockPostProcessor(
 	store dataRetriever.StorageService,
 	blockType block.Type,
 	storageType dataRetriever.UnitType,
+	economicsFee process.FeeHandler,
 ) (*oneMBPostProcessor, error) {
 	if check.IfNil(hasher) {
 		return nil, process.ErrNilHasher
@@ -43,6 +44,9 @@ func NewOneMiniBlockPostProcessor(
 	if check.IfNil(store) {
 		return nil, process.ErrNilStorage
 	}
+	if check.IfNil(economicsFee) {
+		return nil, process.ErrNilEconomicsFeeHandler
+	}
 
 	base := &basePostProcessor{
 		hasher:           hasher,
@@ -51,6 +55,7 @@ func NewOneMiniBlockPostProcessor(
 		store:            store,
 		storageType:      storageType,
 		mapTxToResult:    make(map[string][]string),
+		economicsFee:     economicsFee,
 	}
 
 	opp := &oneMBPostProcessor{
@@ -113,9 +118,14 @@ func (opp *oneMBPostProcessor) CreateAllInterMiniBlocks() []*block.MiniBlock {
 // VerifyInterMiniBlocks verifies if the receipts/bad transactions added to the block are valid
 func (opp *oneMBPostProcessor) VerifyInterMiniBlocks(body *block.Body) error {
 	scrMbs := opp.CreateAllInterMiniBlocks()
-	createdMapMbs := make(map[uint32]*block.MiniBlock)
+	createdMapMbs := make(map[uint32][]*block.MiniBlock)
 	for _, mb := range scrMbs {
-		createdMapMbs[mb.ReceiverShardID] = mb
+		_, ok := createdMapMbs[mb.ReceiverShardID]
+		if !ok {
+			createdMapMbs[mb.ReceiverShardID] = make([]*block.MiniBlock, 0)
+		}
+
+		createdMapMbs[mb.ReceiverShardID] = append(createdMapMbs[mb.ReceiverShardID], mb)
 	}
 
 	verifiedOne := false

--- a/process/block/postprocess/oneMBPostProcessor.go
+++ b/process/block/postprocess/oneMBPostProcessor.go
@@ -118,15 +118,7 @@ func (opp *oneMBPostProcessor) CreateAllInterMiniBlocks() []*block.MiniBlock {
 // VerifyInterMiniBlocks verifies if the receipts/bad transactions added to the block are valid
 func (opp *oneMBPostProcessor) VerifyInterMiniBlocks(body *block.Body) error {
 	scrMbs := opp.CreateAllInterMiniBlocks()
-	createdMapMbs := make(map[uint32][]*block.MiniBlock)
-	for _, mb := range scrMbs {
-		_, ok := createdMapMbs[mb.ReceiverShardID]
-		if !ok {
-			createdMapMbs[mb.ReceiverShardID] = make([]*block.MiniBlock, 0)
-		}
-
-		createdMapMbs[mb.ReceiverShardID] = append(createdMapMbs[mb.ReceiverShardID], mb)
-	}
+	createdMapMbs := createMiniBlocksMap(scrMbs)
 
 	verifiedOne := false
 	for i := 0; i < len(body.MiniBlocks); i++ {

--- a/process/block/postprocess/oneMBPostProcessor_test.go
+++ b/process/block/postprocess/oneMBPostProcessor_test.go
@@ -25,6 +25,7 @@ func TestNewOneMBPostProcessor_NilHasher(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.TxBlock,
 		dataRetriever.TransactionUnit,
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, irp)
@@ -41,6 +42,7 @@ func TestNewOneMBPostProcessor_NilMarshalizer(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.TxBlock,
 		dataRetriever.TransactionUnit,
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, irp)
@@ -57,6 +59,7 @@ func TestNewOneMBPostProcessor_NilShardCoord(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.TxBlock,
 		dataRetriever.TransactionUnit,
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, irp)
@@ -73,10 +76,28 @@ func TestNewOneMBPostProcessor_NilStorer(t *testing.T) {
 		nil,
 		block.TxBlock,
 		dataRetriever.TransactionUnit,
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, irp)
 	assert.Equal(t, process.ErrNilStorage, err)
+}
+
+func TestNewOneMBPostProcessor_NilEconomicsFeeHandler(t *testing.T) {
+	t.Parallel()
+
+	irp, err := NewOneMiniBlockPostProcessor(
+		&mock.HasherMock{},
+		&mock.MarshalizerMock{},
+		mock.NewMultiShardsCoordinatorMock(5),
+		&mock.ChainStorerMock{},
+		block.TxBlock,
+		dataRetriever.TransactionUnit,
+		nil,
+	)
+
+	assert.Nil(t, irp)
+	assert.Equal(t, process.ErrNilEconomicsFeeHandler, err)
 }
 
 func TestNewOneMBPostProcessor_OK(t *testing.T) {
@@ -89,6 +110,7 @@ func TestNewOneMBPostProcessor_OK(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.TxBlock,
 		dataRetriever.TransactionUnit,
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, err)
@@ -105,6 +127,7 @@ func TestOneMBPostProcessor_CreateAllInterMiniBlocks(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.TxBlock,
 		dataRetriever.TransactionUnit,
+		&mock.FeeHandlerStub{},
 	)
 
 	mbs := irp.CreateAllInterMiniBlocks()
@@ -121,6 +144,7 @@ func TestOneMBPostProcessor_CreateAllInterMiniBlocksOneMinBlock(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.TxBlock,
 		dataRetriever.TransactionUnit,
+		&mock.FeeHandlerStub{},
 	)
 
 	txs := make([]data.TransactionHandler, 0)
@@ -144,6 +168,7 @@ func TestOneMBPostProcessor_VerifyNilBody(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.TxBlock,
 		dataRetriever.TransactionUnit,
+		&mock.FeeHandlerStub{},
 	)
 
 	err := irp.VerifyInterMiniBlocks(&block.Body{})
@@ -160,6 +185,7 @@ func TestOneMBPostProcessor_VerifyTooManyBlock(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.TxBlock,
 		dataRetriever.TransactionUnit,
+		&mock.FeeHandlerStub{},
 	)
 
 	txs := make([]data.TransactionHandler, 0)
@@ -204,6 +230,7 @@ func TestOneMBPostProcessor_VerifyNilMiniBlocks(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.TxBlock,
 		dataRetriever.TransactionUnit,
+		&mock.FeeHandlerStub{},
 	)
 
 	miniBlock := &block.MiniBlock{
@@ -227,6 +254,7 @@ func TestOneMBPostProcessor_VerifyOk(t *testing.T) {
 		&mock.ChainStorerMock{},
 		block.TxBlock,
 		dataRetriever.TransactionUnit,
+		&mock.FeeHandlerStub{},
 	)
 
 	txs := make([]data.TransactionHandler, 0)

--- a/process/block/postprocess/testIntermediateResult.go
+++ b/process/block/postprocess/testIntermediateResult.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/hashing"
 	"github.com/ElrondNetwork/elrond-go/marshal"
+	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 )
 
@@ -26,8 +27,9 @@ func NewTestIntermediateResultsProcessor(
 	store dataRetriever.StorageService,
 	blockType block.Type,
 	currTxs dataRetriever.TransactionCacher,
+	economicsFee process.FeeHandler,
 ) (*TestIntermediateResProc, error) {
-	interimProc, err := NewIntermediateResultsProcessor(hasher, marshalizer, coordinator, pubkeyConv, store, blockType, currTxs)
+	interimProc, err := NewIntermediateResultsProcessor(hasher, marshalizer, coordinator, pubkeyConv, store, blockType, currTxs, economicsFee)
 	return &TestIntermediateResProc{interimProc}, err
 }
 

--- a/process/coordinator/process_test.go
+++ b/process/coordinator/process_test.go
@@ -647,6 +647,7 @@ func createInterimProcessorContainer() process.IntermediateProcessorContainer {
 		createMockPubkeyConverter(),
 		initStore(),
 		initDataPool([]byte("test_hash1")),
+		&mock.FeeHandlerStub{},
 	)
 	container, _ := preFactory.Create()
 
@@ -2516,6 +2517,7 @@ func TestTransactionCoordinator_VerifyCreatedBlockTransactionsNilOrMiss(t *testi
 		createMockPubkeyConverter(),
 		&mock.ChainStorerMock{},
 		tdp,
+		&mock.FeeHandlerStub{},
 	)
 	container, _ := preFactory.Create()
 
@@ -2582,6 +2584,7 @@ func TestTransactionCoordinator_VerifyCreatedBlockTransactionsOk(t *testing.T) {
 		createMockPubkeyConverter(),
 		&mock.ChainStorerMock{},
 		tdp,
+		&mock.FeeHandlerStub{},
 	)
 	container, _ := interFactory.Create()
 

--- a/process/coordinator/process_test.go
+++ b/process/coordinator/process_test.go
@@ -2584,7 +2584,11 @@ func TestTransactionCoordinator_VerifyCreatedBlockTransactionsOk(t *testing.T) {
 		createMockPubkeyConverter(),
 		&mock.ChainStorerMock{},
 		tdp,
-		&mock.FeeHandlerStub{},
+		&mock.FeeHandlerStub{
+			MaxGasLimitPerBlockCalled: func() uint64 {
+				return MaxGasLimitPerBlock
+			},
+		},
 	)
 	container, _ := interFactory.Create()
 

--- a/process/factory/metachain/intermediateProcessorsContainerFactory.go
+++ b/process/factory/metachain/intermediateProcessorsContainerFactory.go
@@ -20,6 +20,7 @@ type intermediateProcessorsContainerFactory struct {
 	pubkeyConverter  core.PubkeyConverter
 	store            dataRetriever.StorageService
 	poolsHolder      dataRetriever.PoolsHolder
+	economicsFee     process.FeeHandler
 }
 
 // NewIntermediateProcessorsContainerFactory is responsible for creating a new intermediate processors factory object
@@ -30,6 +31,7 @@ func NewIntermediateProcessorsContainerFactory(
 	pubkeyConverter core.PubkeyConverter,
 	store dataRetriever.StorageService,
 	poolsHolder dataRetriever.PoolsHolder,
+	economicsFee process.FeeHandler,
 ) (*intermediateProcessorsContainerFactory, error) {
 
 	if check.IfNil(shardCoordinator) {
@@ -50,6 +52,9 @@ func NewIntermediateProcessorsContainerFactory(
 	if check.IfNil(poolsHolder) {
 		return nil, process.ErrNilPoolsHolder
 	}
+	if check.IfNil(economicsFee) {
+		return nil, process.ErrNilEconomicsFeeHandler
+	}
 
 	return &intermediateProcessorsContainerFactory{
 		shardCoordinator: shardCoordinator,
@@ -58,6 +63,7 @@ func NewIntermediateProcessorsContainerFactory(
 		pubkeyConverter:  pubkeyConverter,
 		poolsHolder:      poolsHolder,
 		store:            store,
+		economicsFee:     economicsFee,
 	}, nil
 }
 
@@ -97,6 +103,7 @@ func (ppcm *intermediateProcessorsContainerFactory) createSmartContractResultsIn
 		ppcm.store,
 		block.SmartContractResultBlock,
 		ppcm.poolsHolder.CurrentBlockTxs(),
+		ppcm.economicsFee,
 	)
 
 	return irp, err
@@ -110,6 +117,7 @@ func (ppcm *intermediateProcessorsContainerFactory) createBadTransactionsInterme
 		ppcm.store,
 		block.InvalidBlock,
 		dataRetriever.TransactionUnit,
+		ppcm.economicsFee,
 	)
 
 	return irp, err

--- a/process/factory/metachain/intermediateProcessorsContainerFactory_test.go
+++ b/process/factory/metachain/intermediateProcessorsContainerFactory_test.go
@@ -24,6 +24,7 @@ func TestNewIntermediateProcessorsContainerFactory_NilShardCoord(t *testing.T) {
 		createMockPubkeyConverter(),
 		&mock.ChainStorerMock{},
 		testscommon.NewPoolsHolderMock(),
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, ipcf)
@@ -40,6 +41,7 @@ func TestNewIntermediateProcessorsContainerFactory_NilMarshalizer(t *testing.T) 
 		createMockPubkeyConverter(),
 		&mock.ChainStorerMock{},
 		testscommon.NewPoolsHolderMock(),
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, ipcf)
@@ -56,6 +58,7 @@ func TestNewIntermediateProcessorsContainerFactory_NilHasher(t *testing.T) {
 		createMockPubkeyConverter(),
 		&mock.ChainStorerMock{},
 		testscommon.NewPoolsHolderMock(),
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, ipcf)
@@ -72,6 +75,7 @@ func TestNewIntermediateProcessorsContainerFactory_NilAdrConv(t *testing.T) {
 		nil,
 		&mock.ChainStorerMock{},
 		testscommon.NewPoolsHolderMock(),
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, ipcf)
@@ -88,10 +92,45 @@ func TestNewIntermediateProcessorsContainerFactory_NilStorer(t *testing.T) {
 		createMockPubkeyConverter(),
 		nil,
 		testscommon.NewPoolsHolderMock(),
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, ipcf)
 	assert.Equal(t, process.ErrNilStorage, err)
+}
+
+func TestNewIntermediateProcessorsContainerFactory_NilPoolsHolder(t *testing.T) {
+	t.Parallel()
+
+	ipcf, err := metachain.NewIntermediateProcessorsContainerFactory(
+		mock.NewMultiShardsCoordinatorMock(5),
+		&mock.MarshalizerMock{},
+		&mock.HasherMock{},
+		createMockPubkeyConverter(),
+		&mock.ChainStorerMock{},
+		nil,
+		&mock.FeeHandlerStub{},
+	)
+
+	assert.Nil(t, ipcf)
+	assert.Equal(t, process.ErrNilPoolsHolder, err)
+}
+
+func TestNewIntermediateProcessorsContainerFactory_NilEconomicsFeeHandler(t *testing.T) {
+	t.Parallel()
+
+	ipcf, err := metachain.NewIntermediateProcessorsContainerFactory(
+		mock.NewMultiShardsCoordinatorMock(5),
+		&mock.MarshalizerMock{},
+		&mock.HasherMock{},
+		createMockPubkeyConverter(),
+		&mock.ChainStorerMock{},
+		testscommon.NewPoolsHolderMock(),
+		nil,
+	)
+
+	assert.Nil(t, ipcf)
+	assert.Equal(t, process.ErrNilEconomicsFeeHandler, err)
 }
 
 func TestNewIntermediateProcessorsContainerFactory(t *testing.T) {
@@ -104,6 +143,7 @@ func TestNewIntermediateProcessorsContainerFactory(t *testing.T) {
 		createMockPubkeyConverter(),
 		&mock.ChainStorerMock{},
 		testscommon.NewPoolsHolderMock(),
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, err)
@@ -121,6 +161,7 @@ func TestIntermediateProcessorsContainerFactory_Create(t *testing.T) {
 		createMockPubkeyConverter(),
 		&mock.ChainStorerMock{},
 		testscommon.NewPoolsHolderMock(),
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, err)

--- a/process/factory/shard/intermediateProcessorsContainerFactory.go
+++ b/process/factory/shard/intermediateProcessorsContainerFactory.go
@@ -20,6 +20,7 @@ type intermediateProcessorsContainerFactory struct {
 	pubkeyConverter  core.PubkeyConverter
 	store            dataRetriever.StorageService
 	poolsHolder      dataRetriever.PoolsHolder
+	economicsFee     process.FeeHandler
 }
 
 // NewIntermediateProcessorsContainerFactory is responsible for creating a new intermediate processors factory object
@@ -30,6 +31,7 @@ func NewIntermediateProcessorsContainerFactory(
 	pubkeyConverter core.PubkeyConverter,
 	store dataRetriever.StorageService,
 	poolsHolder dataRetriever.PoolsHolder,
+	economicsFee process.FeeHandler,
 ) (*intermediateProcessorsContainerFactory, error) {
 
 	if check.IfNil(shardCoordinator) {
@@ -50,6 +52,9 @@ func NewIntermediateProcessorsContainerFactory(
 	if check.IfNil(poolsHolder) {
 		return nil, process.ErrNilPoolsHolder
 	}
+	if check.IfNil(economicsFee) {
+		return nil, process.ErrNilEconomicsFeeHandler
+	}
 
 	return &intermediateProcessorsContainerFactory{
 		shardCoordinator: shardCoordinator,
@@ -58,6 +63,7 @@ func NewIntermediateProcessorsContainerFactory(
 		pubkeyConverter:  pubkeyConverter,
 		store:            store,
 		poolsHolder:      poolsHolder,
+		economicsFee:     economicsFee,
 	}, nil
 }
 
@@ -107,6 +113,7 @@ func (ppcm *intermediateProcessorsContainerFactory) createSmartContractResultsIn
 		ppcm.store,
 		block.SmartContractResultBlock,
 		ppcm.poolsHolder.CurrentBlockTxs(),
+		ppcm.economicsFee,
 	)
 
 	return irp, err
@@ -120,6 +127,7 @@ func (ppcm *intermediateProcessorsContainerFactory) createReceiptIntermediatePro
 		ppcm.store,
 		block.ReceiptBlock,
 		dataRetriever.UnsignedTransactionUnit,
+		ppcm.economicsFee,
 	)
 
 	return irp, err
@@ -133,6 +141,7 @@ func (ppcm *intermediateProcessorsContainerFactory) createBadTransactionsInterme
 		ppcm.store,
 		block.InvalidBlock,
 		dataRetriever.TransactionUnit,
+		ppcm.economicsFee,
 	)
 
 	return irp, err

--- a/process/factory/shard/intermediateProcessorsContainerFactory_test.go
+++ b/process/factory/shard/intermediateProcessorsContainerFactory_test.go
@@ -59,6 +59,7 @@ func TestNewIntermediateProcessorsContainerFactory_NilShardCoord(t *testing.T) {
 		createMockPubkeyConverter(),
 		&mock.ChainStorerMock{},
 		dPool,
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, ipcf)
@@ -76,6 +77,7 @@ func TestNewIntermediateProcessorsContainerFactory_NilMarshalizer(t *testing.T) 
 		createMockPubkeyConverter(),
 		&mock.ChainStorerMock{},
 		dPool,
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, ipcf)
@@ -93,6 +95,7 @@ func TestNewIntermediateProcessorsContainerFactory_NilHasher(t *testing.T) {
 		createMockPubkeyConverter(),
 		&mock.ChainStorerMock{},
 		dPool,
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, ipcf)
@@ -110,6 +113,7 @@ func TestNewIntermediateProcessorsContainerFactory_NilAdrConv(t *testing.T) {
 		nil,
 		&mock.ChainStorerMock{},
 		dPool,
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, ipcf)
@@ -127,10 +131,46 @@ func TestNewIntermediateProcessorsContainerFactory_NilStorer(t *testing.T) {
 		createMockPubkeyConverter(),
 		nil,
 		dPool,
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, ipcf)
 	assert.Equal(t, process.ErrNilStorage, err)
+}
+
+func TestNewIntermediateProcessorsContainerFactory_NilPoolsHolder(t *testing.T) {
+	t.Parallel()
+
+	ipcf, err := shard.NewIntermediateProcessorsContainerFactory(
+		mock.NewMultiShardsCoordinatorMock(3),
+		&mock.MarshalizerMock{},
+		&mock.HasherMock{},
+		createMockPubkeyConverter(),
+		&mock.ChainStorerMock{},
+		nil,
+		&mock.FeeHandlerStub{},
+	)
+
+	assert.Nil(t, ipcf)
+	assert.Equal(t, process.ErrNilPoolsHolder, err)
+}
+
+func TestNewIntermediateProcessorsContainerFactory_NilEconomicsFeeHandler(t *testing.T) {
+	t.Parallel()
+
+	dPool := createDataPools()
+	ipcf, err := shard.NewIntermediateProcessorsContainerFactory(
+		mock.NewMultiShardsCoordinatorMock(3),
+		&mock.MarshalizerMock{},
+		&mock.HasherMock{},
+		createMockPubkeyConverter(),
+		&mock.ChainStorerMock{},
+		dPool,
+		nil,
+	)
+
+	assert.Nil(t, ipcf)
+	assert.Equal(t, process.ErrNilEconomicsFeeHandler, err)
 }
 
 func TestNewIntermediateProcessorsContainerFactory(t *testing.T) {
@@ -144,6 +184,7 @@ func TestNewIntermediateProcessorsContainerFactory(t *testing.T) {
 		createMockPubkeyConverter(),
 		&mock.ChainStorerMock{},
 		dPool,
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, err)
@@ -162,6 +203,7 @@ func TestIntermediateProcessorsContainerFactory_Create(t *testing.T) {
 		createMockPubkeyConverter(),
 		&mock.ChainStorerMock{},
 		dPool,
+		&mock.FeeHandlerStub{},
 	)
 
 	assert.Nil(t, err)


### PR DESCRIPTION
* Fixed out of gas situation created by scrs generated in destination shard and added in one single mini block and sent back to the source shard

**How to be tested**

Repeat scenario in which there are unstaked many nodes, forcing meta to create a mini block with too many scrs, which would lead to a stuck situation in the initial source shard

After the scenario will be finished, search after message "basePostProcessor.splitMiniBlocksIfNeeded: gas limit exceeded". If this message will be found that means that a stuck situation was avoided, by splitting the resulted scrs mini block in more mini blocks each of them containing a limited number of txs, whose gas used is not exceed the max gas limit accepted per one mini block.