### PR TITLE
Epoch start info meta block API

### DIFF
--- a/data/api/apiBlock.go
+++ b/data/api/apiBlock.go
@@ -43,6 +43,7 @@ type EpochStartInfo struct {
 type NotarizedBlock struct {
 	Hash  string `json:"hash"`
 	Nonce uint64 `json:"nonce"`
+	Round uint64 `json:"round"`
 	Shard uint32 `json:"shard"`
 }
 

--- a/data/api/apiBlock.go
+++ b/data/api/apiBlock.go
@@ -27,7 +27,7 @@ type Block struct {
 	EpochStartInfo         *EpochStartInfo   `json:"epochStartInfo,omitempty"`
 }
 
-// EpochStartInfo is a structure that hold information about epoch start meta block
+// EpochStartInfo is a structure that holds information about epoch start meta block
 type EpochStartInfo struct {
 	TotalSupply                      string `json:"totalSupply"`
 	TotalToDistribute                string `json:"totalToDistribute"`

--- a/data/api/apiBlock.go
+++ b/data/api/apiBlock.go
@@ -24,6 +24,19 @@ type Block struct {
 	AccumulatedFeesInEpoch string            `json:"accumulatedFeesInEpoch,omitempty"`
 	DeveloperFeesInEpoch   string            `json:"developerFeesInEpoch,omitempty"`
 	Status                 string            `json:"status,omitempty"`
+	EpochStartInfo         *EpochStartInfo   `json:"epochStartInfo,omitempty"`
+}
+
+// EpochStartInfo is a structure that hold information about epoch start meta block
+type EpochStartInfo struct {
+	TotalSupply                      string `json:"totalSupply"`
+	TotalToDistribute                string `json:"totalToDistribute"`
+	TotalNewlyMinted                 string `json:"totalNewlyMinted"`
+	RewardsPerBlock                  string `json:"rewardsPerBlock"`
+	RewardsForProtocolSustainability string `json:"rewardsForProtocolSustainability"`
+	NodePrice                        string `json:"nodePrice"`
+	PrevEpochStartRound              uint64 `json:"prevEpochStartRound"`
+	PrevEpochStartHash               string `json:"prevEpochStartHash"`
 }
 
 // NotarizedBlock represents a notarized block

--- a/node/blockAPI/metaBlock.go
+++ b/node/blockAPI/metaBlock.go
@@ -108,7 +108,7 @@ func (mbp *metaAPIBlockProcessor) convertMetaBlockBytesToAPIBlock(hash []byte, b
 		notarizedBlocks = append(notarizedBlocks, notarizedBlock)
 	}
 
-	return &api.Block{
+	metaBlock := &api.Block{
 		Nonce:                  blockHeader.Nonce,
 		Round:                  blockHeader.Round,
 		Epoch:                  blockHeader.Epoch,
@@ -124,5 +124,22 @@ func (mbp *metaAPIBlockProcessor) convertMetaBlockBytesToAPIBlock(hash []byte, b
 		DeveloperFeesInEpoch:   blockHeader.DevFeesInEpoch.String(),
 		Timestamp:              time.Duration(blockHeader.GetTimeStamp()),
 		Status:                 BlockStatusOnChain,
-	}, nil
+	}
+
+	if blockHeader.IsStartOfEpochBlock() {
+		epochStartEconomics := blockHeader.EpochStart.Economics
+
+		metaBlock.EpochStartInfo = &api.EpochStartInfo{
+			TotalSupply:                      epochStartEconomics.TotalSupply.String(),
+			TotalToDistribute:                epochStartEconomics.TotalToDistribute.String(),
+			TotalNewlyMinted:                 epochStartEconomics.TotalNewlyMinted.String(),
+			RewardsPerBlock:                  epochStartEconomics.RewardsPerBlock.String(),
+			RewardsForProtocolSustainability: epochStartEconomics.RewardsForProtocolSustainability.String(),
+			NodePrice:                        epochStartEconomics.NodePrice.String(),
+			PrevEpochStartRound:              epochStartEconomics.PrevEpochStartRound,
+			PrevEpochStartHash:               hex.EncodeToString(epochStartEconomics.PrevEpochStartHash),
+		}
+	}
+
+	return metaBlock, nil
 }

--- a/node/blockAPI/metaBlock.go
+++ b/node/blockAPI/metaBlock.go
@@ -102,6 +102,7 @@ func (mbp *metaAPIBlockProcessor) convertMetaBlockBytesToAPIBlock(hash []byte, b
 		notarizedBlock := &api.NotarizedBlock{
 			Hash:  hex.EncodeToString(shardData.HeaderHash),
 			Nonce: shardData.Nonce,
+			Round: shardData.Round,
 			Shard: shardData.ShardID,
 		}
 

--- a/node/blockAPI/metaBlock_test.go
+++ b/node/blockAPI/metaBlock_test.go
@@ -313,7 +313,14 @@ func TestMetaAPIBlockProcessor_GetBlockByHashEpochStartBlock(t *testing.T) {
 		DeveloperFees:          big.NewInt(0),
 		AccumulatedFeesInEpoch: big.NewInt(10),
 		DevFeesInEpoch:         big.NewInt(5),
-
+		ShardInfo: []block.ShardData{
+			{
+				HeaderHash: []byte("hash"),
+				ShardID:    0,
+				Nonce:      1,
+				Round:      2,
+			},
+		},
 		EpochStart: block.EpochStart{
 			LastFinalizedHeaders: []block.EpochStartShardData{{}},
 			Economics: block.Economics{
@@ -333,12 +340,19 @@ func TestMetaAPIBlockProcessor_GetBlockByHashEpochStartBlock(t *testing.T) {
 	_ = storerMock.Put(headerHash, headerBytes)
 
 	expectedBlock := &api.Block{
-		Nonce:           nonce,
-		Round:           round,
-		Shard:           core.MetachainShardId,
-		Epoch:           epoch,
-		Hash:            hex.EncodeToString(headerHash),
-		NotarizedBlocks: []*api.NotarizedBlock{},
+		Nonce: nonce,
+		Round: round,
+		Shard: core.MetachainShardId,
+		Epoch: epoch,
+		Hash:  hex.EncodeToString(headerHash),
+		NotarizedBlocks: []*api.NotarizedBlock{
+			{
+				Hash:  "68617368",
+				Shard: 0,
+				Nonce: 1,
+				Round: 2,
+			},
+		},
 		MiniBlocks: []*api.MiniBlock{
 			{
 				Hash: hex.EncodeToString(miniblockHeader),


### PR DESCRIPTION
Added in the API block  information about the epoch start block like:
- Total supply
- Total to distribute
- Total newly minted
- Previous epoch start block hash