### PR TITLE
new endpoints for esdt, sft and nft

### DIFF
--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -52,7 +52,7 @@ type Facade struct {
 	GetBlockByHashCalled                    func(hash string, withTxs bool) (*api.Block, error)
 	GetBlockByNonceCalled                   func(nonce uint64, withTxs bool) (*api.Block, error)
 	GetTotalStakedValueHandler              func() (*api.StakeValues, error)
-	GetAllIssuedESDTsCalled                 func() ([]string, error)
+	GetAllIssuedESDTsCalled                 func(tokenType string) ([]string, error)
 	GetDirectStakedListHandler              func() ([]*api.DirectStakedValue, error)
 	GetDelegatorsListHandler                func() ([]*api.Delegator, error)
 }
@@ -145,10 +145,11 @@ func (f *Facade) GetAllESDTTokens(address string) (map[string]*esdt.ESDigitalTok
 }
 
 // GetAllIssuedESDTs -
-func (f *Facade) GetAllIssuedESDTs() ([]string, error) {
+func (f *Facade) GetAllIssuedESDTs(tokenType string) ([]string, error) {
 	if f.GetAllIssuedESDTsCalled != nil {
-		return f.GetAllIssuedESDTsCalled()
+		return f.GetAllIssuedESDTsCalled(tokenType)
 	}
+
 	return make([]string, 0), nil
 }
 

--- a/api/network/routes.go
+++ b/api/network/routes.go
@@ -17,6 +17,9 @@ const (
 	getStatusPath        = "/status"
 	economicsPath        = "/economics"
 	getESDTsPath         = "/esdts"
+	getFFTsPath          = "/esdt/fungible-tokens"
+	getSFTsPath          = "/esdt/semi-fungible-tokens"
+	getNFTsPath          = "/esdt/non-fungible-tokens"
 	directStakedInfoPath = "/direct-staked-info"
 	delegatedInfoPath    = "/delegated-info"
 )
@@ -27,7 +30,7 @@ type FacadeHandler interface {
 	GetDirectStakedList() ([]*api.DirectStakedValue, error)
 	GetDelegatorsList() ([]*api.Delegator, error)
 	StatusMetrics() external.StatusMetricsHandler
-	GetAllIssuedESDTs() ([]string, error)
+	GetAllIssuedESDTs(tokenType string) ([]string, error)
 	IsInterfaceNil() bool
 }
 
@@ -36,7 +39,10 @@ func Routes(router *wrapper.RouterWrapper) {
 	router.RegisterHandler(http.MethodGet, getConfigPath, GetNetworkConfig)
 	router.RegisterHandler(http.MethodGet, getStatusPath, GetNetworkStatus)
 	router.RegisterHandler(http.MethodGet, economicsPath, EconomicsMetrics)
-	router.RegisterHandler(http.MethodGet, getESDTsPath, GetAllIssuedESDTs)
+	router.RegisterHandler(http.MethodGet, getESDTsPath, getHandlerFuncForEsdt(""))
+	router.RegisterHandler(http.MethodGet, getFFTsPath, getHandlerFuncForEsdt(core.FungibleESDT))
+	router.RegisterHandler(http.MethodGet, getSFTsPath, getHandlerFuncForEsdt(core.SemiFungibleESDT))
+	router.RegisterHandler(http.MethodGet, getNFTsPath, getHandlerFuncForEsdt(core.NonFungibleESDT))
 	router.RegisterHandler(http.MethodGet, directStakedInfoPath, DirectStakedInfo)
 	router.RegisterHandler(http.MethodGet, delegatedInfoPath, DelegatedInfo)
 }
@@ -141,34 +147,35 @@ func EconomicsMetrics(c *gin.Context) {
 	)
 }
 
-// GetAllIssuedESDTs returns all the issued esdts from the metachain
-func GetAllIssuedESDTs(c *gin.Context) {
-	facade, ok := getFacade(c)
-	if !ok {
-		return
-	}
+func getHandlerFuncForEsdt(tokenType string) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		facade, ok := getFacade(c)
+		if !ok {
+			return
+		}
 
-	tokens, err := facade.GetAllIssuedESDTs()
-	if err != nil {
+		tokens, err := facade.GetAllIssuedESDTs(tokenType)
+		if err != nil {
+			c.JSON(
+				http.StatusInternalServerError,
+				shared.GenericAPIResponse{
+					Data:  nil,
+					Error: err.Error(),
+					Code:  shared.ReturnCodeInternalError,
+				},
+			)
+			return
+		}
+
 		c.JSON(
-			http.StatusInternalServerError,
+			http.StatusOK,
 			shared.GenericAPIResponse{
-				Data:  nil,
-				Error: err.Error(),
-				Code:  shared.ReturnCodeInternalError,
+				Data:  gin.H{"tokens": tokens},
+				Error: "",
+				Code:  shared.ReturnCodeSuccess,
 			},
 		)
-		return
 	}
-
-	c.JSON(
-		http.StatusOK,
-		shared.GenericAPIResponse{
-			Data:  gin.H{"tokens": tokens},
-			Error: "",
-			Code:  shared.ReturnCodeSuccess,
-		},
-	)
 }
 
 // DirectStakedInfo is the endpoint that will return the directed staked info list

