### PR TITLE
Requests to preferred peers

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -588,7 +588,7 @@
    Version = 0  # Setting 0 means 'use default value'
 
 [StateTriesConfig]
-    CheckpointRoundsModulus = 100
+    CheckpointRoundsModulus = 10000000 # TODO: revert this value before merging
     AccountsStatePruningEnabled = true
     PeerStatePruningEnabled = true
     MaxStateTrieLevelInMemory = 5

--- a/core/p2pCore.go
+++ b/core/p2pCore.go
@@ -63,3 +63,22 @@ type QueryP2PPeerInfo struct {
 	PeerSubType   string   `json:"peersubtype"`
 	Addresses     []string `json:"addresses"`
 }
+
+// PeerTopicType represents the type of a peer in regards to the topic it is used
+type PeerTopicType string
+
+// String returns a string version of the peer topic type
+func (pt PeerTopicType) String() string {
+	return string(pt)
+}
+
+const (
+	// IntraShardPeer represents the identifier for intra shard peers to be used in intra shard topics
+	IntraShardPeer PeerTopicType = "intra peer"
+
+	// CrossShardPeer represents the identifier for intra shard peers to be used in cross shard topics
+	CrossShardPeer PeerTopicType = "cross peer"
+
+	// FullHistoryPeer represents the identifier for intra shard peers to be used in full history topics
+	FullHistoryPeer PeerTopicType = "full history peer"
+)

