### PR TITLE
Fixed merge error in nodeTransactions.go

### DIFF
--- a/node/nodeTransactions.go
+++ b/node/nodeTransactions.go
@@ -351,7 +351,6 @@ func (n *Node) prepareUnsignedTx(tx *smartContractResult.SmartContractResult) (*
 		CodeMetadata:            tx.GetCodeMetadata(),
 		PreviousTransactionHash: hex.EncodeToString(tx.GetPrevTxHash()),
 		OriginalTransactionHash: hex.EncodeToString(tx.GetOriginalTxHash()),
-		OriginalSender:          n.coreComponents.AddressPubKeyConverter().Encode(tx.GetOriginalSender()),
 		ReturnMessage:           string(tx.GetReturnMessage()),
 	}
 	if len(tx.GetOriginalSender()) == n.coreComponents.AddressPubKeyConverter().Len() {


### PR DESCRIPTION
- fixed merge error in nodeTransactions.go
The warning was:
```
DEBUG[2021-08-10 11:56:15.092]   bech32PubkeyConverter.Encode PkBytesLength hex buff =  error = wrong size stack trace = goroutine 23238 [running]:
runtime/debug.Stack(0x0, 0x36dbf80, 0x0)
        /usr/local/go/src/runtime/debug/stack.go:24 +0x9f
github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter.(*bech32PubkeyConverter).Encode(0xc00092d820, 0x0, 0x0, 0x0, 0x40, 0x20)
        /home/ubuntu/go/pkg/mod/github.com/!elrond!network/elrond-go-core@v1.0.1-0.20210802100738-75f99b3e75a0/core/pubkeyConverter/bech32PubkeyConverter.go:88 +0x105
github.com/ElrondNetwork/elrond-go/node.(*Node).prepareUnsignedTx(0xc0166643c0, 0xc001fab7a0, 0xc001fab7a0, 0xc01f3ba790, 0xa6)
        /home/ubuntu/go/src/github.com/ElrondNetwork/elrond-go/node/nodeTransactions.go:354 +0x465
github.com/ElrondNetwork/elrond-go/node.(*Node).unmarshalTransaction(0xc0166643c0, 0xc01f3ba790, 0xa6, 0xa6, 0x2009e8f, 0x8, 0x43f405, 0xc00ef0f018, 0x36dbf80)
        /home/ubuntu/go/src/github.com/ElrondNetwork/elrond-go/node/nodeTransactions.go:285 +0x4dd
github.com/ElrondNetwork/elrond-go/node/blockAPI.(*baseAPIBlockProcessor).getTxsFromMiniblock(0xc012435440, 0xc01a36f1c0, 0xc020382160, 0x20, 0x20, 0x2a8, 0x2009e8f, 0x8, 0x5, 0x0, ...)
        /home/ubuntu/go/src/github.com/ElrondNetwork/elrond-go/node/blockAPI/baseBlock.go:95 +0x34b
github.com/ElrondNetwork/elrond-go/node/blockAPI.(*baseAPIBlockProcessor).getTxsByMb(0xc012435440, 0xc00ef0f2c0, 0x2a8, 0xc0205f2480, 0x40, 0x20)
        /home/ubuntu/go/src/github.com/ElrondNetwork/elrond-go/node/blockAPI/baseBlock.go:67 +0x448
github.com/ElrondNetwork/elrond-go/node/blockAPI.(*shardAPIBlockProcessor).convertShardBlockBytesToAPIBlock(0xc018702b18, 0xc0205f2140, 0x20, 0x40, 0xc01fd3b860, 0x1df, 0x1df, 0x101, 0x0, 0x0, ...)
        /home/ubuntu/go/src/github.com/ElrondNetwork/elrond-go/node/blockAPI/shardBlock.go:96 +0x9e7
github.com/ElrondNetwork/elrond-go/node/blockAPI.(*shardAPIBlockProcessor).GetBlockByHash(0xc018702b18, 0xc0205f2140, 0x20, 0x40, 0x1, 0x40, 0x20, 0x0)
        /home/ubuntu/go/src/github.com/ElrondNetwork/elrond-go/node/blockAPI/shardBlock.go:60 +0xc5
github.com/ElrondNetwork/elrond-go/node.(*Node).GetBlockByHash(0xc0166643c0, 0xc0112cc633, 0x40, 0x503a01, 0x6112695f, 0x57342ac, 0x2af56f77c232b9)
        /home/ubuntu/go/src/github.com/ElrondNetwork/elrond-go/node/nodeBlocks.go:25 +0x11f
github.com/ElrondNetwork/elrond-go/facade.(*nodeFacade).GetBlockByHash(0xc01076fa40, 0xc0112cc633, 0x40, 0x1, 0x4, 0xc0112cc633, 0x40)
        /home/ubuntu/go/src/github.com/ElrondNetwork/elrond-go/facade/nodeFacade.go:379 +0x50
github.com/ElrondNetwork/elrond-go/api/block.getBlockByHash(0xc001a35600)
        /home/ubuntu/go/src/github.com/ElrondNetwork/elrond-go/api/block/routes.go:99 +0x148
github.com/gin-gonic/gin.(*Context).Next(0xc001a35600)
        /home/ubuntu/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x3b
github.com/ElrondNetwork/elrond-go/api/middleware.(*globalThrottler).MiddlewareHandlerFunc.func1(0xc001a35600)
        /home/ubuntu/go/src/github.com/ElrondNetwork/elrond-go/api/middleware/globalThrottler.go:62 +0x14f
github.com/gin-gonic/gin.(*Context).Next(0xc001a35600)
        /home/ubuntu/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x3b
github.com/ElrondNetwork/elrond-go/api/middleware.(*sourceThrottler).MiddlewareHandlerFunc.func1(0xc001a35600)
        /home/ubuntu/go/src/github.com/ElrondNetwork/elrond-go/api/middleware/sourceThrottler.go:67 +0x2f6
github.com/gin-gonic/gin.(*Context).Next(0xc001a35600)
        /home/ubuntu/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x3b
github.com/ElrondNetwork/elrond-go/api/middleware.WithFacade.func1(0xc001a35600)
        /home/ubuntu/go/src/github.com/ElrondNetwork/elrond-go/api/middleware/middleware.go:15 +0x65
github.com/gin-gonic/gin.(*Context).Next(0xc001a35600)
        /home/ubuntu/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x3b
github.com/gin-gonic/gin.CustomRecoveryWithWriter.func1(0xc001a35600)
        /home/ubuntu/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/recovery.go:99 +0x69
github.com/gin-gonic/gin.(*Context).Next(0xc001a35600)
        /home/ubuntu/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x3b
github.com/gin-gonic/gin.LoggerWithConfig.func1(0xc001a35600)
        /home/ubuntu/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/logger.go:241 +0xe5
github.com/gin-gonic/gin.(*Context).Next(0xc001a35600)
        /home/ubuntu/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x3b
github.com/gin-gonic/gin.(*Engine).handleHTTPRequest(0xc01a3251e0, 0xc001a35600)
        /home/ubuntu/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:489 +0x618
github.com/gin-gonic/gin.(*Engine).ServeHTTP(0xc01a3251e0, 0x24b6b80, 0xc0107a2d20, 0xc0123a0d00)
        /home/ubuntu/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:445 +0x15c
net/http.serverHandler.ServeHTTP(0xc0167b5340, 0x24b6b80, 0xc0107a2d20, 0xc0123a0d00)
        /usr/local/go/src/net/http/server.go:2843 +0xa3
net/http.(*conn).serve(0xc00a809c20, 0x24bd140, 0xc01fd3d400)
        /usr/local/go/src/net/http/server.go:1925 +0x8ad
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:2969 +0x36c
```

testing scenario: start a testnet with SC calls. Find a block that contains SC calls & smart contract results (using the testnet explorer). Query the observer node from that shard with the following get request:
`http://ip.of.the.node:8080/block/by-hash/[hash]`
ensure that the received data, having json marshalized smartcontract results properly display the `OriginalSender` field (either an erd1... address or the field is empty/missing)
GREP the observer node's log with the following string "bech32PubkeyConverter.Encode" -> should not find any results
