### PR TITLE
Different default shard as observer

### DIFF
--- a/core/converters.go
+++ b/core/converters.go
@@ -201,8 +201,8 @@ func ProcessDestinationShardAsObserver(destinationShardIdAsObserver string) (uin
 	return uint32(val), err
 }
 
-// AssignShardForPubKeyWhenNotSpecified will return the same shard ID when the same seed source is set to the randomizer
-// This function sums all the bytes from the public key and based on a modulo operation it will return a shard ID
+// AssignShardForPubKeyWhenNotSpecified will return the same shard ID when it is called with the same parameters
+// This function fetched the last byte of the public key and based on a modulo operation it will return a shard ID
 func AssignShardForPubKeyWhenNotSpecified(pubKey []byte, numShards uint32) uint32 {
 	if len(pubKey) == 0 {
 		return 0 // should never happen

--- a/core/converters.go
+++ b/core/converters.go
@@ -204,14 +204,14 @@ func ProcessDestinationShardAsObserver(destinationShardIdAsObserver string) (uin
 // AssignShardForPubKeyWhenNotSpecified will return the same shard ID when the same seed source is set to the randomizer
 // This function sums all the bytes from the public key and based on a modulo operation it will return a shard ID
 func AssignShardForPubKeyWhenNotSpecified(pubKey []byte, numShards uint32) uint32 {
-	sum := 0
-	for _, b := range pubKey {
-		sum += int(b)
+	if len(pubKey) == 0 {
+		return 0 // should never happen
 	}
 
+	lastByte := pubKey[len(pubKey)-1]
 	numShardsIncludingMeta := numShards + 1
 
-	randomShardID := uint32(sum) % numShardsIncludingMeta
+	randomShardID := uint32(lastByte) % numShardsIncludingMeta
 	if randomShardID == numShards {
 		randomShardID = MetachainShardId
 	}

--- a/core/converters.go
+++ b/core/converters.go
@@ -200,3 +200,22 @@ func ProcessDestinationShardAsObserver(destinationShardIdAsObserver string) (uin
 
 	return uint32(val), err
 }
+
+// AssignShardForPubKeyWhenNotSpecified will return the same shard ID when the same seed source is set to the randomizer
+// This function sums all the bytes from the public key and based on a modulo operation it will return a shard ID
+func AssignShardForPubKeyWhenNotSpecified(pubKey []byte, numShards uint32) uint32 {
+	sum := 0
+	for _, b := range pubKey {
+		sum += int(b)
+	}
+
+	numShardsIncludingMeta := numShards + 1
+
+	randomShardID := uint32(sum) % numShardsIncludingMeta
+
+	if randomShardID == numShards {
+		randomShardID = MetachainShardId
+	}
+
+	return randomShardID
+}

--- a/core/converters.go
+++ b/core/converters.go
@@ -212,7 +212,6 @@ func AssignShardForPubKeyWhenNotSpecified(pubKey []byte, numShards uint32) uint3
 	numShardsIncludingMeta := numShards + 1
 
 	randomShardID := uint32(sum) % numShardsIncludingMeta
-
 	if randomShardID == numShards {
 		randomShardID = MetachainShardId
 	}

--- a/core/converters_test.go
+++ b/core/converters_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/mock"
+	"github.com/ElrondNetwork/elrond-go/crypto/signing"
+	"github.com/ElrondNetwork/elrond-go/crypto/signing/mcl"
 	"github.com/ElrondNetwork/elrond-go/data/batch"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -272,4 +274,38 @@ func TestAssignShardForPubKeyWhenNotSpecifiedShouldReturnSameShardForSameKey(t *
 	result1 := core.AssignShardForPubKeyWhenNotSpecified(key, numShards)
 
 	require.Equal(t, result0, result1)
+}
+
+func TestShardAssignment(t *testing.T) {
+	t.Skip()
+
+	numShards := uint32(3)
+	counts := map[uint32]uint64{
+		0:                     0,
+		1:                     0,
+		2:                     0,
+		core.MetachainShardId: 0,
+	}
+
+	numAccounts := 1000
+
+	for i := 0; i < numAccounts; i++ {
+		pubKey := generatePubKey()
+		shId := core.AssignShardForPubKeyWhenNotSpecified(pubKey, numShards)
+		counts[shId]++
+	}
+
+	for sh, cnt := range counts {
+		fmt.Printf("Shard %d:\n\t\t%d accounts\n", sh, cnt)
+	}
+
+}
+
+var keyGen = signing.NewKeyGenerator(mcl.NewSuiteBLS12())
+
+func generatePubKey() []byte {
+	_, pk := keyGen.GeneratePair()
+	pkB, _ := pk.ToByteArray()
+
+	return pkB
 }

--- a/core/converters_test.go
+++ b/core/converters_test.go
@@ -243,19 +243,22 @@ func TestAssignShardForPubKeyWhenNotSpecified(t *testing.T) {
 
 	numShards := uint32(3)
 
-	key := []byte{5, 7, 4} // sum = 16 ; 16 % 4 = 0
+	key := []byte{5, 7, 4} // 4 % 4 = 0
 	require.Equal(t, uint32(0), core.AssignShardForPubKeyWhenNotSpecified(key, numShards))
 
-	key = []byte{5, 7, 5} // sum = 17 ; 17 % 4 = 1
+	key = []byte{5, 7, 5} // 5 % 4 = 1
 	require.Equal(t, uint32(1), core.AssignShardForPubKeyWhenNotSpecified(key, numShards))
 
-	key = []byte{5, 7, 6} // sum = 18 ; 18 % 4 = 2
+	key = []byte{5, 7, 6} // 6 % 4 = 2
 	require.Equal(t, uint32(2), core.AssignShardForPubKeyWhenNotSpecified(key, numShards))
 
-	key = []byte{5, 7, 7} // sum = 19 ; 19 % 4 = 3 => metachain
+	key = []byte{5, 7, 7} // 7 % 4 = 3 => metachain
 	require.Equal(t, core.MetachainShardId, core.AssignShardForPubKeyWhenNotSpecified(key, numShards))
 
-	key = []byte{5, 7, 8} // sum = 20 ; 20 % 4 = 0
+	key = []byte{5, 7, 8} // 8 % 4 = 0
+	require.Equal(t, uint32(0), core.AssignShardForPubKeyWhenNotSpecified(key, numShards))
+
+	key = []byte{} // empty
 	require.Equal(t, uint32(0), core.AssignShardForPubKeyWhenNotSpecified(key, numShards))
 }
 

--- a/core/converters_test.go
+++ b/core/converters_test.go
@@ -279,6 +279,14 @@ func TestAssignShardForPubKeyWhenNotSpecifiedShouldReturnSameShardForSameKey(t *
 func TestShardAssignment(t *testing.T) {
 	t.Skip()
 
+	keyGen := signing.NewKeyGenerator(mcl.NewSuiteBLS12())
+	generatePubKey := func() []byte {
+		_, pk := keyGen.GeneratePair()
+		pkB, _ := pk.ToByteArray()
+
+		return pkB
+	}
+
 	numShards := uint32(3)
 	counts := map[uint32]uint64{
 		0:                     0,
@@ -299,13 +307,4 @@ func TestShardAssignment(t *testing.T) {
 		fmt.Printf("Shard %d:\n\t\t%d accounts\n", sh, cnt)
 	}
 
-}
-
-var keyGen = signing.NewKeyGenerator(mcl.NewSuiteBLS12())
-
-func generatePubKey() []byte {
-	_, pk := keyGen.GeneratePair()
-	pkB, _ := pk.ToByteArray()
-
-	return pkB
 }

--- a/factory/shardingFactory.go
+++ b/factory/shardingFactory.go
@@ -40,8 +40,7 @@ func CreateShardCoordinator(
 		if selfShardId == core.DisabledShardIDAsObserver {
 			pubKeyBytes, err := pubKey.ToByteArray()
 			if err != nil {
-				log.Warn("cannot get public key bytes", "error", err)
-				return nil, core.NodeTypeObserver, err
+				return nil, core.NodeTypeObserver, fmt.Errorf("%w while assigning random shard ID for observer", err)
 			}
 
 			selfShardId = core.AssignShardForPubKeyWhenNotSpecified(pubKeyBytes, nodesConfig.NumberOfShards())
@@ -108,8 +107,7 @@ func CreateNodesCoordinator(
 	if shardIDAsObserver == core.DisabledShardIDAsObserver {
 		pubKeyBytes, err := pubKey.ToByteArray()
 		if err != nil {
-			log.Warn("cannot get public key bytes", "error", err)
-			return nil, err
+			return nil, fmt.Errorf("%w while assigning random shard ID for observer", err)
 		}
 
 		shardIDAsObserver = core.AssignShardForPubKeyWhenNotSpecified(pubKeyBytes, nodesConfig.NumberOfShards())

--- a/factory/shardingFactory.go
+++ b/factory/shardingFactory.go
@@ -38,7 +38,13 @@ func CreateShardCoordinator(
 			return nil, "", err
 		}
 		if selfShardId == core.DisabledShardIDAsObserver {
-			selfShardId = uint32(0)
+			pubKeyBytes, err := pubKey.ToByteArray()
+			if err != nil {
+				log.Warn("cannot get public key bytes", "error", err)
+				return nil, core.NodeTypeObserver, err
+			}
+
+			selfShardId = core.AssignShardForPubKeyWhenNotSpecified(pubKeyBytes, nodesConfig.NumberOfShards())
 		}
 	}
 	if err != nil {
@@ -100,7 +106,13 @@ func CreateNodesCoordinator(
 		return nil, err
 	}
 	if shardIDAsObserver == core.DisabledShardIDAsObserver {
-		shardIDAsObserver = uint32(0)
+		pubKeyBytes, err := pubKey.ToByteArray()
+		if err != nil {
+			log.Warn("cannot get public key bytes", "error", err)
+			return nil, err
+		}
+
+		shardIDAsObserver = core.AssignShardForPubKeyWhenNotSpecified(pubKeyBytes, nodesConfig.NumberOfShards())
 	}
 
 	nbShards := nodesConfig.NumberOfShards()


### PR DESCRIPTION
Before this fix, if no destination shard as observer was set (so `DestinationShardAsObserver = "disabled"` in `prefs.toml`) then the "chosen" shard would have been `0`. In order to avoid this, a random (or at least one that isn't always `0`) shard should be generated.

Because the default `0` value was set in multiple instances, a deterministic algorithm for the same entry was needed. So, the last byte from the public key is divided by the number of shards, assigning the reminder to the shard ID.