--- a/dataRetriever/errors.go
+++ b/dataRetriever/errors.go
@@ -155,6 +155,9 @@ var ErrBadRequest = errors.New("request should not be done as it doesn't follow 
 // ErrNilAntifloodHandler signals that a nil antiflood handler has been provided
 var ErrNilAntifloodHandler = errors.New("nil antiflood handler")
 
+// ErrNilPreferredPeersHolder signals that a nil preferred peers holder handler has been provided
+var ErrNilPreferredPeersHolder = errors.New("nil preferred peers holder")
+
 // ErrNilCurrentNetworkEpochProvider signals that a nil CurrentNetworkEpochProvider handler has been provided
 var ErrNilCurrentNetworkEpochProvider = errors.New("nil current network epoch provider")
 

--- a/dataRetriever/errors.go
+++ b/dataRetriever/errors.go
@@ -158,6 +158,9 @@ var ErrNilAntifloodHandler = errors.New("nil antiflood handler")
 // ErrNilPreferredPeersHolder signals that a nil preferred peers holder handler has been provided
 var ErrNilPreferredPeersHolder = errors.New("nil preferred peers holder")
 
+// ErrNilSelfShardIDProvider signals that a nil self shard ID provider has been provided
+var ErrNilSelfShardIDProvider = errors.New("nil self shard ID provider")
+
 // ErrNilCurrentNetworkEpochProvider signals that a nil CurrentNetworkEpochProvider handler has been provided
 var ErrNilCurrentNetworkEpochProvider = errors.New("nil current network epoch provider")
 

--- a/dataRetriever/factory/resolverscontainer/args.go
+++ b/dataRetriever/factory/resolverscontainer/args.go
@@ -6,13 +6,13 @@ import (
 	"github.com/ElrondNetwork/elrond-go/data/typeConverters"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/marshal"
+	"github.com/ElrondNetwork/elrond-go/p2p"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 )
 
 // FactoryArgs will hold the arguments for ResolversContainerFactory for both shard and meta
 type FactoryArgs struct {
 	ResolverConfig              config.ResolverConfig
-	SizeCheckDelta              uint32
 	NumConcurrentResolvingJobs  int32
 	ShardCoordinator            sharding.Coordinator
 	Messenger                   dataRetriever.TopicMessageHandler
@@ -24,6 +24,8 @@ type FactoryArgs struct {
 	TriesContainer              state.TriesHolder
 	InputAntifloodHandler       dataRetriever.P2PAntifloodHandler
 	OutputAntifloodHandler      dataRetriever.P2PAntifloodHandler
-	IsFullHistoryNode           bool
 	CurrentNetworkEpochProvider dataRetriever.CurrentNetworkEpochProviderHandler
+	PreferredPeersHolder        p2p.PreferredPeersHolderHandler
+	SizeCheckDelta              uint32
+	IsFullHistoryNode           bool
 }

--- a/dataRetriever/factory/resolverscontainer/baseResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/baseResolversContainerFactory.go
@@ -35,6 +35,7 @@ type baseResolversContainerFactory struct {
 	intraShardTopic             string
 	isFullHistoryNode           bool
 	currentNetworkEpochProvider dataRetriever.CurrentNetworkEpochProviderHandler
+	preferredPeersHolder        dataRetriever.PreferredPeersHolderHandler
 	numCrossShardPeers          int
 	numIntraShardPeers          int
 	numFullHistoryPeers         int
@@ -76,6 +77,9 @@ func (brcf *baseResolversContainerFactory) checkParams() error {
 	}
 	if check.IfNil(brcf.currentNetworkEpochProvider) {
 		return dataRetriever.ErrNilCurrentNetworkEpochProvider
+	}
+	if check.IfNil(brcf.preferredPeersHolder) {
+		return dataRetriever.ErrNilPreferredPeersHolder
 	}
 	if brcf.numCrossShardPeers <= 0 {
 		return fmt.Errorf("%w for numCrossShardPeers", dataRetriever.ErrInvalidValue)
@@ -287,6 +291,7 @@ func (brcf *baseResolversContainerFactory) createOneResolverSenderWithSpecifiedN
 		NumIntraShardPeers:          numIntraShard,
 		NumFullHistoryPeers:         numFullHistory,
 		CurrentNetworkEpochProvider: currentNetworkEpochProvider,
+		PreferredPeersHolder:        brcf.preferredPeersHolder,
 	}
 	//TODO instantiate topic sender resolver with the shard IDs for which this resolver is supposed to serve the data
 	// this will improve the serving of transactions as the searching will be done only on 2 sharded data units

--- a/dataRetriever/factory/resolverscontainer/baseResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/baseResolversContainerFactory.go
@@ -292,6 +292,7 @@ func (brcf *baseResolversContainerFactory) createOneResolverSenderWithSpecifiedN
 		NumFullHistoryPeers:         numFullHistory,
 		CurrentNetworkEpochProvider: currentNetworkEpochProvider,
 		PreferredPeersHolder:        brcf.preferredPeersHolder,
+		SelfShardIdProvider:         brcf.shardCoordinator,
 	}
 	//TODO instantiate topic sender resolver with the shard IDs for which this resolver is supposed to serve the data
 	// this will improve the serving of transactions as the searching will be done only on 2 sharded data units

--- a/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory.go
@@ -50,6 +50,7 @@ func NewMetaResolversContainerFactory(
 		throttler:                   thr,
 		isFullHistoryNode:           args.IsFullHistoryNode,
 		currentNetworkEpochProvider: args.CurrentNetworkEpochProvider,
+		preferredPeersHolder:        args.PreferredPeersHolder,
 		numCrossShardPeers:          int(args.ResolverConfig.NumCrossShardPeers),
 		numIntraShardPeers:          int(args.ResolverConfig.NumIntraShardPeers),
 		numFullHistoryPeers:         int(args.ResolverConfig.NumFullHistoryPeers),

--- a/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory_test.go
+++ b/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process/factory"
 	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -152,6 +153,17 @@ func TestNewMetaResolversContainerFactory_NilDataPoolShouldErr(t *testing.T) {
 	assert.Equal(t, dataRetriever.ErrNilDataPoolHolder, err)
 }
 
+func TestNewMetaResolversContainerFactory_NilPreferredPeersHolderShouldErr(t *testing.T) {
+	t.Parallel()
+
+	args := getArgumentsMeta()
+	args.PreferredPeersHolder = nil
+	rcf, err := resolverscontainer.NewMetaResolversContainerFactory(args)
+
+	assert.Nil(t, rcf)
+	assert.Equal(t, dataRetriever.ErrNilPreferredPeersHolder, err)
+}
+
 func TestNewMetaResolversContainerFactory_NilUint64SliceConverterShouldErr(t *testing.T) {
 	t.Parallel()
 
@@ -270,6 +282,7 @@ func getArgumentsMeta() resolverscontainer.FactoryArgs {
 		OutputAntifloodHandler:      &mock.P2PAntifloodHandlerStub{},
 		NumConcurrentResolvingJobs:  10,
 		CurrentNetworkEpochProvider: &mock.CurrentNetworkEpochProviderStub{},
+		PreferredPeersHolder:        &p2pmocks.PeersHolderStub{},
 		ResolverConfig: config.ResolverConfig{
 			NumCrossShardPeers:  1,
 			NumIntraShardPeers:  2,

--- a/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory.go
@@ -48,6 +48,7 @@ func NewShardResolversContainerFactory(
 		throttler:                   thr,
 		isFullHistoryNode:           args.IsFullHistoryNode,
 		currentNetworkEpochProvider: args.CurrentNetworkEpochProvider,
+		preferredPeersHolder:        args.PreferredPeersHolder,
 		numCrossShardPeers:          int(args.ResolverConfig.NumCrossShardPeers),
 		numIntraShardPeers:          int(args.ResolverConfig.NumIntraShardPeers),
 		numFullHistoryPeers:         int(args.ResolverConfig.NumFullHistoryPeers),

--- a/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory_test.go
+++ b/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process/factory"
 	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -179,6 +180,17 @@ func TestNewShardResolversContainerFactory_NilDataPackerShouldErr(t *testing.T) 
 
 	assert.Nil(t, rcf)
 	assert.Equal(t, dataRetriever.ErrNilDataPacker, err)
+}
+
+func TestNewShardResolversContainerFactory_NilPreferredPeersHolderShouldErr(t *testing.T) {
+	t.Parallel()
+
+	args := getArgumentsShard()
+	args.PreferredPeersHolder = nil
+	rcf, err := resolverscontainer.NewShardResolversContainerFactory(args)
+
+	assert.Nil(t, rcf)
+	assert.Equal(t, dataRetriever.ErrNilPreferredPeersHolder, err)
 }
 
 func TestNewShardResolversContainerFactory_NilTriesContainerShouldErr(t *testing.T) {
@@ -348,6 +360,7 @@ func getArgumentsShard() resolverscontainer.FactoryArgs {
 		OutputAntifloodHandler:      &mock.P2PAntifloodHandlerStub{},
 		NumConcurrentResolvingJobs:  10,
 		CurrentNetworkEpochProvider: &mock.CurrentNetworkEpochProviderStub{},
+		PreferredPeersHolder:        &p2pmocks.PeersHolderStub{},
 		ResolverConfig: config.ResolverConfig{
 			NumCrossShardPeers:  1,
 			NumIntraShardPeers:  2,

--- a/dataRetriever/interface.go
+++ b/dataRetriever/interface.go
@@ -382,3 +382,10 @@ type CurrentNetworkEpochProviderHandler interface {
 	EpochConfirmed(newEpoch uint32, newTimestamp uint64)
 	IsInterfaceNil() bool
 }
+
+// PreferredPeersHolderHandler defines the behavior of a component able to handle preferred peers operations
+type PreferredPeersHolderHandler interface {
+	Get() map[uint32][]core.PeerID
+	Contains(peerID core.PeerID) bool
+	IsInterfaceNil() bool
+}

--- a/dataRetriever/interface.go
+++ b/dataRetriever/interface.go
@@ -236,7 +236,7 @@ type StorageType uint8
 
 // PeerListCreator is used to create a peer list
 type PeerListCreator interface {
-	PeerList() []core.PeerID
+	CrossShardPeerList() []core.PeerID
 	IntraShardPeerList() []core.PeerID
 	FullHistoryList() []core.PeerID
 	IsInterfaceNil() bool
@@ -387,5 +387,11 @@ type CurrentNetworkEpochProviderHandler interface {
 type PreferredPeersHolderHandler interface {
 	Get() map[uint32][]core.PeerID
 	Contains(peerID core.PeerID) bool
+	IsInterfaceNil() bool
+}
+
+// SelfShardIDProvider defines the behavior of a component able to provide the self shard ID
+type SelfShardIDProvider interface {
+	SelfId() uint32
 	IsInterfaceNil() bool
 }

--- a/dataRetriever/mock/peerListCreatorStub.go
+++ b/dataRetriever/mock/peerListCreatorStub.go
@@ -6,14 +6,14 @@ import (
 
 // PeerListCreatorStub -
 type PeerListCreatorStub struct {
-	PeerListCalled           func() []core.PeerID
+	CrossShardPeerListCalled func() []core.PeerID
 	IntraShardPeerListCalled func() []core.PeerID
 	FullHistoryListCalled    func() []core.PeerID
 }
 
-// PeerList -
-func (p *PeerListCreatorStub) PeerList() []core.PeerID {
-	return p.PeerListCalled()
+// CrossShardPeerList -
+func (p *PeerListCreatorStub) CrossShardPeerList() []core.PeerID {
+	return p.CrossShardPeerListCalled()
 }
 
 // IntraShardPeerList -

--- a/dataRetriever/resolvers/topicResolverSender/diffPeerListCreator.go
+++ b/dataRetriever/resolvers/topicResolverSender/diffPeerListCreator.go
@@ -45,8 +45,8 @@ func NewDiffPeerListCreator(
 	}, nil
 }
 
-// PeerList will return the generated list of peers
-func (dplc *DiffPeerListCreator) PeerList() []core.PeerID {
+// CrossShardPeerList will return the generated list of cross shard peers
+func (dplc *DiffPeerListCreator) CrossShardPeerList() []core.PeerID {
 	allConnectedPeers := dplc.messenger.ConnectedPeersOnTopic(dplc.mainTopic)
 	mainTopicHasPeers := len(allConnectedPeers) != 0
 	if !mainTopicHasPeers {

--- a/dataRetriever/resolvers/topicResolverSender/diffPeerListCreator_test.go
+++ b/dataRetriever/resolvers/topicResolverSender/diffPeerListCreator_test.go
@@ -138,7 +138,7 @@ func TestDiffPeerListCreator_PeersListEmptyMainListShouldRetEmpty(t *testing.T) 
 		excludedTopic,
 	)
 
-	assert.Empty(t, dplc.PeerList())
+	assert.Empty(t, dplc.CrossShardPeerList())
 }
 
 func TestDiffPeerListCreator_PeersListNoExcludedTopicSetShouldRetPeersOnMain(t *testing.T) {
@@ -158,7 +158,7 @@ func TestDiffPeerListCreator_PeersListNoExcludedTopicSetShouldRetPeersOnMain(t *
 		emptyTopic,
 	)
 
-	assert.Equal(t, peersOnMain, dplc.PeerList())
+	assert.Equal(t, peersOnMain, dplc.CrossShardPeerList())
 }
 
 func TestDiffPeerListCreator_PeersListDiffShouldWork(t *testing.T) {
@@ -187,7 +187,7 @@ func TestDiffPeerListCreator_PeersListDiffShouldWork(t *testing.T) {
 		excludedTopic,
 	)
 
-	resultingList := dplc.PeerList()
+	resultingList := dplc.CrossShardPeerList()
 
 	assert.Equal(t, 1, len(resultingList))
 	assert.Equal(t, pID1, resultingList[0])
@@ -218,7 +218,7 @@ func TestDiffPeerListCreator_PeersListNoDifferenceShouldReturnMain(t *testing.T)
 		excludedTopic,
 	)
 
-	resultingList := dplc.PeerList()
+	resultingList := dplc.CrossShardPeerList()
 
 	assert.Equal(t, peersOnMain, resultingList)
 }

--- a/dataRetriever/resolvers/topicResolverSender/diffPeerListCreator_test.go
+++ b/dataRetriever/resolvers/topicResolverSender/diffPeerListCreator_test.go
@@ -75,8 +75,6 @@ func TestNewDiffPeerListCreator_ShouldWork(t *testing.T) {
 	assert.Equal(t, excludedTopic, dplc.ExcludedPeersOnTopic())
 }
 
-// ------- MakeDiffList
-
 func TestMakeDiffList_EmptyExcludedShoudRetAllPeersList(t *testing.T) {
 	t.Parallel()
 
@@ -122,9 +120,7 @@ func TestMakeDiffList_NoneFoundInExcludedShouldRetAllPeers(t *testing.T) {
 	assert.Equal(t, allPeers, diff)
 }
 
-//------- PeersList
-
-func TestDiffPeerListCreator_PeersListEmptyMainListShouldRetEmpty(t *testing.T) {
+func TestDiffPeerListCreator_CrossShardPeersListEmptyMainListShouldRetEmpty(t *testing.T) {
 	t.Parallel()
 
 	dplc, _ := topicResolverSender.NewDiffPeerListCreator(
@@ -141,7 +137,7 @@ func TestDiffPeerListCreator_PeersListEmptyMainListShouldRetEmpty(t *testing.T) 
 	assert.Empty(t, dplc.CrossShardPeerList())
 }
 
-func TestDiffPeerListCreator_PeersListNoExcludedTopicSetShouldRetPeersOnMain(t *testing.T) {
+func TestDiffPeerListCreator_CrossShardPeersListNoExcludedTopicSetShouldRetPeersOnMain(t *testing.T) {
 	t.Parallel()
 
 	pID1 := core.PeerID("peer1")
@@ -161,7 +157,7 @@ func TestDiffPeerListCreator_PeersListNoExcludedTopicSetShouldRetPeersOnMain(t *
 	assert.Equal(t, peersOnMain, dplc.CrossShardPeerList())
 }
 
-func TestDiffPeerListCreator_PeersListDiffShouldWork(t *testing.T) {
+func TestDiffPeerListCreator_CrossShardPeersListDiffShouldWork(t *testing.T) {
 	t.Parallel()
 
 	pID1 := core.PeerID("peer1")
@@ -193,7 +189,7 @@ func TestDiffPeerListCreator_PeersListDiffShouldWork(t *testing.T) {
 	assert.Equal(t, pID1, resultingList[0])
 }
 
-func TestDiffPeerListCreator_PeersListNoDifferenceShouldReturnMain(t *testing.T) {
+func TestDiffPeerListCreator_CrossShardPeersListNoDifferenceShouldReturnMain(t *testing.T) {
 	t.Parallel()
 
 	pID1 := core.PeerID("peer1")

--- a/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
+++ b/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
@@ -274,6 +274,11 @@ func (trs *topicResolverSender) sendToConnectedPeer(topic string, buff []byte, p
 		TopicField: topic,
 	}
 
+	shouldAvoidAntiFloodCheck := trs.preferredPeersHolderHandler.Contains(peer)
+	if shouldAvoidAntiFloodCheck {
+		return trs.messenger.SendToConnectedPeer(topic, buff, peer)
+	}
+
 	err := trs.outputAntiflooder.CanProcessMessage(msg, peer)
 	if err != nil {
 		return fmt.Errorf("%w while sending %d bytes to peer %s",

--- a/epochStart/bootstrap/disabled/disabledPreferredPeersHolder.go
+++ b/epochStart/bootstrap/disabled/disabledPreferredPeersHolder.go
@@ -1,0 +1,40 @@
+package disabled
+
+import (
+	"github.com/ElrondNetwork/elrond-go/core"
+)
+
+type disabledPreferredPeersHolder struct {
+}
+
+// NewPreferredPeersHolder returns a new instance of disabledPreferredPeersHolder
+func NewPreferredPeersHolder() *disabledPreferredPeersHolder {
+	return &disabledPreferredPeersHolder{}
+}
+
+// Put won't do anything
+func (d *disabledPreferredPeersHolder) Put(_ []byte, _ core.PeerID, _ uint32) {
+}
+
+// Get will return an empty map
+func (d *disabledPreferredPeersHolder) Get() map[uint32][]core.PeerID {
+	return make(map[uint32][]core.PeerID)
+}
+
+// Contains returns false
+func (d *disabledPreferredPeersHolder) Contains(_ core.PeerID) bool {
+	return false
+}
+
+// Remove won't do anything
+func (d *disabledPreferredPeersHolder) Remove(_ core.PeerID) {
+}
+
+// Clear won't do anything
+func (d *disabledPreferredPeersHolder) Clear() {
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (d *disabledPreferredPeersHolder) IsInterfaceNil() bool {
+	return d == nil
+}

--- a/epochStart/bootstrap/factory/epochStartInterceptorsContainerFactory.go
+++ b/epochStart/bootstrap/factory/epochStartInterceptorsContainerFactory.go
@@ -92,6 +92,7 @@ func NewEpochStartInterceptorsContainer(args ArgsEpochStartInterceptorContainer)
 		AntifloodHandler:          antiFloodHandler,
 		ArgumentsParser:           args.ArgumentsParser,
 		EnableSignTxWithHashEpoch: args.EnableSignTxWithHashEpoch,
+		PreferredPeersHolder:      disabled.NewPreferredPeersHolder(),
 	}
 
 	interceptorsContainerFactory, err := interceptorscontainer.NewMetaInterceptorsContainerFactory(containerFactoryArgs)

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -977,6 +977,7 @@ func (e *epochStartBootstrap) createRequestHandler() error {
 		InputAntifloodHandler:       disabled.NewAntiFloodHandler(),
 		OutputAntifloodHandler:      disabled.NewAntiFloodHandler(),
 		CurrentNetworkEpochProvider: disabled.NewCurrentNetworkEpochProviderHandler(),
+		PreferredPeersHolder:        disabled.NewPreferredPeersHolder(),
 		ResolverConfig:              e.generalConfig.Resolvers,
 	}
 	resolverFactory, err := resolverscontainer.NewMetaResolversContainerFactory(resolversContainerArgs)

--- a/epochStart/bootstrap/syncEpochStartMeta.go
+++ b/epochStart/bootstrap/syncEpochStartMeta.go
@@ -91,13 +91,14 @@ func NewEpochStartMetaSyncer(args ArgsNewEpochStartMetaSyncer) (*epochStartMetaS
 
 	e.singleDataInterceptor, err = interceptors.NewSingleDataInterceptor(
 		interceptors.ArgSingleDataInterceptor{
-			Topic:            factory.MetachainBlocksTopic,
-			DataFactory:      interceptedMetaHdrDataFactory,
-			Processor:        args.MetaBlockProcessor,
-			Throttler:        disabled.NewThrottler(),
-			AntifloodHandler: disabled.NewAntiFloodHandler(),
-			WhiteListRequest: args.WhitelistHandler,
-			CurrentPeerId:    args.Messenger.ID(),
+			Topic:                factory.MetachainBlocksTopic,
+			DataFactory:          interceptedMetaHdrDataFactory,
+			Processor:            args.MetaBlockProcessor,
+			Throttler:            disabled.NewThrottler(),
+			AntifloodHandler:     disabled.NewAntiFloodHandler(),
+			WhiteListRequest:     args.WhitelistHandler,
+			CurrentPeerId:        args.Messenger.ID(),
+			PreferredPeersHolder: disabled.NewPreferredPeersHolder(),
 		},
 	)
 	if err != nil {

--- a/factory/processComponents.go
+++ b/factory/processComponents.go
@@ -919,6 +919,7 @@ func (pcf *processComponentsFactory) newShardResolverContainerFactory(
 		IsFullHistoryNode:           pcf.config.StoragePruning.FullArchive,
 		CurrentNetworkEpochProvider: currentEpochProvider,
 		ResolverConfig:              pcf.config.Resolvers,
+		PreferredPeersHolder:        pcf.network.PreferredPeersHolderHandler(),
 	}
 	resolversContainerFactory, err := resolverscontainer.NewShardResolversContainerFactory(resolversContainerFactoryArgs)
 	if err != nil {
@@ -953,6 +954,7 @@ func (pcf *processComponentsFactory) newMetaResolverContainerFactory(
 		IsFullHistoryNode:           pcf.config.StoragePruning.FullArchive,
 		CurrentNetworkEpochProvider: currentEpochProvider,
 		ResolverConfig:              pcf.config.Resolvers,
+		PreferredPeersHolder:        pcf.network.PreferredPeersHolderHandler(),
 	}
 	resolversContainerFactory, err := resolverscontainer.NewMetaResolversContainerFactory(resolversContainerFactoryArgs)
 	if err != nil {
@@ -1134,6 +1136,7 @@ func (pcf *processComponentsFactory) newShardInterceptorContainerFactory(
 		ArgumentsParser:           smartContract.NewArgumentParser(),
 		SizeCheckDelta:            pcf.config.Marshalizer.SizeCheckDelta,
 		EnableSignTxWithHashEpoch: pcf.epochConfig.EnableEpochs.TransactionSignedWithTxHashEnableEpoch,
+		PreferredPeersHolder:      pcf.network.PreferredPeersHolderHandler(),
 	}
 	log.Debug("shardInterceptor: enable epoch for transaction signed with tx hash", "epoch", shardInterceptorsContainerFactoryArgs.EnableSignTxWithHashEpoch)
 
@@ -1174,6 +1177,7 @@ func (pcf *processComponentsFactory) newMetaInterceptorContainerFactory(
 		ArgumentsParser:           smartContract.NewArgumentParser(),
 		SizeCheckDelta:            pcf.config.Marshalizer.SizeCheckDelta,
 		EnableSignTxWithHashEpoch: pcf.epochConfig.EnableEpochs.TransactionSignedWithTxHashEnableEpoch,
+		PreferredPeersHolder:      pcf.network.PreferredPeersHolderHandler(),
 	}
 	log.Debug("metaInterceptor: enable epoch for transaction signed with tx hash", "epoch", metaInterceptorsContainerFactoryArgs.EnableSignTxWithHashEpoch)
 

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -841,7 +841,7 @@ func (tpn *TestProcessorNode) createFullSCQueryService() {
 					DelegationManagerEnableEpoch:       0,
 				},
 			},
-			ShardCoordinator:    tpn.ShardCoordinator,
+			ShardCoordinator: tpn.ShardCoordinator,
 		}
 		vmFactory, _ = metaProcess.NewVMContainerFactory(argsNewVmFactory)
 	} else {
@@ -1126,6 +1126,7 @@ func (tpn *TestProcessorNode) initInterceptors() {
 			WhiteListerVerifiedTxs:  tpn.WhiteListerVerifiedTxs,
 			AntifloodHandler:        &mock.NilAntifloodHandler{},
 			ArgumentsParser:         smartContract.NewArgumentParser(),
+			PreferredPeersHolder:    &p2pmocks.PeersHolderStub{},
 		}
 		interceptorContainerFactory, _ := interceptorscontainer.NewMetaInterceptorsContainerFactory(metaIntercContFactArgs)
 
@@ -1180,6 +1181,7 @@ func (tpn *TestProcessorNode) initInterceptors() {
 			WhiteListerVerifiedTxs:  tpn.WhiteListerVerifiedTxs,
 			AntifloodHandler:        &mock.NilAntifloodHandler{},
 			ArgumentsParser:         smartContract.NewArgumentParser(),
+			PreferredPeersHolder:    &p2pmocks.PeersHolderStub{},
 		}
 		interceptorContainerFactory, _ := interceptorscontainer.NewShardInterceptorsContainerFactory(shardInterContFactArgs)
 
@@ -1209,6 +1211,7 @@ func (tpn *TestProcessorNode) initResolvers() {
 		OutputAntifloodHandler:      &mock.NilAntifloodHandler{},
 		NumConcurrentResolvingJobs:  10,
 		CurrentNetworkEpochProvider: &mock.CurrentNetworkEpochProviderStub{},
+		PreferredPeersHolder:        &p2pmocks.PeersHolderStub{},
 		ResolverConfig: config.ResolverConfig{
 			NumCrossShardPeers:  2,
 			NumIntraShardPeers:  1,
@@ -1572,7 +1575,7 @@ func (tpn *TestProcessorNode) initMetaInnerProcessors() {
 				DelegationManagerEnableEpoch:       0,
 			},
 		},
-		ShardCoordinator:    tpn.ShardCoordinator,
+		ShardCoordinator: tpn.ShardCoordinator,
 	}
 	vmFactory, _ := metaProcess.NewVMContainerFactory(argsVMContainerFactory)
 

--- a/process/errors.go
+++ b/process/errors.go
@@ -644,6 +644,9 @@ var ErrNilMiniBlocksProvider = errors.New("nil miniblocks provider")
 // ErrNilWhiteListHandler signals that white list handler is nil
 var ErrNilWhiteListHandler = errors.New("nil whitelist handler")
 
+// ErrNilPreferredPeersHolder signals that preferred peers holder is nil
+var ErrNilPreferredPeersHolder = errors.New("nil preferred peers holder")
+
 // ErrMiniBlocksInWrongOrder signals the miniblocks are in wrong order
 var ErrMiniBlocksInWrongOrder = errors.New("miniblocks in wrong order, should have been only from me")
 
@@ -1003,9 +1006,6 @@ var ErrNilArgsBuiltInFunctionsConstHandler = errors.New("nil arguments for built
 
 // ErrInvalidEpochStartMetaBlockConsensusPercentage signals that a small epoch start meta block consensus percentage has been provided
 var ErrInvalidEpochStartMetaBlockConsensusPercentage = errors.New("invalid epoch start meta block consensus percentage")
-
-// ErrNilCurrentNetworkEpochSetter signals that a nil current network epoch setter has been provided
-var ErrNilCurrentNetworkEpochSetter = errors.New("nil current network epoch setter")
 
 // ErrNilNumConnectedPeersProvider signals that a nil number of connected peers provider has been provided
 var ErrNilNumConnectedPeersProvider = errors.New("nil number of connected peers provider")

--- a/process/factory/interceptorscontainer/args.go
+++ b/process/factory/interceptorscontainer/args.go
@@ -28,6 +28,7 @@ type ShardInterceptorsContainerFactoryArgs struct {
 	WhiteListerVerifiedTxs    process.WhiteListHandler
 	AntifloodHandler          process.P2PAntifloodHandler
 	ArgumentsParser           process.ArgumentsParser
+	PreferredPeersHolder      process.PreferredPeersHolderHandler
 	SizeCheckDelta            uint32
 	EnableSignTxWithHashEpoch uint32
 }
@@ -53,6 +54,7 @@ type MetaInterceptorsContainerFactoryArgs struct {
 	WhiteListerVerifiedTxs    process.WhiteListHandler
 	AntifloodHandler          process.P2PAntifloodHandler
 	ArgumentsParser           process.ArgumentsParser
+	PreferredPeersHolder      process.PreferredPeersHolderHandler
 	SizeCheckDelta            uint32
 	EnableSignTxWithHashEpoch uint32
 }

--- a/process/factory/interceptorscontainer/baseInterceptorsContainerFactory.go
+++ b/process/factory/interceptorscontainer/baseInterceptorsContainerFactory.go
@@ -32,6 +32,7 @@ type baseInterceptorsContainerFactory struct {
 	antifloodHandler       process.P2PAntifloodHandler
 	whiteListHandler       process.WhiteListHandler
 	whiteListerVerifiedTxs process.WhiteListHandler
+	preferredPeersHolder   process.PreferredPeersHolderHandler
 }
 
 func checkBaseParams(
@@ -47,6 +48,7 @@ func checkBaseParams(
 	antifloodHandler process.P2PAntifloodHandler,
 	whiteListHandler process.WhiteListHandler,
 	whiteListerVerifiedTxs process.WhiteListHandler,
+	preferredPeersHolder process.PreferredPeersHolderHandler,
 ) error {
 	if check.IfNil(coreComponents) {
 		return process.ErrNilCoreComponentsHolder
@@ -122,6 +124,9 @@ func checkBaseParams(
 	}
 	if check.IfNil(coreComponents.AddressPubKeyConverter()) {
 		return process.ErrNilPubkeyConverter
+	}
+	if check.IfNil(preferredPeersHolder) {
+		return process.ErrNilPreferredPeersHolder
 	}
 
 	return nil
@@ -215,14 +220,15 @@ func (bicf *baseInterceptorsContainerFactory) createOneTxInterceptor(topic strin
 	internalMarshalizer := bicf.argInterceptorFactory.CoreComponents.InternalMarshalizer()
 	interceptor, err := interceptors.NewMultiDataInterceptor(
 		interceptors.ArgMultiDataInterceptor{
-			Topic:            topic,
-			Marshalizer:      internalMarshalizer,
-			DataFactory:      txFactory,
-			Processor:        txProcessor,
-			Throttler:        bicf.globalThrottler,
-			AntifloodHandler: bicf.antifloodHandler,
-			WhiteListRequest: bicf.whiteListHandler,
-			CurrentPeerId:    bicf.messenger.ID(),
+			Topic:                topic,
+			Marshalizer:          internalMarshalizer,
+			DataFactory:          txFactory,
+			Processor:            txProcessor,
+			Throttler:            bicf.globalThrottler,
+			AntifloodHandler:     bicf.antifloodHandler,
+			WhiteListRequest:     bicf.whiteListHandler,
+			CurrentPeerId:        bicf.messenger.ID(),
+			PreferredPeersHolder: bicf.preferredPeersHolder,
 		},
 	)
 	if err != nil {
@@ -262,14 +268,15 @@ func (bicf *baseInterceptorsContainerFactory) createOneUnsignedTxInterceptor(top
 	internalMarshalizer := bicf.argInterceptorFactory.CoreComponents.InternalMarshalizer()
 	interceptor, err := interceptors.NewMultiDataInterceptor(
 		interceptors.ArgMultiDataInterceptor{
-			Topic:            topic,
-			Marshalizer:      internalMarshalizer,
-			DataFactory:      txFactory,
-			Processor:        txProcessor,
-			Throttler:        bicf.globalThrottler,
-			AntifloodHandler: bicf.antifloodHandler,
-			WhiteListRequest: bicf.whiteListHandler,
-			CurrentPeerId:    bicf.messenger.ID(),
+			Topic:                topic,
+			Marshalizer:          internalMarshalizer,
+			DataFactory:          txFactory,
+			Processor:            txProcessor,
+			Throttler:            bicf.globalThrottler,
+			AntifloodHandler:     bicf.antifloodHandler,
+			WhiteListRequest:     bicf.whiteListHandler,
+			CurrentPeerId:        bicf.messenger.ID(),
+			PreferredPeersHolder: bicf.preferredPeersHolder,
 		},
 	)
 	if err != nil {
@@ -309,14 +316,15 @@ func (bicf *baseInterceptorsContainerFactory) createOneRewardTxInterceptor(topic
 	internalMarshalizer := bicf.argInterceptorFactory.CoreComponents.InternalMarshalizer()
 	interceptor, err := interceptors.NewMultiDataInterceptor(
 		interceptors.ArgMultiDataInterceptor{
-			Topic:            topic,
-			Marshalizer:      internalMarshalizer,
-			DataFactory:      txFactory,
-			Processor:        txProcessor,
-			Throttler:        bicf.globalThrottler,
-			AntifloodHandler: bicf.antifloodHandler,
-			WhiteListRequest: bicf.whiteListHandler,
-			CurrentPeerId:    bicf.messenger.ID(),
+			Topic:                topic,
+			Marshalizer:          internalMarshalizer,
+			DataFactory:          txFactory,
+			Processor:            txProcessor,
+			Throttler:            bicf.globalThrottler,
+			AntifloodHandler:     bicf.antifloodHandler,
+			WhiteListRequest:     bicf.whiteListHandler,
+			CurrentPeerId:        bicf.messenger.ID(),
+			PreferredPeersHolder: bicf.preferredPeersHolder,
 		},
 	)
 	if err != nil {
@@ -358,13 +366,14 @@ func (bicf *baseInterceptorsContainerFactory) generateHeaderInterceptors() error
 	//only one intrashard header topic
 	interceptor, err := interceptors.NewSingleDataInterceptor(
 		interceptors.ArgSingleDataInterceptor{
-			Topic:            identifierHdr,
-			DataFactory:      hdrFactory,
-			Processor:        hdrProcessor,
-			Throttler:        bicf.globalThrottler,
-			AntifloodHandler: bicf.antifloodHandler,
-			WhiteListRequest: bicf.whiteListHandler,
-			CurrentPeerId:    bicf.messenger.ID(),
+			Topic:                identifierHdr,
+			DataFactory:          hdrFactory,
+			Processor:            hdrProcessor,
+			Throttler:            bicf.globalThrottler,
+			AntifloodHandler:     bicf.antifloodHandler,
+			WhiteListRequest:     bicf.whiteListHandler,
+			CurrentPeerId:        bicf.messenger.ID(),
+			PreferredPeersHolder: bicf.preferredPeersHolder,
 		},
 	)
 	if err != nil {
@@ -444,14 +453,15 @@ func (bicf *baseInterceptorsContainerFactory) createOneMiniBlocksInterceptor(top
 
 	interceptor, err := interceptors.NewMultiDataInterceptor(
 		interceptors.ArgMultiDataInterceptor{
-			Topic:            topic,
-			Marshalizer:      internalMarshalizer,
-			DataFactory:      miniblockFactory,
-			Processor:        miniblockProcessor,
-			Throttler:        bicf.globalThrottler,
-			AntifloodHandler: bicf.antifloodHandler,
-			WhiteListRequest: bicf.whiteListHandler,
-			CurrentPeerId:    bicf.messenger.ID(),
+			Topic:                topic,
+			Marshalizer:          internalMarshalizer,
+			DataFactory:          miniblockFactory,
+			Processor:            miniblockProcessor,
+			Throttler:            bicf.globalThrottler,
+			AntifloodHandler:     bicf.antifloodHandler,
+			WhiteListRequest:     bicf.whiteListHandler,
+			CurrentPeerId:        bicf.messenger.ID(),
+			PreferredPeersHolder: bicf.preferredPeersHolder,
 		},
 	)
 	if err != nil {
@@ -490,13 +500,14 @@ func (bicf *baseInterceptorsContainerFactory) generateMetachainHeaderInterceptor
 	//only one metachain header topic
 	interceptor, err := interceptors.NewSingleDataInterceptor(
 		interceptors.ArgSingleDataInterceptor{
-			Topic:            identifierHdr,
-			DataFactory:      hdrFactory,
-			Processor:        hdrProcessor,
-			Throttler:        bicf.globalThrottler,
-			AntifloodHandler: bicf.antifloodHandler,
-			WhiteListRequest: bicf.whiteListHandler,
-			CurrentPeerId:    bicf.messenger.ID(),
+			Topic:                identifierHdr,
+			DataFactory:          hdrFactory,
+			Processor:            hdrProcessor,
+			Throttler:            bicf.globalThrottler,
+			AntifloodHandler:     bicf.antifloodHandler,
+			WhiteListRequest:     bicf.whiteListHandler,
+			CurrentPeerId:        bicf.messenger.ID(),
+			PreferredPeersHolder: bicf.preferredPeersHolder,
 		},
 	)
 	if err != nil {
@@ -525,14 +536,15 @@ func (bicf *baseInterceptorsContainerFactory) createOneTrieNodesInterceptor(topi
 	internalMarshalizer := bicf.argInterceptorFactory.CoreComponents.InternalMarshalizer()
 	interceptor, err := interceptors.NewMultiDataInterceptor(
 		interceptors.ArgMultiDataInterceptor{
-			Topic:            topic,
-			Marshalizer:      internalMarshalizer,
-			DataFactory:      trieNodesFactory,
-			Processor:        trieNodesProcessor,
-			Throttler:        bicf.globalThrottler,
-			AntifloodHandler: bicf.antifloodHandler,
-			WhiteListRequest: bicf.whiteListHandler,
-			CurrentPeerId:    bicf.messenger.ID(),
+			Topic:                topic,
+			Marshalizer:          internalMarshalizer,
+			DataFactory:          trieNodesFactory,
+			Processor:            trieNodesProcessor,
+			Throttler:            bicf.globalThrottler,
+			AntifloodHandler:     bicf.antifloodHandler,
+			WhiteListRequest:     bicf.whiteListHandler,
+			CurrentPeerId:        bicf.messenger.ID(),
+			PreferredPeersHolder: bicf.preferredPeersHolder,
 		},
 	)
 	if err != nil {

--- a/process/factory/interceptorscontainer/metaInterceptorsContainerFactory.go
+++ b/process/factory/interceptorscontainer/metaInterceptorsContainerFactory.go
@@ -38,6 +38,7 @@ func NewMetaInterceptorsContainerFactory(
 		args.AntifloodHandler,
 		args.WhiteListHandler,
 		args.WhiteListerVerifiedTxs,
+		args.PreferredPeersHolder,
 	)
 	if err != nil {
 		return nil, err
@@ -99,6 +100,7 @@ func NewMetaInterceptorsContainerFactory(
 		antifloodHandler:       args.AntifloodHandler,
 		whiteListHandler:       args.WhiteListHandler,
 		whiteListerVerifiedTxs: args.WhiteListerVerifiedTxs,
+		preferredPeersHolder:   args.PreferredPeersHolder,
 	}
 
 	icf := &metaInterceptorsContainerFactory{
@@ -226,13 +228,14 @@ func (micf *metaInterceptorsContainerFactory) createOneShardHeaderInterceptor(to
 
 	interceptor, err := processInterceptors.NewSingleDataInterceptor(
 		processInterceptors.ArgSingleDataInterceptor{
-			Topic:            topic,
-			DataFactory:      hdrFactory,
-			Processor:        hdrProcessor,
-			Throttler:        micf.globalThrottler,
-			AntifloodHandler: micf.antifloodHandler,
-			WhiteListRequest: micf.whiteListHandler,
-			CurrentPeerId:    micf.messenger.ID(),
+			Topic:                topic,
+			DataFactory:          hdrFactory,
+			Processor:            hdrProcessor,
+			Throttler:            micf.globalThrottler,
+			AntifloodHandler:     micf.antifloodHandler,
+			WhiteListRequest:     micf.whiteListHandler,
+			CurrentPeerId:        micf.messenger.ID(),
+			PreferredPeersHolder: micf.preferredPeersHolder,
 		},
 	)
 	if err != nil {

--- a/process/factory/interceptorscontainer/metaInterceptorsContainerFactory_test.go
+++ b/process/factory/interceptorscontainer/metaInterceptorsContainerFactory_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process/mock"
 	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -559,5 +560,6 @@ func getArgumentsMeta(
 		WhiteListHandler:        &mock.WhiteListHandlerStub{},
 		WhiteListerVerifiedTxs:  &mock.WhiteListHandlerStub{},
 		ArgumentsParser:         &mock.ArgumentParserMock{},
+		PreferredPeersHolder:    &p2pmocks.PeersHolderStub{},
 	}
 }

--- a/process/factory/interceptorscontainer/shardInterceptorsContainerFactory.go
+++ b/process/factory/interceptorscontainer/shardInterceptorsContainerFactory.go
@@ -35,6 +35,7 @@ func NewShardInterceptorsContainerFactory(
 		args.AntifloodHandler,
 		args.WhiteListHandler,
 		args.WhiteListerVerifiedTxs,
+		args.PreferredPeersHolder,
 	)
 	if err != nil {
 		return nil, err
@@ -62,6 +63,9 @@ func NewShardInterceptorsContainerFactory(
 	}
 	if check.IfNil(args.EpochStartTrigger) {
 		return nil, process.ErrNilEpochStartTrigger
+	}
+	if check.IfNil(args.PreferredPeersHolder) {
+		return nil, process.ErrNilPreferredPeersHolder
 	}
 
 	argInterceptorFactory := &interceptorFactory.ArgInterceptedDataFactory{
@@ -94,6 +98,7 @@ func NewShardInterceptorsContainerFactory(
 		antifloodHandler:       args.AntifloodHandler,
 		whiteListHandler:       args.WhiteListHandler,
 		whiteListerVerifiedTxs: args.WhiteListerVerifiedTxs,
+		preferredPeersHolder:   args.PreferredPeersHolder,
 	}
 
 	icf := &shardInterceptorsContainerFactory{

--- a/process/factory/interceptorscontainer/shardInterceptorsContainerFactory_test.go
+++ b/process/factory/interceptorscontainer/shardInterceptorsContainerFactory_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process/mock"
 	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -570,6 +571,7 @@ func TestShardInterceptorsContainerFactory_With4ShardsShouldWork(t *testing.T) {
 	args.ShardCoordinator = shardCoordinator
 	args.NodesCoordinator = nodesCoordinator
 	args.Messenger = mesenger
+	args.PreferredPeersHolder = &p2pmocks.PeersHolderStub{}
 
 	icf, _ := interceptorscontainer.NewShardInterceptorsContainerFactory(args)
 
@@ -603,7 +605,7 @@ func createMockComponentHolders() (*mock.CoreComponentsMock, *mock.CryptoCompone
 		MinTransactionVersionCalled: func() uint32 {
 			return 1
 		},
-		EpochNotifierField: &mock.EpochNotifierStub{},
+		EpochNotifierField:  &mock.EpochNotifierStub{},
 		TxVersionCheckField: versioning.NewTxVersionChecker(1),
 	}
 	cryptoComponents := &mock.CryptoComponentsMock{
@@ -642,5 +644,6 @@ func getArgumentsShard(
 		WhiteListHandler:        &mock.WhiteListHandlerStub{},
 		WhiteListerVerifiedTxs:  &mock.WhiteListHandlerStub{},
 		ArgumentsParser:         &mock.ArgumentParserMock{},
+		PreferredPeersHolder:    &p2pmocks.PeersHolderStub{},
 	}
 }

--- a/process/interceptors/baseDataInterceptor.go
+++ b/process/interceptors/baseDataInterceptor.go
@@ -11,13 +11,14 @@ import (
 )
 
 type baseDataInterceptor struct {
-	throttler        process.InterceptorThrottler
-	antifloodHandler process.P2PAntifloodHandler
-	topic            string
-	currentPeerId    core.PeerID
-	processor        process.InterceptorProcessor
-	mutDebugHandler  sync.RWMutex
-	debugHandler     process.InterceptedDebugger
+	throttler            process.InterceptorThrottler
+	antifloodHandler     process.P2PAntifloodHandler
+	topic                string
+	currentPeerId        core.PeerID
+	processor            process.InterceptorProcessor
+	mutDebugHandler      sync.RWMutex
+	debugHandler         process.InterceptedDebugger
+	preferredPeersHolder process.PreferredPeersHolderHandler
 }
 
 func (bdi *baseDataInterceptor) preProcessMesage(message p2p.MessageP2P, fromConnectedPeer core.PeerID) error {
@@ -28,7 +29,7 @@ func (bdi *baseDataInterceptor) preProcessMesage(message p2p.MessageP2P, fromCon
 		return process.ErrNilDataToProcess
 	}
 
-	if !bdi.isMessageFromSelfToSelf(fromConnectedPeer, message) {
+	if !bdi.shouldSkipAntifloodChecks(fromConnectedPeer, message) {
 		err := bdi.antifloodHandler.CanProcessMessage(message, fromConnectedPeer)
 		if err != nil {
 			return err
@@ -45,6 +46,14 @@ func (bdi *baseDataInterceptor) preProcessMesage(message p2p.MessageP2P, fromCon
 
 	bdi.throttler.StartProcessing()
 	return nil
+}
+
+func (bdi *baseDataInterceptor) shouldSkipAntifloodChecks(fromConnectedPeer core.PeerID, message p2p.MessageP2P) bool {
+	if bdi.isMessageFromSelfToSelf(fromConnectedPeer, message) {
+		return true
+	}
+
+	return bdi.preferredPeersHolder.Contains(fromConnectedPeer)
 }
 
 func (bdi *baseDataInterceptor) isMessageFromSelfToSelf(fromConnectedPeer core.PeerID, message p2p.MessageP2P) bool {

--- a/process/interceptors/multiDataInterceptor.go
+++ b/process/interceptors/multiDataInterceptor.go
@@ -15,14 +15,15 @@ var log = logger.GetOrCreate("process/interceptors")
 
 // ArgMultiDataInterceptor is the argument for the multi-data interceptor
 type ArgMultiDataInterceptor struct {
-	Topic            string
-	Marshalizer      marshal.Marshalizer
-	DataFactory      process.InterceptedDataFactory
-	Processor        process.InterceptorProcessor
-	Throttler        process.InterceptorThrottler
-	AntifloodHandler process.P2PAntifloodHandler
-	WhiteListRequest process.WhiteListHandler
-	CurrentPeerId    core.PeerID
+	Topic                string
+	Marshalizer          marshal.Marshalizer
+	DataFactory          process.InterceptedDataFactory
+	Processor            process.InterceptorProcessor
+	Throttler            process.InterceptorThrottler
+	AntifloodHandler     process.P2PAntifloodHandler
+	WhiteListRequest     process.WhiteListHandler
+	PreferredPeersHolder process.PreferredPeersHolderHandler
+	CurrentPeerId        core.PeerID
 }
 
 // MultiDataInterceptor is used for intercepting packed multi data
@@ -56,18 +57,22 @@ func NewMultiDataInterceptor(arg ArgMultiDataInterceptor) (*MultiDataInterceptor
 	if check.IfNil(arg.WhiteListRequest) {
 		return nil, process.ErrNilWhiteListHandler
 	}
+	if check.IfNil(arg.PreferredPeersHolder) {
+		return nil, process.ErrNilPreferredPeersHolder
+	}
 	if len(arg.CurrentPeerId) == 0 {
 		return nil, process.ErrEmptyPeerID
 	}
 
 	multiDataIntercept := &MultiDataInterceptor{
 		baseDataInterceptor: &baseDataInterceptor{
-			throttler:        arg.Throttler,
-			antifloodHandler: arg.AntifloodHandler,
-			topic:            arg.Topic,
-			currentPeerId:    arg.CurrentPeerId,
-			processor:        arg.Processor,
-			debugHandler:     resolver.NewDisabledInterceptorResolver(),
+			throttler:            arg.Throttler,
+			antifloodHandler:     arg.AntifloodHandler,
+			topic:                arg.Topic,
+			currentPeerId:        arg.CurrentPeerId,
+			processor:            arg.Processor,
+			preferredPeersHolder: arg.PreferredPeersHolder,
+			debugHandler:         resolver.NewDisabledInterceptorResolver(),
 		},
 		marshalizer:      arg.Marshalizer,
 		factory:          arg.DataFactory,

--- a/process/interceptors/multiDataInterceptor_test.go
+++ b/process/interceptors/multiDataInterceptor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/interceptors"
 	"github.com/ElrondNetwork/elrond-go/process/mock"
+	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,14 +22,15 @@ var fromConnectedPeerId = core.PeerID("from connected peer Id")
 
 func createMockArgMultiDataInterceptor() interceptors.ArgMultiDataInterceptor {
 	return interceptors.ArgMultiDataInterceptor{
-		Topic:            "test topic",
-		Marshalizer:      &mock.MarshalizerMock{},
-		DataFactory:      &mock.InterceptedDataFactoryStub{},
-		Processor:        &mock.InterceptorProcessorStub{},
-		Throttler:        createMockThrottler(),
-		AntifloodHandler: &mock.P2PAntifloodHandlerStub{},
-		WhiteListRequest: &mock.WhiteListHandlerStub{},
-		CurrentPeerId:    "pid",
+		Topic:                "test topic",
+		Marshalizer:          &mock.MarshalizerMock{},
+		DataFactory:          &mock.InterceptedDataFactoryStub{},
+		Processor:            &mock.InterceptorProcessorStub{},
+		Throttler:            createMockThrottler(),
+		AntifloodHandler:     &mock.P2PAntifloodHandlerStub{},
+		WhiteListRequest:     &mock.WhiteListHandlerStub{},
+		PreferredPeersHolder: &p2pmocks.PeersHolderStub{},
+		CurrentPeerId:        "pid",
 	}
 }
 
@@ -96,6 +98,17 @@ func TestNewMultiDataInterceptor_NilAntifloodHandlerShouldErr(t *testing.T) {
 
 	assert.Nil(t, mdi)
 	assert.Equal(t, process.ErrNilAntifloodHandler, err)
+}
+
+func TestNewMultiDataInterceptor_NilPreferredPeersHolderShouldErr(t *testing.T) {
+	t.Parallel()
+
+	arg := createMockArgMultiDataInterceptor()
+	arg.PreferredPeersHolder = nil
+	mdi, err := interceptors.NewMultiDataInterceptor(arg)
+
+	assert.Nil(t, mdi)
+	assert.Equal(t, process.ErrNilPreferredPeersHolder, err)
 }
 
 func TestNewMultiDataInterceptor_NilWhiteListHandlerShouldErr(t *testing.T) {

--- a/process/interceptors/singleDataInterceptor.go
+++ b/process/interceptors/singleDataInterceptor.go
@@ -10,13 +10,14 @@ import (
 
 // ArgSingleDataInterceptor is the argument for the single-data interceptor
 type ArgSingleDataInterceptor struct {
-	Topic            string
-	DataFactory      process.InterceptedDataFactory
-	Processor        process.InterceptorProcessor
-	Throttler        process.InterceptorThrottler
-	AntifloodHandler process.P2PAntifloodHandler
-	WhiteListRequest process.WhiteListHandler
-	CurrentPeerId    core.PeerID
+	Topic                string
+	DataFactory          process.InterceptedDataFactory
+	Processor            process.InterceptorProcessor
+	Throttler            process.InterceptorThrottler
+	AntifloodHandler     process.P2PAntifloodHandler
+	WhiteListRequest     process.WhiteListHandler
+	PreferredPeersHolder process.PreferredPeersHolderHandler
+	CurrentPeerId        core.PeerID
 }
 
 // SingleDataInterceptor is used for intercepting packed multi data
@@ -46,18 +47,22 @@ func NewSingleDataInterceptor(arg ArgSingleDataInterceptor) (*SingleDataIntercep
 	if check.IfNil(arg.WhiteListRequest) {
 		return nil, process.ErrNilWhiteListHandler
 	}
+	if check.IfNil(arg.PreferredPeersHolder) {
+		return nil, process.ErrNilPreferredPeersHolder
+	}
 	if len(arg.CurrentPeerId) == 0 {
 		return nil, process.ErrEmptyPeerID
 	}
 
 	singleDataIntercept := &SingleDataInterceptor{
 		baseDataInterceptor: &baseDataInterceptor{
-			throttler:        arg.Throttler,
-			antifloodHandler: arg.AntifloodHandler,
-			topic:            arg.Topic,
-			currentPeerId:    arg.CurrentPeerId,
-			processor:        arg.Processor,
-			debugHandler:     resolver.NewDisabledInterceptorResolver(),
+			throttler:            arg.Throttler,
+			antifloodHandler:     arg.AntifloodHandler,
+			topic:                arg.Topic,
+			currentPeerId:        arg.CurrentPeerId,
+			processor:            arg.Processor,
+			preferredPeersHolder: arg.PreferredPeersHolder,
+			debugHandler:         resolver.NewDisabledInterceptorResolver(),
 		},
 		factory:          arg.DataFactory,
 		whiteListRequest: arg.WhiteListRequest,

--- a/process/interceptors/singleDataInterceptor_test.go
+++ b/process/interceptors/singleDataInterceptor_test.go
@@ -11,19 +11,21 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/interceptors"
 	"github.com/ElrondNetwork/elrond-go/process/mock"
+	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func createMockArgSingleDataInterceptor() interceptors.ArgSingleDataInterceptor {
 	return interceptors.ArgSingleDataInterceptor{
-		Topic:            "test topic",
-		DataFactory:      &mock.InterceptedDataFactoryStub{},
-		Processor:        &mock.InterceptorProcessorStub{},
-		Throttler:        createMockThrottler(),
-		AntifloodHandler: &mock.P2PAntifloodHandlerStub{},
-		WhiteListRequest: &mock.WhiteListHandlerStub{},
-		CurrentPeerId:    "pid",
+		Topic:                "test topic",
+		DataFactory:          &mock.InterceptedDataFactoryStub{},
+		Processor:            &mock.InterceptorProcessorStub{},
+		Throttler:            createMockThrottler(),
+		AntifloodHandler:     &mock.P2PAntifloodHandlerStub{},
+		WhiteListRequest:     &mock.WhiteListHandlerStub{},
+		PreferredPeersHolder: &p2pmocks.PeersHolderStub{},
+		CurrentPeerId:        "pid",
 	}
 }
 
@@ -107,6 +109,17 @@ func TestNewSingleDataInterceptor_NilP2PAntifloodHandlerShouldErr(t *testing.T) 
 
 	assert.Nil(t, sdi)
 	assert.Equal(t, process.ErrNilAntifloodHandler, err)
+}
+
+func TestNewSingleDataInterceptor_NilPreferredPeersHolderShouldErr(t *testing.T) {
+	t.Parallel()
+
+	arg := createMockArgSingleDataInterceptor()
+	arg.PreferredPeersHolder = nil
+	sdi, err := interceptors.NewSingleDataInterceptor(arg)
+
+	assert.Nil(t, sdi)
+	assert.Equal(t, process.ErrNilPreferredPeersHolder, err)
 }
 
 func TestNewSingleDataInterceptor_NilWhiteListHandlerShouldErr(t *testing.T) {

--- a/process/interface.go
+++ b/process/interface.go
@@ -973,6 +973,13 @@ type InterceptedDebugger interface {
 	IsInterfaceNil() bool
 }
 
+// PreferredPeersHolderHandler defines the behavior of a component able to handle preferred peers operations
+type PreferredPeersHolderHandler interface {
+	Get() map[uint32][]core.PeerID
+	Contains(peerID core.PeerID) bool
+	IsInterfaceNil() bool
+}
+
 // AntifloodDebugger defines an interface for debugging the antiflood behavior
 type AntifloodDebugger interface {
 	AddData(pid core.PeerID, topic string, numRejected uint32, sizeRejected uint64, sequence []byte, isBlacklisted bool)

--- a/update/disabled/preferredPeersHolder.go
+++ b/update/disabled/preferredPeersHolder.go
@@ -1,0 +1,40 @@
+package disabled
+
+import (
+	"github.com/ElrondNetwork/elrond-go/core"
+)
+
+type disabledPreferredPeersHolder struct {
+}
+
+// NewPreferredPeersHolder returns a new instance of disabledPreferredPeersHolder
+func NewPreferredPeersHolder() *disabledPreferredPeersHolder {
+	return &disabledPreferredPeersHolder{}
+}
+
+// Put won't do anything
+func (d *disabledPreferredPeersHolder) Put(_ []byte, _ core.PeerID, _ uint32) {
+}
+
+// Get will return an empty map
+func (d *disabledPreferredPeersHolder) Get() map[uint32][]core.PeerID {
+	return make(map[uint32][]core.PeerID)
+}
+
+// Contains returns false
+func (d *disabledPreferredPeersHolder) Contains(_ core.PeerID) bool {
+	return false
+}
+
+// Remove won't do anything
+func (d *disabledPreferredPeersHolder) Remove(_ core.PeerID) {
+}
+
+// Clear won't do anything
+func (d *disabledPreferredPeersHolder) Clear() {
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (d *disabledPreferredPeersHolder) IsInterfaceNil() bool {
+	return d == nil
+}

--- a/update/factory/fullSyncResolversContainerFactory.go
+++ b/update/factory/fullSyncResolversContainerFactory.go
@@ -177,6 +177,7 @@ func (rcf *resolversContainerFactory) createTrieNodesResolver(baseTopic string, 
 		NumIntraShardPeers:          numIntraShardPeers,
 		NumFullHistoryPeers:         numFullHistoryPeers,
 		CurrentNetworkEpochProvider: disabled.NewCurrentNetworkEpochProviderHandler(),
+		PreferredPeersHolder:        disabled.NewPreferredPeersHolder(),
 	}
 	resolverSender, err := topicResolverSender.NewTopicResolverSender(arg)
 	if err != nil {

--- a/update/factory/fullSyncResolversContainerFactory.go
+++ b/update/factory/fullSyncResolversContainerFactory.go
@@ -178,6 +178,7 @@ func (rcf *resolversContainerFactory) createTrieNodesResolver(baseTopic string, 
 		NumFullHistoryPeers:         numFullHistoryPeers,
 		CurrentNetworkEpochProvider: disabled.NewCurrentNetworkEpochProviderHandler(),
 		PreferredPeersHolder:        disabled.NewPreferredPeersHolder(),
+		SelfShardIdProvider:         rcf.shardCoordinator,
 	}
 	resolverSender, err := topicResolverSender.NewTopicResolverSender(arg)
 	if err != nil {

--- a/update/interface.go
+++ b/update/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data"
 	"github.com/ElrondNetwork/elrond-go/data/block"
 	"github.com/ElrondNetwork/elrond-go/data/state"
@@ -255,5 +256,15 @@ type GenesisNodesSetupHandler interface {
 type RoundHandler interface {
 	Index() int64
 	TimeStamp() time.Time
+	IsInterfaceNil() bool
+}
+
+// PreferredPeersHolderHandler defines the behavior of a component able to handle preferred peers operations
+type PreferredPeersHolderHandler interface {
+	Put(publicKey []byte, peerID core.PeerID, shardID uint32)
+	Get() map[uint32][]core.PeerID
+	Contains(peerID core.PeerID) bool
+	Remove(peerID core.PeerID)
+	Clear()
 	IsInterfaceNil() bool
 }


### PR DESCRIPTION
Integrated the preferred peers holder component inside resolvers so if any preferred peer in the target shard exists, it will be used first when sending requests (only if there is more than one peer to request). Also skipped the antiflood checks if the peer the messages were received from is a preferred one.

Testing procedure:
1. in `prefs.toml` add public keys of any observer/validator from the testnet. 
2. start the testnet and run it with regular and upgrade scenarios for some time.
3. check the logs and look for the following log lines:

- `network connection status` - should contain a preferred peers histogram that isn't empty
- `sending request to preferred peer` 
- `request peers histogram` - should contain a peers histogram and preferred peers must be part of it 