### PR TITLE
prevent too much mint

### DIFF
--- a/core/constants.go
+++ b/core/constants.go
@@ -654,3 +654,6 @@ const MinLenArgumentsESDTTransfer = 2
 
 // MinLenArgumentsESDTNFTTransfer defines the minimum length for esdt nft transfer
 const MinLenArgumentsESDTNFTTransfer = 4
+
+// MaxLenForESDTIssueMint defines the maximum length in bytes for the issued/minted balance
+const MaxLenForESDTIssueMint = 100

--- a/process/smartContract/builtInFunctions/esdtLocalMint.go
+++ b/process/smartContract/builtInFunctions/esdtLocalMint.go
@@ -1,6 +1,7 @@
 package builtInFunctions
 
 import (
+	"fmt"
 	"math/big"
 	"sync"
 
@@ -80,6 +81,10 @@ func (e *esdtLocalMint) ProcessBuiltinFunction(
 	err = e.rolesHandler.CheckAllowedToExecute(acntSnd, tokenID, []byte(core.ESDTRoleLocalMint))
 	if err != nil {
 		return nil, err
+	}
+
+	if len(vmInput.Arguments[1]) > core.MaxLenForESDTIssueMint {
+		return nil, fmt.Errorf("%w max length for esdt issue is %d", process.ErrInvalidArguments, core.MaxLenForESDTIssueMint)
 	}
 
 	value := big.NewInt(0).SetBytes(vmInput.Arguments[1])

--- a/process/smartContract/builtInFunctions/esdtLocalMint_test.go
+++ b/process/smartContract/builtInFunctions/esdtLocalMint_test.go
@@ -174,4 +174,16 @@ func TestEsdtLocalMint_ProcessBuiltinFunction_ShouldWork(t *testing.T) {
 		GasRemaining: 450,
 	}
 	require.Equal(t, expectedVMOutput, vmOutput)
+
+	mintTooMuch := make([]byte, 101)
+	mintTooMuch[0] = 1
+	vmOutput, err = esdtLocalMintF.ProcessBuiltinFunction(sndAccout, &mock.AccountWrapMock{}, &vmcommon.ContractCallInput{
+		VMInput: vmcommon.VMInput{
+			CallValue:   big.NewInt(0),
+			Arguments:   [][]byte{[]byte("arg1"), mintTooMuch},
+			GasProvided: 500,
+		},
+	})
+	require.True(t, errors.Is(err, process.ErrInvalidArguments))
+	require.Nil(t, vmOutput)
 }

--- a/vm/systemSmartContracts/esdt.go
+++ b/vm/systemSmartContracts/esdt.go
@@ -546,7 +546,7 @@ func (e *esdt) mint(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
 		return returnCode
 	}
 	if len(args.Arguments[1]) > core.MaxLenForESDTIssueMint {
-		returnMessage := fmt.Sprintf("max length for esdt issue is %d", core.MaxLenForESDTIssueMint)
+		returnMessage := fmt.Sprintf("max length for esdt mint is %d", core.MaxLenForESDTIssueMint)
 		e.eei.AddReturnMessage(returnMessage)
 		return vmcommon.UserError
 	}

--- a/vm/systemSmartContracts/esdt.go
+++ b/vm/systemSmartContracts/esdt.go
@@ -232,6 +232,12 @@ func (e *esdt) issue(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
 		return returnCode
 	}
 
+	if len(args.Arguments[2]) > core.MaxLenForESDTIssueMint {
+		returnMessage := fmt.Sprintf("max length for esdt issue is %d", core.MaxLenForESDTIssueMint)
+		e.eei.AddReturnMessage(returnMessage)
+		return vmcommon.UserError
+	}
+
 	initialSupply := big.NewInt(0).SetBytes(args.Arguments[2])
 	if initialSupply.Cmp(big.NewInt(0)) <= 0 {
 		e.eei.AddReturnMessage(vm.ErrNegativeOrZeroInitialSupply.Error())
@@ -539,6 +545,12 @@ func (e *esdt) mint(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
 	if returnCode != vmcommon.Ok {
 		return returnCode
 	}
+	if len(args.Arguments[1]) > core.MaxLenForESDTIssueMint {
+		returnMessage := fmt.Sprintf("max length for esdt issue is %d", core.MaxLenForESDTIssueMint)
+		e.eei.AddReturnMessage(returnMessage)
+		return vmcommon.UserError
+	}
+
 	mintValue := big.NewInt(0).SetBytes(args.Arguments[1])
 	if mintValue.Cmp(big.NewInt(0)) <= 0 {
 		e.eei.AddReturnMessage("negative or zero mint value")

--- a/vm/systemSmartContracts/esdt_test.go
+++ b/vm/systemSmartContracts/esdt_test.go
@@ -167,7 +167,7 @@ func TestEsdt_ExecuteIssue(t *testing.T) {
 	assert.Equal(t, vmcommon.UserError, output)
 }
 
-func TestEsdt_ExecuteIssueToMuchSupply(t *testing.T) {
+func TestEsdt_ExecuteIssueTooMuchSupply(t *testing.T) {
 	t.Parallel()
 
 	args := createMockArgumentsForESDT()

--- a/vm/systemSmartContracts/esdt_test.go
+++ b/vm/systemSmartContracts/esdt_test.go
@@ -167,6 +167,41 @@ func TestEsdt_ExecuteIssue(t *testing.T) {
 	assert.Equal(t, vmcommon.UserError, output)
 }
 
+func TestEsdt_ExecuteIssueToMuchSupply(t *testing.T) {
+	t.Parallel()
+
+	args := createMockArgumentsForESDT()
+	eei, _ := NewVMContext(
+		&mock.BlockChainHookStub{},
+		hooks.NewVMCryptoHook(),
+		&mock.ArgumentParserMock{},
+		&mock.AccountsStub{},
+		&mock.RaterMock{})
+	args.Eei = eei
+	e, _ := NewESDTSmartContract(args)
+
+	vmInput := &vmcommon.ContractCallInput{
+		VMInput: vmcommon.VMInput{
+			CallerAddr:  []byte("addr"),
+			CallValue:   big.NewInt(0),
+			GasProvided: 100000,
+		},
+		RecipientAddr: []byte("addr"),
+		Function:      "issue",
+	}
+	eei.gasRemaining = vmInput.GasProvided
+
+	vmInput.Arguments = [][]byte{[]byte("name"), []byte("TICKER")}
+	tooMuchToIssue := make([]byte, 101)
+	tooMuchToIssue[0] = 1
+	vmInput.Arguments = append(vmInput.Arguments, tooMuchToIssue)
+	vmInput.Arguments = append(vmInput.Arguments, big.NewInt(10).Bytes())
+	vmInput.CallValue, _ = big.NewInt(0).SetString(args.ESDTSCConfig.BaseIssuingCost, 10)
+	vmInput.GasProvided = args.GasCost.MetaChainSystemSCsCost.ESDTIssue
+	output := e.Execute(vmInput)
+	assert.Equal(t, vmcommon.UserError, output)
+}
+
 func TestEsdt_IssueInvalidNumberOfDecimals(t *testing.T) {
 	t.Parallel()
 
@@ -635,6 +670,10 @@ func TestEsdt_ExecuteMintSavesTokenWithMintedTokensAdded(t *testing.T) {
 	esdtData := &ESDTData{}
 	_ = args.Marshalizer.Unmarshal(esdtData, eei.GetStorage(tokenName))
 	assert.Equal(t, big.NewInt(300), esdtData.MintedValue)
+
+	vmInput.Arguments[1] = make([]byte, 101)
+	returnCode := e.Execute(vmInput)
+	assert.Equal(t, vmcommon.UserError, returnCode)
 }
 
 func TestEsdt_ExecuteMintInvalidDestinationAddressShouldFail(t *testing.T) {


### PR DESCRIPTION
prevents minting and issueing balance with over 100 bytes length