### PR TITLE
New unBondTokens implementation

### DIFF
--- a/cmd/node/config/systemSmartContractsConfig.toml
+++ b/cmd/node/config/systemSmartContractsConfig.toml
@@ -9,6 +9,7 @@
     StakingV2Epoch = 1
     CorrectLastUnjailedEpoch = 2
     DoubleKeyProtectionEnableEpoch = 1
+    UnbondTokensV2EnableEpoch = 2
     NumRoundsWithoutBleed = 100
     MaximumPercentageToBleed = 0.5
     BleedPercentagePerRound = 0.00001

--- a/config/systemSmartContractsConfig.go
+++ b/config/systemSmartContractsConfig.go
@@ -26,6 +26,7 @@ type StakingSystemSCConfig struct {
 	StakeEnableEpoch                     uint32
 	CorrectLastUnjailedEpoch             uint32
 	DoubleKeyProtectionEnableEpoch       uint32
+	UnbondTokensV2EnableEpoch            uint32
 	ActivateBLSPubKeyMessageVerification bool
 }
 

--- a/integrationTests/vm/testInitializer.go
+++ b/integrationTests/vm/testInitializer.go
@@ -71,6 +71,7 @@ type ArgEnableEpoch struct {
 	DeployEnableEpoch              uint32
 	MetaProtectionEnableEpoch      uint32
 	RelayedTxEnableEpoch           uint32
+	UnbondTokensV2                 uint32
 }
 
 // VMTestContext -
