### PR TITLE
epochStart: adjust eoe economics invariant to consider carry blocks

### DIFF
--- a/epochStart/metachain/economics.go
+++ b/epochStart/metachain/economics.go
@@ -186,7 +186,8 @@ func (e *economics) ComputeEndOfEpochEconomics(
 		rewardsForProtocolSustainability,
 	)
 
-	err = e.checkEconomicsInvariants(computedEconomics, inflationRate, maxBlocksInEpoch, totalNumBlocksInEpoch, metaBlock, metaBlock.Epoch)
+	maxPossibleNotarizedBlocks := e.maxPossibleNotarizedBlocks(metaBlock.Round, prevEpochStart)
+	err = e.checkEconomicsInvariants(computedEconomics, inflationRate, maxBlocksInEpoch, totalNumBlocksInEpoch, metaBlock, metaBlock.Epoch, maxPossibleNotarizedBlocks)
 	if err != nil {
 		log.Warn("ComputeEndOfEpochEconomics", "error", err.Error())
 
@@ -406,6 +407,15 @@ func (e *economics) startNoncePerShardFromEpochStart(epoch uint32) (map[uint32]u
 	return mapShardIdNonce, previousEpochStartMeta, nil
 }
 
+func (e *economics) maxPossibleNotarizedBlocks(currentRound uint64, prev *block.MetaBlock) uint64 {
+	maxBlocks := uint64(0)
+	for _, shardData := range prev.EpochStart.LastFinalizedHeaders {
+		maxBlocks += currentRound - shardData.Round
+	}
+
+	return maxBlocks
+}
+
 func (e *economics) startNoncePerShardFromLastCrossNotarized(metaNonce uint64, epochStart block.EpochStart) (map[uint32]uint64, error) {
 	mapShardIdNonce := make(map[uint32]uint64, e.shardCoordinator.NumberOfShards()+1)
 	for i := uint32(0); i < e.shardCoordinator.NumberOfShards(); i++ {
@@ -427,6 +437,7 @@ func (e *economics) checkEconomicsInvariants(
 	totalNumBlocksInEpoch uint64,
 	metaBlock *block.MetaBlock,
 	epoch uint32,
+	maxPossibleNotarizedBlocks uint64,
 ) error {
 	if epoch <= e.stakingV2EnableEpoch {
 		return nil
@@ -449,7 +460,12 @@ func (e *economics) checkEconomicsInvariants(
 		)
 	}
 
-	inflationPerEpoch := e.computeInflationForEpoch(inflationRate, maxBlocksInEpoch)
+	actualMaxBlocks := maxBlocksInEpoch
+	if maxPossibleNotarizedBlocks > actualMaxBlocks{
+		actualMaxBlocks = maxPossibleNotarizedBlocks
+	}
+
+	inflationPerEpoch := e.computeInflationForEpoch(inflationRate, actualMaxBlocks)
 	maxRewardsInEpoch := core.GetIntTrimmedPercentageOfValue(computedEconomics.TotalSupply, inflationPerEpoch)
 	if maxRewardsInEpoch.Cmp(metaBlock.AccumulatedFeesInEpoch) < 0 {
 		maxRewardsInEpoch = metaBlock.AccumulatedFeesInEpoch
@@ -462,7 +478,6 @@ func (e *economics) checkEconomicsInvariants(
 			maxRewardsInEpoch,
 		)
 	}
-
 	if !core.IsInRangeInclusive(computedEconomics.TotalNewlyMinted, zero, maxRewardsInEpoch) {
 		return fmt.Errorf("%w, computed minted tokens %s, max allowed %s",
 			epochStart.ErrInvalidAmountMintedTokens,

--- a/epochStart/metachain/economics.go
+++ b/epochStart/metachain/economics.go
@@ -412,6 +412,8 @@ func (e *economics) maxPossibleNotarizedBlocks(currentRound uint64, prev *block.
 	for _, shardData := range prev.EpochStart.LastFinalizedHeaders {
 		maxBlocks += currentRound - shardData.Round
 	}
+	// For metaChain blocks
+	maxBlocks += currentRound - prev.Round
 
 	return maxBlocks
 }
@@ -461,7 +463,7 @@ func (e *economics) checkEconomicsInvariants(
 	}
 
 	actualMaxBlocks := maxBlocksInEpoch
-	if maxPossibleNotarizedBlocks > actualMaxBlocks{
+	if maxPossibleNotarizedBlocks > actualMaxBlocks {
 		actualMaxBlocks = maxPossibleNotarizedBlocks
 	}
 

--- a/epochStart/metachain/economics_test.go
+++ b/epochStart/metachain/economics_test.go
@@ -1217,7 +1217,8 @@ func TestEconomics_checkEconomicsInvariantsV1ReturnsOK(t *testing.T) {
 		300,
 		260,
 		metaBlock,
-		1)
+		1,
+		300)
 	require.Nil(t, err)
 }
 
@@ -1240,7 +1241,8 @@ func TestEconomics_checkEconomicsInvariantsInflationOutOfRange(t *testing.T) {
 		300,
 		260,
 		metaBlock,
-		1)
+		1,
+		300)
 
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), epochStart.ErrInvalidInflationRate.Error())
@@ -1252,7 +1254,8 @@ func TestEconomics_checkEconomicsInvariantsInflationOutOfRange(t *testing.T) {
 		300,
 		260,
 		metaBlock,
-		1)
+		1,
+		300)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), epochStart.ErrInvalidInflationRate.Error())
 }
