### PR TITLE
En 9502/validator to delegation

### DIFF
--- a/cmd/node/config/gasSchedules/gasScheduleV1.toml
+++ b/cmd/node/config/gasSchedules/gasScheduleV1.toml
@@ -14,26 +14,27 @@
     ESDTNFTChangeCreateOwner = 1000000
 
 [MetaChainSystemSCsCost]
-    Stake               = 5000000
-    UnStake             = 5000000
-    UnBond              = 5000000
-    Claim               = 5000000
-    Get                 = 5000000
-    ChangeRewardAddress = 5000000
-    ChangeValidatorKeys = 5000000
-    UnJail              = 5000000
-    ESDTIssue           = 50000000
-    ESDTOperations      = 50000000
-    Proposal            = 5000000
-    Vote                = 500000
-    DelegateVote        = 1000000
-    RevokeVote          = 500000
-    CloseProposal       = 1000000
-    DelegationOps       = 1000000
-    UnstakeTokens       = 5000000
-    UnbondTokens        = 5000000
-    DelegationMgrOps    = 50000000
-    GetAllNodeStates    = 100000000
+    Stake                 = 5000000
+    UnStake               = 5000000
+    UnBond                = 5000000
+    Claim                 = 5000000
+    Get                   = 5000000
+    ChangeRewardAddress   = 5000000
+    ChangeValidatorKeys   = 5000000
+    UnJail                = 5000000
+    ESDTIssue             = 50000000
+    ESDTOperations        = 50000000
+    Proposal              = 5000000
+    Vote                  = 500000
+    DelegateVote          = 1000000
+    RevokeVote            = 500000
+    CloseProposal         = 1000000
+    DelegationOps         = 1000000
+    UnstakeTokens         = 5000000
+    UnbondTokens          = 5000000
+    DelegationMgrOps      = 50000000
+    ValidatorToDelegation = 500000000
+    GetAllNodeStates      = 100000000
 
 [BaseOperationCost]
     StorePerByte      = 50000

--- a/cmd/node/config/gasSchedules/gasScheduleV2.toml
+++ b/cmd/node/config/gasSchedules/gasScheduleV2.toml
@@ -14,24 +14,25 @@
     ESDTNFTChangeCreateOwner = 1000000
 
 [MetaChainSystemSCsCost]
-    Stake               = 5000000
-    UnStake             = 5000000
-    UnBond              = 5000000
-    Claim               = 5000000
-    Get                 = 5000000
-    ChangeRewardAddress = 5000000
-    ChangeValidatorKeys = 5000000
-    UnJail              = 5000000
-    DelegationOps       = 1000000
-    DelegationMgrOps    = 50000000
-    ESDTIssue           = 50000000
-    ESDTOperations      = 50000000
-    Proposal            = 5000000
-    Vote                = 500000
-    DelegateVote        = 1000000
-    RevokeVote          = 500000
-    CloseProposal       = 1000000
-    GetAllNodeStates    = 20000000
+    Stake                 = 5000000
+    UnStake               = 5000000
+    UnBond                = 5000000
+    Claim                 = 5000000
+    Get                   = 5000000
+    ChangeRewardAddress   = 5000000
+    ChangeValidatorKeys   = 5000000
+    UnJail                = 5000000
+    DelegationOps         = 1000000
+    DelegationMgrOps      = 50000000
+    ValidatorToDelegation = 500000000
+    ESDTIssue             = 50000000
+    ESDTOperations        = 50000000
+    Proposal              = 5000000
+    Vote                  = 500000
+    DelegateVote          = 1000000
+    RevokeVote            = 500000
+    CloseProposal         = 1000000
+    GetAllNodeStates      = 20000000
 
 [BaseOperationCost]
     StorePerByte      = 50000

--- a/cmd/node/config/gasSchedules/gasScheduleV3.toml
+++ b/cmd/node/config/gasSchedules/gasScheduleV3.toml
@@ -14,26 +14,27 @@
     ESDTNFTChangeCreateOwner = 1000000
 
 [MetaChainSystemSCsCost]
-    Stake               = 5000000
-    UnStake             = 5000000
-    UnBond              = 5000000
-    Claim               = 5000000
-    Get                 = 5000000
-    ChangeRewardAddress = 5000000
-    ChangeValidatorKeys = 5000000
-    UnJail              = 5000000
-    DelegationOps       = 1000000
-    DelegationMgrOps    = 50000000
-    ESDTIssue           = 50000000
-    ESDTOperations      = 50000000
-    Proposal            = 5000000
-    Vote                = 500000
-    DelegateVote        = 1000000
-    RevokeVote          = 500000
-    CloseProposal       = 1000000
-    GetAllNodeStates    = 20000000
-    UnstakeTokens       = 5000000
-    UnbondTokens        = 5000000
+    Stake                 = 5000000
+    UnStake               = 5000000
+    UnBond                = 5000000
+    Claim                 = 5000000
+    Get                   = 5000000
+    ChangeRewardAddress   = 5000000
+    ChangeValidatorKeys   = 5000000
+    UnJail                = 5000000
+    DelegationOps         = 1000000
+    DelegationMgrOps      = 50000000
+    ValidatorToDelegation = 500000000
+    ESDTIssue             = 50000000
+    ESDTOperations        = 50000000
+    Proposal              = 5000000
+    Vote                  = 500000
+    DelegateVote          = 1000000
+    RevokeVote            = 500000
+    CloseProposal         = 1000000
+    GetAllNodeStates      = 20000000
+    UnstakeTokens         = 5000000
+    UnbondTokens          = 5000000
 
 [BaseOperationCost]
     StorePerByte      = 50000

