### PR TITLE
Fixed staking processors for the API routes

### DIFF
--- a/api/network/routes.go
+++ b/api/network/routes.go
@@ -128,7 +128,7 @@ func EconomicsMetrics(c *gin.Context) {
 	}
 
 	metrics := facade.StatusMetrics().EconomicsMetrics()
-	metrics[core.MetricTotalStakedValue] = stakeValues.TotalStaked.String()
+	metrics[core.MetricTotalBaseStakedValue] = stakeValues.BaseStaked.String()
 	metrics[core.MetricTopUpValue] = stakeValues.TopUp.String()
 
 	c.JSON(

--- a/api/network/routes_test.go
+++ b/api/network/routes_test.go
@@ -170,8 +170,8 @@ func TestEconomicsMetrics_ShouldWork(t *testing.T) {
 	facade := mock.Facade{
 		GetTotalStakedValueHandler: func() (*api.StakeValues, error) {
 			return &api.StakeValues{
-				TotalStaked: big.NewInt(100),
-				TopUp:       big.NewInt(20),
+				BaseStaked: big.NewInt(100),
+				TopUp:      big.NewInt(20),
 			}, nil
 		},
 	}
@@ -267,16 +267,16 @@ func TestDirectStakedInfo_NilContextShouldErr(t *testing.T) {
 
 func TestDirectStakedInfo_ShouldWork(t *testing.T) {
 	stakedData1 := api.DirectStakedValue{
-		Address: "addr1",
-		Staked:  "1111",
-		TopUp:   "2222",
-		Total:   "3333",
+		Address:    "addr1",
+		BaseStaked: "1111",
+		TopUp:      "2222",
+		Total:      "3333",
 	}
 	stakedData2 := api.DirectStakedValue{
-		Address: "addr2",
-		Staked:  "4444",
-		TopUp:   "5555",
-		Total:   "9999",
+		Address:    "addr2",
+		BaseStaked: "4444",
+		TopUp:      "5555",
+		Total:      "9999",
 	}
 
 	facade := mock.Facade{
@@ -300,7 +300,7 @@ func TestDirectStakedInfo_ShouldWork(t *testing.T) {
 
 func directStakedFoundInResponse(response string, stakedData api.DirectStakedValue) bool {
 	return strings.Contains(response, stakedData.Address) && strings.Contains(response, stakedData.Total) &&
-		strings.Contains(response, stakedData.Staked) && strings.Contains(response, stakedData.TopUp)
+		strings.Contains(response, stakedData.BaseStaked) && strings.Contains(response, stakedData.TopUp)
 }
 
 func TestDirectStakedInfo_CannotGetDirectStakedList(t *testing.T) {

--- a/core/constants.go
+++ b/core/constants.go
@@ -345,8 +345,8 @@ const MetricAverageBlockTxCount = "erd_average_block_tx_count"
 // MetricTotalSupply holds the total supply value for the last epoch
 const MetricTotalSupply = "erd_total_supply"
 
-// MetricTotalStakedValue holds the total staked value
-const MetricTotalStakedValue = "erd_total_staked_value"
+// MetricTotalBaseStakedValue holds the total base staked value
+const MetricTotalBaseStakedValue = "erd_total_base_staked_value"
 
 // MetricTopUpValue holds the total top up value
 const MetricTopUpValue = "erd_total_top_up_value"

--- a/data/api/apiBlock.go
+++ b/data/api/apiBlock.go
@@ -44,16 +44,16 @@ type MiniBlock struct {
 
 // StakeValues is the structure that contains the total staked value and the total top up value
 type StakeValues struct {
-	TotalStaked *big.Int
-	TopUp       *big.Int
+	BaseStaked *big.Int
+	TopUp      *big.Int
 }
 
 // DirectStakedValue holds the total staked value for an address
 type DirectStakedValue struct {
-	Address string `json:"address"`
-	Staked  string `json:"staked"`
-	TopUp   string `json:"topUp"`
-	Total   string `json:"total"`
+	Address    string `json:"address"`
+	BaseStaked string `json:"baseStaked"`
+	TopUp      string `json:"topUp"`
+	Total      string `json:"total"`
 }
 
 // DelegatedValue holds the value and the delegation system SC address

--- a/node/trieIterators/directStakedListProcessor.go
+++ b/node/trieIterators/directStakedListProcessor.go
@@ -69,18 +69,18 @@ func (dslp *directStakedListProcessor) getAllStakedAccounts(validatorAccount sta
 			continue
 		}
 
-		totalStakedCurrentAccount, totalTopUpCurrentAccount, errGet := dslp.getValidatorInfoFromSC(leafKey)
+		info, errGet := dslp.getValidatorInfoFromSC(leafKey)
 		if errGet != nil {
 			continue
 		}
 
-		staked := big.NewInt(0).Set(totalStakedCurrentAccount)
-		staked.Sub(staked, totalTopUpCurrentAccount)
+		staked := big.NewInt(0).Set(info.totalStakedValue)
+		staked.Sub(staked, info.topUpValue)
 		val := &api.DirectStakedValue{
 			Address: dslp.publicKeyConverter.Encode(leafKey),
 			Staked:  staked.String(),
-			TopUp:   totalTopUpCurrentAccount.String(),
-			Total:   totalStakedCurrentAccount.String(),
+			TopUp:   info.topUpValue.String(),
+			Total:   info.totalStakedValue.String(),
 		}
 
 		stakedAccounts = append(stakedAccounts, val)

--- a/node/trieIterators/directStakedListProcessor.go
+++ b/node/trieIterators/directStakedListProcessor.go
@@ -74,13 +74,13 @@ func (dslp *directStakedListProcessor) getAllStakedAccounts(validatorAccount sta
 			continue
 		}
 
-		staked := big.NewInt(0).Set(info.totalStakedValue)
-		staked.Sub(staked, info.topUpValue)
+		baseStaked := big.NewInt(0).Set(info.totalStakedValue)
+		baseStaked.Sub(baseStaked, info.topUpValue)
 		val := &api.DirectStakedValue{
-			Address: dslp.publicKeyConverter.Encode(leafKey),
-			Staked:  staked.String(),
-			TopUp:   info.topUpValue.String(),
-			Total:   info.totalStakedValue.String(),
+			Address:    dslp.publicKeyConverter.Encode(leafKey),
+			BaseStaked: baseStaked.String(),
+			TopUp:      info.topUpValue.String(),
+			Total:      info.totalStakedValue.String(),
 		}
 
 		stakedAccounts = append(stakedAccounts, val)

--- a/node/trieIterators/directStakedListProcessor.go
+++ b/node/trieIterators/directStakedListProcessor.go
@@ -74,11 +74,13 @@ func (dslp *directStakedListProcessor) getAllStakedAccounts(validatorAccount sta
 			continue
 		}
 
+		staked := big.NewInt(0).Set(totalStakedCurrentAccount)
+		staked.Sub(staked, totalTopUpCurrentAccount)
 		val := &api.DirectStakedValue{
 			Address: dslp.publicKeyConverter.Encode(leafKey),
-			Staked:  totalStakedCurrentAccount.String(),
+			Staked:  staked.String(),
 			TopUp:   totalTopUpCurrentAccount.String(),
-			Total:   big.NewInt(0).Add(totalTopUpCurrentAccount, totalStakedCurrentAccount).String(),
+			Total:   totalStakedCurrentAccount.String(),
 		}
 
 		stakedAccounts = append(stakedAccounts, val)

--- a/node/trieIterators/directStakedListProcessor_test.go
+++ b/node/trieIterators/directStakedListProcessor_test.go
@@ -106,15 +106,15 @@ func TestDirectStakedListProc_GetDelegatorsListShouldWork(t *testing.T) {
 
 	expectedDirectStake1 := api.DirectStakedValue{
 		Address: arg.PublicKeyConverter.Encode(validators[0]),
-		Staked:  "10",
+		Staked:  "9",
 		TopUp:   "1",
-		Total:   "11",
+		Total:   "10",
 	}
 	expectedDirectStake2 := api.DirectStakedValue{
 		Address: arg.PublicKeyConverter.Encode(validators[1]),
-		Staked:  "20",
+		Staked:  "18",
 		TopUp:   "2",
-		Total:   "22",
+		Total:   "20",
 	}
 
 	assert.Equal(t, []*api.DirectStakedValue{&expectedDirectStake1, &expectedDirectStake2}, directStakedList)

--- a/node/trieIterators/directStakedListProcessor_test.go
+++ b/node/trieIterators/directStakedListProcessor_test.go
@@ -105,16 +105,16 @@ func TestDirectStakedListProc_GetDelegatorsListShouldWork(t *testing.T) {
 	require.Equal(t, 2, len(directStakedList))
 
 	expectedDirectStake1 := api.DirectStakedValue{
-		Address: arg.PublicKeyConverter.Encode(validators[0]),
-		Staked:  "9",
-		TopUp:   "1",
-		Total:   "10",
+		Address:    arg.PublicKeyConverter.Encode(validators[0]),
+		BaseStaked: "9",
+		TopUp:      "1",
+		Total:      "10",
 	}
 	expectedDirectStake2 := api.DirectStakedValue{
-		Address: arg.PublicKeyConverter.Encode(validators[1]),
-		Staked:  "18",
-		TopUp:   "2",
-		Total:   "20",
+		Address:    arg.PublicKeyConverter.Encode(validators[1]),
+		BaseStaked: "18",
+		TopUp:      "2",
+		Total:      "20",
 	}
 
 	assert.Equal(t, []*api.DirectStakedValue{&expectedDirectStake1, &expectedDirectStake2}, directStakedList)

--- a/node/trieIterators/stakeValuesProcessor.go
+++ b/node/trieIterators/stakeValuesProcessor.go
@@ -74,18 +74,18 @@ func checkArguments(arg ArgTrieIteratorProcessor) error {
 
 // GetTotalStakedValue will calculate total staked value if needed and return calculated value
 func (svp *stakedValuesProcessor) GetTotalStakedValue() (*api.StakeValues, error) {
-	totalStaked, topUp, err := svp.computeStakedValueAndTopUp()
+	baseStaked, topUp, err := svp.computeBaseStakedAndTopUp()
 	if err != nil {
 		return nil, err
 	}
 
 	return &api.StakeValues{
-		TotalStaked: totalStaked,
-		TopUp:       topUp,
+		BaseStaked: baseStaked,
+		TopUp:      topUp,
 	}, nil
 }
 
-func (svp *stakedValuesProcessor) computeStakedValueAndTopUp() (*big.Int, *big.Int, error) {
+func (svp *stakedValuesProcessor) computeBaseStakedAndTopUp() (*big.Int, *big.Int, error) {
 	svp.accounts.Lock()
 	defer svp.accounts.Unlock()
 
@@ -106,7 +106,7 @@ func (svp *stakedValuesProcessor) computeStakedValueAndTopUp() (*big.Int, *big.I
 		return nil, nil, err
 	}
 
-	totalStaked, totalTopUp := big.NewInt(0), big.NewInt(0)
+	totalBaseStaked, totalTopUp := big.NewInt(0), big.NewInt(0)
 	for leaf := range chLeaves {
 		leafKey := leaf.Key()
 		if len(leafKey) != svp.publicKeyConverter.Len() {
@@ -117,14 +117,14 @@ func (svp *stakedValuesProcessor) computeStakedValueAndTopUp() (*big.Int, *big.I
 		if errGet != nil {
 			continue
 		}
-		staked := big.NewInt(0).Set(info.totalStakedValue)
-		staked.Sub(staked, info.topUpValue)
+		baseStaked := big.NewInt(0).Set(info.totalStakedValue)
+		baseStaked.Sub(baseStaked, info.topUpValue)
 
-		totalStaked = totalStaked.Add(totalStaked, staked)
+		totalBaseStaked = totalBaseStaked.Add(totalBaseStaked, baseStaked)
 		totalTopUp = totalTopUp.Add(totalTopUp, info.topUpValue)
 	}
 
-	return totalStaked, totalTopUp, nil
+	return totalBaseStaked, totalTopUp, nil
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/node/trieIterators/stakeValuesProcessor.go
+++ b/node/trieIterators/stakeValuesProcessor.go
@@ -113,15 +113,15 @@ func (svp *stakedValuesProcessor) computeStakedValueAndTopUp() (*big.Int, *big.I
 			continue
 		}
 
-		totalStakedCurrentAccount, totalTopUpCurrentAccount, errGet := svp.getValidatorInfoFromSC(leafKey)
+		info, errGet := svp.getValidatorInfoFromSC(leafKey)
 		if errGet != nil {
 			continue
 		}
-		staked := big.NewInt(0).Set(totalStakedCurrentAccount)
-		staked.Sub(staked, totalTopUpCurrentAccount)
+		staked := big.NewInt(0).Set(info.totalStakedValue)
+		staked.Sub(staked, info.topUpValue)
 
 		totalStaked = totalStaked.Add(totalStaked, staked)
-		totalTopUp = totalTopUp.Add(totalTopUp, totalTopUpCurrentAccount)
+		totalTopUp = totalTopUp.Add(totalTopUp, info.topUpValue)
 	}
 
 	return totalStaked, totalTopUp, nil

--- a/node/trieIterators/stakeValuesProcessor.go
+++ b/node/trieIterators/stakeValuesProcessor.go
@@ -117,8 +117,10 @@ func (svp *stakedValuesProcessor) computeStakedValueAndTopUp() (*big.Int, *big.I
 		if errGet != nil {
 			continue
 		}
+		staked := big.NewInt(0).Set(totalStakedCurrentAccount)
+		staked.Sub(staked, totalTopUpCurrentAccount)
 
-		totalStaked = totalStaked.Add(totalStaked, totalStakedCurrentAccount)
+		totalStaked = totalStaked.Add(totalStaked, staked)
 		totalTopUp = totalTopUp.Add(totalTopUp, totalTopUpCurrentAccount)
 	}
 

--- a/node/trieIterators/stakeValuesProcessor_test.go
+++ b/node/trieIterators/stakeValuesProcessor_test.go
@@ -367,8 +367,8 @@ func TestTotalStakedValueProcessor_GetTotalStakedValue(t *testing.T) {
 
 	stakeValues, err := totalStakedProc.GetTotalStakedValue()
 	require.Equal(t, &api.StakeValues{
-		TotalStaked: big.NewInt(490),
-		TopUp:       big.NewInt(110),
+		BaseStaked: big.NewInt(490),
+		TopUp:      big.NewInt(110),
 	}, stakeValues)
 	require.Nil(t, err)
 }

--- a/node/trieIterators/stakeValuesProcessor_test.go
+++ b/node/trieIterators/stakeValuesProcessor_test.go
@@ -367,7 +367,7 @@ func TestTotalStakedValueProcessor_GetTotalStakedValue(t *testing.T) {
 
 	stakeValues, err := totalStakedProc.GetTotalStakedValue()
 	require.Equal(t, &api.StakeValues{
-		TotalStaked: big.NewInt(600),
+		TotalStaked: big.NewInt(490),
 		TopUp:       big.NewInt(110),
 	}, stakeValues)
 	require.Nil(t, err)


### PR DESCRIPTION
- fixed staking processors for the API routes

Testing scenario: do a top-up stake on an existing node. The routes: `/network/economics` should return the  `erd_total_base_staked_value` value as a multiple of 2500 and `erd_total_top_up_value` the exact top-up-ed value. Next, the `/network/direct-staked-info` should return the correct value for that top-up-ed address (the `BaseStaked` should be a 2500 multiple, the `TopUp` should contain the top up value and the `Total` should be BaseStaked + TopUp)