### PR TITLE
Trie nodes chunk processor

### DIFF
--- a/dataRetriever/requestHandlers/requestHandler.go
+++ b/dataRetriever/requestHandlers/requestHandler.go
@@ -1,6 +1,7 @@
 package requestHandlers
 
 import (
+	"encoding/binary"
 	"fmt"
 	"sync"
 	"time"
@@ -174,7 +175,7 @@ func (rrh *resolverRequestHandler) requestReferenceWithChunkIndex(
 ) {
 	err := resolver.RequestDataFromReferenceAndChunk(reference, chunkIndex)
 	if err != nil {
-		log.Debug("requestByHashes.requestHashWithChunkIndex",
+		log.Debug("requestByHashes.requestReferenceWithChunkIndex",
 			"error", err.Error(),
 			"reference", reference,
 			"chunk index", chunkIndex,
@@ -443,20 +444,27 @@ func (rrh *resolverRequestHandler) RequestTrieNodes(destShardID uint32, hashes [
 	rrh.trieHashesAccumulator = make(map[string]struct{})
 }
 
+func (rrh *resolverRequestHandler) createIdentifier(requestHash []byte, chunkIndex uint32) []byte {
+	chunkBuffer := make([]byte, 4)
+	binary.BigEndian.PutUint32(chunkBuffer, chunkIndex)
+
+	return append(requestHash, chunkBuffer...)
+}
+
 // RequestTrieNode method asks for a trie node from the connected peers by the hash and the chunk index
 func (rrh *resolverRequestHandler) RequestTrieNode(destShardID uint32, requestHash []byte, topic string, chunkIndex uint32) {
-	unrequestedHashes := rrh.getUnrequestedHashes([][]byte{requestHash})
+	identifier := rrh.createIdentifier(requestHash, chunkIndex)
+	unrequestedHashes := rrh.getUnrequestedHashes([][]byte{identifier})
 	if len(unrequestedHashes) == 0 {
 		return
 	}
 
-	hash := unrequestedHashes[0]
 	rrh.whiteList.Add(unrequestedHashes)
 
 	log.Trace("requesting trie node from network",
 		"topic", topic,
 		"shard", destShardID,
-		"hash", hash,
+		"hash", requestHash,
 		"chunk index", chunkIndex,
 	)
 
@@ -476,9 +484,9 @@ func (rrh *resolverRequestHandler) RequestTrieNode(destShardID uint32, requestHa
 		return
 	}
 
-	go rrh.requestReferenceWithChunkIndex(hash, chunkIndex, trieResolver)
+	go rrh.requestReferenceWithChunkIndex(requestHash, chunkIndex, trieResolver)
 
-	rrh.addRequestedItems([][]byte{hash})
+	rrh.addRequestedItems([][]byte{identifier})
 }
 
 func (rrh *resolverRequestHandler) logTrieHashesFromAccumulator() {

--- a/dataRetriever/requestHandlers/requestHandler.go
+++ b/dataRetriever/requestHandlers/requestHandler.go
@@ -19,6 +19,7 @@ var _ epochStart.RequestHandler = (*resolverRequestHandler)(nil)
 
 var log = logger.GetOrCreate("dataretriever/requesthandlers")
 
+const bytesInUint32 = 4
 const timeToAccumulateTrieHashes = 100 * time.Millisecond
 
 //TODO move the keys definitions that are whitelisted in core and use them in InterceptedData implementations, Identifiers() function
@@ -445,7 +446,7 @@ func (rrh *resolverRequestHandler) RequestTrieNodes(destShardID uint32, hashes [
 }
 
 func (rrh *resolverRequestHandler) createIdentifier(requestHash []byte, chunkIndex uint32) []byte {
-	chunkBuffer := make([]byte, 4)
+	chunkBuffer := make([]byte, bytesInUint32)
 	binary.BigEndian.PutUint32(chunkBuffer, chunkIndex)
 
 	return append(requestHash, chunkBuffer...)

--- a/genesis/process/disabled/requestHandler.go
+++ b/genesis/process/disabled/requestHandler.go
@@ -6,70 +6,74 @@ import "time"
 type RequestHandler struct {
 }
 
-// SetEpoch -
+// SetEpoch does nothing
 func (r *RequestHandler) SetEpoch(_ uint32) {
 }
 
-// RequestShardHeader -
+// RequestShardHeader does nothing
 func (r *RequestHandler) RequestShardHeader(_ uint32, _ []byte) {
 }
 
-// RequestMetaHeader -
+// RequestMetaHeader does nothing
 func (r *RequestHandler) RequestMetaHeader(_ []byte) {
 }
 
-// RequestMetaHeaderByNonce -
+// RequestMetaHeaderByNonce does nothing
 func (r *RequestHandler) RequestMetaHeaderByNonce(_ uint64) {
 }
 
-// RequestShardHeaderByNonce -
+// RequestShardHeaderByNonce does nothing
 func (r *RequestHandler) RequestShardHeaderByNonce(_ uint32, _ uint64) {
 }
 
-// RequestTransaction -
+// RequestTransaction does nothing
 func (r *RequestHandler) RequestTransaction(_ uint32, _ [][]byte) {
 }
 
-// RequestUnsignedTransactions -
+// RequestUnsignedTransactions does nothing
 func (r *RequestHandler) RequestUnsignedTransactions(_ uint32, _ [][]byte) {
 }
 
-// RequestRewardTransactions -
+// RequestRewardTransactions does nothing
 func (r *RequestHandler) RequestRewardTransactions(_ uint32, _ [][]byte) {
 }
 
-// RequestMiniBlock -
+// RequestMiniBlock does nothing
 func (r *RequestHandler) RequestMiniBlock(_ uint32, _ []byte) {
 }
 
-// RequestMiniBlocks -
+// RequestMiniBlocks does nothing
 func (r *RequestHandler) RequestMiniBlocks(_ uint32, _ [][]byte) {
 }
 
-// RequestTrieNodes -
+// RequestTrieNodes does nothing
 func (r *RequestHandler) RequestTrieNodes(_ uint32, _ [][]byte, _ string) {
 }
 
-// RequestStartOfEpochMetaBlock -
+// RequestStartOfEpochMetaBlock does nothing
 func (r *RequestHandler) RequestStartOfEpochMetaBlock(_ uint32) {
 }
 
-// RequestInterval -
+// RequestInterval returns one second
 func (r *RequestHandler) RequestInterval() time.Duration {
 	return time.Second
 }
 
-// SetNumPeersToQuery -
+// SetNumPeersToQuery returns nil
 func (r *RequestHandler) SetNumPeersToQuery(_ string, _ int, _ int) error {
 	return nil
 }
 
-// GetNumPeersToQuery -
+// GetNumPeersToQuery returns 0, 0 and nil
 func (r *RequestHandler) GetNumPeersToQuery(_ string) (int, int, error) {
 	return 0, 0, nil
 }
 
-// IsInterfaceNil -
+// RequestTrieNode does nothing
+func (r *RequestHandler) RequestTrieNode(_ uint32, _ []byte, _ string, _ uint32) {
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
 func (r *RequestHandler) IsInterfaceNil() bool {
 	return r == nil
 }

--- a/process/errors.go
+++ b/process/errors.go
@@ -1012,3 +1012,6 @@ var ErrNilChunksProcessor = errors.New("nil chunks processor")
 
 // ErrIncompatibleReference signals that an incompatible reference
 var ErrIncompatibleReference = errors.New("incompatible reference when processing batch")
+
+// ErrProcessClosed signals that an incomplete processing occurred due to the early process closing
+var ErrProcessClosed = errors.New("incomplete processing: process is closing")

--- a/process/errors.go
+++ b/process/errors.go
@@ -1010,7 +1010,7 @@ var ErrNilNumConnectedPeersProvider = errors.New("nil number of connected peers 
 // ErrNilChunksProcessor signals that a nil chunks processor has been provided
 var ErrNilChunksProcessor = errors.New("nil chunks processor")
 
-// ErrIncompatibleReference signals that an incompatible reference
+// ErrIncompatibleReference signals that an incompatible reference was provided when processing a batch
 var ErrIncompatibleReference = errors.New("incompatible reference when processing batch")
 
 // ErrProcessClosed signals that an incomplete processing occurred due to the early process closing

--- a/process/errors.go
+++ b/process/errors.go
@@ -1009,3 +1009,6 @@ var ErrNilNumConnectedPeersProvider = errors.New("nil number of connected peers 
 
 // ErrNilChunksProcessor signals that a nil chunks processor has been provided
 var ErrNilChunksProcessor = errors.New("nil chunks processor")
+
+// ErrIncompatibleReference signals that an incompatible reference
+var ErrIncompatibleReference = errors.New("incompatible reference when processing batch")

--- a/process/interceptors/export_test.go
+++ b/process/interceptors/export_test.go
@@ -2,10 +2,12 @@ package interceptors
 
 import "github.com/ElrondNetwork/elrond-go/process"
 
+// Topic -
 func (mdi *MultiDataInterceptor) Topic() string {
 	return mdi.topic
 }
 
+// InterceptedDebugHandler -
 func (mdi *MultiDataInterceptor) InterceptedDebugHandler() process.InterceptedDebugger {
 	mdi.mutDebugHandler.RLock()
 	defer mdi.mutDebugHandler.RUnlock()
@@ -13,13 +15,23 @@ func (mdi *MultiDataInterceptor) InterceptedDebugHandler() process.InterceptedDe
 	return mdi.debugHandler
 }
 
+// Topic -
 func (sdi *SingleDataInterceptor) Topic() string {
 	return sdi.topic
 }
 
+// InterceptedDebugHandler -
 func (sdi *SingleDataInterceptor) InterceptedDebugHandler() process.InterceptedDebugger {
 	sdi.mutDebugHandler.RLock()
 	defer sdi.mutDebugHandler.RUnlock()
 
 	return sdi.debugHandler
+}
+
+// ChunksProcessor
+func (mdi *MultiDataInterceptor) ChunksProcessor() process.InterceptedChunksProcessor {
+	mdi.mutChunksProcessor.RLock()
+	defer mdi.mutChunksProcessor.RUnlock()
+
+	return mdi.chunksProcessor
 }

--- a/process/interceptors/multiDataInterceptor.go
+++ b/process/interceptors/multiDataInterceptor.go
@@ -127,7 +127,7 @@ func (mdi *MultiDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, 
 	mdi.mutChunksProcessor.RUnlock()
 	if err != nil {
 		mdi.throttler.EndProcessing()
-		return nil
+		return err
 	}
 
 	isIncompleteChunk := checkChunksRes.IsChunk && !checkChunksRes.HaveAllChunks
@@ -225,8 +225,7 @@ func (mdi *MultiDataInterceptor) RegisterHandler(handler func(topic string, hash
 }
 
 // SetChunkProcessor sets the intercepted chunks processor
-// TODO: use this in epoch bootstrapper, hardfork, interceptor for trie nodes
-// TODO(next PR) add unit tests for this function & L123-L140
+// TODO(next PR): use this in epoch bootstrapper, hardfork, interceptor for trie nodes
 func (mdi *MultiDataInterceptor) SetChunkProcessor(processor process.InterceptedChunksProcessor) error {
 	if check.IfNil(processor) {
 		return process.ErrNilChunksProcessor

--- a/process/interceptors/processor/chunk/chunk.go
+++ b/process/interceptors/processor/chunk/chunk.go
@@ -1,0 +1,76 @@
+package chunk
+
+import (
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+)
+
+var log = logger.GetOrCreate("process/interceptors/processor")
+
+type chunk struct {
+	maxChunks uint32
+	data      map[uint32][]byte
+	size      int
+}
+
+// NewChunk creates a new chunk instance able to account for the existing and missing chunks of a larger buffer
+// Not a concurrent safe component
+func NewChunk(maxChunks uint32) *chunk {
+	return &chunk{
+		data:      make(map[uint32][]byte),
+		maxChunks: maxChunks,
+	}
+}
+
+// Put will add are rewrite an existing chunk
+func (c *chunk) Put(chunkIndex uint32, buff []byte) {
+	if chunkIndex >= c.maxChunks {
+		return
+	}
+
+	existing, _ := c.data[chunkIndex]
+	c.data[chunkIndex] = buff
+	c.size = c.size - len(existing) + len(buff)
+}
+
+// TryAssembleAllChunks will try to assemble the original payload by iterating all available chunks
+// It returns nil if at least one chunk is missing
+func (c *chunk) TryAssembleAllChunks() []byte {
+	gotAllParts := c.maxChunks > 0 && len(c.data) == int(c.maxChunks)
+	if !gotAllParts {
+		//TODO(iulian) remove this log
+		log.Warn("not all parts got", "max chunks", c.maxChunks, "len chunk", len(c.data))
+		return nil
+	}
+
+	buff := make([]byte, 0, c.size)
+	for i := uint32(0); i < c.maxChunks; i++ {
+		part := c.data[i]
+
+		buff = append(buff, part...)
+	}
+
+	return buff
+}
+
+// GetAllMissingChunkIndexes returns all missing chunk indexes
+func (c *chunk) GetAllMissingChunkIndexes() []uint32 {
+	missing := make([]uint32, 0)
+	for i := uint32(0); i < c.maxChunks; i++ {
+		_, partFound := c.data[i]
+		if !partFound {
+			missing = append(missing, i)
+		}
+	}
+
+	return missing
+}
+
+// Size returns the size in bytes stored in the values of the inner map
+func (c *chunk) Size() int {
+	return c.size
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (c *chunk) IsInterfaceNil() bool {
+	return c == nil
+}

--- a/process/interceptors/processor/chunk/chunk.go
+++ b/process/interceptors/processor/chunk/chunk.go
@@ -21,7 +21,7 @@ func NewChunk(maxChunks uint32) *chunk {
 	}
 }
 
-// Put will add are rewrite an existing chunk
+// Put will add or rewrite an existing chunk
 func (c *chunk) Put(chunkIndex uint32, buff []byte) {
 	if chunkIndex >= c.maxChunks {
 		return

--- a/process/interceptors/processor/chunk/chunk.go
+++ b/process/interceptors/processor/chunk/chunk.go
@@ -45,7 +45,6 @@ func (c *chunk) TryAssembleAllChunks() []byte {
 	buff := make([]byte, 0, c.size)
 	for i := uint32(0); i < c.maxChunks; i++ {
 		part := c.data[i]
-
 		buff = append(buff, part...)
 	}
 

--- a/process/interceptors/processor/chunk/chunk_test.go
+++ b/process/interceptors/processor/chunk/chunk_test.go
@@ -1,0 +1,100 @@
+package chunk
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/core/check"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewChunk(t *testing.T) {
+	t.Parallel()
+
+	c := NewChunk(0)
+	assert.False(t, check.IfNil(c))
+}
+
+func TestChunk_Put(t *testing.T) {
+	t.Parallel()
+
+	c := NewChunk(2)
+	val1 := []byte("val1")
+	c.Put(1, val1)
+	require.Equal(t, 1, len(c.data))
+	assert.Equal(t, val1, c.data[1])
+	assert.Equal(t, 4, c.Size())
+
+	val2 := []byte("val222222")
+	c.Put(1, val2)
+	require.Equal(t, 1, len(c.data))
+	assert.Equal(t, val2, c.data[1])
+	assert.Equal(t, 9, c.Size())
+}
+
+func TestChunk_PutOutOfBounds(t *testing.T) {
+	t.Parallel()
+
+	c := NewChunk(2)
+	val1 := []byte("val1")
+	c.Put(2, val1)
+	require.Equal(t, 0, len(c.data))
+	assert.Equal(t, 0, c.Size())
+}
+
+func TestChunk_TryAssembleAllChunks(t *testing.T) {
+	t.Parallel()
+
+	c := NewChunk(3)
+	completeBuff := c.TryAssembleAllChunks()
+	assert.Nil(t, completeBuff)
+
+	buff4 := []byte("buff4")
+	c.Put(4, buff4)
+	completeBuff = c.TryAssembleAllChunks()
+	assert.Nil(t, completeBuff)
+
+	buff2 := []byte("buff2")
+	c.Put(1, buff2)
+	completeBuff = c.TryAssembleAllChunks()
+	assert.Nil(t, completeBuff)
+
+	buff1 := []byte("buff1")
+	c.Put(0, buff1)
+	completeBuff = c.TryAssembleAllChunks()
+	assert.Nil(t, completeBuff)
+
+	buff3 := []byte("buff3")
+	c.Put(2, buff3)
+	completeBuff = c.TryAssembleAllChunks()
+	expectedBuff := append(append(buff1, buff2...), buff3...)
+	assert.Equal(t, expectedBuff, completeBuff)
+}
+
+func TestChunk_GetAllMissingChunkIndexes(t *testing.T) {
+	t.Parallel()
+
+	c := NewChunk(3)
+	missing := c.GetAllMissingChunkIndexes()
+	assert.Equal(t, []uint32{0, 1, 2}, missing)
+
+	buff4 := []byte("buff4")
+	c.Put(4, buff4)
+	missing = c.GetAllMissingChunkIndexes()
+	assert.Equal(t, []uint32{0, 1, 2}, missing)
+
+	buff2 := []byte("buff2")
+	c.Put(1, buff2)
+	missing = c.GetAllMissingChunkIndexes()
+	assert.Equal(t, []uint32{0, 2}, missing)
+
+	buff1 := []byte("buff1")
+	c.Put(0, buff1)
+	missing = c.GetAllMissingChunkIndexes()
+	assert.Equal(t, []uint32{2}, missing)
+
+	buff3 := []byte("buff3")
+	c.Put(2, buff3)
+	missing = c.GetAllMissingChunkIndexes()
+	assert.Equal(t, 0, len(missing))
+}

--- a/process/interceptors/processor/trieNodeChunksProcessor.go
+++ b/process/interceptors/processor/trieNodeChunksProcessor.go
@@ -119,7 +119,12 @@ func (proc *trieNodeChunksProcessor) CheckBatch(b *batch.Batch) (process.Checked
 		chanResponse: respChan,
 	}
 
-	proc.chanCheckRequests <- req
+	select {
+	case proc.chanCheckRequests <- req:
+	case <-proc.chanClose:
+		return process.CheckedChunkResult{}, process.ErrProcessClosed
+	}
+
 	select {
 	case response := <-respChan:
 		return response, nil

--- a/process/interceptors/processor/trieNodeChunksProcessor.go
+++ b/process/interceptors/processor/trieNodeChunksProcessor.go
@@ -1,3 +1,214 @@
 package processor
 
-// TODO (next PR) - implement this
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go/core/check"
+	"github.com/ElrondNetwork/elrond-go/data/batch"
+	"github.com/ElrondNetwork/elrond-go/hashing"
+	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/process/interceptors/processor/chunk"
+	"github.com/ElrondNetwork/elrond-go/storage"
+)
+
+const minimumRequestTimeInterval = time.Second
+
+type chunkHandler interface {
+	Put(chunkIndex uint32, buff []byte)
+	TryAssembleAllChunks() []byte
+	GetAllMissingChunkIndexes() []uint32
+	Size() int
+	IsInterfaceNil() bool
+}
+
+type checkRequest struct {
+	batch        *batch.Batch
+	chanResponse chan process.CheckedChunkResult
+}
+
+// TrieNodesChunksProcessorArgs is the argument DTO used in the trieNodeChunksProcessor constructor
+type TrieNodesChunksProcessorArgs struct {
+	Hasher          hashing.Hasher
+	ChunksCacher    storage.Cacher
+	RequestInterval time.Duration
+	RequestHandler  process.RequestHandler
+	Topic           string
+	ShardID         uint32
+}
+
+type trieNodeChunksProcessor struct {
+	hasher            hashing.Hasher
+	chunksCacher      storage.Cacher
+	chanCheckRequests chan checkRequest
+	requestInterval   time.Duration
+	requestHandler    process.RequestHandler
+	topic             string
+	shardID           uint32
+	cancel            func()
+}
+
+// NewTrieNodeChunksProcessor creates a new trieNodeChunksProcessor instance
+func NewTrieNodeChunksProcessor(arg TrieNodesChunksProcessorArgs) (*trieNodeChunksProcessor, error) {
+	if check.IfNil(arg.Hasher) {
+		return nil, fmt.Errorf("%w in NewTrieNodeChunksProcessor", process.ErrNilHasher)
+	}
+	if check.IfNil(arg.ChunksCacher) {
+		return nil, fmt.Errorf("%w in NewTrieNodeChunksProcessor", process.ErrNilCacher)
+	}
+	if arg.RequestInterval < minimumRequestTimeInterval {
+		return nil, fmt.Errorf("%w in NewTrieNodeChunksProcessor, minimum request interval is %v",
+			process.ErrInvalidValue, minimumRequestTimeInterval)
+	}
+	if check.IfNil(arg.RequestHandler) {
+		return nil, fmt.Errorf("%w in NewTrieNodeChunksProcessor", process.ErrNilRequestHandler)
+	}
+	if len(arg.Topic) == 0 {
+		return nil, fmt.Errorf("%w in NewTrieNodeChunksProcessor", process.ErrEmptyTopic)
+	}
+
+	tncp := &trieNodeChunksProcessor{
+		hasher:            arg.Hasher,
+		chunksCacher:      arg.ChunksCacher,
+		chanCheckRequests: make(chan checkRequest),
+		requestInterval:   arg.RequestInterval,
+		requestHandler:    arg.RequestHandler,
+		topic:             arg.Topic,
+		shardID:           arg.ShardID,
+	}
+	var ctx context.Context
+	ctx, tncp.cancel = context.WithCancel(context.Background())
+	go tncp.processLoop(ctx)
+
+	return tncp, nil
+}
+
+func (proc *trieNodeChunksProcessor) processLoop(ctx context.Context) {
+	chanDoRequests := time.After(proc.requestInterval)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Debug("trieNodeChunksProcessor.processLoop go routine is stopping...")
+			return
+		case request := <-proc.chanCheckRequests:
+			proc.processCheckRequest(request)
+		case <-chanDoRequests:
+			proc.doRequests(ctx)
+			chanDoRequests = time.After(proc.requestInterval)
+		}
+	}
+}
+
+// CheckBatch will check the batch returning a checked chunk result containing result processing
+func (proc *trieNodeChunksProcessor) CheckBatch(b *batch.Batch) (process.CheckedChunkResult, error) {
+	batchValid, err := proc.batchIsValid(b)
+	if !batchValid {
+		return process.CheckedChunkResult{
+			IsChunk:        false,
+			HaveAllChunks:  false,
+			CompleteBuffer: nil,
+		}, err
+	}
+
+	respChan := make(chan process.CheckedChunkResult, 1)
+	req := checkRequest{
+		batch:        b,
+		chanResponse: respChan,
+	}
+
+	proc.chanCheckRequests <- req
+	response := <-respChan
+
+	return response, nil
+}
+
+func (proc *trieNodeChunksProcessor) processCheckRequest(cr checkRequest) {
+	chunkObject, found := proc.chunksCacher.Get(cr.batch.Reference)
+	if !found {
+		chunkObject = chunk.NewChunk(cr.batch.MaxChunks)
+	}
+	chunkData, ok := chunkObject.(chunkHandler)
+	if !ok {
+		chunkData = chunk.NewChunk(cr.batch.MaxChunks)
+	}
+
+	chunkData.Put(cr.batch.ChunkIndex, cr.batch.Data[0])
+
+	buff := chunkData.TryAssembleAllChunks()
+	haveAllChunks := len(buff) > 0
+	if haveAllChunks {
+		proc.chunksCacher.Remove(cr.batch.Reference)
+	} else {
+		proc.chunksCacher.Put(cr.batch.Reference, chunkData, chunkData.Size())
+	}
+
+	cr.chanResponse <- process.CheckedChunkResult{
+		IsChunk:        true,
+		HaveAllChunks:  haveAllChunks,
+		CompleteBuffer: buff,
+	}
+}
+
+func (proc *trieNodeChunksProcessor) batchIsValid(b *batch.Batch) (bool, error) {
+	if b.MaxChunks < 2 {
+		return false, nil
+	}
+	if len(b.Reference) != proc.hasher.Size() {
+		return false, process.ErrIncompatibleReference
+	}
+	if len(b.Data) != 1 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (proc *trieNodeChunksProcessor) doRequests(ctx context.Context) {
+	references := proc.chunksCacher.Keys()
+	for _, ref := range references {
+		select {
+		case <-ctx.Done():
+			//early exit
+			return
+		default:
+		}
+
+		proc.requestMissingForReference(ref, ctx)
+	}
+}
+
+func (proc *trieNodeChunksProcessor) requestMissingForReference(reference []byte, ctx context.Context) {
+	data, found := proc.chunksCacher.Get(reference)
+	if !found {
+		return
+	}
+
+	chunkData, ok := data.(chunkHandler)
+	if !ok {
+		return
+	}
+
+	missing := chunkData.GetAllMissingChunkIndexes()
+	for _, missingChunkIndex := range missing {
+		select {
+		case <-ctx.Done():
+			//early exit
+			return
+		default:
+		}
+
+		proc.requestHandler.RequestTrieNode(proc.shardID, reference, proc.topic, missingChunkIndex)
+	}
+}
+
+// Close will close the process go routine
+func (proc *trieNodeChunksProcessor) Close() error {
+	proc.cancel()
+	return nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (proc *trieNodeChunksProcessor) IsInterfaceNil() bool {
+	return proc == nil
+}

--- a/process/interceptors/processor/trieNodeChunksProcessor_test.go
+++ b/process/interceptors/processor/trieNodeChunksProcessor_test.go
@@ -167,6 +167,30 @@ func TestTrieNodeChunksProcessor_CheckBatchShouldWork(t *testing.T) {
 	_ = tncp.Close()
 }
 
+func TestTrieNodeChunksProcessor_CheckBatchComponentClosed(t *testing.T) {
+	t.Parallel()
+
+	expectedCheckedChunkResult := process.CheckedChunkResult{
+		IsChunk:        false,
+		HaveAllChunks:  false,
+		CompleteBuffer: nil,
+	}
+
+	args := createMockTrieNodesChunksProcessorArgs()
+	tncp, _ := NewTrieNodeChunksProcessor(args)
+
+	_ = tncp.Close()
+
+	chunkResult, err := tncp.CheckBatch(&batch.Batch{
+		Data:       [][]byte{[]byte("buff1")},
+		Reference:  reference,
+		ChunkIndex: 0,
+		MaxChunks:  2,
+	})
+	assert.Equal(t, process.ErrProcessClosed, err)
+	assert.Equal(t, expectedCheckedChunkResult, chunkResult)
+}
+
 func TestTrieNodeChunksProcessor_RequestShouldWork(t *testing.T) {
 	t.Parallel()
 

--- a/process/interceptors/processor/trieNodeChunksProcessor_test.go
+++ b/process/interceptors/processor/trieNodeChunksProcessor_test.go
@@ -1,0 +1,200 @@
+package processor
+
+import (
+	"bytes"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go/core/check"
+	"github.com/ElrondNetwork/elrond-go/data/batch"
+	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/stretchr/testify/assert"
+)
+
+var reference = bytes.Repeat([]byte{1}, 32)
+
+func createMockTrieNodesChunksProcessorArgs() TrieNodesChunksProcessorArgs {
+	return TrieNodesChunksProcessorArgs{
+		Hasher: &testscommon.HasherStub{
+			SizeCalled: func() int {
+				return 32
+			},
+		},
+		ChunksCacher:    testscommon.NewCacherMock(),
+		RequestInterval: time.Second,
+		RequestHandler:  &testscommon.RequestHandlerStub{},
+		Topic:           "topic",
+		ShardID:         0,
+	}
+}
+
+func TestNewTrieNodeChunksProcessor_NilHasher(t *testing.T) {
+	t.Parallel()
+
+	args := createMockTrieNodesChunksProcessorArgs()
+	args.Hasher = nil
+	tncp, err := NewTrieNodeChunksProcessor(args)
+	assert.True(t, errors.Is(err, process.ErrNilHasher))
+	assert.True(t, check.IfNil(tncp))
+}
+
+func TestNewTrieNodeChunksProcessor_NilCacher(t *testing.T) {
+	t.Parallel()
+
+	args := createMockTrieNodesChunksProcessorArgs()
+	args.ChunksCacher = nil
+	tncp, err := NewTrieNodeChunksProcessor(args)
+	assert.True(t, errors.Is(err, process.ErrNilCacher))
+	assert.True(t, check.IfNil(tncp))
+}
+
+func TestNewTrieNodeChunksProcessor_InvalidInterval(t *testing.T) {
+	t.Parallel()
+
+	args := createMockTrieNodesChunksProcessorArgs()
+	args.RequestInterval = time.Second - time.Nanosecond
+	tncp, err := NewTrieNodeChunksProcessor(args)
+	assert.True(t, errors.Is(err, process.ErrInvalidValue))
+	assert.True(t, check.IfNil(tncp))
+}
+
+func TestNewTrieNodeChunksProcessor_NilRequestHandler(t *testing.T) {
+	t.Parallel()
+
+	args := createMockTrieNodesChunksProcessorArgs()
+	args.RequestHandler = nil
+	tncp, err := NewTrieNodeChunksProcessor(args)
+	assert.True(t, errors.Is(err, process.ErrNilRequestHandler))
+	assert.True(t, check.IfNil(tncp))
+}
+
+func TestNewTrieNodeChunksProcessor_EmptyTopic(t *testing.T) {
+	t.Parallel()
+
+	args := createMockTrieNodesChunksProcessorArgs()
+	args.Topic = ""
+	tncp, err := NewTrieNodeChunksProcessor(args)
+	assert.True(t, errors.Is(err, process.ErrEmptyTopic))
+	assert.True(t, check.IfNil(tncp))
+}
+
+func TestNewTrieNodeChunksProcessor_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	args := createMockTrieNodesChunksProcessorArgs()
+	tncp, err := NewTrieNodeChunksProcessor(args)
+	assert.Nil(t, err)
+	assert.False(t, check.IfNil(tncp))
+	assert.Nil(t, tncp.Close())
+}
+
+func TestTrieNodeChunksProcessor_CheckBatchInvalidBatch(t *testing.T) {
+	t.Parallel()
+
+	emptyCheckedChunkResult := process.CheckedChunkResult{}
+
+	args := createMockTrieNodesChunksProcessorArgs()
+	tncp, _ := NewTrieNodeChunksProcessor(args)
+	chunkResult, err := tncp.CheckBatch(&batch.Batch{
+		Data:       make([][]byte, 1),
+		Reference:  make([]byte, 32),
+		ChunkIndex: 0,
+		MaxChunks:  1,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, emptyCheckedChunkResult, chunkResult)
+
+	chunkResult, err = tncp.CheckBatch(&batch.Batch{
+		Data:       make([][]byte, 1),
+		Reference:  nil,
+		ChunkIndex: 0,
+		MaxChunks:  2,
+	})
+	assert.Equal(t, err, process.ErrIncompatibleReference)
+	assert.Equal(t, emptyCheckedChunkResult, chunkResult)
+
+	chunkResult, err = tncp.CheckBatch(&batch.Batch{
+		Data:       nil,
+		Reference:  make([]byte, 32),
+		ChunkIndex: 0,
+		MaxChunks:  2,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, emptyCheckedChunkResult, chunkResult)
+	_ = tncp.Close()
+}
+
+func TestTrieNodeChunksProcessor_CheckBatchShouldWork(t *testing.T) {
+	t.Parallel()
+
+	expectedCheckedChunkResult := process.CheckedChunkResult{
+		IsChunk:        true,
+		HaveAllChunks:  false,
+		CompleteBuffer: nil,
+	}
+
+	args := createMockTrieNodesChunksProcessorArgs()
+	tncp, _ := NewTrieNodeChunksProcessor(args)
+	chunkResult, err := tncp.CheckBatch(&batch.Batch{
+		Data:       [][]byte{[]byte("buff1")},
+		Reference:  reference,
+		ChunkIndex: 0,
+		MaxChunks:  2,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, expectedCheckedChunkResult, chunkResult)
+	assert.Equal(t, 1, args.ChunksCacher.Len())
+
+	chunkResult, err = tncp.CheckBatch(&batch.Batch{
+		Data:       [][]byte{[]byte("buff2")},
+		Reference:  reference,
+		ChunkIndex: 1,
+		MaxChunks:  2,
+	})
+	assert.Nil(t, err)
+
+	expectedCheckedChunkResult = process.CheckedChunkResult{
+		IsChunk:        true,
+		HaveAllChunks:  true,
+		CompleteBuffer: []byte("buff1buff2"),
+	}
+	assert.Equal(t, expectedCheckedChunkResult, chunkResult)
+	assert.Equal(t, 0, args.ChunksCacher.Len())
+
+	_ = tncp.Close()
+}
+
+func TestTrieNodeChunksProcessor_RequestShouldWork(t *testing.T) {
+	t.Parallel()
+
+	args := createMockTrieNodesChunksProcessorArgs()
+	args.ShardID = 2
+	numRequested := uint32(0)
+	args.RequestHandler = &testscommon.RequestHandlerStub{
+		RequestTrieNodeCalled: func(destShardID uint32, requestHash []byte, topic string, chunkIndex uint32) {
+			atomic.AddUint32(&numRequested, 1)
+			assert.Equal(t, args.ShardID, destShardID)
+			assert.Equal(t, reference, requestHash)
+			assert.Equal(t, args.Topic, topic)
+			assert.True(t, chunkIndex >= 1 && chunkIndex <= 2)
+		},
+	}
+	tncp, _ := NewTrieNodeChunksProcessor(args)
+	_, err := tncp.CheckBatch(&batch.Batch{
+		Data:       [][]byte{[]byte("buff1")},
+		Reference:  reference,
+		ChunkIndex: 0,
+		MaxChunks:  3,
+	})
+	assert.Nil(t, err)
+
+	time.Sleep(time.Second + time.Millisecond*500)
+
+	assert.Equal(t, 1, args.ChunksCacher.Len())
+	assert.Equal(t, uint32(2), atomic.LoadUint32(&numRequested))
+
+	_ = tncp.Close()
+}

--- a/process/interface.go
+++ b/process/interface.go
@@ -502,6 +502,7 @@ type RequestHandler interface {
 	RequestInterval() time.Duration
 	SetNumPeersToQuery(key string, intra int, cross int) error
 	GetNumPeersToQuery(key string) (int, int, error)
+	RequestTrieNode(destShardID uint32, requestHash []byte, topic string, chunkIndex uint32)
 	IsInterfaceNil() bool
 }
 

--- a/process/mock/chunkProcessorStub.go
+++ b/process/mock/chunkProcessorStub.go
@@ -1,0 +1,25 @@
+package mock
+
+import (
+	"github.com/ElrondNetwork/elrond-go/data/batch"
+	"github.com/ElrondNetwork/elrond-go/process"
+)
+
+// ChunkProcessorStub -
+type ChunkProcessorStub struct {
+	CheckBatchCalled func(b *batch.Batch) (process.CheckedChunkResult, error)
+}
+
+// CheckBatch -
+func (c *ChunkProcessorStub) CheckBatch(b *batch.Batch) (process.CheckedChunkResult, error) {
+	if c.CheckBatchCalled != nil {
+		return c.CheckBatchCalled(b)
+	}
+
+	return process.CheckedChunkResult{}, nil
+}
+
+// IsInterfaceNil -
+func (c *ChunkProcessorStub) IsInterfaceNil() bool {
+	return c == nil
+}

--- a/testscommon/hasherStub.go
+++ b/testscommon/hasherStub.go
@@ -4,10 +4,11 @@ package testscommon
 type HasherStub struct {
 	ComputeCalled   func(s string) []byte
 	EmptyHashCalled func() []byte
+	SizeCalled      func() int
 }
 
 // Compute -
-func (hash HasherStub) Compute(s string) []byte {
+func (hash *HasherStub) Compute(s string) []byte {
 	if hash.ComputeCalled != nil {
 		return hash.ComputeCalled(s)
 	}
@@ -15,7 +16,7 @@ func (hash HasherStub) Compute(s string) []byte {
 }
 
 // EmptyHash -
-func (hash HasherStub) EmptyHash() []byte {
+func (hash *HasherStub) EmptyHash() []byte {
 	if hash.EmptyHashCalled != nil {
 		hash.EmptyHashCalled()
 	}
@@ -23,11 +24,15 @@ func (hash HasherStub) EmptyHash() []byte {
 }
 
 // Size -
-func (HasherStub) Size() int {
+func (hash *HasherStub) Size() int {
+	if hash.SizeCalled != nil {
+		return hash.SizeCalled()
+	}
+
 	return 0
 }
 
 // IsInterfaceNil returns true if there is no value under the interface
-func (hash HasherStub) IsInterfaceNil() bool {
+func (hash *HasherStub) IsInterfaceNil() bool {
 	return false
 }

--- a/testscommon/requestHandlerStub.go
+++ b/testscommon/requestHandlerStub.go
@@ -17,6 +17,7 @@ type RequestHandlerStub struct {
 	RequestStartOfEpochMetaBlockCalled func(epoch uint32)
 	SetNumPeersToQueryCalled           func(key string, intra int, cross int) error
 	GetNumPeersToQueryCalled           func(key string) (int, int, error)
+	RequestTrieNodeCalled              func(destShardID uint32, requestHash []byte, topic string, chunkIndex uint32)
 }
 
 // SetNumPeersToQuery -
@@ -132,6 +133,13 @@ func (rhs *RequestHandlerStub) RequestTrieNodes(destShardID uint32, hashes [][]b
 		return
 	}
 	rhs.RequestTrieNodesCalled(destShardID, hashes, topic)
+}
+
+// RequestTrieNode -
+func (rhs *RequestHandlerStub) RequestTrieNode(destShardID uint32, requestHash []byte, topic string, chunkIndex uint32) {
+	if rhs.RequestTrieNodeCalled != nil {
+		rhs.RequestTrieNodeCalled(destShardID, requestHash, topic, chunkIndex)
+	}
 }
 
 // IsInterfaceNil returns true if there is no value under the interface


### PR DESCRIPTION
- added the trie nodes chunk processor. This processor is able to hold the completeness of a large trie nodes set and also is able to trigger requests for the missing parts.