### PR TITLE
Re-delegate dust check

### DIFF
--- a/cmd/node/config/economics.toml
+++ b/cmd/node/config/economics.toml
@@ -18,11 +18,23 @@
     Denomination = 18 # represents the smallest eGLD subdivision (10^-X eGLD for a denomination of X)
 
 [RewardsSettings]
-    RewardsConfigByEpoch = [
-        # valid for all fractional values: 0.3 is 30%, 0.1 is 10% and so on
-        { EpochEnable = 0, LeaderPercentage = 0.1, DeveloperPercentage = 0.3, ProtocolSustainabilityPercentage = 0.1, ProtocolSustainabilityAddress = "erd1j25xk97yf820rgdp3mj5scavhjkn6tjyn0t63pmv5qyjj7wxlcfqqe2rw5", TopUpGradientPoint = "3000000000000000000000000", TopUpFactor = 0.25 },
-        { EpochEnable = 2, LeaderPercentage = 0.1, DeveloperPercentage = 0.3, ProtocolSustainabilityPercentage = 0.1, ProtocolSustainabilityAddress = "erd1j25xk97yf820rgdp3mj5scavhjkn6tjyn0t63pmv5qyjj7wxlcfqqe2rw5", TopUpGradientPoint = "2000000000000000000000000", TopUpFactor = 0.5 }
-    ]
+    [[RewardsSettings.RewardsConfigByEpoch]]
+    EpochEnable = 0
+    LeaderPercentage = 0.1 #fraction of value 0.1 - 10%
+    DeveloperPercentage = 0.3 #fraction of value 0.3 - 30%
+    ProtocolSustainabilityPercentage = 0.1 #fraction of value 0.1 - 10%
+    ProtocolSustainabilityAddress = "erd1j25xk97yf820rgdp3mj5scavhjkn6tjyn0t63pmv5qyjj7wxlcfqqe2rw5"
+    TopUpGradientPoint = "3000000000000000000000000" # 3MIL eGLD (eligible topUp)
+    TopUpFactor = 0.25 # fraction of value 0.25 - 25%
+
+    [[RewardsSettings.RewardsConfigByEpoch]]
+    EpochEnable = 2
+    LeaderPercentage = 0.1 #fraction of value 0.1 - 10%
+    DeveloperPercentage = 0.3 #fraction of value 0.3 - 30%
+    ProtocolSustainabilityPercentage = 0.1 #fraction of value 0.1 - 10%
+    ProtocolSustainabilityAddress = "erd1j25xk97yf820rgdp3mj5scavhjkn6tjyn0t63pmv5qyjj7wxlcfqqe2rw5"
+    TopUpGradientPoint = "2000000000000000000000000" # 2MIL eGLD (eligible topUp)
+    TopUpFactor = 0.5 # fraction of value 0.5 - 50%
 
 [FeeSettings]
     MaxGasLimitPerBlock     = "1500000000"

--- a/cmd/node/config/economics.toml
+++ b/cmd/node/config/economics.toml
@@ -19,24 +19,9 @@
 
 [RewardsSettings]
     RewardsConfigByEpoch = [
-        {
-            LeaderPercentage = 0.1, #fraction of value 0.1 - 10%
-            DeveloperPercentage = 0.3, #fraction of value 0.3 - 30%
-            ProtocolSustainabilityPercentage = 0.1, #fraction of value 0.1 - 10%
-            ProtocolSustainabilityAddress = "erd1j25xk97yf820rgdp3mj5scavhjkn6tjyn0t63pmv5qyjj7wxlcfqqe2rw5",
-            TopUpGradientPoint = "3000000000000000000000000", # 3MIL eGLD (eligible topUp)
-            TopUpFactor = 0.25, # fraction of value 0.25 - 25%
-            EpochEnable = 0
-        },
-        {
-            LeaderPercentage = 0.1, #fraction of value 0.1 - 10%
-            DeveloperPercentage = 0.3, #fraction of value 0.3 - 30%
-            ProtocolSustainabilityPercentage = 0.1, #fraction of value 0.1 - 10%
-            ProtocolSustainabilityAddress = "erd1j25xk97yf820rgdp3mj5scavhjkn6tjyn0t63pmv5qyjj7wxlcfqqe2rw5",
-            TopUpGradientPoint = "2000000000000000000000000", # 2MIL eGLD (eligible topUp)
-            TopUpFactor = 0.5, # fraction of value 0.5 - 50%
-            EpochEnable = 2
-        }
+        # valid for all fractional values: 0.3 is 30%, 0.1 is 10% and so on
+        { EpochEnable = 0, LeaderPercentage = 0.1, DeveloperPercentage = 0.3, ProtocolSustainabilityPercentage = 0.1, ProtocolSustainabilityAddress = "erd1j25xk97yf820rgdp3mj5scavhjkn6tjyn0t63pmv5qyjj7wxlcfqqe2rw5", TopUpGradientPoint = "3000000000000000000000000", TopUpFactor = 0.25 },
+        { EpochEnable = 2, LeaderPercentage = 0.1, DeveloperPercentage = 0.3, ProtocolSustainabilityPercentage = 0.1, ProtocolSustainabilityAddress = "erd1j25xk97yf820rgdp3mj5scavhjkn6tjyn0t63pmv5qyjj7wxlcfqqe2rw5", TopUpGradientPoint = "2000000000000000000000000", TopUpFactor = 0.5 }
     ]
 
 [FeeSettings]

