### PR TITLE
update arwen and vm-common

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ElrondNetwork/concurrent-map v0.1.3
 	github.com/ElrondNetwork/elastic-indexer-go v1.0.7
 	github.com/ElrondNetwork/elrond-go-logger v1.0.4
-	github.com/ElrondNetwork/elrond-vm-common v0.3.4-0.20210707100510-6cef7cea933f
+	github.com/ElrondNetwork/elrond-vm-common v1.0.0
 	github.com/beevik/ntp v0.3.0
 	github.com/btcsuite/btcd v0.22.0-beta
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
@@ -49,4 +49,4 @@ require (
 
 replace github.com/gogo/protobuf => github.com/ElrondNetwork/protobuf v1.3.2
 
-replace github.com/ElrondNetwork/arwen-wasm-vm/v1_3 v1.3.19 => github.com/ElrondNetwork/arwen-wasm-vm v1.3.20-0.20210707101801-4f643c5e630b
+replace github.com/ElrondNetwork/arwen-wasm-vm/v1_3 v1.3.19 => github.com/ElrondNetwork/arwen-wasm-vm v1.3.20-0.20210709090429-e03405ee6e0b

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/ElrondNetwork/arwen-wasm-vm v1.2.24-0.20210625151658-9d052957d105 h1:
 github.com/ElrondNetwork/arwen-wasm-vm v1.2.24-0.20210625151658-9d052957d105/go.mod h1:eic6T0rZK5zR2ZOsbsxMPaXBV8GJpG6FfpgNzr81Fqg=
 github.com/ElrondNetwork/arwen-wasm-vm v1.3.20-0.20210707101801-4f643c5e630b h1:mVgKatDJ+szpanDjlXURBsqYQs5xkyIO3pKYADNkYe4=
 github.com/ElrondNetwork/arwen-wasm-vm v1.3.20-0.20210707101801-4f643c5e630b/go.mod h1:JEmB2IcgZ1cxWYQJ4PVfIqYhPSuI504kdiSK9+bY4Z8=
+github.com/ElrondNetwork/arwen-wasm-vm v1.3.20-0.20210709090429-e03405ee6e0b h1:gfYib9wLSI/Zg8XDjlRGWgo/LhCux2c406o1KHPEclo=
+github.com/ElrondNetwork/arwen-wasm-vm v1.3.20-0.20210709090429-e03405ee6e0b/go.mod h1:3XzZd7XRHqCX1Vuu+Qpi5HFfcJt4S8DY9QJclE0BaL0=
 github.com/ElrondNetwork/big-int-util v0.0.5/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg1IJLPAK6GVHMbC7Aw4=
 github.com/ElrondNetwork/big-int-util v0.1.0 h1:vTMoJ5azhVmr7jhpSD3JUjQdkdyXoEPVkOvhdw1RjV4=
 github.com/ElrondNetwork/big-int-util v0.1.0/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg1IJLPAK6GVHMbC7Aw4=
@@ -77,6 +79,8 @@ github.com/ElrondNetwork/elrond-vm-common v0.3.4-0.20210625102705-01a81e6a1fa4/g
 github.com/ElrondNetwork/elrond-vm-common v0.3.4-0.20210625150635-525789454b6f/go.mod h1:7hBvPplhnrputKHXcrO0oZEdws87Exatc3PMt3XAL/k=
 github.com/ElrondNetwork/elrond-vm-common v0.3.4-0.20210707100510-6cef7cea933f h1:972J5HdUMwSCgOrBBh1guafiAAIaUCfblvfCT3I5NRU=
 github.com/ElrondNetwork/elrond-vm-common v0.3.4-0.20210707100510-6cef7cea933f/go.mod h1:7hBvPplhnrputKHXcrO0oZEdws87Exatc3PMt3XAL/k=
+github.com/ElrondNetwork/elrond-vm-common v1.0.0 h1:tE9+AFxy6yZSDF0OGjhAuU919UFZrtxN2BZJ8/rAlBk=
+github.com/ElrondNetwork/elrond-vm-common v1.0.0/go.mod h1:7hBvPplhnrputKHXcrO0oZEdws87Exatc3PMt3XAL/k=
 github.com/ElrondNetwork/elrond-vm-util v0.3.5/go.mod h1:+ecDJZLTwN/yeRXXEqd+sa9WoalLsT4nFtQWCo0YKWA=
 github.com/ElrondNetwork/elrond-vm-util v0.4.5/go.mod h1:YqFO7HkKfBnVQesisZuJ/Qce0/oTOnqx562iZCb8El0=
 github.com/ElrondNetwork/protobuf v1.3.2 h1:qoCSYiO+8GtXBEZWEjw0WPcZfM3g7QuuJrwpN+y6Mvg=

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,6 @@ github.com/ElrondNetwork/arwen-wasm-vm v1.2.0/go.mod h1:Io5YGUs48YNnXlyJYSBX6Evx
 github.com/ElrondNetwork/arwen-wasm-vm v1.2.7/go.mod h1:Q+ay1aQID+M4q/PWcE9Jmheojpu9nkmOuv1eSDmpBwE=
 github.com/ElrondNetwork/arwen-wasm-vm v1.2.24-0.20210625151658-9d052957d105 h1:7PVr2hCSq8OnEGY9AtBX5v2aNNdmVe+Y7qAo8pB6WYM=
 github.com/ElrondNetwork/arwen-wasm-vm v1.2.24-0.20210625151658-9d052957d105/go.mod h1:eic6T0rZK5zR2ZOsbsxMPaXBV8GJpG6FfpgNzr81Fqg=
-github.com/ElrondNetwork/arwen-wasm-vm v1.3.20-0.20210707101801-4f643c5e630b h1:mVgKatDJ+szpanDjlXURBsqYQs5xkyIO3pKYADNkYe4=
-github.com/ElrondNetwork/arwen-wasm-vm v1.3.20-0.20210707101801-4f643c5e630b/go.mod h1:JEmB2IcgZ1cxWYQJ4PVfIqYhPSuI504kdiSK9+bY4Z8=
 github.com/ElrondNetwork/arwen-wasm-vm v1.3.20-0.20210709090429-e03405ee6e0b h1:gfYib9wLSI/Zg8XDjlRGWgo/LhCux2c406o1KHPEclo=
 github.com/ElrondNetwork/arwen-wasm-vm v1.3.20-0.20210709090429-e03405ee6e0b/go.mod h1:3XzZd7XRHqCX1Vuu+Qpi5HFfcJt4S8DY9QJclE0BaL0=
 github.com/ElrondNetwork/big-int-util v0.0.5/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg1IJLPAK6GVHMbC7Aw4=
@@ -77,8 +75,6 @@ github.com/ElrondNetwork/elrond-vm-common v0.1.23/go.mod h1:ZakxPST/Wt8umnRtA9go
 github.com/ElrondNetwork/elrond-vm-common v0.3.3/go.mod h1:ZakxPST/Wt8umnRtA9gobcy3Dw2bywxwkC54P5VhO9g=
 github.com/ElrondNetwork/elrond-vm-common v0.3.4-0.20210625102705-01a81e6a1fa4/go.mod h1:Knh5+i+BvTcn/QMT+COzeb76ZqMHGeijS6gbac25RPc=
 github.com/ElrondNetwork/elrond-vm-common v0.3.4-0.20210625150635-525789454b6f/go.mod h1:7hBvPplhnrputKHXcrO0oZEdws87Exatc3PMt3XAL/k=
-github.com/ElrondNetwork/elrond-vm-common v0.3.4-0.20210707100510-6cef7cea933f h1:972J5HdUMwSCgOrBBh1guafiAAIaUCfblvfCT3I5NRU=
-github.com/ElrondNetwork/elrond-vm-common v0.3.4-0.20210707100510-6cef7cea933f/go.mod h1:7hBvPplhnrputKHXcrO0oZEdws87Exatc3PMt3XAL/k=
 github.com/ElrondNetwork/elrond-vm-common v1.0.0 h1:tE9+AFxy6yZSDF0OGjhAuU919UFZrtxN2BZJ8/rAlBk=
 github.com/ElrondNetwork/elrond-vm-common v1.0.0/go.mod h1:7hBvPplhnrputKHXcrO0oZEdws87Exatc3PMt3XAL/k=
 github.com/ElrondNetwork/elrond-vm-util v0.3.5/go.mod h1:+ecDJZLTwN/yeRXXEqd+sa9WoalLsT4nFtQWCo0YKWA=

--- a/process/smartContract/process.go
+++ b/process/smartContract/process.go
@@ -886,7 +886,19 @@ func (sc *scProcessor) ExecuteBuiltInFunction(
 		}
 	}
 
