### PR TITLE
EN-9839: esdt tokens new endpoints

### DIFF
--- a/api/address/routes.go
+++ b/api/address/routes.go
@@ -24,7 +24,7 @@ const (
 	getESDTTokens         = "/:address/esdt"
 	getESDTBalance        = "/:address/esdt/:tokenIdentifier"
 	getESDTTokensWithRole = "/:address/esdts-with-role/:role"
-	getOwnedNFTs          = "/:address/owned-nfts"
+	getRegisteredNFTs     = "/:address/registered-nfts"
 	getESDTNFTData        = "/:address/nft/:tokenIdentifier/nonce/:nonce"
 )
 
@@ -36,7 +36,7 @@ type FacadeHandler interface {
 	GetAccount(address string) (state.UserAccountHandler, error)
 	GetCode(account state.UserAccountHandler) []byte
 	GetESDTData(address string, key string, nonce uint64) (*esdt.ESDigitalToken, error)
-	GetOwnedNFTs(address string) ([]string, error)
+	GetNFTTokenIDsRegisteredByAddress(address string) ([]string, error)
 	GetESDTsWithRole(address string, role string) ([]string, error)
 	GetAllESDTTokens(address string) (map[string]*esdt.ESDigitalToken, error)
 	GetKeyValuePairs(address string) (map[string]string, error)
@@ -82,7 +82,7 @@ func Routes(router *wrapper.RouterWrapper) {
 	router.RegisterHandler(http.MethodGet, getESDTBalance, GetESDTBalance)
 	router.RegisterHandler(http.MethodGet, getESDTNFTData, GetESDTNFTData)
 	router.RegisterHandler(http.MethodGet, getESDTTokens, GetAllESDTData)
-	router.RegisterHandler(http.MethodGet, getOwnedNFTs, GetOwnedNFTs)
+	router.RegisterHandler(http.MethodGet, getRegisteredNFTs, GetNFTTokenIDsRegisteredByAddress)
 	router.RegisterHandler(http.MethodGet, getESDTTokensWithRole, GetESDTTokensWithRole)
 }
 
@@ -462,8 +462,8 @@ func GetESDTTokensWithRole(c *gin.Context) {
 	)
 }
 
-// GetOwnedNFTs returns the token identifiers of the tokens where a given address is the owner
-func GetOwnedNFTs(c *gin.Context) {
+// GetNFTTokenIDsRegisteredByAddress returns the token identifiers of the tokens where a given address is the owner
+func GetNFTTokenIDsRegisteredByAddress(c *gin.Context) {
 	facade, ok := getFacade(c)
 	if !ok {
 		return
@@ -482,7 +482,7 @@ func GetOwnedNFTs(c *gin.Context) {
 		return
 	}
 
-	tokens, err := facade.GetOwnedNFTs(addr)
+	tokens, err := facade.GetNFTTokenIDsRegisteredByAddress(addr)
 	if err != nil {
 		c.JSON(
 			http.StatusInternalServerError,

--- a/api/address/routes.go
+++ b/api/address/routes.go
@@ -358,7 +358,7 @@ func GetESDTBalance(c *gin.Context) {
 			http.StatusBadRequest,
 			shared.GenericAPIResponse{
 				Data:  nil,
-				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTBalance.Error(), errors.ErrEmptyKey.Error()),
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTBalance.Error(), errors.ErrEmptyTokenIdentifier.Error()),
 				Code:  shared.ReturnCodeRequestError,
 			},
 		)
@@ -420,7 +420,7 @@ func GetESDTTokensWithRole(c *gin.Context) {
 			http.StatusBadRequest,
 			shared.GenericAPIResponse{
 				Data:  nil,
-				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTBalance.Error(), errors.ErrEmptyKey.Error()),
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTBalance.Error(), errors.ErrEmptyRole.Error()),
 				Code:  shared.ReturnCodeRequestError,
 			},
 		)
@@ -531,7 +531,7 @@ func GetESDTNFTData(c *gin.Context) {
 			http.StatusBadRequest,
 			shared.GenericAPIResponse{
 				Data:  nil,
-				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTNFTData.Error(), errors.ErrEmptyKey.Error()),
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTNFTData.Error(), errors.ErrEmptyTokenIdentifier.Error()),
 				Code:  shared.ReturnCodeRequestError,
 			},
 		)

--- a/api/address/routes.go
+++ b/api/address/routes.go
@@ -24,6 +24,7 @@ const (
 	getESDTTokens         = "/:address/esdt"
 	getESDTBalance        = "/:address/esdt/:tokenIdentifier"
 	getESDTTokensWithRole = "/:address/esdts-with-role/:role"
+	getOwnedNFTs          = "/:address/owned-nfts"
 	getESDTNFTData        = "/:address/nft/:tokenIdentifier/nonce/:nonce"
 )
 
