### PR TITLE
Remove token type from log entry

### DIFF
--- a/process/smartContract/builtInFunctions/esdtNFTCreate.go
+++ b/process/smartContract/builtInFunctions/esdtNFTCreate.go
@@ -126,14 +126,12 @@ func (e *esdtNFTCreate) ProcessBuiltinFunction(
 		return nil, fmt.Errorf("%w, invalid quantity", process.ErrInvalidArguments)
 	}
 
-	tokenType := core.NonFungibleESDT
 	if quantity.Cmp(big.NewInt(1)) > 0 {
 		err = e.rolesHandler.CheckAllowedToExecute(acntSnd, vmInput.Arguments[0], []byte(core.ESDTRoleNFTAddQuantity))
 		if err != nil {
 			return nil, err
 		}
 
-		tokenType = core.SemiFungibleESDT
 	}
 
 	nextNonce := nonce + 1
@@ -162,7 +160,6 @@ func (e *esdtNFTCreate) ProcessBuiltinFunction(
 	}
 
 	logEntry := newEntryForNFT(core.BuiltInFunctionESDTNFTCreate, vmInput.CallerAddr, tokenID, nextNonce)
-	logEntry.Topics = append(logEntry.Topics, []byte(tokenType))
 
 	vmOutput := &vmcommon.VMOutput{
 		ReturnCode:   vmcommon.Ok,


### PR DESCRIPTION
Removed token type from log entry that is generated on the NFTCreate.
We cannot know the token type from shard perspective.