### PR TITLE
balanced destination shard as observer

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -1869,7 +1869,12 @@ func createShardCoordinator(
 			return nil, "", err
 		}
 		if selfShardId == core.DisabledShardIDAsObserver {
-			selfShardId = uint32(0)
+			pubKeyBytes, err := pubKey.ToByteArray()
+			if err != nil {
+				return nil, core.NodeTypeObserver, fmt.Errorf("%w while assigning random shard ID for observer", err)
+			}
+
+			selfShardId = core.AssignShardForPubKeyWhenNotSpecified(pubKeyBytes, nodesConfig.NumberOfShards())
 		}
 	}
 	if err != nil {
@@ -1914,7 +1919,12 @@ func createNodesCoordinator(
 		return nil, nil, err
 	}
 	if shardIDAsObserver == core.DisabledShardIDAsObserver {
-		shardIDAsObserver = uint32(0)
+		pubKeyBytes, err := pubKey.ToByteArray()
+		if err != nil {
+			return nil, nil, fmt.Errorf("%w while assigning random shard ID for observer", err)
+		}
+
+		shardIDAsObserver = core.AssignShardForPubKeyWhenNotSpecified(pubKeyBytes, nodesConfig.NumberOfShards())
 	}
 
 	nbShards := nodesConfig.NumberOfShards()

--- a/core/converters.go
+++ b/core/converters.go
@@ -177,3 +177,21 @@ func ConvertToEvenHexBigInt(value *big.Int) string {
 
 	return str
 }
+
+// AssignShardForPubKeyWhenNotSpecified will return the same shard ID when it is called with the same parameters
+// This function fetched the last byte of the public key and based on a modulo operation it will return a shard ID
+func AssignShardForPubKeyWhenNotSpecified(pubKey []byte, numShards uint32) uint32 {
+	if len(pubKey) == 0 {
+		return 0 // should never happen
+	}
+
+	lastByte := pubKey[len(pubKey)-1]
+	numShardsIncludingMeta := numShards + 1
+
+	randomShardID := uint32(lastByte) % numShardsIncludingMeta
+	if randomShardID == numShards {
+		randomShardID = MetachainShardId
+	}
+
+	return randomShardID
+}

--- a/core/converters_test.go
+++ b/core/converters_test.go
@@ -11,8 +11,11 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/mock"
+	"github.com/ElrondNetwork/elrond-go/crypto/signing"
+	"github.com/ElrondNetwork/elrond-go/crypto/signing/mcl"
 	"github.com/ElrondNetwork/elrond-go/data/batch"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCalculateHash_NilMarshalizer(t *testing.T) {
@@ -235,4 +238,72 @@ func TestConvertShardIDToUint32(t *testing.T) {
 	shardID, err = core.ConvertShardIDToUint32("wrongID")
 	assert.Error(t, err)
 	assert.Equal(t, uint32(0), shardID)
+}
+
+func TestAssignShardForPubKeyWhenNotSpecified(t *testing.T) {
+	t.Parallel()
+
+	numShards := uint32(3)
+
+	key := []byte{5, 7, 4} // 4 % 4 = 0
+	require.Equal(t, uint32(0), core.AssignShardForPubKeyWhenNotSpecified(key, numShards))
+
+	key = []byte{5, 7, 5} // 5 % 4 = 1
+	require.Equal(t, uint32(1), core.AssignShardForPubKeyWhenNotSpecified(key, numShards))
+
+	key = []byte{5, 7, 6} // 6 % 4 = 2
+	require.Equal(t, uint32(2), core.AssignShardForPubKeyWhenNotSpecified(key, numShards))
+
+	key = []byte{5, 7, 7} // 7 % 4 = 3 => metachain
+	require.Equal(t, core.MetachainShardId, core.AssignShardForPubKeyWhenNotSpecified(key, numShards))
+
+	key = []byte{5, 7, 8} // 8 % 4 = 0
+	require.Equal(t, uint32(0), core.AssignShardForPubKeyWhenNotSpecified(key, numShards))
+
+	key = []byte{} // empty
+	require.Equal(t, uint32(0), core.AssignShardForPubKeyWhenNotSpecified(key, numShards))
+}
+
+func TestAssignShardForPubKeyWhenNotSpecifiedShouldReturnSameShardForSameKey(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("test pub key number 0")
+	numShards := uint32(3)
+
+	result0 := core.AssignShardForPubKeyWhenNotSpecified(key, numShards)
+	result1 := core.AssignShardForPubKeyWhenNotSpecified(key, numShards)
+
+	require.Equal(t, result0, result1)
+}
+
+func TestShardAssignment(t *testing.T) {
+	t.Skip()
+
+	keyGen := signing.NewKeyGenerator(mcl.NewSuiteBLS12())
+	generatePubKey := func() []byte {
+		_, pk := keyGen.GeneratePair()
+		pkB, _ := pk.ToByteArray()
+
+		return pkB
+	}
+
+	numShards := uint32(3)
+	counts := map[uint32]uint64{
+		0:                     0,
+		1:                     0,
+		2:                     0,
+		core.MetachainShardId: 0,
+	}
+
+	numAccounts := 1000
+
+	for i := 0; i < numAccounts; i++ {
+		pubKey := generatePubKey()
+		shId := core.AssignShardForPubKeyWhenNotSpecified(pubKey, numShards)
+		counts[shId]++
+	}
+
+	for sh, cnt := range counts {
+		fmt.Printf("Shard %d:\n\t\t%d accounts\n", sh, cnt)
+	}
 }


### PR DESCRIPTION
different destination shard as an observer when no shard is specified. same as #2960 but targeted to `master` branch

Testing procedure:
- start an observer by using this branch
- if the key is not in consensus and the node will start as observer, it should be routed to a "random" shard. The same key in multiple tries should be routed to the same shard.
- try with multiple keys in order to see the shard balancing