@@ -35,6 +36,7 @@ type FacadeHandler interface {
 	GetAccount(address string) (state.UserAccountHandler, error)
 	GetCode(account state.UserAccountHandler) []byte
 	GetESDTData(address string, key string, nonce uint64) (*esdt.ESDigitalToken, error)
+	GetOwnedNFTs(address string) ([]string, error)
 	GetESDTsWithRole(address string, role string) ([]string, error)
 	GetAllESDTTokens(address string) (map[string]*esdt.ESDigitalToken, error)
 	GetKeyValuePairs(address string) (map[string]string, error)
@@ -80,6 +82,7 @@ func Routes(router *wrapper.RouterWrapper) {
 	router.RegisterHandler(http.MethodGet, getESDTBalance, GetESDTBalance)
 	router.RegisterHandler(http.MethodGet, getESDTNFTData, GetESDTNFTData)
 	router.RegisterHandler(http.MethodGet, getESDTTokens, GetAllESDTData)
+	router.RegisterHandler(http.MethodGet, getOwnedNFTs, GetOwnedNFTs)
 	router.RegisterHandler(http.MethodGet, getESDTTokensWithRole, GetESDTTokensWithRole)
 }
 
@@ -437,6 +440,49 @@ func GetESDTTokensWithRole(c *gin.Context) {
 	}
 
 	tokens, err := facade.GetESDTsWithRole(addr, role)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTBalance.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"tokens": tokens},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// GetOwnedNFTs returns the token identifiers of the tokens where a given address is the owner
