### PR TITLE
Refactor state snapshot

### DIFF
--- a/data/interface.go
+++ b/data/interface.go
@@ -209,8 +209,8 @@ type TrieSyncer interface {
 // StorageManager manages all trie storage operations
 type StorageManager interface {
 	Database() DBWriteCacher
-	TakeSnapshot([]byte, bool)
-	SetCheckpoint([]byte)
+	TakeSnapshot([]byte, bool, chan core.KeyValueHolder)
+	SetCheckpoint([]byte, chan core.KeyValueHolder)
 	GetSnapshotThatContainsHash(rootHash []byte) SnapshotDbHandler
 	IsPruningEnabled() bool
 	IsPruningBlocked() bool

--- a/data/state/accountsDB.go
+++ b/data/state/accountsDB.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	createNewDb   = true
-	useExistingDb = false
+	createNewDb       = true
+	useExistingDb     = false
+	leavesChannelSize = 100
 )
 
 var numCheckpointsKey = []byte("state checkpoint")
@@ -962,7 +963,7 @@ func (adb *AccountsDB) SnapshotState(rootHash []byte) {
 	go func() {
 		stopWatch := core.NewStopWatch()
 		stopWatch.Start("snapshotState")
-		leavesChannel := make(chan core.KeyValueHolder, 100)
+		leavesChannel := make(chan core.KeyValueHolder, leavesChannelSize)
 		trieStorageManager.TakeSnapshot(rootHash, createNewDb, leavesChannel)
 		adb.snapshotUserAccountDataTrie(true, leavesChannel)
 		stopWatch.Stop("snapshotState")
@@ -1012,7 +1013,7 @@ func (adb *AccountsDB) setStateCheckpoint(rootHash []byte) {
 	go func() {
 		stopWatch := core.NewStopWatch()
 		stopWatch.Start("setStateCheckpoint")
-		leavesChannel := make(chan core.KeyValueHolder, 100)
+		leavesChannel := make(chan core.KeyValueHolder, leavesChannelSize)
 		trieStorageManager.SetCheckpoint(rootHash, leavesChannel)
 		adb.snapshotUserAccountDataTrie(false, leavesChannel)
 		stopWatch.Stop("setStateCheckpoint")

--- a/data/state/accountsDB.go
+++ b/data/state/accountsDB.go
@@ -962,8 +962,9 @@ func (adb *AccountsDB) SnapshotState(rootHash []byte) {
 	go func() {
 		stopWatch := core.NewStopWatch()
 		stopWatch.Start("snapshotState")
-		trieStorageManager.TakeSnapshot(rootHash, createNewDb)
-		adb.snapshotUserAccountDataTrie(rootHash, true)
+		leavesChannel := make(chan core.KeyValueHolder, 100)
+		trieStorageManager.TakeSnapshot(rootHash, createNewDb, leavesChannel)
+		adb.snapshotUserAccountDataTrie(true, leavesChannel)
 		stopWatch.Stop("snapshotState")
 
 		log.Debug("snapshotState", stopWatch.GetMeasurements()...)
@@ -973,17 +974,10 @@ func (adb *AccountsDB) SnapshotState(rootHash []byte) {
 	}()
 }
 
-func (adb *AccountsDB) snapshotUserAccountDataTrie(rootHash []byte, isSnapshot bool) {
-	// TODO improve GetAllLeaves to return only the accounts that have dirty data tries
-	leavesChannel, err := adb.GetAllLeaves(rootHash)
-	if err != nil {
-		log.Error("incomplete snapshot as getAllLeaves error", "error", err)
-		return
-	}
-
+func (adb *AccountsDB) snapshotUserAccountDataTrie(isSnapshot bool, leavesChannel chan core.KeyValueHolder) {
 	for leaf := range leavesChannel {
 		account := &userAccount{}
-		err = adb.marshalizer.Unmarshal(account, leaf.Value())
+		err := adb.marshalizer.Unmarshal(account, leaf.Value())
 		if err != nil {
 			log.Trace("this must be a leaf with code", "err", err)
 			continue
@@ -994,11 +988,11 @@ func (adb *AccountsDB) snapshotUserAccountDataTrie(rootHash []byte, isSnapshot b
 		}
 
 		if isSnapshot {
-			adb.mainTrie.GetStorageManager().TakeSnapshot(account.RootHash, useExistingDb)
+			adb.mainTrie.GetStorageManager().TakeSnapshot(account.RootHash, useExistingDb, nil)
 			continue
 		}
 
-		adb.mainTrie.GetStorageManager().SetCheckpoint(account.RootHash)
+		adb.mainTrie.GetStorageManager().SetCheckpoint(account.RootHash, nil)
 	}
 }
 
@@ -1018,8 +1012,9 @@ func (adb *AccountsDB) setStateCheckpoint(rootHash []byte) {
 	go func() {
 		stopWatch := core.NewStopWatch()
 		stopWatch.Start("setStateCheckpoint")
-		trieStorageManager.SetCheckpoint(rootHash)
-		adb.snapshotUserAccountDataTrie(rootHash, false)
+		leavesChannel := make(chan core.KeyValueHolder, 100)
+		trieStorageManager.SetCheckpoint(rootHash, leavesChannel)
+		adb.snapshotUserAccountDataTrie(false, leavesChannel)
 		stopWatch.Stop("setStateCheckpoint")
 
 		log.Debug("setStateCheckpoint", stopWatch.GetMeasurements()...)

--- a/data/state/accountsDB_test.go
+++ b/data/state/accountsDB_test.go
@@ -2021,7 +2021,6 @@ func TestAccountsDB_CommitSetsStateCheckpointIfCheckpointHashesHolderIsFull(t *t
 func TestAccountsDB_SnapshotStateCommitsAllStateInOneDbAndCleansCheckpointHashesHolder(t *testing.T) {
 	t.Parallel()
 
-	newHashes := make(data.ModifiedHashes)
 	removeCommitedCalled := false
 	checkpointHashesHolder := &testscommon.CheckpointHashesHolderStub{
 		PutCalled: func(_ []byte, _ data.ModifiedHashes) bool {
@@ -2037,7 +2036,7 @@ func TestAccountsDB_SnapshotStateCommitsAllStateInOneDbAndCleansCheckpointHashes
 	adb, tr, trieStorage := getDefaultStateComponents(checkpointHashesHolder)
 
 	accountsAddresses := generateAccounts(t, 3, adb)
-	newHashes = modifyDataTries(t, accountsAddresses, adb)
+	newHashes := modifyDataTries(t, accountsAddresses, adb)
 	newHashesMainTrie, _ := tr.GetDirtyHashes()
 	mergeMaps(newHashes, newHashesMainTrie)
 
@@ -2059,7 +2058,6 @@ func TestAccountsDB_SnapshotStateCommitsAllStateInOneDbAndCleansCheckpointHashes
 func TestAccountsDB_SetStateCheckpointCommitsOnlyMissingData(t *testing.T) {
 	t.Parallel()
 
-	newHashes := make(data.ModifiedHashes)
 	checkpointHashesHolder := hashesHolder.NewCheckpointHashesHolder(100000, testscommon.HashSize)
 	adb, tr, trieStorage := getDefaultStateComponents(checkpointHashesHolder)
 
@@ -2070,7 +2068,7 @@ func TestAccountsDB_SetStateCheckpointCommitsOnlyMissingData(t *testing.T) {
 	assert.Nil(t, err)
 	checkpointHashesHolder.RemoveCommitted(rootHash)
 
-	newHashes = modifyDataTries(t, accountsAddresses, adb)
+	newHashes := modifyDataTries(t, accountsAddresses, adb)
 
 	_ = generateAccounts(t, 2, adb)
 

--- a/data/state/peerAccountsDB.go
+++ b/data/state/peerAccountsDB.go
@@ -63,7 +63,7 @@ func (adb *PeerAccountsDB) SnapshotState(rootHash []byte) {
 	trieStorageManager := adb.mainTrie.GetStorageManager()
 
 	trieStorageManager.EnterPruningBufferingMode()
-	trieStorageManager.TakeSnapshot(rootHash, true)
+	trieStorageManager.TakeSnapshot(rootHash, true, nil)
 	trieStorageManager.ExitPruningBufferingMode()
 
 	adb.increaseNumCheckpoints()
@@ -75,7 +75,7 @@ func (adb *PeerAccountsDB) SetStateCheckpoint(rootHash []byte) {
 	trieStorageManager := adb.mainTrie.GetStorageManager()
 
 	trieStorageManager.EnterPruningBufferingMode()
-	trieStorageManager.SetCheckpoint(rootHash)
+	trieStorageManager.SetCheckpoint(rootHash, nil)
 	trieStorageManager.ExitPruningBufferingMode()
 
 	adb.increaseNumCheckpoints()

--- a/data/state/storagePruningManager/storagePruningManager_test.go
+++ b/data/state/storagePruningManager/storagePruningManager_test.go
@@ -57,7 +57,7 @@ func TestAccountsDB_PruningIsDoneAfterSnapshotIsFinished(t *testing.T) {
 	rootHash, _ := tr.RootHash()
 
 	trieStorage := tr.GetStorageManager()
-	trieStorage.TakeSnapshot(rootHash, true)
+	trieStorage.TakeSnapshot(rootHash, true, nil)
 	time.Sleep(trieDbOperationDelay)
 	spm.PruneTrie(rootHash, data.NewRoot, trieStorage)
 	time.Sleep(trieDbOperationDelay)

--- a/data/trie/branchNode.go
+++ b/data/trie/branchNode.go
@@ -285,7 +285,12 @@ func (bn *branchNode) commitDirty(level byte, maxTrieLevelInMemory uint, originD
 	return nil
 }
 
-func (bn *branchNode) commitCheckpoint(originDb data.DBWriteCacher, targetDb data.DBWriteCacher, checkpointHashes data.CheckpointHashesHolder) error {
+func (bn *branchNode) commitCheckpoint(
+	originDb data.DBWriteCacher,
+	targetDb data.DBWriteCacher,
+	checkpointHashes data.CheckpointHashesHolder,
+	leavesChan chan core.KeyValueHolder,
+) error {
 	err := bn.isEmptyOrNil()
 	if err != nil {
 		return fmt.Errorf("commit checkpoint error %w", err)
@@ -311,7 +316,7 @@ func (bn *branchNode) commitCheckpoint(originDb data.DBWriteCacher, targetDb dat
 			continue
 		}
 
-		err = bn.children[i].commitCheckpoint(originDb, targetDb, checkpointHashes)
+		err = bn.children[i].commitCheckpoint(originDb, targetDb, checkpointHashes, leavesChan)
 		if err != nil {
 			return err
 		}
@@ -321,7 +326,11 @@ func (bn *branchNode) commitCheckpoint(originDb data.DBWriteCacher, targetDb dat
 	return bn.saveToStorage(targetDb)
 }
 
-func (bn *branchNode) commitSnapshot(originDb data.DBWriteCacher, targetDb data.DBWriteCacher) error {
+func (bn *branchNode) commitSnapshot(
+	originDb data.DBWriteCacher,
+	targetDb data.DBWriteCacher,
+	leavesChan chan core.KeyValueHolder,
+) error {
 	err := bn.isEmptyOrNil()
 	if err != nil {
 		return fmt.Errorf("commit snapshot error %w", err)
@@ -337,7 +346,7 @@ func (bn *branchNode) commitSnapshot(originDb data.DBWriteCacher, targetDb data.
 			continue
 		}
 
-		err = bn.children[i].commitSnapshot(originDb, targetDb)
+		err = bn.children[i].commitSnapshot(originDb, targetDb, leavesChan)
 		if err != nil {
 			return err
 		}

--- a/data/trie/branchNode_test.go
+++ b/data/trie/branchNode_test.go
@@ -1040,7 +1040,7 @@ func TestBranchNode_getChildrenCollapsedBn(t *testing.T) {
 
 	db := mock.NewMemDbMock()
 	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	_ = bn.commitSnapshot(db, db)
+	_ = bn.commitSnapshot(db, db, nil)
 
 	children, err := collapsedBn.getChildren(db)
 	assert.Nil(t, err)
@@ -1240,8 +1240,8 @@ func TestBranchNode_printShouldNotPanicEvenIfNodeIsCollapsed(t *testing.T) {
 
 	db := mock.NewMemDbMock()
 	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	_ = bn.commitSnapshot(db, db)
-	_ = collapsedBn.commitSnapshot(db, db)
+	_ = bn.commitSnapshot(db, db, nil)
+	_ = collapsedBn.commitSnapshot(db, db, nil)
 
 	bn.print(bnWriter, 0, db)
 	collapsedBn.print(collapsedBnWriter, 0, db)
@@ -1278,7 +1278,7 @@ func TestBranchNode_getAllHashesResolvesCollapsed(t *testing.T) {
 
 	db := mock.NewMemDbMock()
 	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	_ = bn.commitSnapshot(db, db)
+	_ = bn.commitSnapshot(db, db, nil)
 
 	hashes, err := collapsedBn.getAllHashes(db)
 	assert.Nil(t, err)

--- a/data/trie/extensionNode.go
+++ b/data/trie/extensionNode.go
@@ -197,7 +197,12 @@ func (en *extensionNode) commitDirty(level byte, maxTrieLevelInMemory uint, orig
 	return nil
 }
 
-func (en *extensionNode) commitCheckpoint(originDb data.DBWriteCacher, targetDb data.DBWriteCacher, checkpointHashes data.CheckpointHashesHolder) error {
+func (en *extensionNode) commitCheckpoint(
+	originDb data.DBWriteCacher,
+	targetDb data.DBWriteCacher,
+	checkpointHashes data.CheckpointHashesHolder,
+	leavesChan chan core.KeyValueHolder,
+) error {
 	err := en.isEmptyOrNil()
 	if err != nil {
 		return fmt.Errorf("commit checkpoint error %w", err)
@@ -218,7 +223,7 @@ func (en *extensionNode) commitCheckpoint(originDb data.DBWriteCacher, targetDb 
 		return nil
 	}
 
-	err = en.child.commitCheckpoint(originDb, targetDb, checkpointHashes)
+	err = en.child.commitCheckpoint(originDb, targetDb, checkpointHashes, leavesChan)
 	if err != nil {
 		return err
 	}
@@ -227,7 +232,11 @@ func (en *extensionNode) commitCheckpoint(originDb data.DBWriteCacher, targetDb 
 	return en.saveToStorage(targetDb)
 }
 
-func (en *extensionNode) commitSnapshot(originDb data.DBWriteCacher, targetDb data.DBWriteCacher) error {
+func (en *extensionNode) commitSnapshot(
+	originDb data.DBWriteCacher,
+	targetDb data.DBWriteCacher,
+	leavesChan chan core.KeyValueHolder,
+) error {
 	err := en.isEmptyOrNil()
 	if err != nil {
 		return fmt.Errorf("commit snapshot error %w", err)
@@ -238,7 +247,7 @@ func (en *extensionNode) commitSnapshot(originDb data.DBWriteCacher, targetDb da
 		return err
 	}
 
-	err = en.child.commitSnapshot(originDb, targetDb)
+	err = en.child.commitSnapshot(originDb, targetDb, leavesChan)
 	if err != nil {
 		return err
 	}

--- a/data/trie/extensionNode_test.go
+++ b/data/trie/extensionNode_test.go
@@ -898,7 +898,7 @@ func TestExtensionNode_printShouldNotPanicEvenIfNodeIsCollapsed(t *testing.T) {
 	db := mock.NewMemDbMock()
 	en, collapsedEn := getEnAndCollapsedEn()
 	_ = en.commitDirty(0, 5, db, db)
-	_ = collapsedEn.commitSnapshot(db, db)
+	_ = collapsedEn.commitSnapshot(db, db, nil)
 
 	en.print(enWriter, 0, db)
 	collapsedEn.print(collapsedEnWriter, 0, db)
@@ -911,7 +911,7 @@ func TestExtensionNode_getDirtyHashesFromCleanNode(t *testing.T) {
 
 	db := mock.NewMemDbMock()
 	en, _ := getEnAndCollapsedEn()
-	_ = en.commitSnapshot(db, db)
+	_ = en.commitSnapshot(db, db, nil)
 	dirtyHashes := make(data.ModifiedHashes)
 
 	err := en.getDirtyHashes(dirtyHashes)
@@ -936,7 +936,7 @@ func TestExtensionNode_getAllHashesResolvesCollapsed(t *testing.T) {
 	trieNodes := 5
 	db := mock.NewMemDbMock()
 	en, collapsedEn := getEnAndCollapsedEn()
-	_ = en.commitSnapshot(db, db)
+	_ = en.commitSnapshot(db, db, nil)
 
 	hashes, err := collapsedEn.getAllHashes(db)
 	assert.Nil(t, err)

--- a/data/trie/interface.go
+++ b/data/trie/interface.go
@@ -43,8 +43,8 @@ type node interface {
 	getNumNodes() data.NumNodesDTO
 
 	commitDirty(level byte, maxTrieLevelInMemory uint, originDb data.DBWriteCacher, targetDb data.DBWriteCacher) error
-	commitCheckpoint(originDb data.DBWriteCacher, targetDb data.DBWriteCacher, checkpointHashes data.CheckpointHashesHolder) error
-	commitSnapshot(originDb data.DBWriteCacher, targetDb data.DBWriteCacher) error
+	commitCheckpoint(originDb data.DBWriteCacher, targetDb data.DBWriteCacher, checkpointHashes data.CheckpointHashesHolder, leavesChan chan core.KeyValueHolder) error
+	commitSnapshot(originDb data.DBWriteCacher, targetDb data.DBWriteCacher, leavesChan chan core.KeyValueHolder) error
 
 	getMarshalizer() marshal.Marshalizer
 	setMarshalizer(marshal.Marshalizer)
@@ -56,8 +56,8 @@ type node interface {
 }
 
 type snapshotNode interface {
-	commitCheckpoint(originDb data.DBWriteCacher, targetDb data.DBWriteCacher, checkpointHashes data.CheckpointHashesHolder) error
-	commitSnapshot(originDb data.DBWriteCacher, targetDb data.DBWriteCacher) error
+	commitCheckpoint(originDb data.DBWriteCacher, targetDb data.DBWriteCacher, checkpointHashes data.CheckpointHashesHolder, leavesChan chan core.KeyValueHolder) error
+	commitSnapshot(originDb data.DBWriteCacher, targetDb data.DBWriteCacher, leavesChan chan core.KeyValueHolder) error
 }
 
 // RequestHandler defines the methods through which request to data can be made

--- a/data/trie/leafNode.go
+++ b/data/trie/leafNode.go
@@ -144,7 +144,7 @@ func (ln *leafNode) commitCheckpoint(
 		return nil
 	}
 
-	err = sendNodeOnChannel(ln, leavesChan)
+	err = writeNodeOnChannel(ln, leavesChan)
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func (ln *leafNode) commitSnapshot(
 		return fmt.Errorf("commit snapshot error %w", err)
 	}
 
-	err = sendNodeOnChannel(ln, leavesChan)
+	err = writeNodeOnChannel(ln, leavesChan)
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func (ln *leafNode) commitSnapshot(
 	return encodeNodeAndCommitToDB(ln, targetDb)
 }
 
-func sendNodeOnChannel(ln *leafNode, leavesChan chan core.KeyValueHolder) error {
+func writeNodeOnChannel(ln *leafNode, leavesChan chan core.KeyValueHolder) error {
 	if leavesChan == nil {
 		return nil
 	}

--- a/data/trie/node_test.go
+++ b/data/trie/node_test.go
@@ -564,7 +564,7 @@ func TestPatriciaMerkleTrie_RecreateFromSnapshotSavesStateToMainDb(t *testing.T)
 	_ = tr.Commit()
 
 	rootHash, _ := tr.RootHash()
-	tsm.TakeSnapshot(rootHash, true)
+	tsm.TakeSnapshot(rootHash, true, nil)
 	time.Sleep(snapshotDelay * 2)
 	err := tsm.db.Remove(rootHash)
 	assert.Nil(t, err)

--- a/data/trie/patriciaMerkleTrie.go
+++ b/data/trie/patriciaMerkleTrie.go
@@ -294,7 +294,7 @@ func (tr *patriciaMerkleTrie) recreateFromSnapshotDb(rootHash []byte) (*patricia
 		return nil, err
 	}
 
-	err = newRoot.commitSnapshot(db, tr.trieStorage.Database())
+	err = newRoot.commitSnapshot(db, tr.trieStorage.Database(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/data/trie/patriciaMerkleTrie_test.go
+++ b/data/trie/patriciaMerkleTrie_test.go
@@ -431,7 +431,7 @@ func TestPatriciaMerkleTrie_GetSerializedNodesGetFromSnapshot(t *testing.T) {
 	rootHash, _ := tr.RootHash()
 
 	storageManager := tr.GetStorageManager()
-	storageManager.TakeSnapshot(rootHash, true)
+	storageManager.TakeSnapshot(rootHash, true, nil)
 	time.Sleep(time.Second)
 
 	err := storageManager.Database().Remove(rootHash)
@@ -486,7 +486,7 @@ func TestPatriciaMerkleTrie_GetSerializedNodesFromSnapshotShouldNotCommitToMainD
 	storageManager := tr.GetStorageManager()
 
 	rootHash, _ := tr.RootHash()
-	storageManager.TakeSnapshot(rootHash, true)
+	storageManager.TakeSnapshot(rootHash, true, nil)
 	time.Sleep(time.Second)
 
 	err := storageManager.Database().Remove(rootHash)

--- a/data/trie/sync_test.go
+++ b/data/trie/sync_test.go
@@ -197,7 +197,7 @@ func TestTrieSync_FoundInStorageShouldNotRequest(t *testing.T) {
 	rootHash := bn.getHash()
 	db := mock.NewMemDbMock()
 
-	err = bn.commitSnapshot(db, db)
+	err = bn.commitSnapshot(db, db, nil)
 	require.Nil(t, err)
 
 	arg := createMockArgument()

--- a/data/trie/trieStorageManagerWithoutPruning.go
+++ b/data/trie/trieStorageManagerWithoutPruning.go
@@ -1,6 +1,7 @@
 package trie
 
 import (
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
 	"github.com/ElrondNetwork/elrond-go/data"
 )
@@ -20,12 +21,12 @@ func NewTrieStorageManagerWithoutPruning(db data.DBWriteCacher) (*trieStorageMan
 }
 
 // TakeSnapshot does nothing if pruning is disabled
-func (tsm *trieStorageManagerWithoutPruning) TakeSnapshot(_ []byte, _ bool) {
+func (tsm *trieStorageManagerWithoutPruning) TakeSnapshot(_ []byte, _ bool, _ chan core.KeyValueHolder) {
 	log.Trace("trieStorageManagerWithoutPruning - TakeSnapshot:trie storage pruning is disabled")
 }
 
 // SetCheckpoint does nothing if pruning is disabled
-func (tsm *trieStorageManagerWithoutPruning) SetCheckpoint(_ []byte) {
+func (tsm *trieStorageManagerWithoutPruning) SetCheckpoint(_ []byte, _ chan core.KeyValueHolder) {
 	log.Trace("trieStorageManagerWithoutPruning - SetCheckpoint:trie storage pruning is disabled")
 }
 

--- a/data/trie/trieStorageManagerWithoutPruning_test.go
+++ b/data/trie/trieStorageManagerWithoutPruning_test.go
@@ -27,14 +27,14 @@ func TestTrieStorageManagerWithoutPruning_TakeSnapshotShouldNotPanic(t *testing.
 	t.Parallel()
 
 	ts, _ := NewTrieStorageManagerWithoutPruning(mock.NewMemDbMock())
-	ts.TakeSnapshot([]byte{}, true)
+	ts.TakeSnapshot([]byte{}, true, nil)
 }
 
 func TestTrieStorageManagerWithoutPruning_SetCheckpointShouldNotPanic(t *testing.T) {
 	t.Parallel()
 
 	ts, _ := NewTrieStorageManagerWithoutPruning(mock.NewMemDbMock())
-	ts.SetCheckpoint([]byte{})
+	ts.SetCheckpoint([]byte{}, nil)
 }
 
 func TestTrieStorageManagerWithoutPruning_IsPruningEnabled(t *testing.T) {

--- a/data/trie/trieStorageManager_test.go
+++ b/data/trie/trieStorageManager_test.go
@@ -115,7 +115,7 @@ func TestNewTrieStorageManagerWithExistingSnapshot(t *testing.T) {
 	_ = tr.Update([]byte("dogglesworth"), []byte("cat"))
 	_ = tr.Commit()
 	rootHash, _ := tr.RootHash()
-	trieStorage.TakeSnapshot(rootHash, true)
+	trieStorage.TakeSnapshot(rootHash, true, nil)
 	time.Sleep(snapshotDelay)
 
 	trieStorage.storageOperationMutex.Lock()
@@ -168,7 +168,7 @@ func TestNewTrieStorageManagerLoadsSnapshotsInOrder(t *testing.T) {
 	_ = tr.Update([]byte("dogglesworth"), []byte("cat"))
 	_ = tr.Commit()
 	rootHash, _ := tr.RootHash()
-	trieStorage.TakeSnapshot(rootHash, true)
+	trieStorage.TakeSnapshot(rootHash, true, nil)
 	time.Sleep(snapshotDelay)
 
 	numSnapshots := 10
@@ -176,7 +176,7 @@ func TestNewTrieStorageManagerLoadsSnapshotsInOrder(t *testing.T) {
 		_ = tr.Update([]byte(strconv.Itoa(i)), []byte(strconv.Itoa(i)))
 		_ = tr.Commit()
 		rootHash, _ = tr.RootHash()
-		trieStorage.TakeSnapshot(rootHash, true)
+		trieStorage.TakeSnapshot(rootHash, true, nil)
 		time.Sleep(snapshotDelay)
 	}
 
@@ -221,7 +221,7 @@ func TestRecreateTrieFromSnapshotDb(t *testing.T) {
 	_ = tr.Commit()
 	storageManager := tr.GetStorageManager()
 	rootHash, _ := tr.RootHash()
-	storageManager.TakeSnapshot(rootHash, true)
+	storageManager.TakeSnapshot(rootHash, true, nil)
 	time.Sleep(snapshotDelay)
 
 	err := storageManager.Database().Remove(rootHash)
@@ -253,7 +253,7 @@ func TestEachSnapshotCreatesOwnDatabase(t *testing.T) {
 	for _, testVal := range testVals {
 		_ = tr.Update(testVal.key, testVal.value)
 		_ = tr.Commit()
-		trieStorage.TakeSnapshot(tr.root.getHash(), true)
+		trieStorage.TakeSnapshot(tr.root.getHash(), true, nil)
 		time.Sleep(snapshotDelay)
 
 		trieStorage.storageOperationMutex.Lock()
@@ -287,7 +287,7 @@ func TestDeleteOldSnapshots(t *testing.T) {
 	for _, testVal := range testVals {
 		_ = tr.Update(testVal.key, testVal.value)
 		_ = tr.Commit()
-		trieStorage.TakeSnapshot(tr.root.getHash(), true)
+		trieStorage.TakeSnapshot(tr.root.getHash(), true, nil)
 	}
 	time.Sleep(snapshotDelay)
 
@@ -312,7 +312,7 @@ func TestTrieCheckpoint(t *testing.T) {
 	_ = tr.Update([]byte("dogglesworth"), []byte("cat"))
 
 	_ = tr.Commit()
-	trieStorage.TakeSnapshot(tr.root.getHash(), true)
+	trieStorage.TakeSnapshot(tr.root.getHash(), true, nil)
 	time.Sleep(snapshotDelay)
 
 	_ = tr.Update([]byte("doge"), []byte("reindeer"))
@@ -342,7 +342,7 @@ func TestTrieCheckpoint(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Nil(t, val)
 
-	trieStorage.SetCheckpoint(tr.root.getHash())
+	trieStorage.SetCheckpoint(tr.root.getHash(), nil)
 	time.Sleep(snapshotDelay)
 
 	val, err = snapshotTrie.Get([]byte("doge"))
@@ -361,7 +361,7 @@ func TestTrieCheckpointWithNoSnapshotCreatesSnapshot(t *testing.T) {
 	assert.Equal(t, 0, len(trieStorage.snapshots))
 
 	_ = tr.Commit()
-	trieStorage.SetCheckpoint(tr.root.getHash())
+	trieStorage.SetCheckpoint(tr.root.getHash(), nil)
 	time.Sleep(snapshotDelay)
 
 	trieStorage.storageOperationMutex.Lock()
@@ -378,7 +378,7 @@ func TestTrieSnapshottingAndCheckpointConcurrently(t *testing.T) {
 	_ = tr.Update([]byte("dogglesworth"), []byte("cat"))
 	_ = tr.Commit()
 
-	trieStorage.TakeSnapshot(tr.root.getHash(), true)
+	trieStorage.TakeSnapshot(tr.root.getHash(), true, nil)
 	time.Sleep(snapshotDelay)
 
 	numSnapshots := 5
@@ -397,7 +397,7 @@ func TestTrieSnapshottingAndCheckpointConcurrently(t *testing.T) {
 			_ = tr.Update([]byte(strconv.Itoa(j)), []byte(strconv.Itoa(j)))
 			_ = tr.Commit()
 			rootHash, _ := tr.RootHash()
-			trieStorage.TakeSnapshot(rootHash, true)
+			trieStorage.TakeSnapshot(rootHash, true, nil)
 			mut.Unlock()
 			snapshotWg.Done()
 		}(i)
@@ -412,7 +412,7 @@ func TestTrieSnapshottingAndCheckpointConcurrently(t *testing.T) {
 			rootHash, _ := tr.RootHash()
 
 			trieStorage.AddDirtyCheckpointHashes(rootHash, newHashes)
-			trieStorage.SetCheckpoint(rootHash)
+			trieStorage.SetCheckpoint(rootHash, nil)
 			mut.Unlock()
 			checkpointWg.Done()
 		}(i)
@@ -447,14 +447,14 @@ func TestIsPresentInLastSnapshotDb(t *testing.T) {
 
 	_ = tr.Commit()
 	rootHash1, _ := tr.RootHash()
-	trieStorage.TakeSnapshot(rootHash1, true)
+	trieStorage.TakeSnapshot(rootHash1, true, nil)
 	time.Sleep(snapshotDelay)
 
 	_ = tr.Update([]byte("dog"), []byte("puppy"))
 
 	_ = tr.Commit()
 	rootHash2, _ := tr.RootHash()
-	trieStorage.TakeSnapshot(rootHash2, true)
+	trieStorage.TakeSnapshot(rootHash2, true, nil)
 	time.Sleep(snapshotDelay)
 
 	trieStorage.storageOperationMutex.Lock()
@@ -478,14 +478,14 @@ func TestTrieSnapshotChecksOnlyLastSnapshotDbForTheHash(t *testing.T) {
 
 	_ = tr.Commit()
 	rootHash1, _ := tr.RootHash()
-	trieStorage.TakeSnapshot(rootHash1, true)
+	trieStorage.TakeSnapshot(rootHash1, true, nil)
 	time.Sleep(snapshotDelay)
 
 	_ = tr.Update([]byte("dog"), []byte("puppy"))
 
 	_ = tr.Commit()
 	rootHash2, _ := tr.RootHash()
-	trieStorage.TakeSnapshot(rootHash2, true)
+	trieStorage.TakeSnapshot(rootHash2, true, nil)
 	time.Sleep(snapshotDelay)
 
 	trieStorage.storageOperationMutex.Lock()
@@ -509,14 +509,14 @@ func TestShouldNotRemoveSnapshotDbIfItIsStillInUse(t *testing.T) {
 
 	_ = tr.Commit()
 	rootHash1, _ := tr.RootHash()
-	trieStorage.TakeSnapshot(rootHash1, true)
+	trieStorage.TakeSnapshot(rootHash1, true, nil)
 	time.Sleep(snapshotDelay)
 
 	_ = tr.Update([]byte("dog"), []byte("puppy"))
 
 	_ = tr.Commit()
 	rootHash2, _ := tr.RootHash()
-	trieStorage.TakeSnapshot(rootHash2, true)
+	trieStorage.TakeSnapshot(rootHash2, true, nil)
 	time.Sleep(snapshotDelay)
 
 	db := trieStorage.GetSnapshotThatContainsHash(rootHash1)
@@ -525,7 +525,7 @@ func TestShouldNotRemoveSnapshotDbIfItIsStillInUse(t *testing.T) {
 
 	_ = tr.Commit()
 	rootHash3, _ := tr.RootHash()
-	trieStorage.TakeSnapshot(rootHash3, true)
+	trieStorage.TakeSnapshot(rootHash3, true, nil)
 	time.Sleep(snapshotDelay)
 
 	val, err := db.Get(rootHash1)
@@ -551,7 +551,7 @@ func TestShouldNotRemoveSnapshotDbsIfKeepSnapshotsTrue(t *testing.T) {
 		_ = tr.Update([]byte(key), []byte(value))
 		_ = tr.Commit()
 		rootHash, _ := tr.RootHash()
-		trieStorage.TakeSnapshot(rootHash, true)
+		trieStorage.TakeSnapshot(rootHash, true, nil)
 		time.Sleep(snapshotDelay)
 	}
 
@@ -579,7 +579,7 @@ func TestShouldRemoveSnapshotDbsIfKeepSnapshotsFalse(t *testing.T) {
 		_ = tr.Update([]byte(key), []byte(value))
 		_ = tr.Commit()
 		rootHash, _ := tr.RootHash()
-		trieStorage.TakeSnapshot(rootHash, true)
+		trieStorage.TakeSnapshot(rootHash, true, nil)
 		time.Sleep(snapshotDelay)
 	}
 
@@ -610,14 +610,14 @@ func TestShouldNotDisconnectSnapshotDbIfItIsStillInUse(t *testing.T) {
 
 	_ = tr.Commit()
 	rootHash1, _ := tr.RootHash()
-	trieStorage.TakeSnapshot(rootHash1, true)
+	trieStorage.TakeSnapshot(rootHash1, true, nil)
 	time.Sleep(snapshotDelay)
 
 	_ = tr.Update([]byte("dog"), []byte("puppy"))
 
 	_ = tr.Commit()
 	rootHash2, _ := tr.RootHash()
-	trieStorage.TakeSnapshot(rootHash2, true)
+	trieStorage.TakeSnapshot(rootHash2, true, nil)
 	time.Sleep(snapshotDelay)
 
 	db := trieStorage.GetSnapshotThatContainsHash(rootHash1)
@@ -626,7 +626,7 @@ func TestShouldNotDisconnectSnapshotDbIfItIsStillInUse(t *testing.T) {
 
 	_ = tr.Commit()
 	rootHash3, _ := tr.RootHash()
-	trieStorage.TakeSnapshot(rootHash3, true)
+	trieStorage.TakeSnapshot(rootHash3, true, nil)
 	time.Sleep(snapshotDelay)
 
 	val, err := db.Get(rootHash1)

--- a/storage/storageCacherAdapter/storageCacherAdapter.go
+++ b/storage/storageCacherAdapter/storageCacherAdapter.go
@@ -52,15 +52,10 @@ func NewStorageCacherAdapter(
 	}, nil
 }
 
-// Clear clears the underlying cacher and db
+// Clear clears the cache
 func (c *storageCacherAdapter) Clear() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-
-	err := c.db.Destroy()
-	if err != nil {
-		log.Error("could not destroy the db", "err", err.Error())
-	}
 
 	c.cacher.Purge()
 }

--- a/testscommon/storageManagerStub.go
+++ b/testscommon/storageManagerStub.go
@@ -1,14 +1,15 @@
 package testscommon
 
 import (
+	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/data"
 )
 
 // StorageManagerStub -
 type StorageManagerStub struct {
 	DatabaseCalled                    func() data.DBWriteCacher
-	TakeSnapshotCalled                func([]byte, bool)
-	SetCheckpointCalled               func([]byte)
+	TakeSnapshotCalled                func([]byte, bool, chan core.KeyValueHolder)
+	SetCheckpointCalled               func([]byte, chan core.KeyValueHolder)
 	GetDbThatContainsHashCalled       func([]byte) data.DBWriteCacher
 	GetSnapshotThatContainsHashCalled func(rootHash []byte) data.SnapshotDbHandler
 	IsPruningEnabledCalled            func() bool
@@ -29,16 +30,16 @@ func (sms *StorageManagerStub) Database() data.DBWriteCacher {
 }
 
 // TakeSnapshot -
-func (sms *StorageManagerStub) TakeSnapshot(rootHash []byte, newDB bool) {
+func (sms *StorageManagerStub) TakeSnapshot(rootHash []byte, newDB bool, leavesChan chan core.KeyValueHolder) {
 	if sms.TakeSnapshotCalled != nil {
-		sms.TakeSnapshotCalled(rootHash, newDB)
+		sms.TakeSnapshotCalled(rootHash, newDB, leavesChan)
 	}
 }
 
 // SetCheckpoint -
-func (sms *StorageManagerStub) SetCheckpoint(rootHash []byte) {
+func (sms *StorageManagerStub) SetCheckpoint(rootHash []byte, leavesChan chan core.KeyValueHolder) {
 	if sms.SetCheckpointCalled != nil {
-		sms.SetCheckpointCalled(rootHash)
+		sms.SetCheckpointCalled(rootHash, leavesChan)
 	}
 }
 


### PR DESCRIPTION
On state checkpoint and snapshot, when traversing the main trie to verify what nodes need to be commited to the snapshot DB, return all leaves found on a channel, so that subsequent data tries can be commited directly, without another main trie traversing.