@@ -1280,7 +1283,8 @@ func TestEconomics_checkEconomicsInvariantsAccumulatedFeesOutOfRange(t *testing.
 		maxBlocksInEpoch,
 		260,
 		metaBlock,
-		1)
+		1,
+		300)
 
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), epochStart.ErrInvalidAccumulatedFees.Error())
@@ -1294,7 +1298,8 @@ func TestEconomics_checkEconomicsInvariantsAccumulatedFeesOutOfRange(t *testing.
 		300,
 		260,
 		metaBlock,
-		1)
+		1,
+		300)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), epochStart.ErrInvalidAccumulatedFees.Error())
 }
@@ -1322,7 +1327,8 @@ func TestEconomics_checkEconomicsInvariantsRewardsForProtocolSustainabilityOutOf
 		maxBlocksInEpoch,
 		260,
 		metaBlock,
-		1)
+		1,
+		300)
 
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), epochStart.ErrInvalidEstimatedProtocolSustainabilityRewards.Error())
@@ -1336,7 +1342,8 @@ func TestEconomics_checkEconomicsInvariantsRewardsForProtocolSustainabilityOutOf
 		300,
 		260,
 		metaBlock,
-		1)
+		1,
+		300)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), epochStart.ErrInvalidEstimatedProtocolSustainabilityRewards.Error())
 }
@@ -1364,7 +1371,8 @@ func TestEconomics_checkEconomicsInvariantsMintedOutOfRange(t *testing.T) {
 		maxBlocksInEpoch,
 		260,
 		metaBlock,
-		1)
+		1,
+		300)
 
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), epochStart.ErrInvalidAmountMintedTokens.Error())
@@ -1378,7 +1386,8 @@ func TestEconomics_checkEconomicsInvariantsMintedOutOfRange(t *testing.T) {
 		300,
 		260,
 		metaBlock,
-		1)
+		1,
+		300)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), epochStart.ErrInvalidAmountMintedTokens.Error())
 }
@@ -1406,7 +1415,8 @@ func TestEconomics_checkEconomicsInvariantsTotalToDistributeOutOfRange(t *testin
 		maxBlocksInEpoch,
 		260,
 		metaBlock,
-		1)
+		1,
+		300)
 
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), epochStart.ErrInvalidTotalToDistribute.Error())
@@ -1420,7 +1430,8 @@ func TestEconomics_checkEconomicsInvariantsTotalToDistributeOutOfRange(t *testin
 		300,
 		260,
 		metaBlock,
-		1)
+		1,
+		300)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), epochStart.ErrInvalidTotalToDistribute.Error())
 }
@@ -1448,7 +1459,8 @@ func TestEconomics_checkEconomicsInvariantsSumRewardsOutOfRange(t *testing.T) {
 		maxBlocksInEpoch,
 		260,
 		metaBlock,
-		1)
+		1,
+		maxBlocksInEpoch)
 
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), epochStart.ErrInvalidRewardsPerBlock.Error())
@@ -1462,7 +1474,8 @@ func TestEconomics_checkEconomicsInvariantsSumRewardsOutOfRange(t *testing.T) {
 		300,
 		260,
 		metaBlock,
-		1)
+		1,
+		300)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), epochStart.ErrInvalidRewardsPerBlock.Error())
 }
@@ -1488,7 +1501,35 @@ func TestEconomics_checkEconomicsInvariantsV2ReturnsOK(t *testing.T) {
 		maxBlocksInEpoch,
 		260,
 		metaBlock,
-		1)
+		1,
+		maxBlocksInEpoch)
+	require.Nil(t, err)
+}
+
+func TestEconomics_checkEconomicsInvariantsV2ExtraBlocksNotarized(t *testing.T) {
+	t.Parallel()
+
+	totalSupply, _ := big.NewInt(0).SetString("20000000000000000000000000", 10) // 20 Million EGLD
+	nodePrice, _ := big.NewInt(0).SetString("1000000000000000000000", 10)       // 1000 EGLD
+	roundDuration := 4
+
+	stakingV2EnableEpoch := uint32(0)
+	args := createArgsForComputeEndOfEpochEconomics(roundDuration, totalSupply, nodePrice, stakingV2EnableEpoch)
+	ec, _ := NewEndOfEpochEconomicsDataCreator(args)
+	maxBlocksInEpoch := uint64(300)
+	inflationRate := 0.1
+	extraBlocksNotarized := uint64(100)
+	actualInflationPerEpochWithCarry := ec.computeInflationForEpoch(inflationRate, maxBlocksInEpoch+extraBlocksNotarized)
+	computedEconomics, metaBlock := defaultComputedEconomicsAndMetaBlock(totalSupply, actualInflationPerEpochWithCarry)
+
+	err := ec.checkEconomicsInvariants(
+		*computedEconomics,
+		inflationRate,
+		maxBlocksInEpoch,
+		260,
+		metaBlock,
+		1,
+		maxBlocksInEpoch+extraBlocksNotarized)
 	require.Nil(t, err)
 }
 


### PR DESCRIPTION
This PR adjusts the economic invariant to take into consideration the blocks unnotarized in a previous epoch that were notarized in the last epoch.