### PR TITLE
arwen 1.2.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ElrondNetwork/elrond-go
 go 1.13
 
 require (
-	github.com/ElrondNetwork/arwen-wasm-vm v1.2.5
+	github.com/ElrondNetwork/arwen-wasm-vm v1.2.6
 	github.com/ElrondNetwork/concurrent-map v0.1.3
 	github.com/ElrondNetwork/elastic-indexer-go v1.0.3
 	github.com/ElrondNetwork/elrond-go-logger v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/ElrondNetwork/arwen-wasm-vm v1.1.3-0.20210309184230-68eac15cd9dd/go.m
 github.com/ElrondNetwork/arwen-wasm-vm v1.1.3-0.20210317161751-82d31c8caa34/go.mod h1:VZVOP47Fa2SRL6RfFbZYDpIQgFwGnfyO11ss3ACc93k=
 github.com/ElrondNetwork/arwen-wasm-vm v1.1.3-0.20210319111725-093234eb3f90/go.mod h1:ecpMev5UmUkMSOB9fEz01Sf88lkuNIXp6H/+kt32XsQ=
 github.com/ElrondNetwork/arwen-wasm-vm v1.2.0/go.mod h1:Io5YGUs48YNnXlyJYSBX6Evxcc0JUfLbjF+65qdl+10=
-github.com/ElrondNetwork/arwen-wasm-vm v1.2.5 h1:6BXnsidLP02K1H6Oatref2C+2UZ0xTSwTz0Jpi2IRik=
-github.com/ElrondNetwork/arwen-wasm-vm v1.2.5/go.mod h1:Q+ay1aQID+M4q/PWcE9Jmheojpu9nkmOuv1eSDmpBwE=
+github.com/ElrondNetwork/arwen-wasm-vm v1.2.6 h1:vmZJGDj+xXZE6svnu8U7nLs0YJYZ2OLjxPoP+n94k5c=
+github.com/ElrondNetwork/arwen-wasm-vm v1.2.6/go.mod h1:Q+ay1aQID+M4q/PWcE9Jmheojpu9nkmOuv1eSDmpBwE=
 github.com/ElrondNetwork/big-int-util v0.0.5/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg1IJLPAK6GVHMbC7Aw4=
 github.com/ElrondNetwork/big-int-util v0.1.0 h1:vTMoJ5azhVmr7jhpSD3JUjQdkdyXoEPVkOvhdw1RjV4=
 github.com/ElrondNetwork/big-int-util v0.1.0/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg1IJLPAK6GVHMbC7Aw4=


### PR DESCRIPTION
arwen 1.2.6 release

This release fixes a possible cyclic import that involves the arwen and elrond-go repo through some mock implementation.