### PR TITLE
Arwen locker fix for genesis

### DIFF
--- a/factory/processComponents.go
+++ b/factory/processComponents.go
@@ -272,7 +272,7 @@ func (pcf *processComponentsFactory) Create() (*processComponents, error) {
 	}
 
 	pcf.txLogsProcessor = txLogsProcessor
-	genesisBlocks, err := pcf.generateGenesisHeadersAndApplyInitialBalances(arwenChangeLocker)
+	genesisBlocks, err := pcf.generateGenesisHeadersAndApplyInitialBalances()
 	if err != nil {
 		return nil, err
 	}
@@ -646,7 +646,7 @@ func (pcf *processComponentsFactory) newEpochStartTrigger(requestHandler process
 	return nil, errors.New("error creating new start of epoch trigger because of invalid shard id")
 }
 
-func (pcf *processComponentsFactory) generateGenesisHeadersAndApplyInitialBalances(arwenChangeLocker process.Locker) (map[uint32]data.HeaderHandler, error) {
+func (pcf *processComponentsFactory) generateGenesisHeadersAndApplyInitialBalances() (map[uint32]data.HeaderHandler, error) {
 	genesisVmConfig := pcf.config.VirtualMachine.Execution
 	genesisVmConfig.OutOfProcessConfig.MaxLoopTime = 5000 // 5 seconds
 	conversionBase := 10
@@ -679,7 +679,6 @@ func (pcf *processComponentsFactory) generateGenesisHeadersAndApplyInitialBalanc
 		GenesisString:        pcf.config.GeneralSettings.GenesisString,
 		GenesisNodePrice:     genesisNodePrice,
 		EpochConfig:          &pcf.epochConfig,
-		ArwenChangeLocker:    arwenChangeLocker,
 	}
 
 	gbc, err := processGenesis.NewGenesisBlockCreator(arg)

--- a/genesis/process/argGenesisBlockCreator.go
+++ b/genesis/process/argGenesisBlockCreator.go
@@ -60,7 +60,6 @@ type ArgsGenesisBlockCreator struct {
 	ImportStartHandler   update.ImportStartHandler
 	WorkingDir           string
 	BlockSignKeyGen      crypto.KeyGenerator
-	ArwenChangeLocker    process.Locker
 
 	GenesisNodePrice *big.Int
 	GenesisString    string

--- a/genesis/process/genesisBlockCreator_test.go
+++ b/genesis/process/genesisBlockCreator_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"math"
 	"math/big"
-	"sync"
 	"testing"
 
 	arwenConfig "github.com/ElrondNetwork/arwen-wasm-vm/config"
@@ -127,7 +126,6 @@ func createMockArgument(
 				PenalizedTooMuchGasEnableEpoch: 0,
 			},
 		},
-		ArwenChangeLocker: &sync.RWMutex{},
 	}
 
 	arg.ShardCoordinator = &mock.ShardCoordinatorMock{

--- a/genesis/process/metaGenesisBlockCreator.go
+++ b/genesis/process/metaGenesisBlockCreator.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/core"
@@ -363,7 +364,7 @@ func createProcessorsForMetaGenesisBlock(arg ArgsGenesisBlockCreator, enableEpoc
 		SenderInOutTransferEnableEpoch:      enableEpochs.SenderInOutTransferEnableEpoch,
 		IsGenesisProcessing:                 true,
 		StakingV2EnableEpoch:                arg.EpochConfig.EnableEpochs.StakingV2EnableEpoch,
-		ArwenChangeLocker:                   arg.ArwenChangeLocker,
+		ArwenChangeLocker:                   &sync.RWMutex{}, //local Locker as to not interfere with the rest of the components
 	}
 	scProcessor, err := smartContract.NewSmartContractProcessor(argsNewSCProcessor)
 	if err != nil {

--- a/genesis/process/shardGenesisBlockCreator.go
+++ b/genesis/process/shardGenesisBlockCreator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"sync"
 
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/config"
@@ -260,6 +261,7 @@ func setBalanceToTrie(arg ArgsGenesisBlockCreator, accnt genesis.InitialAccountH
 }
 
 func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, enableEpochs config.EnableEpochs) (*genesisProcessors, error) {
+	genesisArwenLocker := &sync.RWMutex{} //use a local instance as to not run in concurrent issues when doing bootstrap
 	epochNotifier := forking.NewGenericEpochNotifier()
 
 	argsBuiltIn := builtInFunctions.ArgsCreateBuiltInFunctionContainer{
@@ -301,7 +303,7 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, enableEpo
 		DeployEnableEpoch:              arg.EpochConfig.EnableEpochs.SCDeployEnableEpoch,
 		AheadOfTimeGasUsageEnableEpoch: arg.EpochConfig.EnableEpochs.AheadOfTimeGasUsageEnableEpoch,
 		ArwenV3EnableEpoch:             arg.EpochConfig.EnableEpochs.RepairCallbackEnableEpoch,
-		ArwenChangeLocker:              arg.ArwenChangeLocker,
+		ArwenChangeLocker:              genesisArwenLocker,
 	}
 	log.Debug("shardGenesisCreator: enable epoch for sc deploy", "epoch", argsNewVMFactory.DeployEnableEpoch)
 	log.Debug("shardGenesisCreator: enable epoch for ahead of time gas usage", "epoch", argsNewVMFactory.AheadOfTimeGasUsageEnableEpoch)
@@ -407,7 +409,7 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, enableEpo
 		SenderInOutTransferEnableEpoch:      enableEpochs.SenderInOutTransferEnableEpoch,
 		IsGenesisProcessing:                 true,
 		StakingV2EnableEpoch:                arg.EpochConfig.EnableEpochs.StakingV2EnableEpoch,
-		ArwenChangeLocker:                   arg.ArwenChangeLocker,
+		ArwenChangeLocker:                   genesisArwenLocker,
 	}
 	scProcessor, err := smartContract.NewSmartContractProcessor(argsNewScProcessor)
 	if err != nil {

--- a/integrationTests/multiShard/hardFork/hardFork_test.go
+++ b/integrationTests/multiShard/hardFork/hardFork_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
@@ -498,7 +497,6 @@ func hardForkImport(
 					DelegationSmartContractEnableEpoch: 0,
 				},
 			},
-			ArwenChangeLocker: &sync.RWMutex{},
 		}
 
 		genesisProcessor, err := process.NewGenesisBlockCreator(argsGenesis)

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -476,7 +476,6 @@ func CreateGenesisBlocks(
 	uint64Converter typeConverters.Uint64ByteSliceConverter,
 	dataPool dataRetriever.PoolsHolder,
 	economics process.EconomicsDataHandler,
-	arwenChangeLocker process.Locker,
 ) map[uint32]data.HeaderHandler {
 
 	genesisBlocks := make(map[uint32]data.HeaderHandler)
@@ -498,7 +497,6 @@ func CreateGenesisBlocks(
 		uint64Converter,
 		dataPool,
 		economics,
-		arwenChangeLocker,
 	)
 
 	return genesisBlocks
@@ -614,7 +612,6 @@ func CreateFullGenesisBlocks(
 				DelegationManagerEnableEpoch:       0,
 			},
 		},