@@ -443,6 +444,7 @@ func CreateVMAndBlockchainHookMeta(
 	accnts state.AccountsAdapter,
 	gasSchedule map[string]map[string]uint64,
 	shardCoordinator sharding.Coordinator,
+	arg ArgEnableEpoch,
 ) (process.VirtualMachinesContainer, *hooks.BlockChainHookImpl) {
 	actualGasSchedule := gasSchedule
 	if gasSchedule == nil {
@@ -490,7 +492,7 @@ func CreateVMAndBlockchainHookMeta(
 		NodesConfigProvider: &mock.NodesSetupStub{},
 		Hasher:              testHasher,
 		Marshalizer:         testMarshalizer,
-		SystemSCConfig:      createSystemSCConfig(),
+		SystemSCConfig:      createSystemSCConfig(arg),
 		ValidatorAccountsDB: accnts,
 		ChanceComputer:      &mock.NodesCoordinatorMock{},
 		EpochNotifier:       &mock.EpochNotifierStub{},
@@ -510,7 +512,7 @@ func CreateVMAndBlockchainHookMeta(
 	return vmContainer, blockChainHook
 }
 
-func createSystemSCConfig() *config.SystemSmartContractsConfig {
+func createSystemSCConfig(arg ArgEnableEpoch) *config.SystemSmartContractsConfig {
 	return &config.SystemSmartContractsConfig{
 		ESDTSystemSCConfig: config.ESDTSystemSCConfig{
 			BaseIssuingCost: "5000000000000000000",
@@ -541,6 +543,7 @@ func createSystemSCConfig() *config.SystemSmartContractsConfig {
 			StakeEnableEpoch:                     0,
 			DoubleKeyProtectionEnableEpoch:       0,
 			ActivateBLSPubKeyMessageVerification: false,
+			UnbondTokensV2EnableEpoch:            arg.UnbondTokensV2,
 		},
 		DelegationManagerSystemSCConfig: config.DelegationManagerSystemSCConfig{
 			MinCreationDeposit:  "1250000000000000000000",
@@ -1012,7 +1015,7 @@ func CreatePreparedTxProcessorWithVMsMultiShard(selfShardID uint32, argEnableEpo
 	var vmContainer process.VirtualMachinesContainer
 	var blockchainHook *hooks.BlockChainHookImpl
 	if selfShardID == core.MetachainShardId {
-		vmContainer, blockchainHook = CreateVMAndBlockchainHookMeta(accounts, nil, shardCoordinator)
+		vmContainer, blockchainHook = CreateVMAndBlockchainHookMeta(accounts, nil, shardCoordinator, argEnableEpoch)
 	} else {
 		vmContainer, blockchainHook = CreateVMAndBlockchainHook(accounts, nil, false, shardCoordinator)
 	}

--- a/integrationTests/vm/testInitializer.go
+++ b/integrationTests/vm/testInitializer.go
@@ -71,7 +71,7 @@ type ArgEnableEpoch struct {
 	DeployEnableEpoch              uint32
 	MetaProtectionEnableEpoch      uint32
 	RelayedTxEnableEpoch           uint32
-	UnbondTokensV2                 uint32
+	UnbondTokensV2EnableEpoch      uint32
 }
 
 // VMTestContext -
@@ -543,7 +543,7 @@ func createSystemSCConfig(arg ArgEnableEpoch) *config.SystemSmartContractsConfig
 			StakeEnableEpoch:                     0,
 			DoubleKeyProtectionEnableEpoch:       0,
 			ActivateBLSPubKeyMessageVerification: false,
-			UnbondTokensV2EnableEpoch:            arg.UnbondTokensV2,
+			UnbondTokensV2EnableEpoch:            arg.UnbondTokensV2EnableEpoch,
 		},
 		DelegationManagerSystemSCConfig: config.DelegationManagerSystemSCConfig{
 			MinCreationDeposit:  "1250000000000000000000",

--- a/integrationTests/vm/txsFee/validatorSC_test.go
+++ b/integrationTests/vm/txsFee/validatorSC_test.go
@@ -131,12 +131,12 @@ func TestValidatorsSC_DoStakePutInQueueUnStakeAndUnBondTokensShouldRefund(t *tes
 
 func TestValidatorsSC_DoStakeWithTopUpValueTryToUnStakeTokensAndUnBondTokens(t *testing.T) {
 	argUnbondTokensV1 := vm.ArgEnableEpoch{
-		UnbondTokensV2: 20000,
+		UnbondTokensV2EnableEpoch: 20000,
 	}
 	testValidatorsSC_DoStakeWithTopUpValueTryToUnStakeTokensAndUnBondTokens(t, argUnbondTokensV1)
 
 	argUnbondTokensV2 := vm.ArgEnableEpoch{
-		UnbondTokensV2: 0,
+		UnbondTokensV2EnableEpoch: 0,
 	}
 	testValidatorsSC_DoStakeWithTopUpValueTryToUnStakeTokensAndUnBondTokens(t, argUnbondTokensV2)
 }

--- a/integrationTests/vm/txsFee/validatorSC_test.go
+++ b/integrationTests/vm/txsFee/validatorSC_test.go
@@ -130,7 +130,19 @@ func TestValidatorsSC_DoStakePutInQueueUnStakeAndUnBondTokensShouldRefund(t *tes
 }
 
 func TestValidatorsSC_DoStakeWithTopUpValueTryToUnStakeTokensAndUnBondTokens(t *testing.T) {
-	testContextMeta, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(core.MetachainShardId, vm.ArgEnableEpoch{})
+	argUnbondTokensV1 := vm.ArgEnableEpoch{
+		UnbondTokensV2: 20000,
+	}
+	testValidatorsSC_DoStakeWithTopUpValueTryToUnStakeTokensAndUnBondTokens(t, argUnbondTokensV1)
+
+	argUnbondTokensV2 := vm.ArgEnableEpoch{
+		UnbondTokensV2: 0,
+	}
+	testValidatorsSC_DoStakeWithTopUpValueTryToUnStakeTokensAndUnBondTokens(t, argUnbondTokensV2)
+}
+
+func testValidatorsSC_DoStakeWithTopUpValueTryToUnStakeTokensAndUnBondTokens(t *testing.T, arg vm.ArgEnableEpoch) {
+	testContextMeta, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(core.MetachainShardId, arg)
 
 	require.Nil(t, err)
 	defer testContextMeta.Close()

--- a/vm/systemSmartContracts/validator.go
+++ b/vm/systemSmartContracts/validator.go
@@ -32,31 +32,31 @@ const (
 )
 
 type validatorSC struct {
-	eei                      vm.SystemEI
-	unBondPeriod             uint64
-	unBondPeriodInEpochs     uint32
-	sigVerifier              vm.MessageSignVerifier
-	baseConfig               ValidatorConfig
-	stakingV2Epoch           uint32
-	stakingSCAddress         []byte
-	validatorSCAddress       []byte
-	walletAddressLen         int
-	enableStakingEpoch       uint32
-	enableDoubleKeyEpoch     uint32
-	gasCost                  vm.GasCost
-	marshalizer              marshal.Marshalizer
-	flagEnableStaking        atomic.Flag
-	flagEnableTopUp          atomic.Flag
-	flagDoubleKey            atomic.Flag
-	minUnstakeTokensValue    *big.Int
-	minDeposit               *big.Int
-	mutExecution             sync.RWMutex
-	endOfEpochAddress        []byte
-	enableDelegationMgrEpoch uint32
-	enableUnbondTokensV2     uint32
-	delegationMgrSCAddress   []byte
-	flagDelegationMgr        atomic.Flag
-	flagUnbondTokensV2       atomic.Flag
+	eei                       vm.SystemEI
+	unBondPeriod              uint64
+	unBondPeriodInEpochs      uint32
+	sigVerifier               vm.MessageSignVerifier
+	baseConfig                ValidatorConfig
+	stakingV2Epoch            uint32
+	stakingSCAddress          []byte
+	validatorSCAddress        []byte
+	walletAddressLen          int
+	enableStakingEpoch        uint32
+	enableDoubleKeyEpoch      uint32
+	gasCost                   vm.GasCost
+	marshalizer               marshal.Marshalizer
+	flagEnableStaking         atomic.Flag
+	flagEnableTopUp           atomic.Flag
+	flagDoubleKey             atomic.Flag
+	minUnstakeTokensValue     *big.Int
+	minDeposit                *big.Int
+	mutExecution              sync.RWMutex
+	endOfEpochAddress         []byte
+	enableDelegationMgrEpoch  uint32
+	enableUnbondTokensV2Epoch uint32
+	delegationMgrSCAddress    []byte
+	flagDelegationMgr         atomic.Flag
+	flagUnbondTokensV2        atomic.Flag
 }
 
 // ArgsValidatorSmartContract is the arguments structure to create a new ValidatorSmartContract
@@ -139,25 +139,25 @@ func NewValidatorSmartContract(
 	}
 
 	reg := &validatorSC{
-		eei:                      args.Eei,
-		unBondPeriod:             args.StakingSCConfig.UnBondPeriod,
-		unBondPeriodInEpochs:     args.StakingSCConfig.UnBondPeriodInEpochs,
-		sigVerifier:              args.SigVerifier,
-		baseConfig:               baseConfig,
-		stakingV2Epoch:           args.StakingSCConfig.StakingV2Epoch,
-		enableStakingEpoch:       args.StakingSCConfig.StakeEnableEpoch,
-		stakingSCAddress:         args.StakingSCAddress,
-		validatorSCAddress:       args.ValidatorSCAddress,
-		gasCost:                  args.GasCost,
-		marshalizer:              args.Marshalizer,
-		minUnstakeTokensValue:    minUnstakeTokensValue,
-		walletAddressLen:         len(args.ValidatorSCAddress),
-		enableDoubleKeyEpoch:     args.StakingSCConfig.DoubleKeyProtectionEnableEpoch,
-		endOfEpochAddress:        args.EndOfEpochAddress,
-		minDeposit:               minDeposit,
-		enableDelegationMgrEpoch: args.DelegationMgrEnableEpoch,
-		delegationMgrSCAddress:   args.DelegationMgrSCAddress,
-		enableUnbondTokensV2:     args.StakingSCConfig.UnbondTokensV2EnableEpoch,
+		eei:                       args.Eei,
+		unBondPeriod:              args.StakingSCConfig.UnBondPeriod,
+		unBondPeriodInEpochs:      args.StakingSCConfig.UnBondPeriodInEpochs,
+		sigVerifier:               args.SigVerifier,
+		baseConfig:                baseConfig,
+		stakingV2Epoch:            args.StakingSCConfig.StakingV2Epoch,
+		enableStakingEpoch:        args.StakingSCConfig.StakeEnableEpoch,
+		stakingSCAddress:          args.StakingSCAddress,
+		validatorSCAddress:        args.ValidatorSCAddress,
+		gasCost:                   args.GasCost,
+		marshalizer:               args.Marshalizer,
+		minUnstakeTokensValue:     minUnstakeTokensValue,
+		walletAddressLen:          len(args.ValidatorSCAddress),
+		enableDoubleKeyEpoch:      args.StakingSCConfig.DoubleKeyProtectionEnableEpoch,
+		endOfEpochAddress:         args.EndOfEpochAddress,
+		minDeposit:                minDeposit,
+		enableDelegationMgrEpoch:  args.DelegationMgrEnableEpoch,
+		delegationMgrSCAddress:    args.DelegationMgrSCAddress,
+		enableUnbondTokensV2Epoch: args.StakingSCConfig.UnbondTokensV2EnableEpoch,
 	}
 
 	args.EpochNotifier.RegisterNotifyHandler(reg)
@@ -1916,7 +1916,7 @@ func (v *validatorSC) EpochConfirmed(epoch uint32) {
 	v.flagDelegationMgr.Toggle(epoch >= v.enableDelegationMgrEpoch)
 	log.Debug("validatorSC: delegation manager", "enabled", v.flagDelegationMgr.IsSet())
 
-	v.flagUnbondTokensV2.Toggle(epoch >= v.enableUnbondTokensV2)
+	v.flagUnbondTokensV2.Toggle(epoch >= v.enableUnbondTokensV2Epoch)
 	log.Debug("validatorSC: unbond tokens v2", "enabled", v.flagUnbondTokensV2.IsSet())
 }
 

--- a/vm/systemSmartContracts/validator_test.go
+++ b/vm/systemSmartContracts/validator_test.go
@@ -3597,7 +3597,7 @@ func TestStakingValidatorSC_UnbondTokensWithCallValueShouldError(t *testing.T) {
 	assert.Equal(t, vm.TransactionValueMustBeZero, vmOutput.ReturnMessage)
 }
 
-func TestStakingValidatorSC_UnBondTokensShouldWork(t *testing.T) {
+func TestStakingValidatorSC_UnBondTokensV1ShouldWork(t *testing.T) {
 	t.Parallel()
 
 	minStakeValue := big.NewInt(1000)
@@ -3613,6 +3613,7 @@ func TestStakingValidatorSC_UnBondTokensShouldWork(t *testing.T) {
 	}
 	args := createMockArgumentsForValidatorSC()
 	args.StakingSCConfig.StakingV2Epoch = 0
+	args.StakingSCConfig.UnbondTokensV2EnableEpoch = 1000
 	args.StakingSCConfig.UnBondPeriodInEpochs = unbondPeriod
 	eei := createVmContextWithStakingSc(minStakeValue, uint64(unbondPeriod), blockChainHook)
 	args.Eei = eei
@@ -3669,6 +3670,259 @@ func TestStakingValidatorSC_UnBondTokensShouldWork(t *testing.T) {
 			},
 		},
 		TotalUnstaked: big.NewInt(4),
+	}
+
+	recovered, err := sc.getOrCreateRegistrationData(caller)
+	require.Nil(t, err)
+
+	assert.Equal(t, expected, recovered)
+}
+
+func TestStakingValidatorSC_UnBondTokensV2ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	minStakeValue := big.NewInt(1000)
+	unbondPeriod := uint32(10)
+	startEpoch := uint32(56)
+	blockChainHook := &mock.BlockChainHookStub{
+		CurrentEpochCalled: func() uint32 {
+			return startEpoch + unbondPeriod
+		},
+		CurrentNonceCalled: func() uint64 {
+			return uint64(startEpoch + unbondPeriod)
+		},
+	}
+	args := createMockArgumentsForValidatorSC()
+	args.StakingSCConfig.StakingV2Epoch = 0
+	args.StakingSCConfig.UnBondPeriodInEpochs = unbondPeriod
+	args.StakingSCConfig.UnbondTokensV2EnableEpoch = 0
+	eei := createVmContextWithStakingSc(minStakeValue, uint64(unbondPeriod), blockChainHook)
+	args.Eei = eei
+	caller := []byte("caller")
+	sc, _ := NewValidatorSmartContract(args)
+	_ = sc.saveRegistrationData(
+		caller,
+		&ValidatorDataV2{
+			RegisterNonce:   0,
+			Epoch:           0,
+			RewardAddress:   caller,
+			TotalStakeValue: big.NewInt(1000),
+			LockedStake:     big.NewInt(1000),
+			MaxStakePerNode: big.NewInt(0),
+			BlsPubKeys:      [][]byte{[]byte("key")},
+			NumRegistered:   1,
+			UnstakedInfo: []*UnstakedValue{
+				{
+					UnstakedEpoch: startEpoch + 1,
+					UnstakedValue: big.NewInt(4),
+				},
+				{
+					UnstakedEpoch: startEpoch - 2,
+					UnstakedValue: big.NewInt(1),
+				},
+				{
+					UnstakedEpoch: startEpoch - 1,
+					UnstakedValue: big.NewInt(2),
+				},
+				{
+					UnstakedEpoch: startEpoch,
+					UnstakedValue: big.NewInt(3),
+				},
+			},
+			TotalUnstaked: big.NewInt(10),
+		},
+	)
+
+	callFunctionAndCheckResult(t, "unBondTokens", sc, caller, nil, zero, vmcommon.Ok)
+
+	expected := &ValidatorDataV2{
+		RegisterNonce:   0,
+		Epoch:           0,
+		RewardAddress:   caller,
+		TotalStakeValue: big.NewInt(1000),
+		LockedStake:     big.NewInt(1000),
+		MaxStakePerNode: big.NewInt(0),
+		BlsPubKeys:      [][]byte{[]byte("key")},
+		NumRegistered:   1,
+		UnstakedInfo: []*UnstakedValue{
+			{
+				UnstakedEpoch: startEpoch + 1,
+				UnstakedValue: big.NewInt(4),
+			},
+		},
+		TotalUnstaked: big.NewInt(4),
+	}
+
+	recovered, err := sc.getOrCreateRegistrationData(caller)
+	require.Nil(t, err)
+
+	assert.Equal(t, expected, recovered)
+}
+
+func TestStakingValidatorSC_UnBondTokensV2WithTooMuchToUnbondShouldWork(t *testing.T) {
+	t.Parallel()
+
+	minStakeValue := big.NewInt(1000)
+	unbondPeriod := uint32(10)
+	startEpoch := uint32(56)
+	blockChainHook := &mock.BlockChainHookStub{
+		CurrentEpochCalled: func() uint32 {
+			return startEpoch + unbondPeriod
+		},
+		CurrentNonceCalled: func() uint64 {
+			return uint64(startEpoch + unbondPeriod)
+		},
+	}
+	args := createMockArgumentsForValidatorSC()
+	args.StakingSCConfig.StakingV2Epoch = 0
+	args.StakingSCConfig.UnBondPeriodInEpochs = unbondPeriod
+	args.StakingSCConfig.UnbondTokensV2EnableEpoch = 0
+	eei := createVmContextWithStakingSc(minStakeValue, uint64(unbondPeriod), blockChainHook)
+	args.Eei = eei
+	caller := []byte("caller")
+	sc, _ := NewValidatorSmartContract(args)
+	_ = sc.saveRegistrationData(
+		caller,
+		&ValidatorDataV2{
+			RegisterNonce:   0,
+			Epoch:           0,
+			RewardAddress:   caller,
+			TotalStakeValue: big.NewInt(1000),
+			LockedStake:     big.NewInt(1000),
+			MaxStakePerNode: big.NewInt(0),
+			BlsPubKeys:      [][]byte{[]byte("key")},
+			NumRegistered:   1,
+			UnstakedInfo: []*UnstakedValue{
+				{
+					UnstakedEpoch: startEpoch + 1,
+					UnstakedValue: big.NewInt(4),
+				},
+				{
+					UnstakedEpoch: startEpoch - 2,
+					UnstakedValue: big.NewInt(1),
+				},
+				{
+					UnstakedEpoch: startEpoch - 1,
+					UnstakedValue: big.NewInt(2),
+				},
+				{
+					UnstakedEpoch: startEpoch,
+					UnstakedValue: big.NewInt(3),
+				},
+			},
+			TotalUnstaked: big.NewInt(10),
+		},
+	)
+
+	unbondValueBytes := big.NewInt(7).Bytes()
+	callFunctionAndCheckResult(t, "unBondTokens", sc, caller, [][]byte{unbondValueBytes}, zero, vmcommon.Ok)
+
+	expected := &ValidatorDataV2{
+		RegisterNonce:   0,
+		Epoch:           0,
+		RewardAddress:   caller,
+		TotalStakeValue: big.NewInt(1000),
+		LockedStake:     big.NewInt(1000),
+		MaxStakePerNode: big.NewInt(0),
+		BlsPubKeys:      [][]byte{[]byte("key")},
+		NumRegistered:   1,
+		UnstakedInfo: []*UnstakedValue{
+			{
+				UnstakedEpoch: startEpoch + 1,
+				UnstakedValue: big.NewInt(4),
+			},
+		},
+		TotalUnstaked: big.NewInt(4),
+	}
+
+	recovered, err := sc.getOrCreateRegistrationData(caller)
+	require.Nil(t, err)
+
+	assert.Equal(t, expected, recovered)
+}
+
+func TestStakingValidatorSC_UnBondTokensV2WithSplitShouldWork(t *testing.T) {
+	t.Parallel()
+
+	minStakeValue := big.NewInt(1000)
+	unbondPeriod := uint32(10)
+	startEpoch := uint32(56)
+	blockChainHook := &mock.BlockChainHookStub{
+		CurrentEpochCalled: func() uint32 {
+			return startEpoch + unbondPeriod
+		},
+		CurrentNonceCalled: func() uint64 {
+			return uint64(startEpoch + unbondPeriod)
+		},
+	}
+	args := createMockArgumentsForValidatorSC()
+	args.StakingSCConfig.StakingV2Epoch = 0
+	args.StakingSCConfig.UnBondPeriodInEpochs = unbondPeriod
+	args.StakingSCConfig.UnbondTokensV2EnableEpoch = 0
+	eei := createVmContextWithStakingSc(minStakeValue, uint64(unbondPeriod), blockChainHook)
+	args.Eei = eei
+	caller := []byte("caller")
+	sc, _ := NewValidatorSmartContract(args)
+	_ = sc.saveRegistrationData(
+		caller,
+		&ValidatorDataV2{
+			RegisterNonce:   0,
+			Epoch:           0,
+			RewardAddress:   caller,
+			TotalStakeValue: big.NewInt(1000),
+			LockedStake:     big.NewInt(1000),
+			MaxStakePerNode: big.NewInt(0),
+			BlsPubKeys:      [][]byte{[]byte("key")},
+			NumRegistered:   1,
+			UnstakedInfo: []*UnstakedValue{
+				{
+					UnstakedEpoch: startEpoch + 1,
+					UnstakedValue: big.NewInt(4),
+				},
+				{
+					UnstakedEpoch: startEpoch - 2,
+					UnstakedValue: big.NewInt(1),
+				},
+				{
+					UnstakedEpoch: startEpoch - 1,
+					UnstakedValue: big.NewInt(2),
+				},
+				{
+					UnstakedEpoch: startEpoch,
+					UnstakedValue: big.NewInt(3),
+				},
+			},
+			TotalUnstaked: big.NewInt(10),
+		},
+	)
+
+	unbondValueBytes := big.NewInt(2).Bytes()
+	callFunctionAndCheckResult(t, "unBondTokens", sc, caller, [][]byte{unbondValueBytes}, zero, vmcommon.Ok)
+
+	expected := &ValidatorDataV2{
+		RegisterNonce:   0,
+		Epoch:           0,
+		RewardAddress:   caller,
+		TotalStakeValue: big.NewInt(1000),
+		LockedStake:     big.NewInt(1000),
+		MaxStakePerNode: big.NewInt(0),
+		BlsPubKeys:      [][]byte{[]byte("key")},
+		NumRegistered:   1,
+		UnstakedInfo: []*UnstakedValue{
+			{
+				UnstakedEpoch: startEpoch + 1,
+				UnstakedValue: big.NewInt(4),
+			},
+			{
+				UnstakedEpoch: startEpoch - 1,
+				UnstakedValue: big.NewInt(1),
+			},
+			{
+				UnstakedEpoch: startEpoch,
+				UnstakedValue: big.NewInt(3),
+			},
+		},
+		TotalUnstaked: big.NewInt(8),
 	}
 
 	recovered, err := sc.getOrCreateRegistrationData(caller)


### PR DESCRIPTION
 - new implementation for unBondTokens as to circumvent found issue

Testing scenario that should happen in epochs 1-4 and should be carried on the `test-fix-unbond-tokens` branch:
1. stake one node in the queue with 2619 eGLD.
2. unstake 119 eGLD top up and check that you have to wait 3 epoch changes.
3. unstake 2500 eGLD from the node (direct from wallet, use the 3 dot button beside the BLS key)
4. finalize the withdraw of 2500 eGLD part, should get "no tokens that can be unbond at this time" error

Wait for epoch 4 that activates the new unBondTokens variant, repeat step 4, should unbond the 2500 value (after a total of 5 epochs between the first unstake, another unBond call should return also the last 119 eGLD).
repeat steps 1-3 with another key. Step 4 should not error, should return the 2500 eGLD and after another 5 epoch changes, a new unBond call should return the last 119 eGLD.
