### PR TITLE
ESDT system SC correct initialization at end-of-epoch

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -2242,6 +2242,11 @@ func newMetaBlockProcessor(
 		EpochNotifier:           epochNotifier,
 	}
 
+	esdtOwnerAddress, err := stateComponents.AddressPubkeyConverter.Decode(systemSCConfig.ESDTSystemSCConfig.OwnerAddress)
+	if err != nil {
+		return nil, fmt.Errorf("%w while decoding systemSCConfig.ESDTSystemSCConfig.OwnerAddress in structs.go", err)
+	}
+
 	argsEpochSystemSC := metachainEpochStart.ArgsNewEpochStartSystemSCProcessing{
 		SystemVM:                               systemVM,
 		UserAccountsDB:                         stateComponents.AccountsAdapter,
@@ -2262,6 +2267,9 @@ func newMetaBlockProcessor(
 		StakingDataProvider:                    stakingDataProvider,
 		NodesConfigProvider:                    nodesCoordinator,
 		ShardCoordinator:                       shardCoordinator,
+		CorrectLastUnJailEnableEpoch:           systemSCConfig.StakingSystemSCConfig.CorrectLastUnjailedEpoch,
+		ESDTOwnerAddressBytes:                  esdtOwnerAddress,
+		ESDTEnableEpoch:                        systemSCConfig.ESDTSystemSCConfig.EnabledEpoch,
 	}
 	epochStartSystemSCProcessor, err := metachainEpochStart.NewSystemSCProcessor(argsEpochSystemSC)
 	if err != nil {

--- a/epochStart/errors.go
+++ b/epochStart/errors.go
@@ -310,3 +310,6 @@ var ErrInvalidRewardsPerBlock = errors.New("invalid rewards per block")
 
 // ErrResetLastUnJailedFromQueue signals that reset unjailed from queue failed
 var ErrResetLastUnJailedFromQueue = errors.New("reset last unjailed from queue failed")
+
+// ErrEmptyESDTOwnerAddress signals that an empty ESDT owner address was provided
+var ErrEmptyESDTOwnerAddress = errors.New("empty ESDT owner address")

--- a/epochStart/metachain/systemSCs.go
+++ b/epochStart/metachain/systemSCs.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"math/big"
 	"sort"
 
@@ -44,7 +45,9 @@ type ArgsNewEpochStartSystemSCProcessing struct {
 	DelegationEnableEpoch                  uint32
 	StakingV2EnableEpoch                   uint32
 	CorrectLastUnJailEnableEpoch           uint32
+	ESDTEnableEpoch                        uint32
 	MaxNodesEnableConfig                   []config.MaxNodesChangeConfig
+	ESDTOwnerAddressBytes                  []byte
 
 	GenesisNodesConfig  sharding.GenesisNodesSetupHandler
 	EpochNotifier       process.EpochNotifier
@@ -71,6 +74,7 @@ type systemSCProcessor struct {
 	delegationEnableEpoch          uint32
 	stakingV2EnableEpoch           uint32
 	correctLastUnJailEpoch         uint32
+	esdtEnableEpoch                uint32
 	maxNodesEnableConfig           []config.MaxNodesChangeConfig
 	maxNodes                       uint32
 	flagSwitchJailedWaiting        atomic.Flag
@@ -80,6 +84,8 @@ type systemSCProcessor struct {
 	flagChangeMaxNodesEnabled      atomic.Flag
 	flagStakingV2Enabled           atomic.Flag
 	flagCorrectLastUnjailedEnabled atomic.Flag
+	flagESDTEnabled                atomic.Flag
+	esdtOwnerAddressBytes          []byte
 	mapNumSwitchedPerShard         map[uint32]uint32
 	mapNumSwitchablePerShard       map[uint32]uint32
 }
@@ -145,6 +151,9 @@ func NewSystemSCProcessor(args ArgsNewEpochStartSystemSCProcessing) (*systemSCPr
 	if check.IfNil(args.ShardCoordinator) {
 		return nil, epochStart.ErrNilShardCoordinator
 	}
+	if len(args.ESDTOwnerAddressBytes) == 0 {
+		return nil, epochStart.ErrEmptyESDTOwnerAddress
+	}
 
 	s := &systemSCProcessor{
 		systemVM:                 args.SystemVM,
@@ -163,10 +172,12 @@ func NewSystemSCProcessor(args ArgsNewEpochStartSystemSCProcessing) (*systemSCPr
 		hystNodesEnableEpoch:     args.SwitchHysteresisForMinNodesEnableEpoch,
 		delegationEnableEpoch:    args.DelegationEnableEpoch,
 		stakingV2EnableEpoch:     args.StakingV2EnableEpoch,
+		esdtEnableEpoch:          args.ESDTEnableEpoch,
 		stakingDataProvider:      args.StakingDataProvider,
 		nodesConfigProvider:      args.NodesConfigProvider,
 		shardCoordinator:         args.ShardCoordinator,
 		correctLastUnJailEpoch:   args.CorrectLastUnJailEnableEpoch,
+		esdtOwnerAddressBytes:    args.ESDTOwnerAddressBytes,
 	}
 
 	s.maxNodesEnableConfig = make([]config.MaxNodesChangeConfig, len(args.MaxNodesEnableConfig))
@@ -251,6 +262,14 @@ func (s *systemSCProcessor) ProcessSystemSmartContract(
 		err = s.stakeNodesFromQueue(validatorInfos, numUnStaked, nonce)
 		if err != nil {
 			return err
+		}
+	}
+
+	if s.flagESDTEnabled.IsSet() {
+		err := s.initESDT()
+		if err != nil {
+			//not a critical error
+			log.Error("error while initializing ESDT", "err", err)
 		}
 	}
 
@@ -1247,6 +1266,65 @@ func (s *systemSCProcessor) addNewlyStakedNodesToValidatorTrie(
 	return nil
 }
 
+func (s *systemSCProcessor) initESDT() error {
+	currentConfigValues, err := s.extractConfigFromESDTContract()
+	if err != nil {
+		return err
+	}
+
+	return s.changeESDTOwner(currentConfigValues)
+}
+
+func (s *systemSCProcessor) extractConfigFromESDTContract() ([][]byte, error) {
+	vmInput := &vmcommon.ContractCallInput{
+		VMInput: vmcommon.VMInput{
+			CallerAddr:  s.endOfEpochCallerAddress,
+			Arguments:   [][]byte{},
+			CallValue:   big.NewInt(0),
+			GasProvided: math.MaxUint64,
+		},
+		Function:      "getContractConfig",
+		RecipientAddr: vm.ESDTSCAddress,
+	}
+
+	output, err := s.systemVM.RunSmartContractCall(vmInput)
+	if err != nil {
+		return nil, err
+	}
+	if len(output.ReturnData) != 4 {
+		return nil, fmt.Errorf("%w getContractConfig should have returned 4 values", epochStart.ErrInvalidSystemSCReturn)
+	}
+
+	return output.ReturnData, nil
+}
+
+func (s *systemSCProcessor) changeESDTOwner(currentConfigValues [][]byte) error {
+	baseIssuingCost := currentConfigValues[1]
+	minTokenNameLength := currentConfigValues[2]
+	maxTokenNameLength := currentConfigValues[3]
+
+	vmInput := &vmcommon.ContractCallInput{
+		VMInput: vmcommon.VMInput{
+			CallerAddr:  s.endOfEpochCallerAddress,
+			Arguments:   [][]byte{s.esdtOwnerAddressBytes, baseIssuingCost, minTokenNameLength, maxTokenNameLength},
+			CallValue:   big.NewInt(0),
+			GasProvided: math.MaxUint64,
+		},
+		Function:      "configChange",
+		RecipientAddr: vm.ESDTSCAddress,
+	}
+
+	output, err := s.systemVM.RunSmartContractCall(vmInput)
+	if err != nil {
+		return err
+	}
+	if output.ReturnCode != vmcommon.Ok {
+		return fmt.Errorf("%w changeESDTOwner should have returned Ok", epochStart.ErrInvalidSystemSCReturn)
+	}
+
+	return s.processSCOutputAccounts(output)
+}
+
 // IsInterfaceNil returns true if underlying object is nil
 func (s *systemSCProcessor) IsInterfaceNil() bool {
 	return s == nil
@@ -1287,4 +1365,7 @@ func (s *systemSCProcessor) EpochConfirmed(epoch uint32) {
 
 	s.flagCorrectLastUnjailedEnabled.Toggle(epoch == s.correctLastUnJailEpoch)
 	log.Debug("systemSCProcessor: correct last unjailed", "enabled", s.flagCorrectLastUnjailedEnabled.IsSet())
+
+	s.flagESDTEnabled.Toggle(epoch == s.esdtEnableEpoch)
+	log.Debug("systemSCProcessor: ESDT", "enabled", s.flagESDTEnabled.IsSet())
 }

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -1149,19 +1149,23 @@ func TestSystemSCProcessor_ESDTInitShouldWork(t *testing.T) {
 	args.EpochNotifier.CheckEpoch(1)
 	s, _ := NewSystemSCProcessor(args)
 
-	contractConfig, err := s.extractConfigFromESDTContract()
+	initialContractConfig, err := s.extractConfigFromESDTContract()
 	require.Nil(t, err)
-	require.Equal(t, 4, len(contractConfig))
-	require.Equal(t, []byte("aaaaaa"), contractConfig[0])
+	require.Equal(t, 4, len(initialContractConfig))
+	require.Equal(t, []byte("aaaaaa"), initialContractConfig[0])
 
 	err = s.ProcessSystemSmartContract(nil, 1, 1)
 
 	require.Nil(t, err)
 
-	contractConfig, err = s.extractConfigFromESDTContract()
+	updatedContractConfig, err := s.extractConfigFromESDTContract()
 	require.Nil(t, err)
-	require.Equal(t, 4, len(contractConfig))
-	require.Equal(t, args.ESDTOwnerAddressBytes, contractConfig[0])
+	require.Equal(t, 4, len(updatedContractConfig))
+	require.Equal(t, args.ESDTOwnerAddressBytes, updatedContractConfig[0])
+	//the other config values should be unchanged
+	for i := 1; i < len(initialContractConfig); i++ {
+		assert.Equal(t, initialContractConfig[i], updatedContractConfig[i])
+	}
 }
 
 func TestSystemSCProcessor_ProcessSystemSmartContractUnStakeOneNodeStakeOthers(t *testing.T) {

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -1884,6 +1884,8 @@ func (tpn *TestProcessorNode) initBlockProcessor(stateCheckpointModulus uint) {
 			StakingDataProvider:     stakingDataProvider,
 			NodesConfigProvider:     tpn.NodesCoordinator,
 			ShardCoordinator:        tpn.ShardCoordinator,
+			ESDTEnableEpoch:         0,
+			ESDTOwnerAddressBytes:   vm.EndOfEpochAddress,
 		}
 		epochStartSystemSCProcessor, _ := metachain.NewSystemSCProcessor(argsEpochSystemSC)
 		tpn.EpochStartSystemSCProcessor = epochStartSystemSCProcessor

--- a/vm/errors.go
+++ b/vm/errors.go
@@ -84,7 +84,7 @@ var ErrNilMessageSignVerifier = errors.New("nil message sign verifier")
 var ErrNilStakingSmartContractAddress = errors.New("nil staking smart contract address")
 
 // ErrNilEndOfEpochSmartContractAddress signals that the end of epoch smart contract address is nil
-var ErrNilEndOfEpochSmartContractAddress = errors.New("nil end of epoch contract address")
+var ErrNilEndOfEpochSmartContractAddress = errors.New("nil end of epoch smart contract address")
 
 // ErrNilArgumentsParser signals that arguments parses is nil
 var ErrNilArgumentsParser = errors.New("nil arguments parser")

--- a/vm/errors.go
+++ b/vm/errors.go
@@ -83,11 +83,11 @@ var ErrNilMessageSignVerifier = errors.New("nil message sign verifier")
 // ErrNilStakingSmartContractAddress signals that staking smart contract address is nil
 var ErrNilStakingSmartContractAddress = errors.New("nil staking smart contract address")
 
+// ErrNilEndOfEpochSmartContractAddress signals that the end of epoch smart contract address is nil
+var ErrNilEndOfEpochSmartContractAddress = errors.New("nil end of epoch contract address")
+
 // ErrNilArgumentsParser signals that arguments parses is nil
 var ErrNilArgumentsParser = errors.New("nil arguments parser")
-
-// ErrOnExecutionAtStakingSC signals that there was an error at staking sc call
-var ErrOnExecutionAtStakingSC = errors.New("execution error at staking sc")
 
 // ErrNilValidatorSmartContractAddress signals that validator smart contract address is nil
 var ErrNilValidatorSmartContractAddress = errors.New("nil validator smart contract address")

--- a/vm/factory/systemSCFactory.go
+++ b/vm/factory/systemSCFactory.go
@@ -203,6 +203,7 @@ func (scf *systemSCFactory) createESDTContract() (vm.SystemSmartContract, error)
 		ESDTSCConfig:           scf.systemSCConfig.ESDTSystemSCConfig,
 		EpochNotifier:          scf.epochNotifier,
 		AddressPubKeyConverter: scf.addressPubKeyConverter,
+		EndOfEpochSCAddress:    vm.EndOfEpochAddress,
 	}
 	esdt, err := systemSmartContracts.NewESDTSmartContract(argsESDT)
 	return esdt, err

--- a/vm/systemSmartContracts/esdt.go
+++ b/vm/systemSmartContracts/esdt.go
@@ -87,6 +87,9 @@ func NewESDTSmartContract(args ArgsNewESDTSmartContract) (*esdt, error) {
 	if check.IfNil(args.AddressPubKeyConverter) {
 		return nil, vm.ErrNilAddressPubKeyConverter
 	}
+	if len(args.EndOfEpochSCAddress) == 0 {
+		return nil, vm.ErrNilEndOfEpochSmartContractAddress
+	}
 
 	baseIssuingCost, okConvert := big.NewInt(0).SetString(args.ESDTSCConfig.BaseIssuingCost, conversionBase)
 	if !okConvert || baseIssuingCost.Cmp(big.NewInt(0)) < 0 {
@@ -94,9 +97,11 @@ func NewESDTSmartContract(args ArgsNewESDTSmartContract) (*esdt, error) {
 	}
 
 	e := &esdt{
-		eei:                    args.Eei,
-		gasCost:                args.GasCost,
-		baseIssuingCost:        baseIssuingCost,
+		eei:             args.Eei,
+		gasCost:         args.GasCost,
+		baseIssuingCost: baseIssuingCost,
+		//we should have called pubkeyConverter.Decode here instead of a byte slice cast. Since that change would break
+		//backwards compatibility, the fix was carried in the epochStart/metachain/systemSCs.go
 		ownerAddress:           []byte(args.ESDTSCConfig.OwnerAddress),
 		eSDTSCAddress:          args.ESDTSCAddress,
 		hasher:                 args.Hasher,
@@ -175,6 +180,8 @@ func (e *esdt) Execute(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
 		return e.stopNFTCreateForever(args)
 	case "getAllAddressesAndRoles":
 		return e.getAllAddressesAndRoles(args)
+	case "getContractConfig":
+		return e.getContractConfig(args)
 	}
 
 	e.eei.AddReturnMessage("invalid method to call")
@@ -762,7 +769,8 @@ func (e *esdt) togglePause(args *vmcommon.ContractCallInput, builtInFunc string)
 }
 
 func (e *esdt) configChange(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
-	if !bytes.Equal(args.CallerAddr, e.ownerAddress) {
+	icCorrectCaller := bytes.Equal(args.CallerAddr, e.ownerAddress) || bytes.Equal(args.CallerAddr, e.endOfEpochSCAddress)
+	if !icCorrectCaller {
 		e.eei.AddReturnMessage("configChange can be called by whitelisted address only")
 		return vmcommon.UserError
 	}
@@ -1435,6 +1443,44 @@ func (e *esdt) isAddressValid(addressBytes []byte) bool {
 // CanUseContract returns true if contract can be used
 func (e *esdt) CanUseContract() bool {
 	return true
+}
+
+func (e *esdt) getContractConfig(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
+	returnCode := e.checkArgumentsForGeneralViewFunc(args)
+	if returnCode != vmcommon.Ok {
+		return returnCode
+	}
+
+	esdtConfig, err := e.getESDTConfig()
+	if err != nil {
+		e.eei.AddReturnMessage(err.Error())
+		return vmcommon.UserError
+	}
+
+	e.eei.Finish(esdtConfig.OwnerAddress)
+	e.eei.Finish(esdtConfig.BaseIssuingCost.Bytes())
+	e.eei.Finish(big.NewInt(int64(esdtConfig.MinTokenNameLength)).Bytes())
+	e.eei.Finish(big.NewInt(int64(esdtConfig.MaxTokenNameLength)).Bytes())
+
+	return vmcommon.Ok
+}
+
+func (e *esdt) checkArgumentsForGeneralViewFunc(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
+	if args.CallValue.Cmp(zero) != 0 {
+		e.eei.AddReturnMessage(vm.ErrCallValueMustBeZero.Error())
+		return vmcommon.UserError
+	}
+	err := e.eei.UseGas(e.gasCost.MetaChainSystemSCsCost.ESDTOperations)
+	if err != nil {
+		e.eei.AddReturnMessage(err.Error())
+		return vmcommon.OutOfGas
+	}
+	if len(args.Arguments) != 0 {
+		e.eei.AddReturnMessage(vm.ErrInvalidNumOfArguments.Error())
+		return vmcommon.UserError
+	}
+
+	return vmcommon.Ok
 }
 
 // IsInterfaceNil returns true if underlying object is nil

--- a/vm/systemSmartContracts/esdt.go
+++ b/vm/systemSmartContracts/esdt.go
@@ -769,8 +769,8 @@ func (e *esdt) togglePause(args *vmcommon.ContractCallInput, builtInFunc string)
 }
 
 func (e *esdt) configChange(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
-	icCorrectCaller := bytes.Equal(args.CallerAddr, e.ownerAddress) || bytes.Equal(args.CallerAddr, e.endOfEpochSCAddress)
-	if !icCorrectCaller {
+	isCorrectCaller := bytes.Equal(args.CallerAddr, e.ownerAddress) || bytes.Equal(args.CallerAddr, e.endOfEpochSCAddress)
+	if !isCorrectCaller {
 		e.eei.AddReturnMessage("configChange can be called by whitelisted address only")
 		return vmcommon.UserError
 	}


### PR DESCRIPTION
- Fixed the ESDT bad initialization of the owner address. At the end of epoch, when the ESDT will be activated, the ESDT owner will be re-rewritten in the contract in the correct form. After that, some contract APIs like `configChange` will work as expected.

Testing scenario: launch a testnet, wait until ESDT feature becomes active (epoch 4) and try issue an ESDT with a base issuing value less than 5 eGLD. The transaction should fail. When trying to issue an ESDT with 5 eGLD, it should work. Use the `erd1fpkcgel4gcmh8zqqdt043yfcn5tyx8373kg6q2qmkxzu4dqamc0swts65c` address (pem file is located in elrond-go/cmd/node/testKeys/esdtWalletKey.pem) to send a transaction with the following parameters:
```
- sender: erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u
- value: 0 eGLD
- gas limit: 51000000
- data: configChange@486d8467f546377388006adf5891389d16431e3e8d91a0281bb185cab41dde1f@b1a2bc2ec50000@0a@14
```
Meaning: "change the ESDT configuration: set the owner to 486d8467f546377388006adf5891389d16431e3e8d91a0281bb185cab41dde1f which is erd1fpkcgel4gcmh8zqqdt043yfcn5tyx8373kg6q2qmkxzu4dqamc0swts65c, set the base issuing cost to 0.05 eGLD and set the minimum and maximum name lengths to 10 and 20 respectively"
The transaction should succeed.
Now, try issuing a new ESDT token with 0.05eGLD. The token should be issued (transaction succeeded).