### PR TITLE
Hotfix for Wasmer error leak and removed Arwen version switching

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -643,12 +643,6 @@
         ArwenVersions = [
             { StartEpoch = 0, Version = "v1.2" },
             { StartEpoch = 3, Version = "v1.3" },
-            { StartEpoch = 4, Version = "v1.2" },
-            { StartEpoch = 5, Version = "v1.3" },
-            { StartEpoch = 6, Version = "v1.2" },
-            { StartEpoch = 7, Version = "v1.3" },
-            { StartEpoch = 8, Version = "v1.2" },
-            { StartEpoch = 9, Version = "v1.3" },
         ]
 
     [VirtualMachine.Querying]
@@ -656,12 +650,6 @@
         ArwenVersions = [
             { StartEpoch = 0, Version = "v1.2" },
             { StartEpoch = 3, Version = "v1.3" },
-            { StartEpoch = 4, Version = "v1.2" },
-            { StartEpoch = 5, Version = "v1.3" },
-            { StartEpoch = 6, Version = "v1.2" },
-            { StartEpoch = 7, Version = "v1.3" },
-            { StartEpoch = 8, Version = "v1.2" },
-            { StartEpoch = 9, Version = "v1.3" },
         ]
 
 [Hardfork]

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/ElrondNetwork/arwen-wasm-vm v1.2.19
-	github.com/ElrondNetwork/arwen-wasm-vm/v1_3 v1.3.16
+	github.com/ElrondNetwork/arwen-wasm-vm/v1_3 v1.3.17
 	github.com/ElrondNetwork/concurrent-map v0.1.3
 	github.com/ElrondNetwork/elastic-indexer-go v1.0.6
 	github.com/ElrondNetwork/elrond-go-logger v1.0.4
@@ -49,4 +49,4 @@ require (
 
 replace github.com/gogo/protobuf => github.com/ElrondNetwork/protobuf v1.3.2
 
-replace github.com/ElrondNetwork/arwen-wasm-vm/v1_3 v1.3.16 => github.com/ElrondNetwork/arwen-wasm-vm v1.3.16
+replace github.com/ElrondNetwork/arwen-wasm-vm/v1_3 v1.3.17 => github.com/ElrondNetwork/arwen-wasm-vm v1.3.17

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/ElrondNetwork/arwen-wasm-vm v1.2.0/go.mod h1:Io5YGUs48YNnXlyJYSBX6Evx
 github.com/ElrondNetwork/arwen-wasm-vm v1.2.7/go.mod h1:Q+ay1aQID+M4q/PWcE9Jmheojpu9nkmOuv1eSDmpBwE=
 github.com/ElrondNetwork/arwen-wasm-vm v1.2.19 h1:j1aWov6w8sBR7Hce23RDKzjt9QZMmiSOdCNXCEB42jg=
 github.com/ElrondNetwork/arwen-wasm-vm v1.2.19/go.mod h1:Q+ay1aQID+M4q/PWcE9Jmheojpu9nkmOuv1eSDmpBwE=
-github.com/ElrondNetwork/arwen-wasm-vm v1.3.16 h1:6EVKO3V0Co+gjAnLHzWa7+d0zuzFf1Nks5FUiVkU8bA=
-github.com/ElrondNetwork/arwen-wasm-vm v1.3.16/go.mod h1:rLkewHY9/azMrdY4Kl5A7jGVKmI1BwCOauJcAr7eTZw=
+github.com/ElrondNetwork/arwen-wasm-vm v1.3.17 h1:xVqYYJhlzsjFPoyeS6JRklKvepO6nX/f7kmr8l2lLac=
+github.com/ElrondNetwork/arwen-wasm-vm v1.3.17/go.mod h1:R6OasLTUmPG7ZP7qoFNXksd2i9jozutwePbhZwVylyM=
 github.com/ElrondNetwork/big-int-util v0.0.5/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg1IJLPAK6GVHMbC7Aw4=
 github.com/ElrondNetwork/big-int-util v0.1.0 h1:vTMoJ5azhVmr7jhpSD3JUjQdkdyXoEPVkOvhdw1RjV4=
 github.com/ElrondNetwork/big-int-util v0.1.0/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg1IJLPAK6GVHMbC7Aw4=
@@ -68,7 +68,7 @@ github.com/ElrondNetwork/elrond-go v1.1.38-0.20210322140841-6a27c533e8a5/go.mod 
 github.com/ElrondNetwork/elrond-go v1.1.42/go.mod h1:mxhdRRV7PY+IHzznJ3MnX5/2YSMNxl2znD6f6Y8nuCM=
 github.com/ElrondNetwork/elrond-go v1.1.51/go.mod h1:0gT8uLRXSqmKDrrn55aXTSca0XGpg8aszx+Q5OPMNpY=
 github.com/ElrondNetwork/elrond-go v1.1.59-0.20210526130950-2a93e2e11c39/go.mod h1:0aZfahOLX4vO+1D6Ejx8XwOLTzd7pfcx94xzAOpt2bs=
-github.com/ElrondNetwork/elrond-go v1.1.62-0.20210609185220-e530a1fd35b7/go.mod h1:SVbvBAYLO/+8sINl0gf6zjaNp9jROqekYrn2vUDYl8k=
+github.com/ElrondNetwork/elrond-go v1.1.63-0.20210616113850-299e605755e6/go.mod h1:HJAV0hUwg8S0Vp7FqTD2SStLyM4F7S/90V/B++rYTuI=
 github.com/ElrondNetwork/elrond-go-logger v1.0.2/go.mod h1:e5D+c97lKUfFdAzFX7rrI2Igl/z4Y0RkKYKWyzprTGk=
 github.com/ElrondNetwork/elrond-go-logger v1.0.4 h1:i5Yu4qyjTZDwvBY/ykbNpp2SP9jxwk/QTivRwSZSTAQ=
 github.com/ElrondNetwork/elrond-go-logger v1.0.4/go.mod h1:e5D+c97lKUfFdAzFX7rrI2Igl/z4Y0RkKYKWyzprTGk=


### PR DESCRIPTION
- bump arwen version to 1.3.17
- removed arwen version switching in config.toml