+	mergeVMOutputLogs(newVMOutput, vmOutput)
+
 	return sc.finishSCExecution(scrResults, txHash, tx, newVMOutput, builtInFuncGasUsed)
+}
+
+func mergeVMOutputLogs(newVMOutput *vmcommon.VMOutput, vmOutput *vmcommon.VMOutput) {
+	if len(vmOutput.Logs) == 0 {
+		return
+	}
+	if newVMOutput.Logs == nil {
+		newVMOutput.Logs = make([]*vmcommon.LogEntry, 0, len(vmOutput.Logs))
+	}
+	newVMOutput.Logs = append(newVMOutput.Logs, vmOutput.Logs...)
 }
 
 func (sc *scProcessor) processSCRForSenderAfterBuiltIn(

--- a/process/smartContract/process.go
+++ b/process/smartContract/process.go
@@ -859,6 +859,8 @@ func (sc *scProcessor) ExecuteBuiltInFunction(
 		if len(newSCRTxs) > 0 {
 			scrResults = append(scrResults, newSCRTxs...)
 		}
+
+		mergeVMOutputLogs(newVMOutput, vmOutput)
 	}
 
 	isSCCallCrossShard := !isSCCallSelfShard && txTypeOnDst == process.SCInvoking
@@ -885,8 +887,6 @@ func (sc *scProcessor) ExecuteBuiltInFunction(
 			scrResults = append(scrResults, scrForRelayer)
 		}
 	}