--- a/api/network/routes_test.go
+++ b/api/network/routes_test.go
@@ -219,7 +219,7 @@ func TestEconomicsMetrics_CannotGetStakeValues(t *testing.T) {
 func TestGetAllIssuedESDTs_ShouldWork(t *testing.T) {
 	tokens := []string{"tokenA", "tokenB"}
 	facade := mock.Facade{
-		GetAllIssuedESDTsCalled: func() ([]string, error) {
+		GetAllIssuedESDTsCalled: func(_ string) ([]string, error) {
 			return tokens, nil
 		},
 	}
@@ -239,7 +239,7 @@ func TestGetAllIssuedESDTs_ShouldWork(t *testing.T) {
 func TestGetAllIssuedESDTs_Error(t *testing.T) {
 	localErr := fmt.Errorf("%s", "local error")
 	facade := mock.Facade{
-		GetAllIssuedESDTsCalled: func() ([]string, error) {
+		GetAllIssuedESDTsCalled: func(_ string) ([]string, error) {
 			return nil, localErr
 		},
 	}

--- a/cmd/node/config/api.toml
+++ b/cmd/node/config/api.toml
@@ -73,6 +73,15 @@
         # /network/esdts will return all the issued esdts on the protocol
         { Name = "/esdts", Open = true },
 
+        # /network/fungible-tokens will return all the issued fungible tokens on the protocol
+        { Name = "/esdt/fungible-tokens", Open = true },
+
+        # /network/semi-fungible-tokens will return all the issued semi fungible tokens on the protocol
+        { Name = "/esdt/semi-fungible-tokens", Open = true },
+
+        # /network/non-fungible-tokens will return all the issued non fungible tokens on the protocol
+        { Name = "/esdt/non-fungible-tokens", Open = true },
+
         # /network/direct-staked-info will return a list containing direct staked list of addresses
         # and their staked values
         {Name = "/direct-staked-info", Open = false},

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -33,7 +33,7 @@ type NodeHandler interface {
 	GetKeyValuePairs(address string) (map[string]string, error)
 
 	// GetAllIssuedESDTs returns all the issued esdt tokens from esdt system smart contract
-	GetAllIssuedESDTs() ([]string, error)
+	GetAllIssuedESDTs(tokenType string) ([]string, error)
 
 	// GetESDTData returns the esdt data from a given account, given key and given nonce
 	GetESDTData(address, tokenID string, nonce uint64) (*esdt.ESDigitalToken, error)

--- a/facade/mock/nodeStub.go
+++ b/facade/mock/nodeStub.go
@@ -44,7 +44,7 @@ type NodeStub struct {
 	GetESDTDataCalled                              func(address string, key string, nonce uint64) (*esdt.ESDigitalToken, error)
 	GetAllESDTTokensCalled                         func(address string) (map[string]*esdt.ESDigitalToken, error)
 	GetKeyValuePairsCalled                         func(address string) (map[string]string, error)
-	GetAllIssuedESDTsCalled                        func() ([]string, error)
+	GetAllIssuedESDTsCalled                        func(tokenType string) ([]string, error)
 }
 
 // GetUsername -
@@ -202,9 +202,9 @@ func (ns *NodeStub) GetAllESDTTokens(address string) (map[string]*esdt.ESDigital
 }
 
 // GetAllIssuedESDTs -
-func (ns *NodeStub) GetAllIssuedESDTs() ([]string, error) {
+func (ns *NodeStub) GetAllIssuedESDTs(tokenType string) ([]string, error) {
 	if ns.GetAllIssuedESDTsCalled != nil {
-		return ns.GetAllIssuedESDTsCalled()
+		return ns.GetAllIssuedESDTsCalled(tokenType)
 	}
 	return make([]string, 0), nil
 }

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -288,8 +288,8 @@ func (nf *nodeFacade) GetAllESDTTokens(address string) (map[string]*esdt.ESDigit
 }
 
 // GetAllIssuedESDTs returns all the issued esdts from the esdt system smart contract
-func (nf *nodeFacade) GetAllIssuedESDTs() ([]string, error) {
-	return nf.node.GetAllIssuedESDTs()
+func (nf *nodeFacade) GetAllIssuedESDTs(tokenType string) ([]string, error) {
+	return nf.node.GetAllIssuedESDTs(tokenType)
 }
 
 // CreateTransaction creates a transaction from all needed fields

--- a/facade/nodeFacade_test.go
+++ b/facade/nodeFacade_test.go
@@ -740,14 +740,14 @@ func TestNodeFacade_GetAllIssuedESDTs(t *testing.T) {
 	expectedValue := []string{"value"}
 	arg := createMockArguments()
 	arg.Node = &mock.NodeStub{
-		GetAllIssuedESDTsCalled: func() ([]string, error) {
+		GetAllIssuedESDTsCalled: func(_ string) ([]string, error) {
 			return expectedValue, nil
 		},
 	}
 
 	nf, _ := NewNodeFacade(arg)
 
-	res, err := nf.GetAllIssuedESDTs()
+	res, err := nf.GetAllIssuedESDTs("")
 	assert.NoError(t, err)
 	assert.Equal(t, expectedValue, res)
 }
@@ -758,14 +758,14 @@ func TestNodeFacade_GetAllIssuedESDTsWithError(t *testing.T) {
 	localErr := errors.New("local")
 	arg := createMockArguments()
 	arg.Node = &mock.NodeStub{
-		GetAllIssuedESDTsCalled: func() ([]string, error) {
+		GetAllIssuedESDTsCalled: func(_ string) ([]string, error) {
 			return nil, localErr
 		},
 	}
 
 	nf, _ := NewNodeFacade(arg)
 
-	_, err := nf.GetAllIssuedESDTs()
+	_, err := nf.GetAllIssuedESDTs("")
 	assert.Equal(t, err, localErr)
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -56,6 +56,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/statusHandler"
 	"github.com/ElrondNetwork/elrond-go/update"
 	"github.com/ElrondNetwork/elrond-go/vm"
+	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts"
 )
 
 const (
@@ -452,7 +453,7 @@ func (n *Node) GetUsername(address string) (string, error) {
 }
 
 // GetAllIssuedESDTs returns all the issued esdt tokens, works only on metachain
-func (n *Node) GetAllIssuedESDTs() ([]string, error) {
+func (n *Node) GetAllIssuedESDTs(tokenType string) ([]string, error) {
 	account, err := n.getAccountHandlerForPubKey(vm.ESDTSCAddress)
 	if err != nil {
 		return nil, err
@@ -480,9 +481,33 @@ func (n *Node) GetAllIssuedESDTs() ([]string, error) {
 	}
 
 	for leaf := range chLeaves {
-		key := string(leaf.Key())
-		if strings.Contains(key, "-") {
-			tokens = append(tokens, key)
+		tokenName := string(leaf.Key())
+		if !strings.Contains(tokenName, "-") {
+			continue
+		}
+
+		if tokenType == "" {
+			tokens = append(tokens, tokenName)
+			continue
+		}
+
+		esdtToken := &systemSmartContracts.ESDTData{}
+		suffix := append(leaf.Key(), userAccount.AddressBytes()...)
+		value, errVal := leaf.ValueWithoutSuffix(suffix)
+		if errVal != nil {
+			log.Warn("cannot get value without suffix", "error", errVal, "key", leaf.Key())
+			continue
+		}
+
+		err = n.internalMarshalizer.Unmarshal(esdtToken, value)
+		if err != nil {
+			log.Warn("cannot unmarshal", "token name", tokenName, "err", err)
+			continue
+		}
+
+		expectedTokenType := []byte(tokenType)
+		if bytes.Equal(esdtToken.TokenType, expectedTokenType) {
+			tokens = append(tokens, tokenName)
 		}
 	}
 
@@ -591,7 +616,7 @@ func (n *Node) GetESDTData(address, tokenID string, nonce uint64) (*esdt.ESDigit
 	return esdtToken, nil
 }
 
-// GetAllESDTTokens returns the value of a key from a given account
+// GetAllESDTTokens returns all the ESDTs that the given address interacted with
 func (n *Node) GetAllESDTTokens(address string) (map[string]*esdt.ESDigitalToken, error) {
 	account, err := n.getAccountHandlerAPIAccounts(address)
 	if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -505,8 +505,7 @@ func (n *Node) GetAllIssuedESDTs(tokenType string) ([]string, error) {
 			continue
 		}
 
-		expectedTokenType := []byte(tokenType)
-		if bytes.Equal(esdtToken.TokenType, expectedTokenType) {
+		if bytes.Equal(esdtToken.TokenType, []byte(tokenType)) {
 			tokens = append(tokens, tokenName)
 		}
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/sharding"
 	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -489,12 +490,24 @@ func TestNode_GetAllESDTTokensShouldReturnEsdtAndFormattedNft(t *testing.T) {
 func TestNode_GetAllIssuedESDTs(t *testing.T) {
 	acc, _ := state.NewUserAccount([]byte("newaddress"))
 	esdtToken := []byte("TCK-RANDOM")
+	sftToken := []byte("SFT-RANDOM")
+	nftToken := []byte("NFT-RANDOM")
 
-	esdtData := &esdt.ESDigitalToken{Value: big.NewInt(10)}
+	esdtData := &systemSmartContracts.ESDTData{TokenName: []byte("fungible"), TokenType: []byte(core.FungibleESDT)}
 	marshalledData, _ := getMarshalizer().Marshal(esdtData)
 	_ = acc.DataTrieTracker().SaveKeyValue(esdtToken, marshalledData)
 
-	suffix := append(esdtToken, acc.AddressBytes()...)
+	sftData := &systemSmartContracts.ESDTData{TokenName: []byte("semi fungible"), TokenType: []byte(core.SemiFungibleESDT)}
+	sftMarshalledData, _ := getMarshalizer().Marshal(sftData)
+	_ = acc.DataTrieTracker().SaveKeyValue(sftToken, sftMarshalledData)
+
+	nftData := &systemSmartContracts.ESDTData{TokenName: []byte("non fungible"), TokenType: []byte(core.NonFungibleESDT)}
+	nftMarshalledData, _ := getMarshalizer().Marshal(nftData)
+	_ = acc.DataTrieTracker().SaveKeyValue(nftToken, nftMarshalledData)
+
+	esdtSuffix := append(esdtToken, acc.AddressBytes()...)
+	nftSuffix := append(nftToken, acc.AddressBytes()...)
+	sftSuffix := append(sftToken, acc.AddressBytes()...)
 
 	acc.DataTrieTracker().SetDataTrie(
 		&mock.TrieStub{
@@ -502,7 +515,13 @@ func TestNode_GetAllIssuedESDTs(t *testing.T) {
 				ch := make(chan core.KeyValueHolder)
 
 				go func() {
-					trieLeaf := keyValStorage.NewKeyValStorage(esdtToken, append(marshalledData, suffix...))
+					trieLeaf := keyValStorage.NewKeyValStorage(esdtToken, append(marshalledData, esdtSuffix...))
+					ch <- trieLeaf
+
+					trieLeaf = keyValStorage.NewKeyValStorage(sftToken, append(sftMarshalledData, sftSuffix...))
+					ch <- trieLeaf
+
+					trieLeaf = keyValStorage.NewKeyValStorage(nftToken, append(nftMarshalledData, nftSuffix...))
 					ch <- trieLeaf
 					close(ch)
 				}()
@@ -532,10 +551,24 @@ func TestNode_GetAllIssuedESDTs(t *testing.T) {
 		}}),
 	)
 
-	value, err := n.GetAllIssuedESDTs()
+	value, err := n.GetAllIssuedESDTs(core.FungibleESDT)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(value))
 	assert.Equal(t, string(esdtToken), value[0])
+
+	value, err = n.GetAllIssuedESDTs(core.SemiFungibleESDT)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(value))
+	assert.Equal(t, string(sftToken), value[0])
+
+	value, err = n.GetAllIssuedESDTs(core.NonFungibleESDT)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(value))
+	assert.Equal(t, string(nftToken), value[0])
+
+	value, err = n.GetAllIssuedESDTs("")
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(value))
 }
 
 //------- GenerateTransaction


### PR DESCRIPTION
Added 3 new endpoints that return only tokens of a specific type:
- `/network/esdt/fungible-tokens`
- `/network/esdt/semi-fungible-tokens`
- `/network/esdt/non-fungible-tokens`

Also, kept the old `network/esdts` functionality due to backwards compatibility reasons.

Testing procedure:
- start a testnet and send transactions for issuing ESDTs, SFTs and NFTs
- check the endpoints:
   - `/network/esdts` -> should contain all the issued tokens
   - `/network/esdt/fungible-tokens` -> should contain only ESDT (fungible) tokens
   - `/network/esdt/semi-fungible-tokens` -> should contain only semi fungible tokens
   - `/network/esdt/non-fungible-tokens` -> should contain only non fungible tokens