--- a/cmd/node/config/systemSmartContractsConfig.toml
+++ b/cmd/node/config/systemSmartContractsConfig.toml
@@ -35,7 +35,7 @@
     EnabledEpoch = 1 #enable epoch should not be 0
     MinStakeAmount = "10000000000000000000" #10 eGLD
     ConfigChangeAddress = "erd1vxy22x0fj4zv6hktmydg8vpfh6euv02cz4yg0aaws6rrad5a5awqgqky80" #should use a multisign contract instead of a wallet address
-    ReDelegateDustCheckEnableEpoch = 3
+    ReDelegateBelowMinCheckEnableEpoch = 3
     ValidatorToDelegationEnableEpoch = 3
 
 [DelegationSystemSCConfig]

--- a/cmd/node/config/systemSmartContractsConfig.toml
+++ b/cmd/node/config/systemSmartContractsConfig.toml
@@ -35,9 +35,10 @@
     EnabledEpoch = 1 #enable epoch should not be 0
     MinStakeAmount = "10000000000000000000" #10 eGLD
     ConfigChangeAddress = "erd1vxy22x0fj4zv6hktmydg8vpfh6euv02cz4yg0aaws6rrad5a5awqgqky80" #should use a multisign contract instead of a wallet address
+    ReDelegateDustCheckEnableEpoch = 3
+    ValidatorToDelegationEnableEpoch = 3
 
 [DelegationSystemSCConfig]
     EnabledEpoch   = 1 #enable epoch should not be 0
-    ValidatorToDelegationEnableEpoch = 3
     MinServiceFee  = 0
     MaxServiceFee  = 10000

--- a/config/economicsConfig.go
+++ b/config/economicsConfig.go
@@ -19,7 +19,7 @@ type RewardsSettings struct {
 	RewardsConfigByEpoch []EpochRewardSettings
 }
 
