### PR TITLE
BlockChainHook return same pointer on LoadAccounts

### DIFF
--- a/process/smartContract/hooks/blockChainHook.go
+++ b/process/smartContract/hooks/blockChainHook.go
@@ -428,6 +428,10 @@ func (bh *BlockChainHookImpl) getUserAccounts(
 		if !ok {
 			return nil, nil, process.ErrWrongTypeAssertion
 		}
+
+		if bytes.Equal(input.CallerAddr, input.RecipientAddr) {
+			return sndAccount, sndAccount, nil
+		}
 	}
 
 	var dstAccount vmcommon.UserAccountHandler


### PR DESCRIPTION
return same pointer if bytes are equal on load account