-		ArwenChangeLocker: &sync.RWMutex{},
 	}
 
 	genesisProcessor, _ := genesisProcess.NewGenesisBlockCreator(argsGenesis)
@@ -638,7 +635,6 @@ func CreateGenesisMetaBlock(
 	uint64Converter typeConverters.Uint64ByteSliceConverter,
 	dataPool dataRetriever.PoolsHolder,
 	economics process.EconomicsDataHandler,
-	arwenChangeLocker process.Locker,
 ) data.HeaderHandler {
 	gasSchedule := arwenConfig.MakeGasMapForTests()
 	defaults.FillGasMapInternal(gasSchedule, 1)
@@ -724,7 +720,6 @@ func CreateGenesisMetaBlock(
 				DelegationSmartContractEnableEpoch: 0,
 			},
 		},
-		ArwenChangeLocker: arwenChangeLocker,
 	}
 
 	if shardCoordinator.SelfId() != core.MetachainShardId {

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -682,7 +682,6 @@ func (tpn *TestProcessorNode) initTestNode() {
 		TestUint64Converter,
 		tpn.DataPool,
 		tpn.EconomicsData,
-		tpn.ArwenChangeLocker,
 	)
 	tpn.initBlockTracker()
 	tpn.initInterceptors()
@@ -733,7 +732,6 @@ func (tpn *TestProcessorNode) initTestNodeWithTrieDBAndGasModel(trieStore storag
 		TestUint64Converter,
 		tpn.DataPool,
 		tpn.EconomicsData,
-		tpn.ArwenChangeLocker,
 	)
 	tpn.initBlockTracker()
 	tpn.initInterceptors()

--- a/integrationTests/testProcessorNodeWithStateCheckpointModulus.go
+++ b/integrationTests/testProcessorNodeWithStateCheckpointModulus.go
@@ -108,7 +108,6 @@ func NewTestProcessorNodeWithStateCheckpointModulus(
 		TestUint64Converter,
 		tpn.DataPool,
 		tpn.EconomicsData,
-		tpn.ArwenChangeLocker,
 	)
 	tpn.initBlockTracker()
 	tpn.initInterceptors()


### PR DESCRIPTION
- fixed Arwen locker usage by having a different instance in the genesis process and thus, avoiding deadlock at genesis time