--- a/cmd/node/config/systemSmartContractsConfig.toml
+++ b/cmd/node/config/systemSmartContractsConfig.toml
@@ -37,6 +37,6 @@
 
 [DelegationSystemSCConfig]
     EnabledEpoch   = 1 #enable epoch should not be 0
-    ValidatorToDelegatorEnableEpoch = 3
+    ValidatorToDelegationEnableEpoch = 3
     MinServiceFee  = 0
     MaxServiceFee  = 10000

--- a/cmd/node/config/systemSmartContractsConfig.toml
+++ b/cmd/node/config/systemSmartContractsConfig.toml
@@ -37,5 +37,6 @@
 
 [DelegationSystemSCConfig]
     EnabledEpoch   = 1 #enable epoch should not be 0
+    ValidatorToDelegatorEnableEpoch = 3
     MinServiceFee  = 0
     MaxServiceFee  = 10000

--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -2104,16 +2104,17 @@ func newMetaBlockProcessor(
 	}
 
 	argsStaking := scToProtocol.ArgStakingToPeer{
-		PubkeyConv:       stateComponents.ValidatorPubkeyConverter,
-		Hasher:           core.Hasher,
-		Marshalizer:      core.InternalMarshalizer,
-		PeerState:        stateComponents.PeerAccounts,
-		BaseState:        stateComponents.AccountsAdapter,
-		ArgParser:        argsParser,
-		CurrTxs:          data.Datapool.CurrentBlockTxs(),
-		RatingsData:      ratingsData,
-		EpochNotifier:    epochNotifier,
-		StakeEnableEpoch: systemSCConfig.StakingSystemSCConfig.StakeEnableEpoch,
+		PubkeyConv:                       stateComponents.ValidatorPubkeyConverter,
+		Hasher:                           core.Hasher,
+		Marshalizer:                      core.InternalMarshalizer,
+		PeerState:                        stateComponents.PeerAccounts,
+		BaseState:                        stateComponents.AccountsAdapter,
+		ArgParser:                        argsParser,
+		CurrTxs:                          data.Datapool.CurrentBlockTxs(),
+		RatingsData:                      ratingsData,
+		EpochNotifier:                    epochNotifier,
+		StakeEnableEpoch:                 systemSCConfig.StakingSystemSCConfig.StakeEnableEpoch,
+		ValidatorToDelegationEnableEpoch: systemSCConfig.DelegationManagerSystemSCConfig.ValidatorToDelegatorEnableEpoch,
 	}
 	smartContractToProtocol, err := scToProtocol.NewStakingToPeer(argsStaking)
 	if err != nil {

--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -2114,7 +2114,7 @@ func newMetaBlockProcessor(
 		RatingsData:                      ratingsData,
 		EpochNotifier:                    epochNotifier,
 		StakeEnableEpoch:                 systemSCConfig.StakingSystemSCConfig.StakeEnableEpoch,
-		ValidatorToDelegationEnableEpoch: systemSCConfig.DelegationManagerSystemSCConfig.ValidatorToDelegatorEnableEpoch,
+		ValidatorToDelegationEnableEpoch: systemSCConfig.DelegationManagerSystemSCConfig.ValidatorToDelegationEnableEpoch,
 	}
 	smartContractToProtocol, err := scToProtocol.NewStakingToPeer(argsStaking)
 	if err != nil {

--- a/config/systemSmartContractsConfig.go
+++ b/config/systemSmartContractsConfig.go
@@ -48,11 +48,11 @@ type GovernanceSystemSCConfig struct {
 
 // DelegationManagerSystemSCConfig defines a set of constants to initialize the delegation manager system smart contract
 type DelegationManagerSystemSCConfig struct {
-	MinCreationDeposit              string
-	EnabledEpoch                    uint32
-	ValidatorToDelegatorEnableEpoch uint32
-	MinStakeAmount                  string
-	ConfigChangeAddress             string
+	MinCreationDeposit               string
+	EnabledEpoch                     uint32
+	ValidatorToDelegationEnableEpoch uint32
+	MinStakeAmount                   string
+	ConfigChangeAddress              string
 }
 
 // DelegationSystemSCConfig defines a set of constants to initialize the delegation system smart contract

--- a/config/systemSmartContractsConfig.go
+++ b/config/systemSmartContractsConfig.go
@@ -48,10 +48,11 @@ type GovernanceSystemSCConfig struct {
 
 // DelegationManagerSystemSCConfig defines a set of constants to initialize the delegation manager system smart contract
 type DelegationManagerSystemSCConfig struct {
-	MinCreationDeposit  string
-	EnabledEpoch        uint32
-	MinStakeAmount      string
-	ConfigChangeAddress string
+	MinCreationDeposit              string
+	EnabledEpoch                    uint32
+	ValidatorToDelegatorEnableEpoch uint32
+	MinStakeAmount                  string
+	ConfigChangeAddress             string
 }
 
 // DelegationSystemSCConfig defines a set of constants to initialize the delegation system smart contract

--- a/process/factory/metachain/vmContainerFactory_test.go
+++ b/process/factory/metachain/vmContainerFactory_test.go
@@ -247,6 +247,7 @@ func FillGasMapMetaChainSystemSCsCosts(value uint64) map[string]uint64 {
 	gasMap["UnBondTokens"] = value
 	gasMap["DelegationMgrOps"] = value
 	gasMap["GetAllNodeStates"] = value
+	gasMap["ValidatorToDelegation"] = value
 
 	return gasMap
 }

--- a/process/scToProtocol/stakingToPeer.go
+++ b/process/scToProtocol/stakingToPeer.go
@@ -26,34 +26,36 @@ var log = logger.GetOrCreate("process/scToProtocol")
 
 // ArgStakingToPeer is struct that contain all components that are needed to create a new stakingToPeer object
 type ArgStakingToPeer struct {
-	PubkeyConv       core.PubkeyConverter
-	Hasher           hashing.Hasher
-	Marshalizer      marshal.Marshalizer
-	PeerState        state.AccountsAdapter
-	BaseState        state.AccountsAdapter
-	ArgParser        process.ArgumentsParser
-	CurrTxs          dataRetriever.TransactionCacher
-	RatingsData      process.RatingsInfoHandler
-	StakeEnableEpoch uint32
-	EpochNotifier    process.EpochNotifier
+	PubkeyConv                       core.PubkeyConverter
+	Hasher                           hashing.Hasher
+	Marshalizer                      marshal.Marshalizer
+	PeerState                        state.AccountsAdapter
+	BaseState                        state.AccountsAdapter
+	ArgParser                        process.ArgumentsParser
+	CurrTxs                          dataRetriever.TransactionCacher
+	RatingsData                      process.RatingsInfoHandler
+	StakeEnableEpoch                 uint32
+	ValidatorToDelegationEnableEpoch uint32
+	EpochNotifier                    process.EpochNotifier
 }
 
 // stakingToPeer defines the component which will translate changes from staking SC state
 // to validator statistics trie
 type stakingToPeer struct {
-	pubkeyConv  core.PubkeyConverter
-	hasher      hashing.Hasher
-	marshalizer marshal.Marshalizer
-	peerState   state.AccountsAdapter
-	baseState   state.AccountsAdapter
-
-	argParser        process.ArgumentsParser
-	currTxs          dataRetriever.TransactionCacher
-	startRating      uint32
-	unJailRating     uint32
-	jailRating       uint32
-	stakeEnableEpoch uint32
-	flagStaking      atomic.Flag
+	pubkeyConv                       core.PubkeyConverter
+	hasher                           hashing.Hasher
+	marshalizer                      marshal.Marshalizer
+	peerState                        state.AccountsAdapter
+	baseState                        state.AccountsAdapter
+	argParser                        process.ArgumentsParser
+	currTxs                          dataRetriever.TransactionCacher
+	startRating                      uint32
+	unJailRating                     uint32
+	jailRating                       uint32
+	stakeEnableEpoch                 uint32
+	flagStaking                      atomic.Flag
+	validatorToDelegationEnableEpoch uint32
+	flagValidatorToDelegation        atomic.Flag
 }
 
 // NewStakingToPeer creates the component which moves from staking sc state to peer state
@@ -64,17 +66,18 @@ func NewStakingToPeer(args ArgStakingToPeer) (*stakingToPeer, error) {
 	}
 
 	st := &stakingToPeer{
-		pubkeyConv:       args.PubkeyConv,
-		hasher:           args.Hasher,
-		marshalizer:      args.Marshalizer,
-		peerState:        args.PeerState,
-		baseState:        args.BaseState,
-		argParser:        args.ArgParser,
-		currTxs:          args.CurrTxs,
-		startRating:      args.RatingsData.StartRating(),
-		unJailRating:     args.RatingsData.StartRating(),
-		jailRating:       args.RatingsData.MinRating(),
-		stakeEnableEpoch: args.StakeEnableEpoch,
+		pubkeyConv:                       args.PubkeyConv,
+		hasher:                           args.Hasher,
+		marshalizer:                      args.Marshalizer,
+		peerState:                        args.PeerState,
+		baseState:                        args.BaseState,
+		argParser:                        args.ArgParser,
+		currTxs:                          args.CurrTxs,
+		startRating:                      args.RatingsData.StartRating(),
+		unJailRating:                     args.RatingsData.StartRating(),
+		jailRating:                       args.RatingsData.MinRating(),
+		stakeEnableEpoch:                 args.StakeEnableEpoch,
+		validatorToDelegationEnableEpoch: args.ValidatorToDelegationEnableEpoch,
 	}
 
 	args.EpochNotifier.RegisterNotifyHandler(st)
@@ -295,7 +298,7 @@ func (stp *stakingToPeer) updatePeerState(
 		}
 		account.SetUnStakedEpoch(stakingData.UnStakedEpoch)
 
-		if !bytes.Equal(account.GetRewardAddress(), stakingData.RewardAddress) {
+		if stp.flagValidatorToDelegation.IsSet() && !bytes.Equal(account.GetRewardAddress(), stakingData.RewardAddress) {
 			log.Debug("new reward address", "blsKey", blsPubKey, "rwdAddr", stakingData.RewardAddress)
 			err = account.SetRewardAddress(stakingData.RewardAddress)
 			if err != nil {
@@ -419,6 +422,9 @@ func (stp *stakingToPeer) getAllModifiedStates(body *block.Body) ([]string, erro
 func (stp *stakingToPeer) EpochConfirmed(epoch uint32) {
 	stp.flagStaking.Toggle(epoch >= stp.stakeEnableEpoch)
 	log.Debug("stakingToPeer: stake", "enabled", stp.flagStaking.IsSet())
+
+	stp.flagValidatorToDelegation.Toggle(epoch >= stp.validatorToDelegationEnableEpoch)
+	log.Debug("stakingToPeer: validator to delegation", "enabled", stp.flagValidatorToDelegation.IsSet())
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/process/scToProtocol/stakingToPeer.go
+++ b/process/scToProtocol/stakingToPeer.go
@@ -295,6 +295,14 @@ func (stp *stakingToPeer) updatePeerState(
 		}
 		account.SetUnStakedEpoch(stakingData.UnStakedEpoch)
 
+		if !bytes.Equal(account.GetRewardAddress(), stakingData.RewardAddress) {
+			log.Debug("new reward address", "blsKey", blsPubKey, "rwdAddr", stakingData.RewardAddress)
+			err = account.SetRewardAddress(stakingData.RewardAddress)
+			if err != nil {
+				return err
+			}
+		}
+
 		return stp.peerState.SaveAccount(account)
 	}
 

--- a/vm/factory/systemSCFactory.go
+++ b/vm/factory/systemSCFactory.go
@@ -168,7 +168,7 @@ func (scf *systemSCFactory) createStakingContract() (vm.SystemSmartContract, err
 		GasCost:                          scf.gasCost,
 		Marshalizer:                      scf.marshalizer,
 		EpochNotifier:                    scf.epochNotifier,
-		ValidatorToDelegationEnableEpoch: scf.systemSCConfig.DelegationManagerSystemSCConfig.ValidatorToDelegatorEnableEpoch,
+		ValidatorToDelegationEnableEpoch: scf.systemSCConfig.DelegationManagerSystemSCConfig.ValidatorToDelegationEnableEpoch,
 	}
 	staking, err := systemSmartContracts.NewStakingSmartContract(argsStaking)
 	return staking, err
@@ -189,7 +189,7 @@ func (scf *systemSCFactory) createValidatorContract() (vm.SystemSmartContract, e
 		MinDeposit:                       scf.systemSCConfig.DelegationManagerSystemSCConfig.MinCreationDeposit,
 		DelegationMgrEnableEpoch:         scf.systemSCConfig.DelegationManagerSystemSCConfig.EnabledEpoch,
 		DelegationMgrSCAddress:           vm.DelegationManagerSCAddress,
-		ValidatorToDelegationEnableEpoch: scf.systemSCConfig.DelegationManagerSystemSCConfig.ValidatorToDelegatorEnableEpoch,
+		ValidatorToDelegationEnableEpoch: scf.systemSCConfig.DelegationManagerSystemSCConfig.ValidatorToDelegationEnableEpoch,
 	}
 	validatorSC, err := systemSmartContracts.NewValidatorSmartContract(args)
 	return validatorSC, err

--- a/vm/factory/systemSCFactory.go
+++ b/vm/factory/systemSCFactory.go
@@ -159,15 +159,16 @@ func (scf *systemSCFactory) GasScheduleChange(gasSchedule map[string]map[string]
 
 func (scf *systemSCFactory) createStakingContract() (vm.SystemSmartContract, error) {
 	argsStaking := systemSmartContracts.ArgsNewStakingSmartContract{
-		MinNumNodes:          uint64(scf.nodesConfigProvider.MinNumberOfNodes()),
-		StakingSCConfig:      scf.systemSCConfig.StakingSystemSCConfig,
-		Eei:                  scf.systemEI,
-		StakingAccessAddr:    vm.ValidatorSCAddress,
-		JailAccessAddr:       vm.JailingAddress,
-		EndOfEpochAccessAddr: vm.EndOfEpochAddress,
-		GasCost:              scf.gasCost,
-		Marshalizer:          scf.marshalizer,
-		EpochNotifier:        scf.epochNotifier,
+		MinNumNodes:                      uint64(scf.nodesConfigProvider.MinNumberOfNodes()),
+		StakingSCConfig:                  scf.systemSCConfig.StakingSystemSCConfig,
+		Eei:                              scf.systemEI,
+		StakingAccessAddr:                vm.ValidatorSCAddress,
+		JailAccessAddr:                   vm.JailingAddress,
+		EndOfEpochAccessAddr:             vm.EndOfEpochAddress,
+		GasCost:                          scf.gasCost,
+		Marshalizer:                      scf.marshalizer,
+		EpochNotifier:                    scf.epochNotifier,
+		ValidatorToDelegationEnableEpoch: scf.systemSCConfig.DelegationManagerSystemSCConfig.ValidatorToDelegatorEnableEpoch,
 	}
 	staking, err := systemSmartContracts.NewStakingSmartContract(argsStaking)
 	return staking, err
@@ -175,19 +176,20 @@ func (scf *systemSCFactory) createStakingContract() (vm.SystemSmartContract, err
 
 func (scf *systemSCFactory) createValidatorContract() (vm.SystemSmartContract, error) {
 	args := systemSmartContracts.ArgsValidatorSmartContract{
-		Eei:                      scf.systemEI,
-		SigVerifier:              scf.sigVerifier,
-		StakingSCConfig:          scf.systemSCConfig.StakingSystemSCConfig,
-		StakingSCAddress:         vm.StakingSCAddress,
-		EndOfEpochAddress:        vm.EndOfEpochAddress,
-		ValidatorSCAddress:       vm.ValidatorSCAddress,
-		GasCost:                  scf.gasCost,
-		Marshalizer:              scf.marshalizer,
-		GenesisTotalSupply:       scf.economics.GenesisTotalSupply(),
-		EpochNotifier:            scf.epochNotifier,
-		MinDeposit:               scf.systemSCConfig.DelegationManagerSystemSCConfig.MinCreationDeposit,
-		DelegationMgrEnableEpoch: scf.systemSCConfig.DelegationManagerSystemSCConfig.EnabledEpoch,
-		DelegationMgrSCAddress:   vm.DelegationManagerSCAddress,
+		Eei:                              scf.systemEI,
+		SigVerifier:                      scf.sigVerifier,
+		StakingSCConfig:                  scf.systemSCConfig.StakingSystemSCConfig,
+		StakingSCAddress:                 vm.StakingSCAddress,
+		EndOfEpochAddress:                vm.EndOfEpochAddress,
+		ValidatorSCAddress:               vm.ValidatorSCAddress,
+		GasCost:                          scf.gasCost,
+		Marshalizer:                      scf.marshalizer,
+		GenesisTotalSupply:               scf.economics.GenesisTotalSupply(),
+		EpochNotifier:                    scf.epochNotifier,
+		MinDeposit:                       scf.systemSCConfig.DelegationManagerSystemSCConfig.MinCreationDeposit,
+		DelegationMgrEnableEpoch:         scf.systemSCConfig.DelegationManagerSystemSCConfig.EnabledEpoch,
+		DelegationMgrSCAddress:           vm.DelegationManagerSCAddress,
+		ValidatorToDelegationEnableEpoch: scf.systemSCConfig.DelegationManagerSystemSCConfig.ValidatorToDelegatorEnableEpoch,
 	}
 	validatorSC, err := systemSmartContracts.NewValidatorSmartContract(args)
 	return validatorSC, err

--- a/vm/gasCost.go
+++ b/vm/gasCost.go
@@ -13,26 +13,27 @@ type BaseOperationCost struct {
 
 // MetaChainSystemSCsCost defines the cost of system staking SCs methods
 type MetaChainSystemSCsCost struct {
-	Stake               uint64
-	UnStake             uint64
-	UnBond              uint64
-	Claim               uint64
-	Get                 uint64
-	ChangeRewardAddress uint64
-	ChangeValidatorKeys uint64
-	UnJail              uint64
-	ESDTIssue           uint64
-	ESDTOperations      uint64
-	Proposal            uint64
-	Vote                uint64
-	DelegateVote        uint64
-	RevokeVote          uint64
-	CloseProposal       uint64
-	DelegationOps       uint64
-	UnStakeTokens       uint64
-	UnBondTokens        uint64
-	DelegationMgrOps    uint64
-	GetAllNodeStates    uint64
+	Stake                 uint64
+	UnStake               uint64
+	UnBond                uint64
+	Claim                 uint64
+	Get                   uint64
+	ChangeRewardAddress   uint64
+	ChangeValidatorKeys   uint64
+	UnJail                uint64
+	ESDTIssue             uint64
+	ESDTOperations        uint64
+	Proposal              uint64
+	Vote                  uint64
+	DelegateVote          uint64
+	RevokeVote            uint64
+	CloseProposal         uint64
+	DelegationOps         uint64
+	UnStakeTokens         uint64
+	UnBondTokens          uint64
+	DelegationMgrOps      uint64
+	ValidatorToDelegation uint64
+	GetAllNodeStates      uint64
 }
 
 // BuiltInCost defines cost for built-in methods

--- a/vm/interface.go
+++ b/vm/interface.go
@@ -36,7 +36,7 @@ type SystemSCContainer interface {
 // SystemEI defines the environment interface system smart contract can use
 type SystemEI interface {
 	ExecuteOnDestContext(destination []byte, sender []byte, value *big.Int, input []byte) (*vmcommon.VMOutput, error)
-	DeploySystemSC(baseContract []byte, newAddress []byte, ownerAddress []byte, value *big.Int, input [][]byte) (vmcommon.ReturnCode, error)
+	DeploySystemSC(baseContract []byte, newAddress []byte, ownerAddress []byte, initFunction string, value *big.Int, input [][]byte) (vmcommon.ReturnCode, error)
 	Transfer(destination []byte, sender []byte, value *big.Int, input []byte, gasLimit uint64) error
 	SendGlobalSettingToAll(sender []byte, input []byte)
 	GetBalance(addr []byte) *big.Int

--- a/vm/mock/systemEIStub.go
+++ b/vm/mock/systemEIStub.go
@@ -114,13 +114,7 @@ func (s *SystemEIStub) ExecuteOnDestContext(
 }
 
 // DeploySystemSC -
-func (s *SystemEIStub) DeploySystemSC(
-	baseContract []byte,
-	newAddress []byte,
-	ownerAddress []byte,
-	value *big.Int,
-	input [][]byte,
-) (vmcommon.ReturnCode, error) {
+func (s *SystemEIStub) DeploySystemSC(baseContract []byte, newAddress []byte, ownerAddress []byte, initFunction string, value *big.Int, input [][]byte) (vmcommon.ReturnCode, error) {
 	if s.DeploySystemSCCalled != nil {
 		return s.DeploySystemSCCalled(baseContract, newAddress, ownerAddress, value, input)
 	}

--- a/vm/mock/systemEIStub.go
+++ b/vm/mock/systemEIStub.go
@@ -27,7 +27,7 @@ type SystemEIStub struct {
 	IsValidatorCalled                   func(blsKey []byte) bool
 	StatusFromValidatorStatisticsCalled func(blsKey []byte) string
 	ExecuteOnDestContextCalled          func(destination, sender []byte, value *big.Int, input []byte) (*vmcommon.VMOutput, error)
-	DeploySystemSCCalled                func(baseContract []byte, newAddress []byte, caller []byte, value *big.Int, args [][]byte) (vmcommon.ReturnCode, error)
+	DeploySystemSCCalled                func(baseContract []byte, newAddress []byte, caller []byte, initFunction string, value *big.Int, args [][]byte) (vmcommon.ReturnCode, error)
 	GetStorageFromAddressCalled         func(address []byte, key []byte) []byte
 	SetStorageForAddressCalled          func(address []byte, key []byte, value []byte)
 	CanUnJailCalled                     func(blsKey []byte) bool
@@ -114,9 +114,16 @@ func (s *SystemEIStub) ExecuteOnDestContext(
 }
 
 // DeploySystemSC -
-func (s *SystemEIStub) DeploySystemSC(baseContract []byte, newAddress []byte, ownerAddress []byte, initFunction string, value *big.Int, input [][]byte) (vmcommon.ReturnCode, error) {
+func (s *SystemEIStub) DeploySystemSC(
+	baseContract []byte,
+	newAddress []byte,
+	ownerAddress []byte,
+	initFunction string,
+	value *big.Int,
+	input [][]byte,
+) (vmcommon.ReturnCode, error) {
 	if s.DeploySystemSCCalled != nil {
-		return s.DeploySystemSCCalled(baseContract, newAddress, ownerAddress, value, input)
+		return s.DeploySystemSCCalled(baseContract, newAddress, ownerAddress, initFunction, value, input)
 	}
 	return vmcommon.Ok, nil
 }

--- a/vm/systemSmartContracts/defaults/gasMap.go
+++ b/vm/systemSmartContracts/defaults/gasMap.go
@@ -67,6 +67,7 @@ func FillGasMapMetaChainSystemSCsCosts(value uint64) map[string]uint64 {
 	gasMap["UnBondTokens"] = value
 	gasMap["DelegationMgrOps"] = value
 	gasMap["GetAllNodeStates"] = value
+	gasMap["ValidatorToDelegation"] = value
 
 	return gasMap
 }

--- a/vm/systemSmartContracts/delegationManager.go
+++ b/vm/systemSmartContracts/delegationManager.go
@@ -102,7 +102,7 @@ func NewDelegationManagerSystemSC(args ArgsNewDelegationManager) (*delegationMan
 		minDelegationAmount:              minDelegationAmount,
 		minFee:                           args.DelegationSCConfig.MinServiceFee,
 		maxFee:                           args.DelegationSCConfig.MaxServiceFee,
-		validatorToDelegationEnableEpoch: args.DelegationMgrSCConfig.ValidatorToDelegatorEnableEpoch,
+		validatorToDelegationEnableEpoch: args.DelegationMgrSCConfig.ValidatorToDelegationEnableEpoch,
 	}
 
 	args.EpochNotifier.RegisterNotifyHandler(d)
@@ -271,7 +271,7 @@ func (d *delegationManager) makeNewContractFromValidatorData(args *vmcommon.Cont
 	err := d.eei.UseGas(d.gasCost.MetaChainSystemSCsCost.ValidatorToDelegation)
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
-		return vmcommon.UserError
+		return vmcommon.OutOfGas
 	}
 	if len(args.Arguments) != 2 {
 		d.eei.AddReturnMessage("invalid number of arguments")
@@ -280,7 +280,7 @@ func (d *delegationManager) makeNewContractFromValidatorData(args *vmcommon.Cont
 
 	arguments := append([][]byte{args.CallerAddr}, args.Arguments...)
 
-	return d.deployNewContract(args, false, "initFromValidatorData", arguments)
+	return d.deployNewContract(args, false, initFromValidatorData, arguments)
 }
 
 func (d *delegationManager) mergeValidatorDataToContract(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
@@ -295,7 +295,7 @@ func (d *delegationManager) mergeValidatorDataToContract(args *vmcommon.Contract
 	err := d.eei.UseGas(d.gasCost.MetaChainSystemSCsCost.ValidatorToDelegation)
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
-		return vmcommon.UserError
+		return vmcommon.OutOfGas
 	}
 
 	// TODO implement this

--- a/vm/systemSmartContracts/delegationManager.go
+++ b/vm/systemSmartContracts/delegationManager.go
@@ -216,7 +216,7 @@ func (d *delegationManager) createNewDelegationContract(args *vmcommon.ContractC
 	depositValue := big.NewInt(0).Set(args.CallValue)
 	newAddress := createNewAddress(delegationManagement.LastAddress)
 
-	returnCode, err := d.eei.DeploySystemSC(vm.FirstDelegationSCAddress, newAddress, args.CallerAddr, depositValue, args.Arguments)
+	returnCode, err := d.eei.DeploySystemSC(vm.FirstDelegationSCAddress, newAddress, args.CallerAddr, core.SCDeployInitFunctionName, depositValue, args.Arguments)
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError

--- a/vm/systemSmartContracts/delegationManager.go
+++ b/vm/systemSmartContracts/delegationManager.go
@@ -22,21 +22,20 @@ const delegationContractsList = "delegationContracts"
 var nextAddressAdd = big.NewInt(1 << 24)
 
 type delegationManager struct {
-	eei                      vm.SystemEI
-	delegationMgrSCAddress   []byte
-	stakingSCAddr            []byte
-	validatorSCAddr          []byte
-	configChangeAddr         []byte
-	gasCost                  vm.GasCost
-	marshalizer              marshal.Marshalizer
-	delegationMgrEnabled     atomic.Flag
-	enableDelegationMgrEpoch uint32
-	minCreationDeposit       *big.Int
-	minDelegationAmount      *big.Int
-	minFee                   uint64
-	maxFee                   uint64
-	mutExecution             sync.RWMutex
-
+	eei                              vm.SystemEI
+	delegationMgrSCAddress           []byte
+	stakingSCAddr                    []byte
+	validatorSCAddr                  []byte
+	configChangeAddr                 []byte
+	gasCost                          vm.GasCost
+	marshalizer                      marshal.Marshalizer
+	delegationMgrEnabled             atomic.Flag
+	enableDelegationMgrEpoch         uint32
+	minCreationDeposit               *big.Int
+	minDelegationAmount              *big.Int
+	minFee                           uint64
+	maxFee                           uint64
+	mutExecution                     sync.RWMutex
 	flagValidatorToDelegation        atomic.Flag
 	validatorToDelegationEnableEpoch uint32
 }

--- a/vm/systemSmartContracts/eei.go
+++ b/vm/systemSmartContracts/eei.go
@@ -318,6 +318,7 @@ func (host *vmContext) DeploySystemSC(
 	baseContract []byte,
 	newAddress []byte,
 	ownerAddress []byte,
+	initFunction string,
 	value *big.Int,
 	input [][]byte,
 ) (vmcommon.ReturnCode, error) {
@@ -326,7 +327,7 @@ func (host *vmContext) DeploySystemSC(
 		return vmcommon.ExecutionFailed, vm.ErrUnknownSystemSmartContract
 	}
 
-	callInput := createDirectCallInput(newAddress, ownerAddress, value, core.SCDeployInitFunctionName, input)
+	callInput := createDirectCallInput(newAddress, ownerAddress, value, initFunction, input)
 	err := host.Transfer(callInput.RecipientAddr, host.scAddress, callInput.CallValue, nil, 0)
 	if err != nil {
 		return vmcommon.ExecutionFailed, err

--- a/vm/systemSmartContracts/staking.go
+++ b/vm/systemSmartContracts/staking.go
@@ -1744,7 +1744,7 @@ func (s *stakingSC) changeOwnerAndRewardAddress(args *vmcommon.ContractCallInput
 		}
 
 		if len(registrationData.RewardAddress) == 0 {
-			s.eei.AddReturnMessage("cannot change owner and reward address for a key is not registered")
+			s.eei.AddReturnMessage("cannot change owner and reward address for a key which is not registered")
 			return vmcommon.UserError
 		}
 

--- a/vm/systemSmartContracts/staking.go
+++ b/vm/systemSmartContracts/staking.go
@@ -1744,7 +1744,7 @@ func (s *stakingSC) changeOwnerAndRewardAddress(args *vmcommon.ContractCallInput
 		}
 
 		if len(registrationData.RewardAddress) == 0 {
-			s.eei.AddReturnMessage("cannot change owner and reward address a key is not registered")
+			s.eei.AddReturnMessage("cannot change owner and reward address for a key is not registered")
 			return vmcommon.UserError
 		}
 

--- a/vm/systemSmartContracts/staking.go
+++ b/vm/systemSmartContracts/staking.go
@@ -1721,7 +1721,7 @@ func (s *stakingSC) changeOwnerAndRewardAddress(args *vmcommon.ContractCallInput
 		return vmcommon.UserError
 	}
 	if args.CallValue.Cmp(zero) != 0 {
-		s.eei.AddReturnMessage("CallValue must be 0")
+		s.eei.AddReturnMessage("callValue must be 0")
 		return vmcommon.UserError
 	}
 	if len(args.Arguments) < 2 {
@@ -1744,7 +1744,7 @@ func (s *stakingSC) changeOwnerAndRewardAddress(args *vmcommon.ContractCallInput
 		}
 
 		if len(registrationData.RewardAddress) == 0 {
-			s.eei.AddReturnMessage("cannot unStake a key that is not registered")
+			s.eei.AddReturnMessage("cannot change owner and reward address a key is not registered")
 			return vmcommon.UserError
 		}
 

--- a/vm/systemSmartContracts/validator.go
+++ b/vm/systemSmartContracts/validator.go
@@ -1850,22 +1850,24 @@ func (v *validatorSC) checkInputArgsForValidatorToDelegation(args *vmcommon.Cont
 		return vmcommon.UserError
 	}
 	if len(args.Arguments) != 2 {
-		v.eei.AddReturnMessage("invalid number of arguments, needed 2")
+		v.eei.AddReturnMessage("invalid number of arguments")
 		return vmcommon.UserError
 	}
-	if len(args.Arguments[0]) != len(args.CallerAddr) || len(args.Arguments[1]) != len(args.CallerAddr) {
-		v.eei.AddReturnMessage("invalid argument, wanted an address")
+	oldAddress := args.Arguments[0]
+	newAddress := args.Arguments[1]
+	if len(oldAddress) != len(args.CallerAddr) || len(newAddress) != len(args.CallerAddr) {
+		v.eei.AddReturnMessage("invalid argument, wanted an address for the first and second argument")
 		return vmcommon.UserError
 	}
-	if !core.IsSmartContractAddress(args.Arguments[1]) {
+	if !core.IsSmartContractAddress(newAddress) {
 		v.eei.AddReturnMessage("destination address must be a delegation smart contract")
 		return vmcommon.UserError
 	}
-	if bytes.Equal(args.Arguments[0], args.Arguments[1]) {
+	if bytes.Equal(oldAddress, newAddress) {
 		v.eei.AddReturnMessage("sender and destination addresses are equal")
 		return vmcommon.UserError
 	}
-	if core.IsSmartContractAddress(args.Arguments[0]) {
+	if core.IsSmartContractAddress(oldAddress) {
 		v.eei.AddReturnMessage("sender address must not be a smart contract")
 		return vmcommon.UserError
 	}
@@ -1897,7 +1899,7 @@ func (v *validatorSC) changeOwnerOfValidatorData(args *vmcommon.ContractCallInpu
 		return vmcommon.UserError
 	}
 	if len(validatorData.RewardAddress) == 0 {
-		v.eei.AddReturnMessage("validator data do not exists")
+		v.eei.AddReturnMessage("validator data does not exists")
 		return vmcommon.UserError
 	}
 	if len(v.eei.GetStorage(newAddress)) != 0 {
@@ -1906,7 +1908,7 @@ func (v *validatorSC) changeOwnerOfValidatorData(args *vmcommon.ContractCallInpu
 	}
 
 	validatorData.RewardAddress = newAddress
-	returnCode = v.changeRewardAndOwnerAddressOnStaking(validatorData)
+	returnCode = v.changeOwnerAndRewardAddressOnStaking(validatorData)
 	if returnCode != vmcommon.Ok {
 		return returnCode
 	}
@@ -1921,7 +1923,7 @@ func (v *validatorSC) changeOwnerOfValidatorData(args *vmcommon.ContractCallInpu
 	return vmcommon.Ok
 }
 
-func (v *validatorSC) changeRewardAndOwnerAddressOnStaking(registrationData *ValidatorDataV2) vmcommon.ReturnCode {
+func (v *validatorSC) changeOwnerAndRewardAddressOnStaking(registrationData *ValidatorDataV2) vmcommon.ReturnCode {
 	txData := "changeOwnerAndRewardAddress@" + hex.EncodeToString(registrationData.RewardAddress)
 	for _, blsKey := range registrationData.BlsPubKeys {
 		txData += "@" + hex.EncodeToString(blsKey)


### PR DESCRIPTION
The first part of the implementation of moving validators to delegation contracts. All being optional.
Implemented the first version where the owner makes a new contract and moves the data there.