-
-	mergeVMOutputLogs(newVMOutput, vmOutput)
 
 	return sc.finishSCExecution(scrResults, txHash, tx, newVMOutput, builtInFuncGasUsed)
 }

--- a/process/smartContract/process.go
+++ b/process/smartContract/process.go
@@ -895,6 +895,7 @@ func mergeVMOutputLogs(newVMOutput *vmcommon.VMOutput, vmOutput *vmcommon.VMOutp
 	if len(vmOutput.Logs) == 0 {
 		return
 	}
+
 	if newVMOutput.Logs == nil {
 		newVMOutput.Logs = make([]*vmcommon.LogEntry, 0, len(vmOutput.Logs))
 	}

--- a/process/smartContract/process_test.go
+++ b/process/smartContract/process_test.go
@@ -3871,3 +3871,46 @@ func computeExpectedResults(
 	}
 	return expectedTotalFee, expectedDevFees
 }
+
+func TestMergeVmOutputLogs(t *testing.T) {
+	t.Parallel()
+
+	vmOutput1 := &vmcommon.VMOutput{
+		Logs: nil,
+	}
+
+	vmOutput2 := &vmcommon.VMOutput{
+		Logs: nil,
+	}
+
+	mergeVMOutputLogs(vmOutput1, vmOutput2)
+	require.Nil(t, vmOutput1.Logs)
+
+	vmOutput1 = &vmcommon.VMOutput{
+		Logs: nil,
+	}
+
+	vmOutput2 = &vmcommon.VMOutput{
+		Logs: []*vmcommon.LogEntry{
+			{},
+		},
+	}
+
+	mergeVMOutputLogs(vmOutput1, vmOutput2)
+	require.Len(t, vmOutput1.Logs, 1)
+
+	vmOutput1 = &vmcommon.VMOutput{
+		Logs: []*vmcommon.LogEntry{
+			{},
+		},
+	}
+
+	vmOutput2 = &vmcommon.VMOutput{
+		Logs: []*vmcommon.LogEntry{
+			{},
+		},
+	}
+
+	mergeVMOutputLogs(vmOutput1, vmOutput2)
+	require.Len(t, vmOutput1.Logs, 2)
+}


### PR DESCRIPTION
Use latest commit from [arwen repository](https://github.com/ElrondNetwork/arwen-wasm-vm/commit/e03405ee6e0b63c9d2cf7da75c2cb06a4d94de73)

Use the latest release from [vm-common](https://github.com/ElrondNetwork/elrond-vm-common/releases/tag/v1.0.0) repository. 