+func GetOwnedNFTs(c *gin.Context) {
+	facade, ok := getFacade(c)
+	if !ok {
+		return
+	}
+
+	addr := c.Param("address")
+	if addr == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTBalance.Error(), errors.ErrEmptyAddress.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	tokens, err := facade.GetOwnedNFTs(addr)
 	if err != nil {
 		c.JSON(
 			http.StatusInternalServerError,

--- a/api/address/routes_test.go
+++ b/api/address/routes_test.go
@@ -730,7 +730,7 @@ func TestGetESDTTokensWithRole_ShouldWork(t *testing.T) {
 	assert.Equal(t, expectedTokens, esdtResponseObj.Data.Tokens)
 }
 
-func TestGetOwnedNFTs_NilContextShouldError(t *testing.T) {
+func TestGetNFTTokenIDsRegisteredByAddress_NilContextShouldError(t *testing.T) {
 	t.Parallel()
 
 	ws := startNodeServer(nil)
@@ -745,13 +745,13 @@ func TestGetOwnedNFTs_NilContextShouldError(t *testing.T) {
 	assert.True(t, strings.Contains(response.Error, apiErrors.ErrNilAppContext.Error()))
 }
 
-func TestGetOwnedNFTs_NodeFailsShouldError(t *testing.T) {
+func TestGetNFTTokenIDsRegisteredByAddress_NodeFailsShouldError(t *testing.T) {
 	t.Parallel()
 
 	testAddress := "address"
 	expectedErr := errors.New("expected error")
 	facade := mock.Facade{
-		GetOwnedNFTsCalled: func(_ string) ([]string, error) {
+		GetNFTTokenIDsRegisteredByAddressCalled: func(_ string) ([]string, error) {
 			return nil, expectedErr
 		},
 	}
@@ -768,13 +768,13 @@ func TestGetOwnedNFTs_NodeFailsShouldError(t *testing.T) {
 	assert.True(t, strings.Contains(esdtResponseObj.Error, expectedErr.Error()))
 }
 
-func TestGetOwnedNFTs_ShouldWork(t *testing.T) {
+func TestGetNFTTokenIDsRegisteredByAddress_ShouldWork(t *testing.T) {
 	t.Parallel()
 
 	testAddress := "address"
 	expectedTokens := []string{"ABC-0o9i8u", "XYZ-r5y7i9"}
 	facade := mock.Facade{
-		GetOwnedNFTsCalled: func(address string) ([]string, error) {
+		GetNFTTokenIDsRegisteredByAddressCalled: func(address string) ([]string, error) {
 			return expectedTokens, nil
 		},
 	}

--- a/api/address/routes_test.go
+++ b/api/address/routes_test.go
@@ -735,7 +735,7 @@ func TestGetNFTTokenIDsRegisteredByAddress_NilContextShouldError(t *testing.T) {
 
 	ws := startNodeServer(nil)
 
-	req, _ := http.NewRequest("GET", "/address/myAddress/owned-nfts", nil)
+	req, _ := http.NewRequest("GET", "/address/myAddress/registered-nfts", nil)
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 	response := shared.GenericAPIResponse{}
@@ -758,7 +758,7 @@ func TestGetNFTTokenIDsRegisteredByAddress_NodeFailsShouldError(t *testing.T) {
 
 	ws := startNodeServer(&facade)
 
-	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/owned-nfts", testAddress), nil)
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/registered-nfts", testAddress), nil)
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
@@ -781,7 +781,7 @@ func TestGetNFTTokenIDsRegisteredByAddress_ShouldWork(t *testing.T) {
 
 	ws := startNodeServer(&facade)
 
-	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/owned-nfts", testAddress), nil)
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/registered-nfts", testAddress), nil)
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
@@ -954,7 +954,7 @@ func getRoutesConfig() config.ApiRoutesConfig {
 					{Name: "/:address/esdt/:tokenIdentifier", Open: true},
 					{Name: "/:address/nft/:tokenIdentifier/nonce/:nonce", Open: true},
 					{Name: "/:address/esdts-with-role/:role", Open: true},
-					{Name: "/:address/owned-nfts", Open: true},
+					{Name: "/:address/registered-nfts", Open: true},
 				},
 			},
 		},

--- a/api/address/routes_test.go
+++ b/api/address/routes_test.go
@@ -77,6 +77,16 @@ type esdtTokenResponseData struct {
 	esdtTokenData `json:"tokenData"`
 }
 
+type esdtsWithRoleResponseData struct {
+	Tokens []string `json:"tokens"`
+}
+
+type esdtsWithRoleResponse struct {
+	Data  esdtsWithRoleResponseData `json:"data"`
+	Error string                    `json:"error"`
+	Code  string                    `json:"code"`
+}
+
 type esdtTokenResponse struct {
 	Data  esdtTokenResponseData `json:"data"`
 	Error string                `json:"error"`
@@ -636,6 +646,90 @@ func TestGetESDTNFTData_ShouldWork(t *testing.T) {
 	assert.Equal(t, testNonce, esdtResponseObj.Data.Nonce)
 }
 
+func TestGetESDTTokensWithRole_NilContextShouldError(t *testing.T) {
+	t.Parallel()
+
+	ws := startNodeServer(nil)
+
+	req, _ := http.NewRequest("GET", "/address/myAddress/esdts-with-role/ESDTRoleNFTCreate", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, shared.ReturnCodeInternalError, response.Code)
+	assert.True(t, strings.Contains(response.Error, apiErrors.ErrNilAppContext.Error()))
+}
+
+func TestGetESDTTokensWithRole_InvalidRoleShouldError(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		GetESDTsWithRoleCalled: func(_ string, _ string) ([]string, error) {
+			return nil, expectedErr
+		},
+	}
+
+	ws := startNodeServer(&facade)
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/esdts-with-role/invalid", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	esdtResponseObj := esdtsWithRoleResponse{}
+	loadResponse(resp.Body, &esdtResponseObj)
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.True(t, strings.Contains(esdtResponseObj.Error, "invalid role"))
+}
+
+func TestGetESDTTokensWithRole_NodeFailsShouldError(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		GetESDTsWithRoleCalled: func(_ string, _ string) ([]string, error) {
+			return nil, expectedErr
+		},
+	}
+
+	ws := startNodeServer(&facade)
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/esdts-with-role/ESDTRoleNFTCreate", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	esdtResponseObj := esdtsWithRoleResponse{}
+	loadResponse(resp.Body, &esdtResponseObj)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(esdtResponseObj.Error, expectedErr.Error()))
+}
+
+func TestGetESDTTokensWithRole_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedTokens := []string{"ABC-0o9i8u", "XYZ-r5y7i9"}
+	facade := mock.Facade{
+		GetESDTsWithRoleCalled: func(address string, role string) ([]string, error) {
+			return expectedTokens, nil
+		},
+	}
+
+	ws := startNodeServer(&facade)
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/esdts-with-role/ESDTRoleNFTCreate", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	esdtResponseObj := esdtsWithRoleResponse{}
+	loadResponse(resp.Body, &esdtResponseObj)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, expectedTokens, esdtResponseObj.Data.Tokens)
+}
+
 func TestGetESDTTokens_NilContextShouldError(t *testing.T) {
 	t.Parallel()
 
@@ -798,6 +892,7 @@ func getRoutesConfig() config.ApiRoutesConfig {
 					{Name: "/:address/esdt", Open: true},
 					{Name: "/:address/esdt/:tokenIdentifier", Open: true},
 					{Name: "/:address/nft/:tokenIdentifier/nonce/:nonce", Open: true},
+					{Name: "/:address/esdts-with-role/:role", Open: true},
 				},
 			},
 		},

--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -37,11 +37,17 @@ var ErrGetESDTBalance = errors.New("get esdt balance for account error")
 // ErrGetESDTNFTData signals an error in getting esdt nft data for given address, tokenID and nonce
 var ErrGetESDTNFTData = errors.New("get esdt nft data for account error")
 
-// ErrEmptyAddress signals an empty address was provided
+// ErrEmptyAddress signals that an empty address was provided
 var ErrEmptyAddress = errors.New("address is empty")
 
-// ErrEmptyKey signals an empty key was provided
+// ErrEmptyKey signals an that empty key was provided
 var ErrEmptyKey = errors.New("key is empty")
+
+// ErrEmptyTokenIdentifier signals that an empty token identifier was provided
+var ErrEmptyTokenIdentifier = errors.New("token identifier is empty")
+
+// ErrEmptyRole signals that an empty role was provided
+var ErrEmptyRole = errors.New("role is empty")
 
 // ErrNonceInvalid signals that nonce is invalid
 var ErrNonceInvalid = errors.New("nonce is invalid")

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -50,6 +50,7 @@ type Facade struct {
 	GetESDTDataCalled                       func(address string, key string, nonce uint64) (*esdt.ESDigitalToken, error)
 	GetAllESDTTokensCalled                  func(address string) (map[string]*esdt.ESDigitalToken, error)
 	GetESDTsWithRoleCalled                  func(address string, role string) ([]string, error)
+	GetOwnedNFTsCalled                      func(address string) ([]string, error)
 	GetBlockByHashCalled                    func(hash string, withTxs bool) (*api.Block, error)
 	GetBlockByNonceCalled                   func(nonce uint64, withTxs bool) (*api.Block, error)
 	GetTotalStakedValueHandler              func() (*api.StakeValues, error)
@@ -143,6 +144,15 @@ func (f *Facade) GetAllESDTTokens(address string) (map[string]*esdt.ESDigitalTok
 	}
 
 	return make(map[string]*esdt.ESDigitalToken), nil
+}
+
+// GetOwnedNFTs -
+func (f *Facade) GetOwnedNFTs(address string) ([]string, error) {
+	if f.GetOwnedNFTsCalled != nil {
+		return f.GetOwnedNFTsCalled(address)
+	}
+
+	return make([]string, 0), nil
 }
 
 // GetESDTsWithRole -

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -49,6 +49,7 @@ type Facade struct {
 	GetNumCheckpointsFromPeerStateCalled    func() uint32
 	GetESDTDataCalled                       func(address string, key string, nonce uint64) (*esdt.ESDigitalToken, error)
 	GetAllESDTTokensCalled                  func(address string) (map[string]*esdt.ESDigitalToken, error)
+	GetESDTsWithRoleCalled                  func(address string, role string) ([]string, error)
 	GetBlockByHashCalled                    func(hash string, withTxs bool) (*api.Block, error)
 	GetBlockByNonceCalled                   func(nonce uint64, withTxs bool) (*api.Block, error)
 	GetTotalStakedValueHandler              func() (*api.StakeValues, error)
@@ -142,6 +143,15 @@ func (f *Facade) GetAllESDTTokens(address string) (map[string]*esdt.ESDigitalTok
 	}
 
 	return make(map[string]*esdt.ESDigitalToken), nil
+}
+
+// GetESDTsWithRole -
+func (f *Facade) GetESDTsWithRole(address string, role string) ([]string, error) {
+	if f.GetESDTsWithRoleCalled != nil {
+		return f.GetESDTsWithRoleCalled(address, role)
+	}
+
+	return make([]string, 0), nil
 }
 
 // GetAllIssuedESDTs -

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -50,7 +50,7 @@ type Facade struct {
 	GetESDTDataCalled                       func(address string, key string, nonce uint64) (*esdt.ESDigitalToken, error)
 	GetAllESDTTokensCalled                  func(address string) (map[string]*esdt.ESDigitalToken, error)
 	GetESDTsWithRoleCalled                  func(address string, role string) ([]string, error)
-	GetOwnedNFTsCalled                      func(address string) ([]string, error)
+	GetNFTTokenIDsRegisteredByAddressCalled func(address string) ([]string, error)
 	GetBlockByHashCalled                    func(hash string, withTxs bool) (*api.Block, error)
 	GetBlockByNonceCalled                   func(nonce uint64, withTxs bool) (*api.Block, error)
 	GetTotalStakedValueHandler              func() (*api.StakeValues, error)
@@ -146,10 +146,10 @@ func (f *Facade) GetAllESDTTokens(address string) (map[string]*esdt.ESDigitalTok
 	return make(map[string]*esdt.ESDigitalToken), nil
 }
 
-// GetOwnedNFTs -
-func (f *Facade) GetOwnedNFTs(address string) ([]string, error) {
-	if f.GetOwnedNFTsCalled != nil {
-		return f.GetOwnedNFTsCalled(address)
+// GetNFTTokenIDsRegisteredByAddress -
+func (f *Facade) GetNFTTokenIDsRegisteredByAddress(address string) ([]string, error) {
+	if f.GetNFTTokenIDsRegisteredByAddressCalled != nil {
+		return f.GetNFTTokenIDsRegisteredByAddressCalled(address)
 	}
 
 	return make([]string, 0), nil

--- a/cmd/node/config/api.toml
+++ b/cmd/node/config/api.toml
@@ -54,8 +54,8 @@
         # /address/:address/esdts-with-role/:role will return the token identifiers with the given role for an address
         { Name = "/:address/esdts-with-role/:role", Open = true },
 
-        # /address/:address/owned-nfts will return the token identifiers of the tokens where the given address is the owner
-        { Name = "/:address/owned-nfts", Open = true }
+        # /address/:address/registered-nfts will return the token identifiers of the tokens registered by the address
+        { Name = "/:address/registered-nfts", Open = true }
 	]
 
 [APIPackages.hardfork]

--- a/cmd/node/config/api.toml
+++ b/cmd/node/config/api.toml
@@ -49,7 +49,10 @@
         { Name = "/:address/esdt/:tokenIdentifier", Open = true },
 
         # /address/:address/nft/:tokenIdentifier/nonce/:nonce will return data of an nft esdt token for a given account, tokenID and nonce
-        { Name = "/:address/nft/:tokenIdentifier/nonce/:nonce", Open = true }
+        { Name = "/:address/nft/:tokenIdentifier/nonce/:nonce", Open = true },
+
+        # /address/:address/esdts-with-role/:role will return the token identifiers with the given role for an address
+        { Name = "/:address/esdts-with-role/:role", Open = true }
 	]
 
 [APIPackages.hardfork]

--- a/cmd/node/config/api.toml
+++ b/cmd/node/config/api.toml
@@ -52,7 +52,10 @@
         { Name = "/:address/nft/:tokenIdentifier/nonce/:nonce", Open = true },
 
         # /address/:address/esdts-with-role/:role will return the token identifiers with the given role for an address
-        { Name = "/:address/esdts-with-role/:role", Open = true }
+        { Name = "/:address/esdts-with-role/:role", Open = true },
+
+        # /address/:address/owned-nfts will return the token identifiers of the tokens where the given address is the owner
+        { Name = "/:address/owned-nfts", Open = true }
 	]
 
 [APIPackages.hardfork]

--- a/core/computers.go
+++ b/core/computers.go
@@ -171,3 +171,13 @@ func SafeAddUint64(a, b uint64) (uint64, error) {
 	}
 	return 0, ErrAdditionOverflow
 }
+
+// IsValidESDTRole returns true if the input string represents a valid ESDT role
+func IsValidESDTRole(role string) bool {
+	switch role {
+	case ESDTRoleNFTCreate, ESDTRoleNFTAddQuantity, ESDTRoleNFTBurn, ESDTRoleLocalMint, ESDTRoleLocalBurn:
+		return true
+	default:
+		return false
+	}
+}

--- a/core/computers_test.go
+++ b/core/computers_test.go
@@ -456,3 +456,49 @@ func BenchmarkGetApproximatePercentageOfValue(b *testing.B) {
 		core.GetApproximatePercentageOfValue(preparedBigInts[n%nbPrepared], preparedFractionals[n%nbPrepared])
 	}
 }
+
+func TestIsValidESDTRole(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input  string
+		output bool
+	}{
+		{
+			input:  core.ESDTRoleLocalMint,
+			output: true,
+		},
+		{
+			input:  core.ESDTRoleLocalBurn,
+			output: true,
+		},
+		{
+			input:  core.ESDTRoleNFTCreate,
+			output: true,
+		},
+		{
+			input:  core.ESDTRoleNFTAddQuantity,
+			output: true,
+		},
+		{
+			input:  core.ESDTRoleNFTBurn,
+			output: true,
+		},
+		{
+			input:  "esdtRoleLocalMint",
+			output: false,
+		},
+		{
+			input:  "",
+			output: false,
+		},
+		{
+			input:  "invalid role",
+			output: false,
+		},
+	}
+
+	for _, tt := range tests {
+		require.Equal(t, tt.output, core.IsValidESDTRole(tt.input))
+	}
+}

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -38,8 +38,8 @@ type NodeHandler interface {
 	// GetESDTData returns the esdt data from a given account, given key and given nonce
 	GetESDTData(address, tokenID string, nonce uint64) (*esdt.ESDigitalToken, error)
 
-	// GetOwnedNFTs returns all the token identifiers for semi or non fungible tokens where the given address is the owner
-	GetOwnedNFTs(address string) ([]string, error)
+	// GetNFTTokenIDsRegisteredByAddress returns all the token identifiers for semi or non fungible tokens registered by the address
+	GetNFTTokenIDsRegisteredByAddress(address string) ([]string, error)
 
 	// GetESDTsWithRole returns the token identifiers where the specified address has the given role
 	GetESDTsWithRole(address string, role string) ([]string, error)

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -38,6 +38,9 @@ type NodeHandler interface {
 	// GetESDTData returns the esdt data from a given account, given key and given nonce
 	GetESDTData(address, tokenID string, nonce uint64) (*esdt.ESDigitalToken, error)
 
+	// GetOwnedNFTs returns all the token identifiers for semi or non fungible tokens where the given address is the owner
+	GetOwnedNFTs(address string) ([]string, error)
+
 	// GetESDTsWithRole returns the token identifiers where the specified address has the given role
 	GetESDTsWithRole(address string, role string) ([]string, error)
 

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -38,6 +38,9 @@ type NodeHandler interface {
 	// GetESDTData returns the esdt data from a given account, given key and given nonce
 	GetESDTData(address, tokenID string, nonce uint64) (*esdt.ESDigitalToken, error)
 
+	// GetESDTsWithRole returns the token identifiers where the specified address has the given role
+	GetESDTsWithRole(address string, role string) ([]string, error)
+
 	// GetAllESDTTokens returns the value of a key from a given account
 	GetAllESDTTokens(address string) (map[string]*esdt.ESDigitalToken, error)
 

--- a/facade/mock/nodeStub.go
+++ b/facade/mock/nodeStub.go
@@ -43,6 +43,7 @@ type NodeStub struct {
 	GetUsernameCalled                              func(address string) (string, error)
 	GetESDTDataCalled                              func(address string, key string, nonce uint64) (*esdt.ESDigitalToken, error)
 	GetAllESDTTokensCalled                         func(address string) (map[string]*esdt.ESDigitalToken, error)
+	GetESDTsWithRoleCalled                         func(address string, role string) ([]string, error)
 	GetKeyValuePairsCalled                         func(address string) (map[string]string, error)
 	GetAllIssuedESDTsCalled                        func(tokenType string) ([]string, error)
 }
@@ -190,6 +191,15 @@ func (ns *NodeStub) GetESDTData(address, tokenID string, nonce uint64) (*esdt.ES
 	}
 
 	return &esdt.ESDigitalToken{Value: big.NewInt(0)}, nil
+}
+
+// GetESDTsWithRole -
+func (ns *NodeStub) GetESDTsWithRole(address string, role string) ([]string, error) {
+	if ns.GetESDTsWithRoleCalled != nil {
+		return ns.GetESDTsWithRoleCalled(address, role)
+	}
+
+	return make([]string, 0), nil
 }
 
 // GetAllESDTTokens -

--- a/facade/mock/nodeStub.go
+++ b/facade/mock/nodeStub.go
@@ -43,7 +43,7 @@ type NodeStub struct {
 	GetUsernameCalled                              func(address string) (string, error)
 	GetESDTDataCalled                              func(address string, key string, nonce uint64) (*esdt.ESDigitalToken, error)
 	GetAllESDTTokensCalled                         func(address string) (map[string]*esdt.ESDigitalToken, error)
-	GetOwnedNFTsCalled                             func(address string) ([]string, error)
+	GetNFTTokenIDsRegisteredByAddressCalled        func(address string) ([]string, error)
 	GetESDTsWithRoleCalled                         func(address string, role string) ([]string, error)
 	GetKeyValuePairsCalled                         func(address string) (map[string]string, error)
 	GetAllIssuedESDTsCalled                        func(tokenType string) ([]string, error)
@@ -220,10 +220,10 @@ func (ns *NodeStub) GetAllIssuedESDTs(tokenType string) ([]string, error) {
 	return make([]string, 0), nil
 }
 
-// GetOwnedNFTs -
-func (ns *NodeStub) GetOwnedNFTs(address string) ([]string, error) {
-	if ns.GetOwnedNFTsCalled != nil {
-		return ns.GetOwnedNFTsCalled(address)
+// GetNFTTokenIDsRegisteredByAddress -
+func (ns *NodeStub) GetNFTTokenIDsRegisteredByAddress(address string) ([]string, error) {
+	if ns.GetNFTTokenIDsRegisteredByAddressCalled != nil {
+		return ns.GetNFTTokenIDsRegisteredByAddressCalled(address)
 	}
 
 	return make([]string, 0), nil

--- a/facade/mock/nodeStub.go
+++ b/facade/mock/nodeStub.go
@@ -43,6 +43,7 @@ type NodeStub struct {
 	GetUsernameCalled                              func(address string) (string, error)
 	GetESDTDataCalled                              func(address string, key string, nonce uint64) (*esdt.ESDigitalToken, error)
 	GetAllESDTTokensCalled                         func(address string) (map[string]*esdt.ESDigitalToken, error)
+	GetOwnedNFTsCalled                             func(address string) ([]string, error)
 	GetESDTsWithRoleCalled                         func(address string, role string) ([]string, error)
 	GetKeyValuePairsCalled                         func(address string) (map[string]string, error)
 	GetAllIssuedESDTsCalled                        func(tokenType string) ([]string, error)
@@ -216,6 +217,15 @@ func (ns *NodeStub) GetAllIssuedESDTs(tokenType string) ([]string, error) {
 	if ns.GetAllIssuedESDTsCalled != nil {
 		return ns.GetAllIssuedESDTsCalled(tokenType)
 	}
+	return make([]string, 0), nil
+}
+
+// GetOwnedNFTs -
+func (ns *NodeStub) GetOwnedNFTs(address string) ([]string, error) {
+	if ns.GetOwnedNFTsCalled != nil {
+		return ns.GetOwnedNFTsCalled(address)
+	}
+
 	return make([]string, 0), nil
 }
 

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -277,9 +277,9 @@ func (nf *nodeFacade) GetESDTData(address string, key string, nonce uint64) (*es
 	return nf.node.GetESDTData(address, key, nonce)
 }
 
-// GetOwnedNFTs returns all the token identifiers for semi or non fungible tokens where the given address is the owner
-func (nf *nodeFacade) GetOwnedNFTs(address string) ([]string, error) {
-	return nf.node.GetOwnedNFTs(address)
+// GetNFTTokenIDsRegisteredByAddress returns all the token identifiers for semi or non fungible tokens registered by the address
+func (nf *nodeFacade) GetNFTTokenIDsRegisteredByAddress(address string) ([]string, error) {
+	return nf.node.GetNFTTokenIDsRegisteredByAddress(address)
 }
 
 // GetESDTsWithRole returns all the tokens with the given role for the given address

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -277,6 +277,11 @@ func (nf *nodeFacade) GetESDTData(address string, key string, nonce uint64) (*es
 	return nf.node.GetESDTData(address, key, nonce)
 }
 
+// GetOwnedNFTs returns all the token identifiers for semi or non fungible tokens where the given address is the owner
+func (nf *nodeFacade) GetOwnedNFTs(address string) ([]string, error) {
+	return nf.node.GetOwnedNFTs(address)
+}
+
 // GetESDTsWithRole returns all the tokens with the given role for the given address
 func (nf *nodeFacade) GetESDTsWithRole(address string, role string) ([]string, error) {
 	return nf.node.GetESDTsWithRole(address, role)

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -277,6 +277,11 @@ func (nf *nodeFacade) GetESDTData(address string, key string, nonce uint64) (*es
 	return nf.node.GetESDTData(address, key, nonce)
 }
 
+// GetESDTsWithRole returns all the tokens with the given role for the given address
+func (nf *nodeFacade) GetESDTsWithRole(address string, role string) ([]string, error) {
+	return nf.node.GetESDTsWithRole(address, role)
+}
+
 // GetKeyValuePairs returns all the key-value pairs under the provided address
 func (nf *nodeFacade) GetKeyValuePairs(address string) (map[string]string, error) {
 	return nf.node.GetKeyValuePairs(address)

--- a/facade/nodeFacade_test.go
+++ b/facade/nodeFacade_test.go
@@ -771,6 +771,25 @@ func TestNodeFacade_GetESDTsWithRole(t *testing.T) {
 	require.Equal(t, expectedResponse, res)
 }
 
+func TestNodeFacade_GetNFTTokenIDsRegisteredByAddress(t *testing.T) {
+	t.Parallel()
+
+	expectedResponse := []string{"ABC-1q2w3e", "PPP-sc78gh"}
+	args := createMockArguments()
+
+	args.Node = &mock.NodeStub{
+		GetNFTTokenIDsRegisteredByAddressCalled: func(address string) ([]string, error) {
+			return expectedResponse, nil
+		},
+	}
+
+	nf, _ := NewNodeFacade(args)
+
+	res, err := nf.GetNFTTokenIDsRegisteredByAddress("address")
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, res)
+}
+
 func TestNodeFacade_GetAllIssuedESDTsWithError(t *testing.T) {
 	t.Parallel()
 

--- a/facade/nodeFacade_test.go
+++ b/facade/nodeFacade_test.go
@@ -752,6 +752,25 @@ func TestNodeFacade_GetAllIssuedESDTs(t *testing.T) {
 	assert.Equal(t, expectedValue, res)
 }
 
+func TestNodeFacade_GetESDTsWithRole(t *testing.T) {
+	t.Parallel()
+
+	expectedResponse := []string{"ABC-1q2w3e", "PPP-sc78gh"}
+	args := createMockArguments()
+
+	args.Node = &mock.NodeStub{
+		GetESDTsWithRoleCalled: func(address string, role string) ([]string, error) {
+			return expectedResponse, nil
+		},
+	}
+
+	nf, _ := NewNodeFacade(args)
+
+	res, err := nf.GetESDTsWithRole("address", "role")
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, res)
+}
+
 func TestNodeFacade_GetAllIssuedESDTsWithError(t *testing.T) {
 	t.Parallel()
 

--- a/integrationTests/interface.go
+++ b/integrationTests/interface.go
@@ -60,7 +60,7 @@ type Facade interface {
 	GetAccount(address string) (state.UserAccountHandler, error)
 	GetCode(account state.UserAccountHandler) []byte
 	GetESDTData(address string, key string, nonce uint64) (*esdt.ESDigitalToken, error)
-	GetOwnedNFTs(address string) ([]string, error)
+	GetNFTTokenIDsRegisteredByAddress(address string) ([]string, error)
 	GetESDTsWithRole(address string, role string) ([]string, error)
 	GetAllESDTTokens(address string) (map[string]*esdt.ESDigitalToken, error)
 	GetBlockByHash(hash string, withTxs bool) (*dataApi.Block, error)

--- a/integrationTests/interface.go
+++ b/integrationTests/interface.go
@@ -60,6 +60,8 @@ type Facade interface {
 	GetAccount(address string) (state.UserAccountHandler, error)
 	GetCode(account state.UserAccountHandler) []byte
 	GetESDTData(address string, key string, nonce uint64) (*esdt.ESDigitalToken, error)
+	GetOwnedNFTs(address string) ([]string, error)
+	GetESDTsWithRole(address string, role string) ([]string, error)
 	GetAllESDTTokens(address string) (map[string]*esdt.ESDigitalToken, error)
 	GetBlockByHash(hash string, withTxs bool) (*dataApi.Block, error)
 	GetBlockByNonce(nonce uint64, withTxs bool) (*dataApi.Block, error)

--- a/node/errors.go
+++ b/node/errors.go
@@ -231,3 +231,6 @@ var ErrNilNodeRedundancyHandler = errors.New("nil node redundancy handler")
 
 // ErrNilBlockHeader signals that current block header is nil
 var ErrNilBlockHeader = errors.New("nil block header")
+
+// ErrInvalidESDTRole signals that an invalid ESDT role has been provided
+var ErrInvalidESDTRole = errors.New("invalid ESDT role")

--- a/node/errors.go
+++ b/node/errors.go
@@ -234,3 +234,6 @@ var ErrNilBlockHeader = errors.New("nil block header")
 
 // ErrInvalidESDTRole signals that an invalid ESDT role has been provided
 var ErrInvalidESDTRole = errors.New("invalid ESDT role")
+
+// ErrMetachainOnlyEndpoint signals that an endpoint was called, but it is only available for metachain nodes
+var ErrMetachainOnlyEndpoint = errors.New("the endpoint is only available on metachain nodes")

--- a/node/node.go
+++ b/node/node.go
@@ -615,6 +615,88 @@ func (n *Node) GetESDTData(address, tokenID string, nonce uint64) (*esdt.ESDigit
 	return esdtToken, nil
 }
 
+// GetESDTsWithRole returns all the tokens with the given role for the given address
+func (n *Node) GetESDTsWithRole(address string, role string) ([]string, error) {
+	if !core.IsValidESDTRole(role) {
+		return nil, ErrInvalidESDTRole
+	}
+
+	addressBytes, err := n.addressPubkeyConverter.Decode(address)
+	if err != nil {
+		return nil, err
+	}
+
+	account, err := n.getAccountHandlerForPubKey(vm.ESDTSCAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	userAccount, ok := account.(state.UserAccountHandler)
+	if !ok {
+		return nil, ErrAccountNotFound
+	}
+
+	tokens := make([]string, 0)
+	if check.IfNil(userAccount.DataTrie()) {
+		return tokens, nil
+	}
+
+	rootHash, err := userAccount.DataTrie().RootHash()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	chLeaves, err := userAccount.DataTrie().GetAllLeavesOnChannel(rootHash, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for leaf := range chLeaves {
+		tokenName := string(leaf.Key())
+		if !strings.Contains(tokenName, "-") {
+			continue
+		}
+
+		esdtToken := &systemSmartContracts.ESDTData{}
+		suffix := append(leaf.Key(), userAccount.AddressBytes()...)
+		value, errVal := leaf.ValueWithoutSuffix(suffix)
+		if errVal != nil {
+			log.Warn("cannot get value without suffix", "error", errVal, "key", leaf.Key())
+			continue
+		}
+
+		err = n.internalMarshalizer.Unmarshal(esdtToken, value)
+		if err != nil {
+			log.Warn("cannot unmarshal", "token name", tokenName, "err", err)
+			continue
+		}
+
+		shouldAdd := isTokenWithRoleForAddress(addressBytes, role, esdtToken)
+		if shouldAdd {
+			tokens = append(tokens, tokenName)
+		}
+	}
+
+	return tokens, nil
+}
+
+func isTokenWithRoleForAddress(addressBytes []byte, role string, token *systemSmartContracts.ESDTData) bool {
+	for _, esdtRoles := range token.SpecialRoles {
+		if !bytes.Equal(esdtRoles.Address, addressBytes) {
+			continue
+		}
+
+		for _, specialRole := range esdtRoles.Roles {
+			if bytes.Equal(specialRole, []byte(role)) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // GetAllESDTTokens returns all the ESDTs that the given address interacted with
 func (n *Node) GetAllESDTTokens(address string) (map[string]*esdt.ESDigitalToken, error) {
 	account, err := n.getAccountHandlerAPIAccounts(address)

--- a/node/node.go
+++ b/node/node.go
@@ -454,6 +454,10 @@ func (n *Node) GetUsername(address string) (string, error) {
 
 // GetAllIssuedESDTs returns all the issued esdt tokens, works only on metachain
 func (n *Node) GetAllIssuedESDTs(tokenType string) ([]string, error) {
+	if n.shardCoordinator.SelfId() != core.MetachainShardId {
+		return nil, ErrMetachainOnlyEndpoint
+	}
+
 	account, err := n.getAccountHandlerForPubKey(vm.ESDTSCAddress)
 	if err != nil {
 		return nil, err
@@ -617,6 +621,10 @@ func (n *Node) GetESDTData(address, tokenID string, nonce uint64) (*esdt.ESDigit
 
 // GetESDTsWithRole returns all the tokens with the given role for the given address
 func (n *Node) GetESDTsWithRole(address string, role string) ([]string, error) {
+	if n.shardCoordinator.SelfId() != core.MetachainShardId {
+		return nil, ErrMetachainOnlyEndpoint
+	}
+
 	if !core.IsValidESDTRole(role) {
 		return nil, ErrInvalidESDTRole
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -640,7 +640,7 @@ func TestNode_GetESDTsWithRole(t *testing.T) {
 	require.Len(t, tokenResult, 0)
 }
 
-func TestNode_GetOwnedNFTs(t *testing.T) {
+func TestNode_GetNFTTokenIDsRegisteredByAddress(t *testing.T) {
 	addrBytes := []byte("newaddress")
 	acc, _ := state.NewUserAccount(addrBytes)
 	esdtToken := []byte("TCK-RANDOM")
@@ -687,7 +687,7 @@ func TestNode_GetOwnedNFTs(t *testing.T) {
 		}}),
 	)
 
-	tokenResult, err := n.GetOwnedNFTs(hex.EncodeToString(addrBytes))
+	tokenResult, err := n.GetNFTTokenIDsRegisteredByAddress(hex.EncodeToString(addrBytes))
 	require.NoError(t, err)
 	require.Equal(t, 1, len(tokenResult))
 	require.Equal(t, string(esdtToken), tokenResult[0])


### PR DESCRIPTION
Added 2 endpoints:
- `/address/<address>/esdts-with-role/<role>` that returns all token identifiers of the tokens where the given address has the given role assigned
- `/address/<address>/owned-nfts` that returns all token identifiers of the NFTs/SFTs where the given address is the owner