### PR TITLE
Always-not-synced exception in block syncer during import-db operation

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -941,6 +941,7 @@ func (n *Node) createShardBootstrapper(rounder consensus.Rounder) (process.Boots
 		MiniblocksProvider:  n.miniblocksProvider,
 		Uint64Converter:     n.uint64ByteSliceConverter,
 		Indexer:             n.indexer,
+		IsInImportMode:      n.isInImportMode,
 	}
 
 	argsShardBootstrapper := sync.ArgShardBootstrapper{
@@ -1003,6 +1004,7 @@ func (n *Node) createMetaChainBootstrapper(rounder consensus.Rounder) (process.B
 		MiniblocksProvider:  n.miniblocksProvider,
 		Uint64Converter:     n.uint64ByteSliceConverter,
 		Indexer:             n.indexer,
+		IsInImportMode:      n.isInImportMode,
 	}
 
 	argsMetaBootstrapper := sync.ArgMetaBootstrapper{

--- a/process/sync/argBootstrapper.go
+++ b/process/sync/argBootstrapper.go
@@ -37,6 +37,7 @@ type ArgBaseBootstrapper struct {
 	MiniblocksProvider  process.MiniBlockProvider
 	Uint64Converter     typeConverters.Uint64ByteSliceConverter
 	Indexer             process.Indexer
+	IsInImportMode      bool
 }
 
 // ArgShardBootstrapper holds all dependencies required by the bootstrap data factory in order to create

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -536,9 +536,7 @@ func (boot *baseBootstrap) incrementSyncedWithErrorsForNonce(nonce uint64) uint3
 // in the blockchain, and all this mechanism will be reiterated for the next block.
 func (boot *baseBootstrap) syncBlock() error {
 	boot.computeNodeState()
-	nodeState := boot.GetNodeState()
-	shouldSync := nodeState == core.NsNotSynchronized || boot.isInImportMode
-	if !shouldSync {
+	if !boot.shouldSync() {
 		return nil
 	}
 
@@ -632,6 +630,15 @@ func (boot *baseBootstrap) syncBlock() error {
 	boot.cleanNoncesSyncedWithErrorsBehindFinal()
 
 	return nil
+}
+
+func (boot *baseBootstrap) shouldSync() bool {
+	if boot.isInImportMode {
+		return true
+	}
+
+	nodeState := boot.GetNodeState()
+	return nodeState == core.NsNotSynchronized
 }
 
 func (boot *baseBootstrap) cleanNoncesSyncedWithErrorsBehindFinal() {

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -112,6 +112,7 @@ type baseBootstrap struct {
 	poolsHolder        dataRetriever.PoolsHolder
 	mutRequestHeaders  sync.Mutex
 	cancelFunc         func()
+	isInImportMode     bool
 }
 
 // setRequestedHeaderNonce method sets the header nonce requested by the sync mechanism
@@ -536,7 +537,8 @@ func (boot *baseBootstrap) incrementSyncedWithErrorsForNonce(nonce uint64) uint3
 func (boot *baseBootstrap) syncBlock() error {
 	boot.computeNodeState()
 	nodeState := boot.GetNodeState()
-	if nodeState != core.NsNotSynchronized {
+	shouldSync := nodeState == core.NsNotSynchronized || boot.isInImportMode
+	if !shouldSync {
 		return nil
 	}
 

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -536,7 +536,8 @@ func (boot *baseBootstrap) incrementSyncedWithErrorsForNonce(nonce uint64) uint3
 // in the blockchain, and all this mechanism will be reiterated for the next block.
 func (boot *baseBootstrap) syncBlock() error {
 	boot.computeNodeState()
-	if !boot.shouldSync() {
+	nodeState := boot.GetNodeState()
+	if nodeState != core.NsNotSynchronized {
 		return nil
 	}
 
@@ -630,15 +631,6 @@ func (boot *baseBootstrap) syncBlock() error {
 	boot.cleanNoncesSyncedWithErrorsBehindFinal()
 
 	return nil
-}
-
-func (boot *baseBootstrap) shouldSync() bool {
-	if boot.isInImportMode {
-		return true
-	}
-
-	nodeState := boot.GetNodeState()
-	return nodeState == core.NsNotSynchronized
 }
 
 func (boot *baseBootstrap) cleanNoncesSyncedWithErrorsBehindFinal() {
@@ -1007,6 +999,10 @@ func (boot *baseBootstrap) requestHeaders(fromNonce uint64, toNonce uint64) {
 // which means that the state of the node in the current round is not calculated yet. Note that when the node is not
 // connected to the network, GetNodeState could return 'NsNotSynchronized' but the SyncBlock is not automatically called.
 func (boot *baseBootstrap) GetNodeState() core.NodeState {
+	if boot.isInImportMode {
+		return core.NsNotSynchronized
+	}
+
 	boot.mutNodeState.RLock()
 	isNodeStateCalculatedInCurrentRound := boot.roundIndex == boot.rounder.Index() && boot.isNodeStateCalculated
 	isNodeSynchronized := boot.isNodeSynchronized

--- a/process/sync/baseSync_test.go
+++ b/process/sync/baseSync_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data/block"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/mock"
@@ -123,7 +124,7 @@ func TestBaseBootstrap_GetOrderedMiniBlocksShouldWork(t *testing.T) {
 	assert.Equal(t, uint32(2), orderedMiniBlocks[2].SenderShardID)
 }
 
-func TestBaseBootstrap_shouldSync(t *testing.T) {
+func TestBaseBootstrap_GetNodeState(t *testing.T) {
 	t.Parallel()
 
 	boot := &baseBootstrap{
@@ -131,14 +132,14 @@ func TestBaseBootstrap_shouldSync(t *testing.T) {
 		isNodeStateCalculated: true,
 		rounder:               &mock.RounderMock{},
 	}
-	assert.True(t, boot.shouldSync())
+	assert.Equal(t, core.NsNotSynchronized, boot.GetNodeState())
 
 	boot = &baseBootstrap{
 		isInImportMode:        false,
 		isNodeStateCalculated: true,
 		rounder:               &mock.RounderMock{},
 	}
-	assert.True(t, boot.shouldSync())
+	assert.Equal(t, core.NsNotSynchronized, boot.GetNodeState())
 
 	boot = &baseBootstrap{
 		roundIndex:            1,
@@ -146,5 +147,5 @@ func TestBaseBootstrap_shouldSync(t *testing.T) {
 		isNodeStateCalculated: true,
 		rounder:               &mock.RounderMock{},
 	}
-	assert.False(t, boot.shouldSync())
+	assert.Equal(t, core.NsNotCalculated, boot.GetNodeState())
 }

--- a/process/sync/baseSync_test.go
+++ b/process/sync/baseSync_test.go
@@ -122,3 +122,29 @@ func TestBaseBootstrap_GetOrderedMiniBlocksShouldWork(t *testing.T) {
 	assert.Equal(t, uint32(1), orderedMiniBlocks[1].SenderShardID)
 	assert.Equal(t, uint32(2), orderedMiniBlocks[2].SenderShardID)
 }
+
+func TestBaseBootstrap_shouldSync(t *testing.T) {
+	t.Parallel()
+
+	boot := &baseBootstrap{
+		isInImportMode:        true,
+		isNodeStateCalculated: true,
+		rounder:               &mock.RounderMock{},
+	}
+	assert.True(t, boot.shouldSync())
+
+	boot = &baseBootstrap{
+		isInImportMode:        false,
+		isNodeStateCalculated: true,
+		rounder:               &mock.RounderMock{},
+	}
+	assert.True(t, boot.shouldSync())
+
+	boot = &baseBootstrap{
+		roundIndex:            1,
+		isInImportMode:        false,
+		isNodeStateCalculated: true,
+		rounder:               &mock.RounderMock{},
+	}
+	assert.False(t, boot.shouldSync())
+}

--- a/process/sync/export_test.go
+++ b/process/sync/export_test.go
@@ -7,30 +7,37 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process"
 )
 
+// RequestHeaderWithNonce -
 func (boot *ShardBootstrap) RequestHeaderWithNonce(nonce uint64) {
 	boot.requestHeaderWithNonce(nonce)
 }
 
+// GetMiniBlocks -
 func (boot *ShardBootstrap) GetMiniBlocks(hashes [][]byte) ([]*process.MiniblockAndHash, [][]byte) {
 	return boot.miniBlocksProvider.GetMiniBlocks(hashes)
 }
 
+// ReceivedHeaders -
 func (boot *MetaBootstrap) ReceivedHeaders(header data.HeaderHandler, key []byte) {
 	boot.processReceivedHeader(header, key)
 }
 
+// ReceivedHeaders -
 func (boot *ShardBootstrap) ReceivedHeaders(header data.HeaderHandler, key []byte) {
 	boot.processReceivedHeader(header, key)
 }
 
+// RollBack -
 func (boot *ShardBootstrap) RollBack(revertUsingForkNonce bool) error {
 	return boot.rollBack(revertUsingForkNonce)
 }
 
+// RollBack -
 func (boot *MetaBootstrap) RollBack(revertUsingForkNonce bool) error {
 	return boot.rollBack(revertUsingForkNonce)
 }
 
+// GetHeaders -
 func (bfd *baseForkDetector) GetHeaders(nonce uint64) []*headerInfo {
 	bfd.mutHeaders.Lock()
 	defer bfd.mutHeaders.Unlock()
@@ -47,88 +54,109 @@ func (bfd *baseForkDetector) GetHeaders(nonce uint64) []*headerInfo {
 	return newHeaders
 }
 
+// LastCheckpointNonce -
 func (bfd *baseForkDetector) LastCheckpointNonce() uint64 {
 	return bfd.lastCheckpoint().nonce
 }
 
+// LastCheckpointRound -
 func (bfd *baseForkDetector) LastCheckpointRound() uint64 {
 	return bfd.lastCheckpoint().round
 }
 
+// SetFinalCheckpoint -
 func (bfd *baseForkDetector) SetFinalCheckpoint(nonce uint64, round uint64, hash []byte) {
 	bfd.setFinalCheckpoint(&checkpointInfo{nonce: nonce, round: round, hash: hash})
 }
 
+// FinalCheckpointNonce -
 func (bfd *baseForkDetector) FinalCheckpointNonce() uint64 {
 	return bfd.finalCheckpoint().nonce
 }
 
+// FinalCheckpointRound -
 func (bfd *baseForkDetector) FinalCheckpointRound() uint64 {
 	return bfd.finalCheckpoint().round
 }
 
+// CheckBlockValidity -
 func (bfd *baseForkDetector) CheckBlockValidity(header *block.Header, headerHash []byte) error {
 	return bfd.checkBlockBasicValidity(header, headerHash)
 }
 
+// RemovePastHeaders -
 func (bfd *baseForkDetector) RemovePastHeaders() {
 	bfd.removePastHeaders()
 }
 
+// RemoveInvalidReceivedHeaders -
 func (bfd *baseForkDetector) RemoveInvalidReceivedHeaders() {
 	bfd.removeInvalidReceivedHeaders()
 }
 
+// ComputeProbableHighestNonce -
 func (bfd *baseForkDetector) ComputeProbableHighestNonce() uint64 {
 	return bfd.computeProbableHighestNonce()
 }
 
+// IsConsensusStuck -
 func (bfd *baseForkDetector) IsConsensusStuck() bool {
 	return bfd.isConsensusStuck()
 }
 
+// Hash -
 func (hi *headerInfo) Hash() []byte {
 	return hi.hash
 }
 
+// GetBlockHeaderState -
 func (hi *headerInfo) GetBlockHeaderState() process.BlockHeaderState {
 	return hi.state
 }
 
+// NotifySyncStateListeners -
 func (boot *ShardBootstrap) NotifySyncStateListeners() {
 	isNodeSynchronized := boot.GetNodeState() == core.NsSynchronized
 	boot.notifySyncStateListeners(isNodeSynchronized)
 }
 
+// NotifySyncStateListeners -
 func (boot *MetaBootstrap) NotifySyncStateListeners() {
 	isNodeSynchronized := boot.GetNodeState() == core.NsSynchronized
 	boot.notifySyncStateListeners(isNodeSynchronized)
 }
 
+// SyncStateListeners -
 func (boot *ShardBootstrap) SyncStateListeners() []func(bool) {
 	return boot.syncStateListeners
 }
 
+// SyncStateListeners -
 func (boot *MetaBootstrap) SyncStateListeners() []func(bool) {
 	return boot.syncStateListeners
 }
 
+// SetForkNonce -
 func (boot *ShardBootstrap) SetForkNonce(nonce uint64) {
 	boot.forkInfo.Nonce = nonce
 }
 
+// SetForkNonce -
 func (boot *MetaBootstrap) SetForkNonce(nonce uint64) {
 	boot.forkInfo.Nonce = nonce
 }
 
+// IsForkDetected -
 func (boot *ShardBootstrap) IsForkDetected() bool {
 	return boot.forkInfo.IsDetected
 }
 
+// IsForkDetected -
 func (boot *MetaBootstrap) IsForkDetected() bool {
 	return boot.forkInfo.IsDetected
 }
 
+// GetNotarizedInfo -
 func (boot *MetaBootstrap) GetNotarizedInfo(
 	lastNotarized map[uint32]*HdrInfo,
 	finalNotarized map[uint32]*HdrInfo,
@@ -145,38 +173,47 @@ func (boot *MetaBootstrap) GetNotarizedInfo(
 	}
 }
 
+// ProcessReceivedHeader -
 func (boot *baseBootstrap) ProcessReceivedHeader(headerHandler data.HeaderHandler, headerHash []byte) {
 	boot.processReceivedHeader(headerHandler, headerHash)
 }
 
+// RequestMiniBlocksFromHeaderWithNonceIfMissing -
 func (boot *ShardBootstrap) RequestMiniBlocksFromHeaderWithNonceIfMissing(headerHandler data.HeaderHandler) {
 	boot.requestMiniBlocksFromHeaderWithNonceIfMissing(headerHandler)
 }
 
+// IsHeaderReceivedTooLate -
 func (bfd *baseForkDetector) IsHeaderReceivedTooLate(header data.HeaderHandler, state process.BlockHeaderState, finality int64) bool {
 	return bfd.isHeaderReceivedTooLate(header, state, finality)
 }
 
+// SetProbableHighestNonce -
 func (bfd *baseForkDetector) SetProbableHighestNonce(nonce uint64) {
 	bfd.setProbableHighestNonce(nonce)
 }
 
+// ComputeFinalCheckpoint -
 func (sfd *shardForkDetector) ComputeFinalCheckpoint() {
 	sfd.computeFinalCheckpoint()
 }
 
+// AddCheckPoint -
 func (bfd *baseForkDetector) AddCheckPoint(round uint64, nonce uint64, hash []byte) {
 	bfd.addCheckpoint(&checkpointInfo{round: round, nonce: nonce, hash: hash})
 }
 
+// ComputeGenesisTimeFromHeader -
 func (bfd *baseForkDetector) ComputeGenesisTimeFromHeader(headerHandler data.HeaderHandler) int64 {
 	return bfd.computeGenesisTimeFromHeader(headerHandler)
 }
 
+// InitNotarizedMap -
 func (boot *baseBootstrap) InitNotarizedMap() map[uint32]*HdrInfo {
 	return make(map[uint32]*HdrInfo)
 }
 
+// SetNotarizedMap -
 func (boot *baseBootstrap) SetNotarizedMap(notarizedMap map[uint32]*HdrInfo, shardId uint32, nonce uint64, hash []byte) {
 	hdrInfo, ok := notarizedMap[shardId]
 	if !ok {
@@ -188,26 +225,31 @@ func (boot *baseBootstrap) SetNotarizedMap(notarizedMap map[uint32]*HdrInfo, sha
 	hdrInfo.Hash = hash
 }
 
+// SetNodeStateCalculated -
 func (boot *baseBootstrap) SetNodeStateCalculated(state bool) {
 	boot.mutNodeState.Lock()
 	boot.isNodeStateCalculated = state
 	boot.mutNodeState.Unlock()
 }
 
+// ComputeNodeState -
 func (boot *baseBootstrap) ComputeNodeState() {
 	boot.computeNodeState()
 }
 
+// DoJobOnSyncBlockFail -
 func (boot *baseBootstrap) DoJobOnSyncBlockFail(bodyHandler data.BodyHandler, headerHandler data.HeaderHandler, err error) {
 	boot.doJobOnSyncBlockFail(bodyHandler, headerHandler, err)
 }
 
+// SetNumSyncedWithErrorsForNonce -
 func (boot *baseBootstrap) SetNumSyncedWithErrorsForNonce(nonce uint64, numSyncedWithErrors uint32) {
 	boot.mutNonceSyncedWithErrors.Lock()
 	boot.mapNonceSyncedWithErrors[nonce] = numSyncedWithErrors
 	boot.mutNonceSyncedWithErrors.Unlock()
 }
 
+// GetNumSyncedWithErrorsForNonce -
 func (boot *baseBootstrap) GetNumSyncedWithErrorsForNonce(nonce uint64) uint32 {
 	boot.mutNonceSyncedWithErrors.RLock()
 	numSyncedWithErrors := boot.mapNonceSyncedWithErrors[nonce]
@@ -216,6 +258,7 @@ func (boot *baseBootstrap) GetNumSyncedWithErrorsForNonce(nonce uint64) uint32 {
 	return numSyncedWithErrors
 }
 
+// GetMapNonceSyncedWithErrorsLen -
 func (boot *baseBootstrap) GetMapNonceSyncedWithErrorsLen() int {
 	boot.mutNonceSyncedWithErrors.RLock()
 	mapNonceSyncedWithErrorsLen := len(boot.mapNonceSyncedWithErrors)
@@ -224,6 +267,12 @@ func (boot *baseBootstrap) GetMapNonceSyncedWithErrorsLen() int {
 	return mapNonceSyncedWithErrorsLen
 }
 
+// CleanNoncesSyncedWithErrorsBehindFinal -
 func (boot *baseBootstrap) CleanNoncesSyncedWithErrorsBehindFinal() {
 	boot.cleanNoncesSyncedWithErrorsBehindFinal()
+}
+
+// IsInImportMode -
+func (boot *baseBootstrap) IsInImportMode() bool {
+	return boot.isInImportMode
 }

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -63,7 +63,7 @@ func NewMetaBootstrap(arguments ArgMetaBootstrapper) (*MetaBootstrap, error) {
 		isInImportMode:      arguments.IsInImportMode,
 	}
 
-	if arguments.IsInImportMode {
+	if base.isInImportMode {
 		log.Warn("using always-not-synced status because the node is running in import-db")
 	}
 

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -60,6 +60,11 @@ func NewMetaBootstrap(arguments ArgMetaBootstrapper) (*MetaBootstrap, error) {
 		uint64Converter:     arguments.Uint64Converter,
 		poolsHolder:         arguments.PoolsHolder,
 		indexer:             arguments.Indexer,
+		isInImportMode:      arguments.IsInImportMode,
+	}
+
+	if arguments.IsInImportMode {
+		log.Warn("using always-not-synced status because the node is running in import-db")
 	}
 
 	boot := MetaBootstrap{

--- a/process/sync/metablock_test.go
+++ b/process/sync/metablock_test.go
@@ -259,13 +259,20 @@ func TestNewMetaBootstrap_OkValsShouldWork(t *testing.T) {
 		return sds
 	}
 	args.PoolsHolder = pools
-
+	args.IsInImportMode = true
 	bs, err := sync.NewMetaBootstrap(args)
 
 	assert.NotNil(t, bs)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, wasCalled)
 	assert.False(t, bs.IsInterfaceNil())
+	assert.True(t, bs.IsInImportMode())
+
+	args.IsInImportMode = false
+	bs, err = sync.NewMetaBootstrap(args)
+	assert.NotNil(t, bs)
+	assert.Nil(t, err)
+	assert.False(t, bs.IsInImportMode())
 }
 
 //------- processing

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -57,6 +57,11 @@ func NewShardBootstrap(arguments ArgShardBootstrapper) (*ShardBootstrap, error) 
 		uint64Converter:     arguments.Uint64Converter,
 		poolsHolder:         arguments.PoolsHolder,
 		indexer:             arguments.Indexer,
+		isInImportMode:      arguments.IsInImportMode,
+	}
+
+	if arguments.IsInImportMode {
+		log.Warn("using always-not-synced status because the node is running in import-db")
 	}
 
 	boot := ShardBootstrap{

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -60,7 +60,7 @@ func NewShardBootstrap(arguments ArgShardBootstrapper) (*ShardBootstrap, error) 
 		isInImportMode:      arguments.IsInImportMode,
 	}
 
-	if arguments.IsInImportMode {
+	if base.isInImportMode {
 		log.Warn("using always-not-synced status because the node is running in import-db")
 	}
 

--- a/process/sync/shardblock_test.go
+++ b/process/sync/shardblock_test.go
@@ -404,13 +404,21 @@ func TestNewShardBootstrap_OkValsShouldWork(t *testing.T) {
 		return cs
 	}
 	args.PoolsHolder = pools
-
+	args.IsInImportMode = true
 	bs, err := sync.NewShardBootstrap(args)
 
 	assert.NotNil(t, bs)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, wasCalled)
 	assert.False(t, bs.IsInterfaceNil())
+	assert.True(t, bs.IsInImportMode())
+
+	args.IsInImportMode = false
+	bs, err = sync.NewShardBootstrap(args)
+
+	assert.NotNil(t, bs)
+	assert.Nil(t, err)
+	assert.False(t, bs.IsInImportMode())
 }
 
 //------- processing


### PR DESCRIPTION
- added an exception to the block syncer as to always consider itself not synchronized in the import-db process

Testing scenario: in the normal operation, the network should behave normally, the WARN message `using always-not-synced status because the node is running in import-db` should not appear on any node. During the import-db operation, the above WARN message should appear and the node should not wait more that 10 rounds between epochs on the metachain.
When testing the import-db operation, the branch `test-always-not-synced-in-import-db` should be used.