-// RewardsConfig holds the economics rewards settings for a specific epoch
+// EpochRewardSettings holds the economics rewards settings for a specific epoch
 type EpochRewardSettings struct {
 	LeaderPercentage                 float64
 	DeveloperPercentage              float64

--- a/config/systemSmartContractsConfig.go
+++ b/config/systemSmartContractsConfig.go
@@ -49,12 +49,12 @@ type GovernanceSystemSCConfig struct {
 
 // DelegationManagerSystemSCConfig defines a set of constants to initialize the delegation manager system smart contract
 type DelegationManagerSystemSCConfig struct {
-	MinCreationDeposit               string
-	EnabledEpoch                     uint32
-	ValidatorToDelegationEnableEpoch uint32
-	ReDelegateDustCheckEnableEpoch   uint32
-	MinStakeAmount                   string
-	ConfigChangeAddress              string
+	MinCreationDeposit                 string
+	EnabledEpoch                       uint32
+	ValidatorToDelegationEnableEpoch   uint32
+	ReDelegateBelowMinCheckEnableEpoch uint32
+	MinStakeAmount                     string
+	ConfigChangeAddress                string
 }
 
 // DelegationSystemSCConfig defines a set of constants to initialize the delegation system smart contract

--- a/config/systemSmartContractsConfig.go
+++ b/config/systemSmartContractsConfig.go
@@ -52,6 +52,7 @@ type DelegationManagerSystemSCConfig struct {
 	MinCreationDeposit               string
 	EnabledEpoch                     uint32
 	ValidatorToDelegationEnableEpoch uint32
+	ReDelegateDustCheckEnableEpoch   uint32
 	MinStakeAmount                   string
 	ConfigChangeAddress              string
 }

--- a/config/tomlConfig_test.go
+++ b/config/tomlConfig_test.go
@@ -139,7 +139,10 @@ func TestTomlParser(t *testing.T) {
 
 func TestTomlEconomicsParser(t *testing.T) {
 	protocolSustainabilityPercentage := 0.1
-	leaderPercentage := 0.1
+	leaderPercentage1 := 0.1
+	leaderPercentage2 := 0.2
+	epoch0 := uint32(0)
+	epoch1 := uint32(1)
 	developerPercentage := 0.3
 	maxGasLimitPerBlock := "18446744073709551615"
 	minGasPrice := "18446744073709551615"
@@ -154,7 +157,15 @@ func TestTomlEconomicsParser(t *testing.T) {
 		RewardsSettings: RewardsSettings{
 			RewardsConfigByEpoch: []EpochRewardSettings{
 				{
-					LeaderPercentage:                 leaderPercentage,
+					EpochEnable:                      epoch0,
+					LeaderPercentage:                 leaderPercentage1,
+					ProtocolSustainabilityPercentage: protocolSustainabilityPercentage,
+					ProtocolSustainabilityAddress:    protocolSustainabilityAddress,
+					DeveloperPercentage:              developerPercentage,
+				},
+				{
+					EpochEnable:                      epoch1,
+					LeaderPercentage:                 leaderPercentage2,
 					ProtocolSustainabilityPercentage: protocolSustainabilityPercentage,
 					ProtocolSustainabilityAddress:    protocolSustainabilityAddress,
 					DeveloperPercentage:              developerPercentage,
@@ -172,14 +183,20 @@ func TestTomlEconomicsParser(t *testing.T) {
 [GlobalSettings]
     Denomination = ` + fmt.Sprintf("%d", denomination) + `
 [RewardsSettings]
-	RewardsConfigByEpoch = [
-		{
-    		ProtocolSustainabilityPercentage = ` + fmt.Sprintf("%.6f", protocolSustainabilityPercentage) + `,
-			ProtocolSustainabilityAddress = "` + protocolSustainabilityAddress + `",
-    		LeaderPercentage = ` + fmt.Sprintf("%.6f", leaderPercentage) + `,
-			DeveloperPercentage = ` + fmt.Sprintf("%.6f", developerPercentage) + `
-   		 }
-    ]
+	[[RewardsSettings.RewardsConfigByEpoch]]
+	EpochEnable = ` + fmt.Sprintf("%d", epoch0) + `
+   	LeaderPercentage = ` + fmt.Sprintf("%.6f", leaderPercentage1) + `
+   	DeveloperPercentage = ` + fmt.Sprintf("%.6f", developerPercentage) + `
+   	ProtocolSustainabilityPercentage = ` + fmt.Sprintf("%.6f", protocolSustainabilityPercentage) + ` #fraction of value 0.1 - 10%
+   	ProtocolSustainabilityAddress = "` + protocolSustainabilityAddress + `"
+
+	[[RewardsSettings.RewardsConfigByEpoch]]
+	EpochEnable = ` + fmt.Sprintf("%d", epoch1) + `
+	LeaderPercentage = ` + fmt.Sprintf("%.6f", leaderPercentage2) + `
+    DeveloperPercentage = ` + fmt.Sprintf("%.6f", developerPercentage) + `
+    ProtocolSustainabilityPercentage = ` + fmt.Sprintf("%.6f", protocolSustainabilityPercentage) + ` #fraction of value 0.1 - 10%
+    ProtocolSustainabilityAddress = "` + protocolSustainabilityAddress + `"
+
 [FeeSettings]
 	MaxGasLimitPerBlock = "` + maxGasLimitPerBlock + `"
     MinGasPrice = "` + minGasPrice + `"

--- a/vm/errors.go
+++ b/vm/errors.go
@@ -229,3 +229,6 @@ var ErrNotEnoughInitialOwnerFunds = errors.New("not enough initial owner funds")
 
 // ErrNFTCreateRoleAlreadyExists signals that NFT create role already exists
 var ErrNFTCreateRoleAlreadyExists = errors.New("NFT create role already exists")
+
+// ErrRedelegateValueWillGenerateDust signals that the re-delegate value will generate dust in the delegation SC
+var ErrRedelegateValueWillGenerateDust = errors.New("re-delegate value will generate dust in the delegation SC")

--- a/vm/errors.go
+++ b/vm/errors.go
@@ -230,5 +230,5 @@ var ErrNotEnoughInitialOwnerFunds = errors.New("not enough initial owner funds")
 // ErrNFTCreateRoleAlreadyExists signals that NFT create role already exists
 var ErrNFTCreateRoleAlreadyExists = errors.New("NFT create role already exists")
 
-// ErrRedelegateValueWillGenerateDust signals that the re-delegate value will generate dust in the delegation SC
-var ErrRedelegateValueWillGenerateDust = errors.New("re-delegate value will generate dust in the delegation SC")
+// ErrRedelegateValueBelowMinimum signals that the re-delegate added to the remaining value will be below the minimum required
+var ErrRedelegateValueBelowMinimum = errors.New("can not re-delegate as the remaining value will be below the minimum required")

--- a/vm/factory/systemSCFactory.go
+++ b/vm/factory/systemSCFactory.go
@@ -230,19 +230,19 @@ func (scf *systemSCFactory) createGovernanceContract() (vm.SystemSmartContract, 
 
 func (scf *systemSCFactory) createDelegationContract() (vm.SystemSmartContract, error) {
 	argsDelegation := systemSmartContracts.ArgsNewDelegation{
-		DelegationSCConfig:               scf.systemSCConfig.DelegationSystemSCConfig,
-		StakingSCConfig:                  scf.systemSCConfig.StakingSystemSCConfig,
-		Eei:                              scf.systemEI,
-		SigVerifier:                      scf.sigVerifier,
-		DelegationMgrSCAddress:           vm.DelegationManagerSCAddress,
-		StakingSCAddress:                 vm.StakingSCAddress,
-		ValidatorSCAddress:               vm.ValidatorSCAddress,
-		GasCost:                          scf.gasCost,
-		Marshalizer:                      scf.marshalizer,
-		EpochNotifier:                    scf.epochNotifier,
-		EndOfEpochAddress:                vm.EndOfEpochAddress,
-		ValidatorToDelegationEnableEpoch: scf.systemSCConfig.DelegationManagerSystemSCConfig.ValidatorToDelegationEnableEpoch,
-		ReDelegateDustCheckEnableEpoch:   scf.systemSCConfig.DelegationManagerSystemSCConfig.ReDelegateDustCheckEnableEpoch,
+		DelegationSCConfig:                 scf.systemSCConfig.DelegationSystemSCConfig,
+		StakingSCConfig:                    scf.systemSCConfig.StakingSystemSCConfig,
+		Eei:                                scf.systemEI,
+		SigVerifier:                        scf.sigVerifier,
+		DelegationMgrSCAddress:             vm.DelegationManagerSCAddress,
+		StakingSCAddress:                   vm.StakingSCAddress,
+		ValidatorSCAddress:                 vm.ValidatorSCAddress,
+		GasCost:                            scf.gasCost,
+		Marshalizer:                        scf.marshalizer,
+		EpochNotifier:                      scf.epochNotifier,
+		EndOfEpochAddress:                  vm.EndOfEpochAddress,
+		ValidatorToDelegationEnableEpoch:   scf.systemSCConfig.DelegationManagerSystemSCConfig.ValidatorToDelegationEnableEpoch,
+		ReDelegateBelowMinCheckEnableEpoch: scf.systemSCConfig.DelegationManagerSystemSCConfig.ReDelegateBelowMinCheckEnableEpoch,
 	}
 	delegation, err := systemSmartContracts.NewDelegationSystemSC(argsDelegation)
 	return delegation, err

--- a/vm/factory/systemSCFactory.go
+++ b/vm/factory/systemSCFactory.go
@@ -230,17 +230,19 @@ func (scf *systemSCFactory) createGovernanceContract() (vm.SystemSmartContract, 
 
 func (scf *systemSCFactory) createDelegationContract() (vm.SystemSmartContract, error) {
 	argsDelegation := systemSmartContracts.ArgsNewDelegation{
-		DelegationSCConfig:     scf.systemSCConfig.DelegationSystemSCConfig,
-		StakingSCConfig:        scf.systemSCConfig.StakingSystemSCConfig,
-		Eei:                    scf.systemEI,
-		SigVerifier:            scf.sigVerifier,
-		DelegationMgrSCAddress: vm.DelegationManagerSCAddress,
-		StakingSCAddress:       vm.StakingSCAddress,
-		ValidatorSCAddress:     vm.ValidatorSCAddress,
-		GasCost:                scf.gasCost,
-		Marshalizer:            scf.marshalizer,
-		EpochNotifier:          scf.epochNotifier,
-		EndOfEpochAddress:      vm.EndOfEpochAddress,
+		DelegationSCConfig:               scf.systemSCConfig.DelegationSystemSCConfig,
+		StakingSCConfig:                  scf.systemSCConfig.StakingSystemSCConfig,
+		Eei:                              scf.systemEI,
+		SigVerifier:                      scf.sigVerifier,
+		DelegationMgrSCAddress:           vm.DelegationManagerSCAddress,
+		StakingSCAddress:                 vm.StakingSCAddress,
+		ValidatorSCAddress:               vm.ValidatorSCAddress,
+		GasCost:                          scf.gasCost,
+		Marshalizer:                      scf.marshalizer,
+		EpochNotifier:                    scf.epochNotifier,
+		EndOfEpochAddress:                vm.EndOfEpochAddress,
+		ValidatorToDelegationEnableEpoch: scf.systemSCConfig.DelegationManagerSystemSCConfig.ValidatorToDelegationEnableEpoch,
+		ReDelegateDustCheckEnableEpoch:   scf.systemSCConfig.DelegationManagerSystemSCConfig.ReDelegateDustCheckEnableEpoch,
 	}
 	delegation, err := systemSmartContracts.NewDelegationSystemSC(argsDelegation)
 	return delegation, err

--- a/vm/systemSmartContracts/delegation.go
+++ b/vm/systemSmartContracts/delegation.go
@@ -1428,7 +1428,7 @@ func (d *delegation) checkActiveFund(delegator *DelegatorData) error {
 
 	belowMinDelegationAmount := fund.Value.Cmp(delegationManagement.MinDelegationAmount) < 0
 	if belowMinDelegationAmount {
-		return vm.ErrRedelegateValueWillGenerateDust
+		return vm.ErrRedelegateValueBelowMinimum
 	}
 
 	return nil

--- a/vm/systemSmartContracts/delegation.go
+++ b/vm/systemSmartContracts/delegation.go
@@ -2807,7 +2807,7 @@ func (d *delegation) EpochConfirmed(epoch uint32) {
 	log.Debug("validator to delegation", "enabled", d.flagValidatorToDelegation.IsSet())
 
 	d.flagReDelegateBelowMinCheck.Toggle(epoch >= d.reDelegateBelowMinCheckEnableEpoch)
-	log.Debug("re-delegate dust check", "enabled", d.flagReDelegateBelowMinCheck.IsSet())
+	log.Debug("re-delegate below minimum check", "enabled", d.flagReDelegateBelowMinCheck.IsSet())
 }
 
 // CanUseContract returns true if contract can be used

--- a/vm/systemSmartContracts/delegationManager_test.go
+++ b/vm/systemSmartContracts/delegationManager_test.go
@@ -374,6 +374,7 @@ func TestDelegationManagerSystemSC_ExecuteCreateNewDelegationContract(t *testing
 	)
 
 	args.Eei = eei
+	createDelegationManagerConfig(eei, args.Marshalizer, big.NewInt(20))
 
 	dm, _ := NewDelegationManagerSystemSC(args)
 	vmInput := getDefaultVmInputForDelegationManager("createNewDelegationContract", [][]byte{maxDelegationCap, serviceFee})


### PR DESCRIPTION
- added redelegation dust check on the delegation system SC
- fixed some issues regarding ValidatorToDelegationEnableEpoch flags
- refactored economics.toml file

Testing scenario:
start with the `test-redelegate-dust-check` that will activate the feature in epoch 6.
In epoch 2 launch a delegation SC. In epoch 3, merge an existing validator into the delegation SC. 
Take 2 addresses (let's call them A and B), delegate a few egld on that delegation SC. 
In epochs 3-5 (whenever is possible), check rewards for address A. It should be in the interval (0, 1) eGLD. 
Undelegate everything. After that, do a redelegate. Now A just delegated some dust, which is not ok.
After epoch 6 activates the extra check, try the same with address B. Remember, claimable rewards should be up until 1eGLD. 
When B does a redelegate, that transaction should fail, stating something like `can not re-delegate as the remaining value will be below the minimum required`. Rewards should be still claimable (please check, claim should work)
Also, please check after the fix is available (epoch 6 and higher) that a call to redelegate of the owner of the delegation SC works.