### PR TITLE
Refactor target shard ID in resolvers

### DIFF
--- a/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory.go
@@ -133,8 +133,15 @@ func (mrcf *metaResolversContainerFactory) AddShardTrieNodeResolvers(container d
 
 	for i := uint32(0); i < shardC.NumberOfShards(); i++ {
 		identifierTrieNodes := factory.AccountTrieNodesTopic + shardC.CommunicationIdentifier(i)
-		resolver, err := mrcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.UserAccountTrie,
-			mrcf.numCrossShardPeers, mrcf.numIntraShardPeers, mrcf.numFullHistoryPeers, mrcf.currentNetworkEpochProvider)
+		resolver, err := mrcf.createTrieNodesResolver(
+			identifierTrieNodes,
+			triesFactory.UserAccountTrie,
+			mrcf.numCrossShardPeers,
+			mrcf.numIntraShardPeers,
+			mrcf.numFullHistoryPeers,
+			i,
+			mrcf.currentNetworkEpochProvider,
+		)
 		if err != nil {
 			return err
 		}
@@ -265,8 +272,15 @@ func (mrcf *metaResolversContainerFactory) generateTrieNodesResolvers() error {
 	resolversSlice := make([]dataRetriever.Resolver, 0)
 
 	identifierTrieNodes := factory.AccountTrieNodesTopic + core.CommunicationIdentifierBetweenShards(core.MetachainShardId, core.MetachainShardId)
-	resolver, err := mrcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.UserAccountTrie,
-		0, mrcf.numIntraShardPeers+mrcf.numCrossShardPeers, mrcf.numFullHistoryPeers, mrcf.currentNetworkEpochProvider)
+	resolver, err := mrcf.createTrieNodesResolver(
+		identifierTrieNodes,
+		triesFactory.UserAccountTrie,
+		0,
+		mrcf.numIntraShardPeers+mrcf.numCrossShardPeers,
+		mrcf.numFullHistoryPeers,
+		core.MetachainShardId,
+		mrcf.currentNetworkEpochProvider,
+	)
 	if err != nil {
 		return err
 	}
@@ -275,8 +289,15 @@ func (mrcf *metaResolversContainerFactory) generateTrieNodesResolvers() error {
 	keys = append(keys, identifierTrieNodes)
 
 	identifierTrieNodes = factory.ValidatorTrieNodesTopic + core.CommunicationIdentifierBetweenShards(core.MetachainShardId, core.MetachainShardId)
-	resolver, err = mrcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.PeerAccountTrie,
-		0, mrcf.numIntraShardPeers+mrcf.numCrossShardPeers, mrcf.numFullHistoryPeers, mrcf.currentNetworkEpochProvider)
+	resolver, err = mrcf.createTrieNodesResolver(
+		identifierTrieNodes,
+		triesFactory.PeerAccountTrie,
+		0,
+		mrcf.numIntraShardPeers+mrcf.numCrossShardPeers,
+		mrcf.numFullHistoryPeers,
+		core.MetachainShardId,
+		mrcf.currentNetworkEpochProvider,
+	)
 	if err != nil {
 		return err
 	}
@@ -304,7 +325,7 @@ func (mrcf *metaResolversContainerFactory) generateRewardsResolvers(
 		identifierTx := topic + shardC.CommunicationIdentifier(idx)
 		excludePeersFromTopic := EmptyExcludePeersOnTopic
 
-		resolver, err := mrcf.createTxResolver(identifierTx, excludePeersFromTopic, unit, dataPool)
+		resolver, err := mrcf.createTxResolver(identifierTx, excludePeersFromTopic, unit, dataPool, idx)
 		if err != nil {
 			return err
 		}

--- a/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory.go
@@ -131,15 +131,15 @@ func (mrcf *metaResolversContainerFactory) AddShardTrieNodeResolvers(container d
 	keys := make([]string, 0)
 	resolversSlice := make([]dataRetriever.Resolver, 0)
 
-	for i := uint32(0); i < shardC.NumberOfShards(); i++ {
-		identifierTrieNodes := factory.AccountTrieNodesTopic + shardC.CommunicationIdentifier(i)
+	for idx := uint32(0); idx < shardC.NumberOfShards(); idx++ {
+		identifierTrieNodes := factory.AccountTrieNodesTopic + shardC.CommunicationIdentifier(idx)
 		resolver, err := mrcf.createTrieNodesResolver(
 			identifierTrieNodes,
 			triesFactory.UserAccountTrie,
 			mrcf.numCrossShardPeers,
 			mrcf.numIntraShardPeers,
 			mrcf.numFullHistoryPeers,
-			i,
+			idx,
 			mrcf.currentNetworkEpochProvider,
 		)
 		if err != nil {

--- a/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory.go
@@ -205,8 +205,15 @@ func (srcf *shardResolversContainerFactory) generateTrieNodesResolvers() error {
 	resolversSlice := make([]dataRetriever.Resolver, 0)
 
 	identifierTrieNodes := factory.AccountTrieNodesTopic + shardC.CommunicationIdentifier(core.MetachainShardId)
-	resolver, err := srcf.createTrieNodesResolver(identifierTrieNodes, triesFactory.UserAccountTrie,
-		0, srcf.numIntraShardPeers+srcf.numCrossShardPeers, srcf.numFullHistoryPeers, srcf.currentNetworkEpochProvider)
+	resolver, err := srcf.createTrieNodesResolver(
+		identifierTrieNodes,
+		triesFactory.UserAccountTrie,
+		0,
+		srcf.numIntraShardPeers+srcf.numCrossShardPeers,
+		srcf.numFullHistoryPeers,
+		core.MetachainShardId,
+		srcf.currentNetworkEpochProvider,
+	)
 	if err != nil {
 		return err
 	}
@@ -222,7 +229,6 @@ func (srcf *shardResolversContainerFactory) generateRewardResolver(
 	unit dataRetriever.UnitType,
 	dataPool dataRetriever.ShardedDataCacherNotifier,
 ) error {
-
 	shardC := srcf.shardCoordinator
 
 	keys := make([]string, 0)
@@ -231,7 +237,7 @@ func (srcf *shardResolversContainerFactory) generateRewardResolver(
 	identifierTx := topic + shardC.CommunicationIdentifier(core.MetachainShardId)
 	excludedPeersOnTopic := factory.TransactionTopic + shardC.CommunicationIdentifier(shardC.SelfId())
 
-	resolver, err := srcf.createTxResolver(identifierTx, excludedPeersOnTopic, unit, dataPool)
+	resolver, err := srcf.createTxResolver(identifierTx, excludedPeersOnTopic, unit, dataPool, core.MetachainShardId)
 	if err != nil {
 		return err
 	}

--- a/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
+++ b/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
@@ -134,7 +134,6 @@ func (trs *topicResolverSender) SendOnRequestTopic(rd *dataRetriever.RequestData
 		numSentIntra = trs.sendOnTopic(fullHistoryPeers, topicToSendRequest, buff, trs.numFullHistoryPeers, "full history peer")
 	}
 
-
 	trs.callDebugHandler(originalHashes, numSentIntra, numSentCross)
 
 	if numSentCross+numSentIntra == 0 {
@@ -172,6 +171,8 @@ func (trs *topicResolverSender) sendOnTopic(peerList []core.PeerID, topicToSendR
 
 	indexes := createIndexList(len(peerList))
 	shuffledIndexes := random.FisherYatesShuffle(indexes, trs.randomizer)
+
+	// TODO: prepend a preferred peer from <trs.targetShardID> shard
 
 	logData := make([]interface{}, 0)
 	msgSentCounter := 0

--- a/go.sum
+++ b/go.sum
@@ -40,9 +40,7 @@ github.com/ElrondNetwork/elastic-indexer-go v1.0.1/go.mod h1:SJfYiNZj5X8olfqcNwq
 github.com/ElrondNetwork/elastic-indexer-go v1.0.2-0.20210303131440-c178c4f2858d/go.mod h1:DRvSw5jYpCe9phUWtRtRmeAu0NdKHX9QOIK12E0JVOk=
 github.com/ElrondNetwork/elastic-indexer-go v1.0.2-0.20210305124948-8191d92dc7fe/go.mod h1:zh6WGlxH/UhQpWsvsSv8Nl0nKm/Q/VG26DLTbKGbF0A=
 github.com/ElrondNetwork/elastic-indexer-go v1.0.2-0.20210308132434-93aea699e448/go.mod h1:xYFnPexpAxxLjDiZRxLqZveHsc5bnyngJitBgI2JrfM=
-github.com/ElrondNetwork/elastic-indexer-go v1.0.3 h1:N0OPEAQD2vhalRupdLVR0SDxJyhd8YBYcn82ksCRE+o=
 github.com/ElrondNetwork/elastic-indexer-go v1.0.3/go.mod h1:Jj5loOE5jRz1E5jn1yeH+M/0kQmsWFDONRaXG3WADLw=
-github.com/ElrondNetwork/elastic-indexer-go v1.0.4 h1:OPf2MZLzxfXeaB3ewuwQO8DVlY01/itP3nPc9afl+OA=
 github.com/ElrondNetwork/elastic-indexer-go v1.0.4/go.mod h1:ipmcRwU+D5yQu5/9NGzOWhHz+C54XunQa9XVxQJKONQ=
 github.com/ElrondNetwork/elastic-indexer-go v1.0.6 h1:dDXHT7/IkJvGW2Ikw1syZTDwde/rDbasue5U0GCl1aI=
 github.com/ElrondNetwork/elastic-indexer-go v1.0.6/go.mod h1:/zazfJoLueLjmVDI3bJOACezl7WE10Hqn7MUfoOPd6E=


### PR DESCRIPTION
Refactored target shard ID inside resolvers. Removed `defaultShardID` and used only the relevant shard ID. it will be used in the next PR for fetching a preferred peer for a given shard