### PR TITLE
Staking phase 3p5 minor changes

### DIFF
--- a/cmd/node/factory/structs.go
+++ b/cmd/node/factory/structs.go
@@ -1910,6 +1910,7 @@ func newMetaBlockProcessor(
 		ValidatorAccountsDB: stateComponents.PeerAccounts,
 		ChanceComputer:      rater,
 		EpochNotifier:       epochNotifier,
+		ShardCoordinator:    shardCoordinator,
 	}
 	vmFactory, err := metachain.NewVMContainerFactory(argsNewVMContainer)
 	if err != nil {

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -2739,6 +2739,7 @@ func createScQueryElement(
 			ValidatorAccountsDB: validatorAccounts,
 			ChanceComputer:      rater,
 			EpochNotifier:       epochNotifier,
+			ShardCoordinator:    shardCoordinator,
 		}
 		vmFactory, err = metachain.NewVMContainerFactory(argsNewVmFactory)
 		if err != nil {

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -960,6 +960,7 @@ func createFullArgumentsForSystemSCProcessing(stakingV2EnableEpoch uint32, trieS
 		ValidatorAccountsDB: peerAccountsDB,
 		ChanceComputer:      &mock.ChanceComputerStub{},
 		EpochNotifier:       epochNotifier,
+		ShardCoordinator:    &mock.ShardCoordinatorStub{},
 	}
 	metaVmFactory, _ := metaProcess.NewVMContainerFactory(argsNewVMContainerFactory)
 

--- a/genesis/process/metaGenesisBlockCreator.go
+++ b/genesis/process/metaGenesisBlockCreator.go
@@ -271,6 +271,7 @@ func createProcessorsForMetaGenesisBlock(arg ArgsGenesisBlockCreator, generalCon
 		ValidatorAccountsDB: arg.ValidatorAccounts,
 		ChanceComputer:      &disabled.Rater{},
 		EpochNotifier:       epochNotifier,
+		ShardCoordinator:    arg.ShardCoordinator,
 	}
 	virtualMachineFactory, err := metachain.NewVMContainerFactory(argsNewVMContainerFactory)
 	if err != nil {

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -828,6 +828,7 @@ func (tpn *TestProcessorNode) createFullSCQueryService() {
 			ValidatorAccountsDB: tpn.PeerState,
 			ChanceComputer:      tpn.NodesCoordinator,
 			EpochNotifier:       tpn.EpochNotifier,
+			ShardCoordinator:    tpn.ShardCoordinator,
 		}
 		vmFactory, _ = metaProcess.NewVMContainerFactory(argsNewVmFactory)
 	} else {
@@ -1540,6 +1541,7 @@ func (tpn *TestProcessorNode) initMetaInnerProcessors() {
 		ValidatorAccountsDB: tpn.PeerState,
 		ChanceComputer:      &mock.RaterMock{},
 		EpochNotifier:       tpn.EpochNotifier,
+		ShardCoordinator:    tpn.ShardCoordinator,
 	}
 	vmFactory, _ := metaProcess.NewVMContainerFactory(argsVMContainerFactory)
 

--- a/integrationTests/vm/testInitializer.go
+++ b/integrationTests/vm/testInitializer.go
@@ -501,6 +501,7 @@ func CreateVMAndBlockchainHookMeta(
 		ValidatorAccountsDB: accnts,
 		ChanceComputer:      &mock.NodesCoordinatorMock{},
 		EpochNotifier:       &mock.EpochNotifierStub{},
+		ShardCoordinator:    mock.NewMultiShardsCoordinatorMock(1),
 	})
 	if err != nil {
 		log.LogIfError(err)

--- a/process/factory/metachain/vmContainerFactory.go
+++ b/process/factory/metachain/vmContainerFactory.go
@@ -62,34 +62,34 @@ type ArgsNewVMContainerFactory struct {
 // NewVMContainerFactory is responsible for creating a new virtual machine factory object
 func NewVMContainerFactory(args ArgsNewVMContainerFactory) (*vmContainerFactory, error) {
 	if check.IfNil(args.Economics) {
-		return nil, process.ErrNilEconomicsData
+		return nil, fmt.Errorf("%w in NewVMContainerFactory", process.ErrNilEconomicsData)
 	}
 	if check.IfNil(args.MessageSignVerifier) {
-		return nil, process.ErrNilKeyGen
+		return nil, fmt.Errorf("%w in NewVMContainerFactory", process.ErrNilKeyGen)
 	}
 	if check.IfNil(args.NodesConfigProvider) {
-		return nil, process.ErrNilNodesConfigProvider
+		return nil, fmt.Errorf("%w in NewVMContainerFactory", process.ErrNilNodesConfigProvider)
 	}
 	if check.IfNil(args.Hasher) {
-		return nil, process.ErrNilHasher
+		return nil, fmt.Errorf("%w in NewVMContainerFactory", process.ErrNilHasher)
 	}
 	if check.IfNil(args.Marshalizer) {
-		return nil, process.ErrNilMarshalizer
+		return nil, fmt.Errorf("%w in NewVMContainerFactory", process.ErrNilMarshalizer)
 	}
 	if args.SystemSCConfig == nil {
-		return nil, process.ErrNilSystemSCConfig
+		return nil, fmt.Errorf("%w in NewVMContainerFactory", process.ErrNilSystemSCConfig)
 	}
 	if check.IfNil(args.ValidatorAccountsDB) {
-		return nil, vm.ErrNilValidatorAccountsDB
+		return nil, fmt.Errorf("%w in NewVMContainerFactory", vm.ErrNilValidatorAccountsDB)
 	}
 	if check.IfNil(args.ChanceComputer) {
-		return nil, vm.ErrNilChanceComputer
+		return nil, fmt.Errorf("%w in NewVMContainerFactory", vm.ErrNilChanceComputer)
 	}
 	if check.IfNil(args.GasSchedule) {
-		return nil, vm.ErrNilGasSchedule
+		return nil, fmt.Errorf("%w in NewVMContainerFactory", vm.ErrNilGasSchedule)
 	}
 	if check.IfNil(args.ArgBlockChainHook.PubkeyConv) {
-		return nil, vm.ErrNilAddressPubKeyConverter
+		return nil, fmt.Errorf("%w in NewVMContainerFactory", vm.ErrNilAddressPubKeyConverter)
 	}
 	if check.IfNil(args.ShardCoordinator) {
 		return nil, fmt.Errorf("%w in NewVMContainerFactory", vm.ErrNilShardCoordinator)
@@ -97,7 +97,7 @@ func NewVMContainerFactory(args ArgsNewVMContainerFactory) (*vmContainerFactory,
 
 	blockChainHookImpl, err := hooks.NewBlockChainHookImpl(args.ArgBlockChainHook)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w in NewVMContainerFactory", err)
 	}
 	cryptoHook := hooks.NewVMCryptoHook()
 

--- a/process/factory/metachain/vmContainerFactory_test.go
+++ b/process/factory/metachain/vmContainerFactory_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/data/state"
+	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/economics"
 	"github.com/ElrondNetwork/elrond-go/process/factory"
 	"github.com/ElrondNetwork/elrond-go/process/mock"
@@ -84,6 +85,138 @@ func createVmContainerMockArgument(gasSchedule core.GasScheduleNotifier) ArgsNew
 		EpochNotifier:       &mock.EpochNotifierStub{},
 		ShardCoordinator:    &mock.ShardCoordinatorStub{},
 	}
+}
+
+func TestNewVMContainerFactory_NilEconomics(t *testing.T) {
+	t.Parallel()
+
+	gasSchedule := makeGasSchedule()
+	argsNewVmContainerFactory := createVmContainerMockArgument(gasSchedule)
+	argsNewVmContainerFactory.Economics = nil
+	vmf, err := NewVMContainerFactory(argsNewVmContainerFactory)
+
+	assert.True(t, check.IfNil(vmf))
+	assert.True(t, errors.Is(err, process.ErrNilEconomicsData))
+}
+
+func TestNewVMContainerFactory_NilMessageSignVerifier(t *testing.T) {
+	t.Parallel()
+
+	gasSchedule := makeGasSchedule()
+	argsNewVmContainerFactory := createVmContainerMockArgument(gasSchedule)
+	argsNewVmContainerFactory.MessageSignVerifier = nil
+	vmf, err := NewVMContainerFactory(argsNewVmContainerFactory)
+
+	assert.True(t, check.IfNil(vmf))
+	assert.True(t, errors.Is(err, process.ErrNilKeyGen))
+}
+
+func TestNewVMContainerFactory_NilNodesConfigProvider(t *testing.T) {
+	t.Parallel()
+
+	gasSchedule := makeGasSchedule()
+	argsNewVmContainerFactory := createVmContainerMockArgument(gasSchedule)
+	argsNewVmContainerFactory.NodesConfigProvider = nil
+	vmf, err := NewVMContainerFactory(argsNewVmContainerFactory)
+
+	assert.True(t, check.IfNil(vmf))
+	assert.True(t, errors.Is(err, process.ErrNilNodesConfigProvider))
+}
+
+func TestNewVMContainerFactory_NilHasher(t *testing.T) {
+	t.Parallel()
+
+	gasSchedule := makeGasSchedule()
+	argsNewVmContainerFactory := createVmContainerMockArgument(gasSchedule)
+	argsNewVmContainerFactory.Hasher = nil
+	vmf, err := NewVMContainerFactory(argsNewVmContainerFactory)
+
+	assert.True(t, check.IfNil(vmf))
+	assert.True(t, errors.Is(err, process.ErrNilHasher))
+}
+
+func TestNewVMContainerFactory_NilMarshalizer(t *testing.T) {
+	t.Parallel()
+
+	gasSchedule := makeGasSchedule()
+	argsNewVmContainerFactory := createVmContainerMockArgument(gasSchedule)
+	argsNewVmContainerFactory.Marshalizer = nil
+	vmf, err := NewVMContainerFactory(argsNewVmContainerFactory)
+
+	assert.True(t, check.IfNil(vmf))
+	assert.True(t, errors.Is(err, process.ErrNilMarshalizer))
+}
+
+func TestNewVMContainerFactory_NilSystemConfig(t *testing.T) {
+	t.Parallel()
+
+	gasSchedule := makeGasSchedule()
+	argsNewVmContainerFactory := createVmContainerMockArgument(gasSchedule)
+	argsNewVmContainerFactory.SystemSCConfig = nil
+	vmf, err := NewVMContainerFactory(argsNewVmContainerFactory)
+
+	assert.True(t, check.IfNil(vmf))
+	assert.True(t, errors.Is(err, process.ErrNilSystemSCConfig))
+}
+
+func TestNewVMContainerFactory_NilValidatorAccountsDB(t *testing.T) {
+	t.Parallel()
+
+	gasSchedule := makeGasSchedule()
+	argsNewVmContainerFactory := createVmContainerMockArgument(gasSchedule)
+	argsNewVmContainerFactory.ValidatorAccountsDB = nil
+	vmf, err := NewVMContainerFactory(argsNewVmContainerFactory)
+
+	assert.True(t, check.IfNil(vmf))
+	assert.True(t, errors.Is(err, vm.ErrNilValidatorAccountsDB))
+}
+
+func TestNewVMContainerFactory_NilChanceComputer(t *testing.T) {
+	t.Parallel()
+
+	gasSchedule := makeGasSchedule()
+	argsNewVmContainerFactory := createVmContainerMockArgument(gasSchedule)
+	argsNewVmContainerFactory.ChanceComputer = nil
+	vmf, err := NewVMContainerFactory(argsNewVmContainerFactory)
+
+	assert.True(t, check.IfNil(vmf))
+	assert.True(t, errors.Is(err, vm.ErrNilChanceComputer))
+}
+
+func TestNewVMContainerFactory_NilGasSchedule(t *testing.T) {
+	t.Parallel()
+
+	gasSchedule := makeGasSchedule()
+	argsNewVmContainerFactory := createVmContainerMockArgument(gasSchedule)
+	argsNewVmContainerFactory.GasSchedule = nil
+	vmf, err := NewVMContainerFactory(argsNewVmContainerFactory)
+
+	assert.True(t, check.IfNil(vmf))
+	assert.True(t, errors.Is(err, vm.ErrNilGasSchedule))
+}
+
+func TestNewVMContainerFactory_NilPubkeyConverter(t *testing.T) {
+	t.Parallel()
+
+	gasSchedule := makeGasSchedule()
+	argsNewVmContainerFactory := createVmContainerMockArgument(gasSchedule)
+	argsNewVmContainerFactory.ArgBlockChainHook.PubkeyConv = nil
+	vmf, err := NewVMContainerFactory(argsNewVmContainerFactory)
+
+	assert.True(t, check.IfNil(vmf))
+	assert.True(t, errors.Is(err, vm.ErrNilAddressPubKeyConverter))
+}
+
+func TestNewVMContainerFactory_NilBlockChainHookFails(t *testing.T) {
+	t.Parallel()
+
+	gasSchedule := makeGasSchedule()
+	argsNewVmContainerFactory := createVmContainerMockArgument(gasSchedule)
+	argsNewVmContainerFactory.ArgBlockChainHook.Accounts = nil
+	vmf, err := NewVMContainerFactory(argsNewVmContainerFactory)
+
+	assert.True(t, check.IfNil(vmf))
+	assert.True(t, errors.Is(err, process.ErrNilAccountsAdapter))
 }
 
 func TestNewVMContainerFactory_NilShardCoordinator(t *testing.T) {

--- a/vm/errors.go
+++ b/vm/errors.go
@@ -232,3 +232,9 @@ var ErrNFTCreateRoleAlreadyExists = errors.New("NFT create role already exists")
 
 // ErrRedelegateValueBelowMinimum signals that the re-delegate added to the remaining value will be below the minimum required
 var ErrRedelegateValueBelowMinimum = errors.New("can not re-delegate as the remaining value will be below the minimum required")
+
+// ErrWrongRewardAddress signals that a wrong reward address was provided
+var ErrWrongRewardAddress = errors.New("wrong reward address")
+
+// ErrNilShardCoordinator signals that a nil shard coordinator was provided
+var ErrNilShardCoordinator = errors.New("nil shard coordinator")

--- a/vm/factory/systemSCFactory.go
+++ b/vm/factory/systemSCFactory.go
@@ -50,31 +50,31 @@ type ArgsNewSystemSCFactory struct {
 // NewSystemSCFactory creates a factory which will instantiate the system smart contracts
 func NewSystemSCFactory(args ArgsNewSystemSCFactory) (*systemSCFactory, error) {
 	if check.IfNil(args.SystemEI) {
-		return nil, vm.ErrNilSystemEnvironmentInterface
+		return nil, fmt.Errorf("%w in NewSystemSCFactory", vm.ErrNilSystemEnvironmentInterface)
 	}
 	if check.IfNil(args.SigVerifier) {
-		return nil, vm.ErrNilMessageSignVerifier
+		return nil, fmt.Errorf("%w in NewSystemSCFactory", vm.ErrNilMessageSignVerifier)
 	}
 	if check.IfNil(args.NodesConfigProvider) {
-		return nil, vm.ErrNilNodesConfigProvider
+		return nil, fmt.Errorf("%w in NewSystemSCFactory", vm.ErrNilNodesConfigProvider)
 	}
 	if check.IfNil(args.Marshalizer) {
-		return nil, vm.ErrNilMarshalizer
+		return nil, fmt.Errorf("%w in NewSystemSCFactory", vm.ErrNilMarshalizer)
 	}
 	if check.IfNil(args.Hasher) {
-		return nil, vm.ErrNilHasher
+		return nil, fmt.Errorf("%w in NewSystemSCFactory", vm.ErrNilHasher)
 	}
 	if check.IfNil(args.Economics) {
-		return nil, vm.ErrNilEconomicsData
+		return nil, fmt.Errorf("%w in NewSystemSCFactory", vm.ErrNilEconomicsData)
 	}
 	if args.SystemSCConfig == nil {
-		return nil, vm.ErrNilSystemSCConfig
+		return nil, fmt.Errorf("%w in NewSystemSCFactory", vm.ErrNilSystemSCConfig)
 	}
 	if check.IfNil(args.EpochNotifier) {
-		return nil, vm.ErrNilEpochNotifier
+		return nil, fmt.Errorf("%w in NewSystemSCFactory", vm.ErrNilEpochNotifier)
 	}
 	if check.IfNil(args.AddressPubKeyConverter) {
-		return nil, vm.ErrNilAddressPubKeyConverter
+		return nil, fmt.Errorf("%w in NewSystemSCFactory", vm.ErrNilAddressPubKeyConverter)
 	}
 	if check.IfNil(args.ShardCoordinator) {
 		return nil, fmt.Errorf("%w in NewSystemSCFactory", vm.ErrNilShardCoordinator)

--- a/vm/factory/systemSCFactory_test.go
+++ b/vm/factory/systemSCFactory_test.go
@@ -81,7 +81,7 @@ func TestNewSystemSCFactory_NilSystemEI(t *testing.T) {
 	scFactory, err := NewSystemSCFactory(arguments)
 
 	assert.Nil(t, scFactory)
-	assert.Equal(t, vm.ErrNilSystemEnvironmentInterface, err)
+	assert.True(t, errors.Is(err, vm.ErrNilSystemEnvironmentInterface))
 }
 
 func TestNewSystemSCFactory_NilSigVerifier(t *testing.T) {
@@ -92,7 +92,7 @@ func TestNewSystemSCFactory_NilSigVerifier(t *testing.T) {
 	scFactory, err := NewSystemSCFactory(arguments)
 
 	assert.Nil(t, scFactory)
-	assert.Equal(t, vm.ErrNilMessageSignVerifier, err)
+	assert.True(t, errors.Is(err, vm.ErrNilMessageSignVerifier))
 }
 
 func TestNewSystemSCFactory_NilNodesConfigProvider(t *testing.T) {
@@ -103,7 +103,7 @@ func TestNewSystemSCFactory_NilNodesConfigProvider(t *testing.T) {
 	scFactory, err := NewSystemSCFactory(arguments)
 
 	assert.Nil(t, scFactory)
-	assert.Equal(t, vm.ErrNilNodesConfigProvider, err)
+	assert.True(t, errors.Is(err, vm.ErrNilNodesConfigProvider))
 }
 
 func TestNewSystemSCFactory_NilMarshalizer(t *testing.T) {
@@ -114,7 +114,7 @@ func TestNewSystemSCFactory_NilMarshalizer(t *testing.T) {
 	scFactory, err := NewSystemSCFactory(arguments)
 
 	assert.Nil(t, scFactory)
-	assert.Equal(t, vm.ErrNilMarshalizer, err)
+	assert.True(t, errors.Is(err, vm.ErrNilMarshalizer))
 }
 
 func TestNewSystemSCFactory_NilHasher(t *testing.T) {
@@ -125,7 +125,7 @@ func TestNewSystemSCFactory_NilHasher(t *testing.T) {
 	scFactory, err := NewSystemSCFactory(arguments)
 
 	assert.Nil(t, scFactory)
-	assert.Equal(t, vm.ErrNilHasher, err)
+	assert.True(t, errors.Is(err, vm.ErrNilHasher))
 }
 
 func TestNewSystemSCFactory_NilEconomicsData(t *testing.T) {
@@ -136,7 +136,7 @@ func TestNewSystemSCFactory_NilEconomicsData(t *testing.T) {
 	scFactory, err := NewSystemSCFactory(arguments)
 
 	assert.Nil(t, scFactory)
-	assert.Equal(t, vm.ErrNilEconomicsData, err)
+	assert.True(t, errors.Is(err, vm.ErrNilEconomicsData))
 }
 
 func TestNewSystemSCFactory_NilSystemScConfig(t *testing.T) {
@@ -147,7 +147,7 @@ func TestNewSystemSCFactory_NilSystemScConfig(t *testing.T) {
 	scFactory, err := NewSystemSCFactory(arguments)
 
 	assert.Nil(t, scFactory)
-	assert.Equal(t, vm.ErrNilSystemSCConfig, err)
+	assert.True(t, errors.Is(err, vm.ErrNilSystemSCConfig))
 }
 
 func TestNewSystemSCFactory_NilEpochNotifier(t *testing.T) {
@@ -158,7 +158,7 @@ func TestNewSystemSCFactory_NilEpochNotifier(t *testing.T) {
 	scFactory, err := NewSystemSCFactory(arguments)
 
 	assert.Nil(t, scFactory)
-	assert.Equal(t, vm.ErrNilEpochNotifier, err)
+	assert.True(t, errors.Is(err, vm.ErrNilEpochNotifier))
 }
 
 func TestNewSystemSCFactory_NilPubKeyConverter(t *testing.T) {
@@ -169,7 +169,7 @@ func TestNewSystemSCFactory_NilPubKeyConverter(t *testing.T) {
 	scFactory, err := NewSystemSCFactory(arguments)
 
 	assert.Nil(t, scFactory)
-	assert.Equal(t, vm.ErrNilAddressPubKeyConverter, err)
+	assert.True(t, errors.Is(err, vm.ErrNilAddressPubKeyConverter))
 }
 
 func TestNewSystemSCFactory_NilShardCoordinator(t *testing.T) {

--- a/vm/factory/systemSCFactory_test.go
+++ b/vm/factory/systemSCFactory_test.go
@@ -69,6 +69,7 @@ func createMockNewSystemScFactoryArgs() ArgsNewSystemSCFactory {
 		},
 		EpochNotifier:          &mock.EpochNotifierStub{},
 		AddressPubKeyConverter: &mock.PubkeyConverterMock{},
+		ShardCoordinator:       &mock.ShardCoordinatorStub{},
 	}
 }
 
@@ -169,6 +170,17 @@ func TestNewSystemSCFactory_NilPubKeyConverter(t *testing.T) {
 
 	assert.Nil(t, scFactory)
 	assert.Equal(t, vm.ErrNilAddressPubKeyConverter, err)
+}
+
+func TestNewSystemSCFactory_NilShardCoordinator(t *testing.T) {
+	t.Parallel()
+
+	arguments := createMockNewSystemScFactoryArgs()
+	arguments.ShardCoordinator = nil
+	scFactory, err := NewSystemSCFactory(arguments)
+
+	assert.True(t, check.IfNil(scFactory))
+	assert.True(t, errors.Is(err, vm.ErrNilShardCoordinator))
 }
 
 func TestNewSystemSCFactory_Ok(t *testing.T) {

--- a/vm/mock/shardCoordinatorStub.go
+++ b/vm/mock/shardCoordinatorStub.go
@@ -1,0 +1,49 @@
+package mock
+
+// ShardCoordinatorStub -
+type ShardCoordinatorStub struct {
+	NumberOfShardsCalled          func() uint32
+	ComputeIdCalled               func(address []byte) uint32
+	SelfIdCalled                  func() uint32
+	SameShardCalled               func(firstAddress, secondAddress []byte) bool
+	CommunicationIdentifierCalled func(destShardID uint32) string
+}
+
+// NumberOfShards -
+func (coordinator *ShardCoordinatorStub) NumberOfShards() uint32 {
+	if coordinator.NumberOfShardsCalled != nil {
+		return coordinator.NumberOfShardsCalled()
+	}
+	return 1
+}
+
+// ComputeId -
+func (coordinator *ShardCoordinatorStub) ComputeId(address []byte) uint32 {
+	if coordinator.ComputeIdCalled != nil {
+		return coordinator.ComputeIdCalled(address)
+	}
+	return 0
+}
+
+// SelfId -
+func (coordinator *ShardCoordinatorStub) SelfId() uint32 {
+	if coordinator.SelfIdCalled != nil {
+		return coordinator.SelfIdCalled()
+	}
+	return 0
+}
+
+// SameShard -
+func (coordinator *ShardCoordinatorStub) SameShard(firstAddress, secondAddress []byte) bool {
+	return coordinator.SameShardCalled(firstAddress, secondAddress)
+}
+
+// CommunicationIdentifier -
+func (coordinator *ShardCoordinatorStub) CommunicationIdentifier(destShardID uint32) string {
+	return coordinator.CommunicationIdentifierCalled(destShardID)
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (coordinator *ShardCoordinatorStub) IsInterfaceNil() bool {
+	return coordinator == nil
+}

--- a/vm/systemSmartContracts/delegationManager.go
+++ b/vm/systemSmartContracts/delegationManager.go
@@ -308,7 +308,7 @@ func (d *delegationManager) checkCallerIsOwnerOfContract(args *vmcommon.Contract
 	lenAddress := len(args.CallerAddr)
 	buff := d.eei.GetStorage(args.CallerAddr)
 	if len(buff) == 0 {
-		d.eei.AddReturnMessage("no sc address under selected user")
+		d.eei.AddReturnMessage("the caller does not own a delegation sc")
 		return vmcommon.UserError
 	}
 

--- a/vm/systemSmartContracts/delegationManager.go
+++ b/vm/systemSmartContracts/delegationManager.go
@@ -305,7 +305,6 @@ func (d *delegationManager) checkValidatorToDelegationInput(args *vmcommon.Contr
 
 func (d *delegationManager) checkCallerIsOwnerOfContract(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
 	scAddress := args.Arguments[0]
-	lenAddress := len(args.CallerAddr)
 	buff := d.eei.GetStorage(args.CallerAddr)
 	if len(buff) == 0 {
 		d.eei.AddReturnMessage("the caller does not own a delegation sc")
@@ -313,6 +312,7 @@ func (d *delegationManager) checkCallerIsOwnerOfContract(args *vmcommon.Contract
 	}
 
 	found := false
+	lenAddress := len(args.CallerAddr)
 	for i := 0; i < len(buff); i += lenAddress {
 		savedAddress := buff[i : i+lenAddress]
 		if bytes.Equal(savedAddress, scAddress) {

--- a/vm/systemSmartContracts/delegationManager.go
+++ b/vm/systemSmartContracts/delegationManager.go
@@ -272,6 +272,10 @@ func (d *delegationManager) makeNewContractFromValidatorData(args *vmcommon.Cont
 		d.eei.AddReturnMessage("invalid number of arguments")
 		return vmcommon.UserError
 	}
+	if d.callerAlreadyDeployed(args.CallerAddr) {
+		d.eei.AddReturnMessage("caller already deployed a delegation sc")
+		return vmcommon.UserError
+	}
 
 	arguments := append([][]byte{args.CallerAddr}, args.Arguments...)
 	return d.deployNewContract(args, false, initFromValidatorData, d.delegationMgrSCAddress, big.NewInt(0), arguments)
@@ -355,6 +359,17 @@ func (d *delegationManager) mergeValidatorToDelegation(
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
 	}
+	if returnCode != vmcommon.Ok {
+		return returnCode
+	}
+
+	txData = deleteWhitelistForMerge
+	vmOutput, err = d.eei.ExecuteOnDestContext(scAddress, d.delegationMgrSCAddress, big.NewInt(0), []byte(txData))
+	if err != nil {
+		d.eei.AddReturnMessage(err.Error())
+		return vmcommon.UserError
+	}
+
 	return vmOutput.ReturnCode
 }
 

--- a/vm/systemSmartContracts/delegationManager_test.go
+++ b/vm/systemSmartContracts/delegationManager_test.go
@@ -881,7 +881,7 @@ func TestDelegationManagerSystemSC_mergeValidatorToDelegationSameOwner(t *testin
 	eei.gasRemaining = vmInput.GasProvided
 	returnCode = d.Execute(vmInput)
 	assert.Equal(t, vmcommon.UserError, returnCode)
-	assert.Equal(t, eei.returnMessage, "no sc address under selected user")
+	assert.Equal(t, eei.returnMessage, "the caller does not own a delegation sc")
 
 	eei.returnMessage = ""
 	eei.gasRemaining = vmInput.GasProvided

--- a/vm/systemSmartContracts/delegationManager_test.go
+++ b/vm/systemSmartContracts/delegationManager_test.go
@@ -974,16 +974,26 @@ func TestDelegationManagerSystemSC_mergeValidatorToDelegationWithWhiteList(t *te
 	assert.Equal(t, vmcommon.UserError, returnCode)
 	assert.Equal(t, eei.returnMessage, vm.ErrUnknownSystemSmartContract.Error())
 
-	_ = eei.SetSystemSCContainer(&mock.SystemSCContainerStub{GetCalled: func(key []byte) (vm.SystemSmartContract, error) {
-		return &mock.SystemSCStub{ExecuteCalled: func(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
-			return vmcommon.Ok
-		}}, nil
-	}})
+	deleteWhiteListCalled := false
+	_ = eei.SetSystemSCContainer(
+		&mock.SystemSCContainerStub{
+			GetCalled: func(key []byte) (vm.SystemSmartContract, error) {
+				return &mock.SystemSCStub{
+					ExecuteCalled: func(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
+						if args.Function == deleteWhitelistForMerge {
+							deleteWhiteListCalled = true
+						}
+
+						return vmcommon.Ok
+					},
+				}, nil
+			}})
 	eei.returnMessage = ""
 	eei.gasRemaining = vmInput.GasProvided
 
 	returnCode = d.Execute(vmInput)
 	assert.Equal(t, vmcommon.Ok, returnCode)
+	assert.True(t, deleteWhiteListCalled)
 }
 
 func TestDelegationManagerSystemSC_MakeNewContractFromValidatorDataWithJailedNodes(t *testing.T) {
@@ -1040,4 +1050,55 @@ func TestDelegationManagerSystemSC_MakeNewContractFromValidatorDataWithJailedNod
 	returnCode = d.Execute(vmInput)
 	assert.Equal(t, vmcommon.UserError, returnCode)
 	assert.Equal(t, eei.returnMessage, "can not migrate nodes while jailed nodes exists")
+}
+
+func TestDelegationManagerSystemSC_MakeNewContractFromValidatorDataCallerAlreadyDeployedADelegationSC(t *testing.T) {
+	maxDelegationCap := []byte{0}
+	serviceFee := []byte{10}
+	args := createMockArgumentsForDelegationManager()
+	eei, _ := NewVMContext(
+		&mock.BlockChainHookStub{},
+		hooks.NewVMCryptoHook(),
+		parsers.NewCallArgsParser(),
+		&mock.AccountsStub{},
+		&mock.RaterMock{},
+	)
+	_ = eei.SetSystemSCContainer(
+		createSystemSCContainer(eei),
+	)
+
+	caller := bytes.Repeat([]byte{1}, 32)
+
+	args.Eei = eei
+	args.GasCost.MetaChainSystemSCsCost.ValidatorToDelegation = 100
+	d, _ := NewDelegationManagerSystemSC(args)
+	vmInput := getDefaultVmInputForDelegationManager("makeNewContractFromValidatorData", [][]byte{maxDelegationCap, serviceFee})
+	vmInput.CallerAddr = caller
+	eei.scAddress = vm.DelegationManagerSCAddress
+	_ = d.init(&vmcommon.ContractCallInput{VMInput: vmcommon.VMInput{CallValue: big.NewInt(0)}})
+
+	validator, _ := eei.systemContracts.Get(d.validatorSCAddr)
+	key1 := []byte("Key1")
+	key2 := []byte("Key2")
+
+	arguments := &vmcommon.ContractCallInput{}
+	arguments.CallerAddr = caller
+	arguments.RecipientAddr = d.validatorSCAddr
+	arguments.Function = "stake"
+	arguments.CallValue = big.NewInt(0).Mul(big.NewInt(2), big.NewInt(10000000))
+	arguments.Arguments = [][]byte{big.NewInt(2).Bytes(), key1, []byte("msg1"), key2, []byte("msg2")}
+
+	eei.scAddress = vm.ValidatorSCAddress
+	returnCode := validator.Execute(arguments)
+	require.Equal(t, returnCode, vmcommon.Ok)
+
+	vmInput = getDefaultVmInputForDelegationManager("makeNewContractFromValidatorData", [][]byte{maxDelegationCap, serviceFee})
+	vmInput.CallerAddr = caller
+	vmInput.RecipientAddr = vm.DelegationManagerSCAddress
+	vmInput.GasProvided = 1000000
+	eei.gasRemaining = 1000000
+	eei.returnMessage = ""
+	returnCode = d.Execute(vmInput)
+	assert.Equal(t, vmcommon.UserError, returnCode)
+	assert.Equal(t, eei.returnMessage, "caller already deployed a delegation sc")
 }

--- a/vm/systemSmartContracts/staking_test.go
+++ b/vm/systemSmartContracts/staking_test.go
@@ -22,12 +22,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createMockStakingScArguments() ArgsNewStakingSmartContract {
+func createMockStakingScArgumentsWithSystemScAddresses(
+	validatorScAddress []byte,
+	jailScAddress []byte,
+	endOfEpochAddress []byte,
+) ArgsNewStakingSmartContract {
 	return ArgsNewStakingSmartContract{
 		Eei:                  &mock.SystemEIStub{},
-		StakingAccessAddr:    []byte("validator"),
-		JailAccessAddr:       []byte("jail"),
-		EndOfEpochAccessAddr: []byte("endOfEpoch"),
+		StakingAccessAddr:    validatorScAddress,
+		JailAccessAddr:       jailScAddress,
+		EndOfEpochAccessAddr: endOfEpochAddress,
 		MinNumNodes:          1,
 		Marshalizer:          &mock.MarshalizerMock{},
 		StakingSCConfig: config.StakingSystemSCConfig{
@@ -47,6 +51,22 @@ func createMockStakingScArguments() ArgsNewStakingSmartContract {
 		},
 		EpochNotifier: &mock.EpochNotifierStub{},
 	}
+}
+
+func createMockStakingScArguments() ArgsNewStakingSmartContract {
+	return createMockStakingScArgumentsWithSystemScAddresses(
+		[]byte("validator"),
+		[]byte("jail"),
+		[]byte("endOfEpoch"),
+	)
+}
+
+func createMockStakingScArgumentsWithRealSystemScAddresses() ArgsNewStakingSmartContract {
+	return createMockStakingScArgumentsWithSystemScAddresses(
+		vm.ValidatorSCAddress,
+		vm.JailingAddress,
+		vm.EndOfEpochAddress,
+	)
 }
 
 func CreateVmContractCallInput() *vmcommon.ContractCallInput {

--- a/vm/systemSmartContracts/validator.go
+++ b/vm/systemSmartContracts/validator.go
@@ -1948,6 +1948,10 @@ func (v *validatorSC) getAndValidateRegistrationData(address []byte) (*Validator
 		v.eei.AddReturnMessage(err.Error())
 		return nil, vmcommon.UserError
 	}
+	if len(oldValidatorData.BlsPubKeys) == 0 {
+		v.eei.AddReturnMessage("address does not contain any staked nodes")
+		return nil, vmcommon.UserError
+	}
 	if !bytes.Equal(oldValidatorData.RewardAddress, address) {
 		v.eei.AddReturnMessage("reward address mismatch")
 		return nil, vmcommon.UserError

--- a/vm/systemSmartContracts/validator.go
+++ b/vm/systemSmartContracts/validator.go
@@ -87,31 +87,31 @@ func NewValidatorSmartContract(
 	args ArgsValidatorSmartContract,
 ) (*validatorSC, error) {
 	if check.IfNil(args.Eei) {
-		return nil, vm.ErrNilSystemEnvironmentInterface
+		return nil, fmt.Errorf("%w in validatorSC", vm.ErrNilSystemEnvironmentInterface)
 	}
 	if len(args.StakingSCAddress) == 0 {
-		return nil, vm.ErrNilStakingSmartContractAddress
+		return nil, fmt.Errorf("%w in validatorSC", vm.ErrNilStakingSmartContractAddress)
 	}
 	if len(args.ValidatorSCAddress) == 0 {
-		return nil, vm.ErrNilValidatorSmartContractAddress
+		return nil, fmt.Errorf("%w in validatorSC", vm.ErrNilValidatorSmartContractAddress)
 	}
 	if check.IfNil(args.Marshalizer) {
-		return nil, vm.ErrNilMarshalizer
+		return nil, fmt.Errorf("%w in validatorSC", vm.ErrNilMarshalizer)
 	}
 	if check.IfNil(args.SigVerifier) {
-		return nil, vm.ErrNilMessageSignVerifier
+		return nil, fmt.Errorf("%w in validatorSC", vm.ErrNilMessageSignVerifier)
 	}
 	if args.GenesisTotalSupply == nil || args.GenesisTotalSupply.Cmp(zero) <= 0 {
-		return nil, fmt.Errorf("%w, value is %v", vm.ErrInvalidGenesisTotalSupply, args.GenesisTotalSupply)
+		return nil, fmt.Errorf("%w, value is %v in validatorSC", vm.ErrInvalidGenesisTotalSupply, args.GenesisTotalSupply)
 	}
 	if check.IfNil(args.EpochNotifier) {
-		return nil, vm.ErrNilEpochNotifier
+		return nil, fmt.Errorf("%w in validatorSC", vm.ErrNilEpochNotifier)
 	}
 	if len(args.EndOfEpochAddress) < 1 {
-		return nil, vm.ErrInvalidEndOfEpochAccessAddress
+		return nil, fmt.Errorf("%w in validatorSC", vm.ErrInvalidEndOfEpochAccessAddress)
 	}
 	if len(args.DelegationMgrSCAddress) < 1 {
-		return nil, fmt.Errorf("%w for delegation sc address", vm.ErrInvalidAddress)
+		return nil, fmt.Errorf("%w for delegation sc address in validatorSC", vm.ErrInvalidAddress)
 	}
 	if check.IfNil(args.ShardCoordinator) {
 		return nil, fmt.Errorf("%w in validatorSC", vm.ErrNilShardCoordinator)

--- a/vm/systemSmartContracts/validator_test.go
+++ b/vm/systemSmartContracts/validator_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/core"
+	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/core/parsers"
 	"github.com/ElrondNetwork/elrond-go/core/vmcommon"
 	"github.com/ElrondNetwork/elrond-go/data/state"
@@ -25,13 +26,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createMockArgumentsForValidatorSC() ArgsValidatorSmartContract {
+func createMockArgumentsForValidatorSCWithSystemScAddresses(
+	validatorScAddress []byte,
+	stakingScAddress []byte,
+	endOfEpochAddress []byte,
+) ArgsValidatorSmartContract {
 	args := ArgsValidatorSmartContract{
 		Eei:                &mock.SystemEIStub{},
 		SigVerifier:        &mock.MessageSignVerifierMock{},
-		ValidatorSCAddress: []byte("validator"),
-		StakingSCAddress:   []byte("staking"),
-		EndOfEpochAddress:  []byte("endOfEpoch"),
+		ValidatorSCAddress: validatorScAddress,
+		StakingSCAddress:   stakingScAddress,
+		EndOfEpochAddress:  endOfEpochAddress,
 		StakingSCConfig: config.StakingSystemSCConfig{
 			GenesisNodePrice:                     "1000",
 			UnJailValue:                          "10",
@@ -54,12 +59,29 @@ func createMockArgumentsForValidatorSC() ArgsValidatorSmartContract {
 		MinDeposit:               "0",
 		DelegationMgrSCAddress:   vm.DelegationManagerSCAddress,
 		DelegationMgrEnableEpoch: 100000,
+		ShardCoordinator:         &mock.ShardCoordinatorStub{},
 	}
 
 	return args
 }
 
-func createABid(totalStakeValue uint64, numBlsKeys uint32, maxStakePerNode uint64) ValidatorDataV2 {
+func createMockArgumentsForValidatorSC() ArgsValidatorSmartContract {
+	return createMockArgumentsForValidatorSCWithSystemScAddresses(
+		[]byte("validator"),
+		[]byte("staking"),
+		[]byte("endOfEpoch"),
+	)
+}
+
+func createMockArgumentsForValidatorSCWithRealAddresses() ArgsValidatorSmartContract {
+	return createMockArgumentsForValidatorSCWithSystemScAddresses(
+		vm.ValidatorSCAddress,
+		vm.StakingSCAddress,
+		vm.EndOfEpochAddress,
+	)
+}
+
+func createAValidatorData(totalStakeValue uint64, numBlsKeys uint32, maxStakePerNode uint64) ValidatorDataV2 {
 	data := ValidatorDataV2{
 		RewardAddress:   []byte("addr"),
 		RegisterNonce:   0,
@@ -275,11 +297,22 @@ func TestNewStakingValidatorSmartContract_EmptyDelegationManagerAddress(t *testi
 	require.True(t, errors.Is(err, vm.ErrInvalidAddress))
 }
 
+func TestNewStakingValidatorSmartContract_NilShardCoordinator(t *testing.T) {
+	t.Parallel()
+
+	arguments := createMockArgumentsForValidatorSC()
+	arguments.ShardCoordinator = nil
+
+	asc, err := NewValidatorSmartContract(arguments)
+	require.True(t, check.IfNil(asc))
+	require.True(t, errors.Is(err, vm.ErrNilShardCoordinator))
+}
+
 func TestStakingValidatorSC_ExecuteStakeWithoutArgumentsShouldWork(t *testing.T) {
 	t.Parallel()
 
 	arguments := CreateVmContractCallInput()
-	validatorData := createABid(25000000, 2, 12500000)
+	validatorData := createAValidatorData(25000000, 2, 12500000)
 	validatorDataBytes, _ := json.Marshal(&validatorData)
 
 	eei := &mock.SystemEIStub{}
@@ -312,7 +345,7 @@ func TestStakingValidatorSC_ExecuteStakeAddedNewPubKeysShouldWork(t *testing.T) 
 	t.Parallel()
 
 	arguments := CreateVmContractCallInput()
-	validatorData := createABid(25000000, 2, 12500000)
+	validatorData := createAValidatorData(25000000, 2, 12500000)
 	validatorDataBytes, _ := json.Marshal(&validatorData)
 
 	key1 := []byte("Key1")
@@ -350,7 +383,7 @@ func TestStakingValidatorSC_ExecuteStakeAddedNewPubKeysShouldWork(t *testing.T) 
 	assert.Equal(t, vmcommon.Ok, errCode)
 }
 
-func TestStakingAuctionSC_ExecuteStakeDoubleKeyAndCleanup(t *testing.T) {
+func TestStakingValidatorSC_ExecuteStakeDoubleKeyAndCleanup(t *testing.T) {
 	t.Parallel()
 
 	arguments := CreateVmContractCallInput()
@@ -496,7 +529,7 @@ func TestStakingValidatorSC_ExecuteStakeUnStakeOneBlsPubKey(t *testing.T) {
 	t.Parallel()
 
 	arguments := CreateVmContractCallInput()
-	validatorData := createABid(25000000, 2, 12500000)
+	validatorData := createAValidatorData(25000000, 2, 12500000)
 	validatorDataBytes, _ := json.Marshal(&validatorData)
 
 	stakedData := StakedDataV2_0{
@@ -1401,13 +1434,13 @@ func TestStakingValidatorSC_ExecuteStakeUnStakeUnBondBlsPubKeyAndReStake(t *test
 	assert.True(t, stakedData.Staked)
 }
 
-func TestStakingValidatorSC_ExecuteUnBound(t *testing.T) {
+func TestStakingValidatorSC_ExecuteUnBond(t *testing.T) {
 	t.Parallel()
 
 	arguments := CreateVmContractCallInput()
 	totalStake := uint64(25000000)
 
-	validatorData := createABid(totalStake, 2, 12500000)
+	validatorData := createAValidatorData(totalStake, 2, 12500000)
 	validatorDataBytes, _ := json.Marshal(&validatorData)
 
 	stakedData := StakedDataV2_0{
@@ -2256,7 +2289,7 @@ func TestValidatorStakingSC_ExecuteUnStake(t *testing.T) {
 	assert.Equal(t, expectedRegistrationData, registrationData)
 }
 
-func TestValidatorStakingSC_ExecuteUnBoundUnmarshalErr(t *testing.T) {
+func TestValidatorStakingSC_ExecuteUnBondUnmarshalErr(t *testing.T) {
 	t.Parallel()
 
 	eei := &mock.SystemEIStub{}
@@ -2276,7 +2309,7 @@ func TestValidatorStakingSC_ExecuteUnBoundUnmarshalErr(t *testing.T) {
 	assert.Equal(t, vmcommon.UserError, retCode)
 }
 
-func TestValidatorStakingSC_ExecuteUnBoundValidatorNotUnStakeShouldErr(t *testing.T) {
+func TestValidatorStakingSC_ExecuteUnBondValidatorNotUnStakeShouldErr(t *testing.T) {
 	t.Parallel()
 
 	eei := &mock.SystemEIStub{}
@@ -3061,18 +3094,22 @@ func TestValidatorStakingSC_ChangeRewardAddress(t *testing.T) {
 	stakerAddress := []byte("stakerA")
 	stakerPubKey := []byte("stakerP")
 	minStakeValue := big.NewInt(1000)
-	unboundPeriod := uint64(10)
+	unbondPeriod := uint64(10)
 	nodesToRunBytes := big.NewInt(1).Bytes()
 	blockChainHook := &mock.BlockChainHookStub{}
 	args := createMockArgumentsForValidatorSC()
-	args.Eei = createVmContextWithStakingSc(minStakeValue, unboundPeriod, blockChainHook)
+	args.ValidatorToDelegationEnableEpoch = 1000
+	eei := createVmContextWithStakingSc(minStakeValue, unbondPeriod, blockChainHook)
+	args.Eei = eei
 
 	sc, _ := NewValidatorSmartContract(args)
 
 	//change reward address should error nil arguments
 	changeRewardAddress(t, sc, stakerAddress, nil, vmcommon.UserError)
 	// change reward address should error wrong address
+	eei.returnMessage = ""
 	changeRewardAddress(t, sc, stakerAddress, []byte("wrongAddress"), vmcommon.UserError)
+	assert.Equal(t, "wrong reward address", eei.returnMessage)
 	// change reward address should error because address is not belongs to any validator
 	newRewardAddr := []byte("newAddr11")
 	changeRewardAddress(t, sc, stakerAddress, newRewardAddr, vmcommon.UserError)
@@ -3084,6 +3121,50 @@ func TestValidatorStakingSC_ChangeRewardAddress(t *testing.T) {
 	changeRewardAddress(t, sc, stakerAddress, stakerAddress, vmcommon.UserError)
 	// change reward address should work
 	changeRewardAddress(t, sc, stakerAddress, newRewardAddr, vmcommon.Ok)
+}
+
+func TestValidatorStakingSC_ChangeRewardAddressWithExtraChecks(t *testing.T) {
+	t.Parallel()
+
+	currentShard := uint32(0)
+
+	receiverAddr := bytes.Repeat([]byte{2}, len(vm.JailingAddress))
+	stakerAddress := bytes.Repeat([]byte{1}, len(vm.JailingAddress))
+	stakerPubKey := []byte("stakerP")
+	minStakeValue := big.NewInt(1000)
+	unbondPeriod := uint64(10)
+	nodesToRunBytes := big.NewInt(1).Bytes()
+	blockChainHook := &mock.BlockChainHookStub{}
+	args := createMockArgumentsForValidatorSCWithRealAddresses()
+	args.ValidatorToDelegationEnableEpoch = 0
+	args.ValidatorSCAddress = vm.ValidatorSCAddress
+	args.ShardCoordinator = &mock.ShardCoordinatorStub{
+		ComputeIdCalled: func(address []byte) uint32 {
+			return currentShard
+		},
+	}
+	eei := createVmContextWithStakingScWithRealAddresses(minStakeValue, unbondPeriod, blockChainHook)
+	args.Eei = eei
+
+	sc, _ := NewValidatorSmartContract(args)
+	nodePrice, _ := big.NewInt(0).SetString(args.StakingSCConfig.GenesisNodePrice, 10)
+	stake(t, sc, nodePrice, receiverAddr, stakerAddress, stakerPubKey, nodesToRunBytes)
+
+	eei.returnMessage = ""
+	changeRewardAddress(t, sc, stakerAddress, vm.JailingAddress, vmcommon.UserError)
+	expectedErr := fmt.Errorf("%w when trying to set the jailing address", vm.ErrWrongRewardAddress)
+	assert.Equal(t, expectedErr.Error(), eei.returnMessage)
+
+	eei.returnMessage = ""
+	changeRewardAddress(t, sc, stakerAddress, vm.EndOfEpochAddress, vmcommon.UserError)
+	expectedErr = fmt.Errorf("%w when trying to set the end-of-epoch reserved address", vm.ErrWrongRewardAddress)
+	assert.Equal(t, expectedErr.Error(), eei.returnMessage)
+
+	eei.returnMessage = ""
+	currentShard = core.MetachainShardId
+	changeRewardAddress(t, sc, stakerAddress, bytes.Repeat([]byte{8}, len(vm.JailingAddress)), vmcommon.UserError)
+	expectedErr = fmt.Errorf("%w when trying to set a metachain address", vm.ErrWrongRewardAddress)
+	assert.Equal(t, expectedErr.Error(), eei.returnMessage)
 }
 
 func TestStakingValidatorSC_UnstakeTokensNotEnabledShouldError(t *testing.T) {
@@ -4484,7 +4565,7 @@ func TestValidatorSC_getUnStakedTokensList(t *testing.T) {
 
 	eeiFinishedValues := make([][]byte, 0)
 	arguments := CreateVmContractCallInput()
-	validatorData := createABid(25000000, 2, 12500000)
+	validatorData := createAValidatorData(25000000, 2, 12500000)
 	validatorData.UnstakedInfo = append(validatorData.UnstakedInfo,
 		&UnstakedValue{
 			UnstakedEpoch: 6,
@@ -4952,6 +5033,24 @@ func createVmContextWithStakingSc(stakeValue *big.Int, unboundPeriod uint64, blo
 	eei, _ := NewVMContext(blockChainHook, hooks.NewVMCryptoHook(), atArgParser, &mock.AccountsStub{}, &mock.RaterMock{})
 
 	argsStaking := createMockStakingScArguments()
+	argsStaking.StakingSCConfig.GenesisNodePrice = stakeValue.Text(10)
+	argsStaking.Eei = eei
+	argsStaking.StakingSCConfig.UnBondPeriod = unboundPeriod
+	stakingSc, _ := NewStakingSmartContract(argsStaking)
+
+	eei.SetSCAddress([]byte("addr"))
+	_ = eei.SetSystemSCContainer(&mock.SystemSCContainerStub{GetCalled: func(key []byte) (contract vm.SystemSmartContract, err error) {
+		return stakingSc, nil
+	}})
+
+	return eei
+}
+
+func createVmContextWithStakingScWithRealAddresses(stakeValue *big.Int, unboundPeriod uint64, blockChainHook vm.BlockchainHook) *vmContext {
+	atArgParser := parsers.NewCallArgsParser()
+	eei, _ := NewVMContext(blockChainHook, hooks.NewVMCryptoHook(), atArgParser, &mock.AccountsStub{}, &mock.RaterMock{})
+
+	argsStaking := createMockStakingScArgumentsWithRealSystemScAddresses()
 	argsStaking.StakingSCConfig.GenesisNodePrice = stakeValue.Text(10)
 	argsStaking.Eei = eei
 	argsStaking.StakingSCConfig.UnBondPeriod = unboundPeriod

--- a/vm/systemSmartContracts/validator_test.go
+++ b/vm/systemSmartContracts/validator_test.go
@@ -4847,7 +4847,7 @@ func TestStakingValidatorSC_ChangeOwnerOfValidatorData(t *testing.T) {
 	assert.Equal(t, eei.returnMessage, "address does not contain any staked nodes")
 
 	validatorData := &ValidatorDataV2{
-		RewardAddress:   []byte("nit a valid address"),
+		RewardAddress:   []byte("not a valid address"),
 		TotalSlashed:    big.NewInt(0),
 		TotalUnstaked:   big.NewInt(0),
 		TotalStakeValue: big.NewInt(0),

--- a/vm/systemSmartContracts/validator_test.go
+++ b/vm/systemSmartContracts/validator_test.go
@@ -194,7 +194,7 @@ func TestNewStakingValidatorSmartContract_NilSystemEnvironmentInterface(t *testi
 
 	asc, err := NewValidatorSmartContract(arguments)
 	require.Nil(t, asc)
-	require.Equal(t, vm.ErrNilSystemEnvironmentInterface, err)
+	assert.True(t, errors.Is(err, vm.ErrNilSystemEnvironmentInterface))
 }
 
 func TestNewStakingValidatorSmartContract_NilStakingSmartContractAddress(t *testing.T) {
@@ -205,7 +205,7 @@ func TestNewStakingValidatorSmartContract_NilStakingSmartContractAddress(t *test
 
 	asc, err := NewValidatorSmartContract(arguments)
 	require.Nil(t, asc)
-	require.Equal(t, vm.ErrNilStakingSmartContractAddress, err)
+	assert.True(t, errors.Is(err, vm.ErrNilStakingSmartContractAddress))
 }
 
 func TestNewStakingValidatorSmartContract_NilValidatorSmartContractAddress(t *testing.T) {
@@ -216,7 +216,7 @@ func TestNewStakingValidatorSmartContract_NilValidatorSmartContractAddress(t *te
 
 	asc, err := NewValidatorSmartContract(arguments)
 	require.Nil(t, asc)
-	require.Equal(t, vm.ErrNilValidatorSmartContractAddress, err)
+	assert.True(t, errors.Is(err, vm.ErrNilValidatorSmartContractAddress))
 }
 
 func TestNewStakingValidatorSmartContract_NilSigVerifier(t *testing.T) {
@@ -227,7 +227,7 @@ func TestNewStakingValidatorSmartContract_NilSigVerifier(t *testing.T) {
 
 	asc, err := NewValidatorSmartContract(arguments)
 	require.Nil(t, asc)
-	require.Equal(t, vm.ErrNilMessageSignVerifier, err)
+	assert.True(t, errors.Is(err, vm.ErrNilMessageSignVerifier))
 }
 
 func TestNewStakingValidatorSmartContract_NilMarshalizer(t *testing.T) {
@@ -238,7 +238,7 @@ func TestNewStakingValidatorSmartContract_NilMarshalizer(t *testing.T) {
 
 	asc, err := NewValidatorSmartContract(arguments)
 	require.Nil(t, asc)
-	require.Equal(t, vm.ErrNilMarshalizer, err)
+	assert.True(t, errors.Is(err, vm.ErrNilMarshalizer))
 }
 
 func TestNewStakingValidatorSmartContract_InvalidGenesisTotalSupply(t *testing.T) {
@@ -272,7 +272,7 @@ func TestNewStakingValidatorSmartContract_NilEpochNotifier(t *testing.T) {
 
 	asc, err := NewValidatorSmartContract(arguments)
 	require.Nil(t, asc)
-	require.Equal(t, vm.ErrNilEpochNotifier, err)
+	assert.True(t, errors.Is(err, vm.ErrNilEpochNotifier))
 }
 
 func TestNewStakingValidatorSmartContract_EmptyEndOfEpochAddress(t *testing.T) {
@@ -283,7 +283,7 @@ func TestNewStakingValidatorSmartContract_EmptyEndOfEpochAddress(t *testing.T) {
 
 	asc, err := NewValidatorSmartContract(arguments)
 	require.Nil(t, asc)
-	require.Equal(t, vm.ErrInvalidEndOfEpochAccessAddress, err)
+	assert.True(t, errors.Is(err, vm.ErrInvalidEndOfEpochAccessAddress))
 }
 
 func TestNewStakingValidatorSmartContract_EmptyDelegationManagerAddress(t *testing.T) {


### PR DESCRIPTION
- changed message when a call to `makeNewContractFromValidatorData` is done from an address with 0 staked nodes
- added protection on `makeNewContractFromValidatorData` call as to not let the same validator to create more than one delegation SC
- added automatic clear whitelisted address feature and a view function for the current set whitelisted address for merge
- changed message when a call to `mergeValidatorToDelegationSameOwner` is done from an address that is not an owner in a delegation SC
- added extra protection when calling validator.changeRewardAddress function so a user can not set metachain addresses, jailing address or end of epoch address 

Testing scenario: 
start a testnet. Before epoch 3 do a staking transaction and then call the function `changeRewardAddress@00000000000000000001000000000000ffffffffffffffffffffffffffffffff` (change the rewards address to the jailing address), transaction should work.
After epoch 3 do the following:
1. from a random address (that did not perform staking) call `makeNewContractFromValidatorData`. The transaction should fail with the message `address does not contain any staked nodes`.
2. create a delegation SC from a validator using the `makeNewContractFromValidatorData` function. Stake a new node on that same validator, try to call `makeNewContractFromValidatorData`. The transaction should fail stating `caller already deployed a delegation sc`.
3. there is a new API get function for the delegation SC called `getWhitelistForMerge`. Try to do a `whitelistForMerge`, check with the `getWhitelistForMerge` that the whitelisting has been done correctly. Complete the merge but **do not call delete white list for merge function**. Call `getWhitelistForMerge`, should return empty string (the merge operation automatically deleted the whitelisted address.
4. do a `mergeValidatorToDelegationSameOwner` operation from a validator **that does not have a delegation SC** providing an existing delegation SC address belonging to someone else - the error should be: "the caller does not own a delegation sc"
5. re-test `changeRewardAddress` functionality with the addresses (all transactions should fail):
    - jailing address (`00000000000000000001000000000000ffffffffffffffffffffffffffffffff`) 
    - end of epoch address (`000000000000000000010000000000ffffffffffffffffffffffffffffffffff`)
    - delegation manager (`000000000000000000010000000000000000000000000000000000000004ffff`)
    - a delegation SC (create or reuse one)