### PR TITLE
Linter fixes

### DIFF
--- a/data/trie/patriciaMerkleTrie.go
+++ b/data/trie/patriciaMerkleTrie.go
@@ -60,7 +60,7 @@ func NewTrie(
 	if check.IfNil(hsh) {
 		return nil, ErrNilHasher
 	}
-	if maxTrieLevelInMemory <= 0 {
+	if maxTrieLevelInMemory == 0 {
 		return nil, ErrInvalidLevelValue
 	}
 	log.Trace("created new trie", "max trie level in memory", maxTrieLevelInMemory)

--- a/statusHandler/presenter/chainInfoGetters.go
+++ b/statusHandler/presenter/chainInfoGetters.go
@@ -163,7 +163,7 @@ func (psh *PresenterStatusHandler) GetEpochInfo() (uint64, uint64, int, string) 
 	if epochFinishRound < currentRound {
 		roundsRemained = 0
 	}
-	if roundsRemained <= 0 || roundsPerEpoch == 0 || roundDuration == 0 {
+	if roundsRemained == 0 || roundsPerEpoch == 0 || roundDuration == 0 {
 		return 0, 0, 0, ""
 	}
 	secondsRemainedInEpoch := roundsRemained * roundDuration / 1000

--- a/vm/systemSmartContracts/delegationManager.go
+++ b/vm/systemSmartContracts/delegationManager.go
@@ -360,7 +360,7 @@ func (d *delegationManager) mergeValidatorToDelegation(
 		return vmcommon.UserError
 	}
 	if vmOutput.ReturnCode != vmcommon.Ok {
-		return returnCode
+		return vmOutput.ReturnCode
 	}
 
 	txData = deleteWhitelistForMerge

--- a/vm/systemSmartContracts/delegationManager.go
+++ b/vm/systemSmartContracts/delegationManager.go
@@ -359,7 +359,7 @@ func (d *delegationManager) mergeValidatorToDelegation(
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.UserError
 	}
-	if returnCode != vmcommon.Ok {
+	if vmOutput.ReturnCode != vmcommon.Ok {
 		return returnCode
 	}
 


### PR DESCRIPTION
- fixed 3 linter issues

testing scenario: try to do a `mergeValidatorToDelegationSameOwner` or `mergeValidatorToDelegationWithWhitelist` operation that will fail (the validator has unstaked/jailed nodes). The transaction should correctly be reported as a failed transaction.