### PR TITLE
Fixed OOMs 2021.08.31

### DIFF
--- a/state/syncer/userAccountsSyncer.go
+++ b/state/syncer/userAccountsSyncer.go
@@ -142,7 +142,8 @@ func (u *userAccountsSyncer) syncAccountDataTries(rootHashes [][]byte, ssh data.
 		//throttler.StartProcessing is required to be here as it prevent the following edge-case:
 		//loop does 100k iterations because throttler.CanProcess allows it and starts 100k go routines that can
 		//not execute their first instructions that could tell the throttler they have started.
-		//This will end up in an OOM exception.
+		//Telling the throttler the processing has started here will prevent OOM exception because of too many go
+		//routines started.
 		u.throttler.StartProcessing()
 
 		go func(trieRootHash []byte) {

--- a/state/syncer/userAccountsSyncer.go
+++ b/state/syncer/userAccountsSyncer.go
@@ -139,7 +139,15 @@ func (u *userAccountsSyncer) syncAccountDataTries(rootHashes [][]byte, ssh data.
 			}
 		}
 
+		//throttler.StartProcessing is required to be here as it prevent the following edge-case:
+		//loop does 100k iterations because throttler.CanProcess allows it and starts 100k go routines that can
+		//not execute their first instructions that could tell the throttler they have started.
+		//This will end up in an OOM exception.
+		u.throttler.StartProcessing()
+
 		go func(trieRootHash []byte) {
+			defer u.throttler.EndProcessing()
+
 			log.Trace("sync data trie", "roothash", trieRootHash)
 			newErr := u.syncDataTrie(trieRootHash, ssh, ctx)
 			if newErr != nil {
@@ -162,9 +170,6 @@ func (u *userAccountsSyncer) syncAccountDataTries(rootHashes [][]byte, ssh data.
 }
 
 func (u *userAccountsSyncer) syncDataTrie(rootHash []byte, ssh data.SyncStatisticsHandler, ctx context.Context) error {
-	u.throttler.StartProcessing()
-	defer u.throttler.EndProcessing()
-
 	u.syncerMutex.Lock()
 	_, ok := u.dataTries[string(rootHash)]
 	if ok {

--- a/trie/trieStorageManager.go
+++ b/trie/trieStorageManager.go
@@ -327,7 +327,7 @@ func (tsm *trieStorageManager) safelyCloseChan(ch chan core.KeyValueHolder) {
 
 func (tsm *trieStorageManager) finishOperation(snapshotEntry *snapshotsQueueEntry, message string) {
 	tsm.ExitPruningBufferingMode()
-	log.Debug(message, "rootHash", snapshotEntry.rootHash)
+	log.Trace(message, "rootHash", snapshotEntry.rootHash)
 	tsm.safelyCloseChan(snapshotEntry.leavesChan)
 }
 

--- a/trie/trieStorageManager.go
+++ b/trie/trieStorageManager.go
@@ -96,12 +96,11 @@ func NewTrieStorageManager(args NewTrieStorageManagerArgs) (*trieStorageManager,
 		closer:                 closing.NewSafeChanCloser(),
 	}
 
-	go tsm.doCheckpintsAndSnapshots(ctx, args.Marshalizer, args.Hasher)
+	go tsm.doCheckpointsAndSnapshots(ctx, args.Marshalizer, args.Hasher)
 	return tsm, nil
 }
 
-//nolint
-func (tsm *trieStorageManager) doCheckpintsAndSnapshots(ctx context.Context, msh marshal.Marshalizer, hsh hashing.Hasher) {
+func (tsm *trieStorageManager) doCheckpointsAndSnapshots(ctx context.Context, msh marshal.Marshalizer, hsh hashing.Hasher) {
 	tsm.doProcessLoop(ctx, msh, hsh)
 	tsm.cleanupChans()
 }
@@ -130,6 +129,7 @@ func (tsm *trieStorageManager) cleanupChans() {
 		case entry := <-tsm.checkpointReq:
 			tsm.finishOperation(entry, "trie checkpoint finished on cleanup")
 		default:
+			log.Debug("finished trieStorageManager.cleanupChans")
 			return
 		}
 	}

--- a/trie/trieStorageManager.go
+++ b/trie/trieStorageManager.go
@@ -96,12 +96,17 @@ func NewTrieStorageManager(args NewTrieStorageManagerArgs) (*trieStorageManager,
 		closer:                 closing.NewSafeChanCloser(),
 	}
 
-	go tsm.storageProcessLoop(ctx, args.Marshalizer, args.Hasher)
+	go tsm.doCheckpintsAndSnapshots(ctx, args.Marshalizer, args.Hasher)
 	return tsm, nil
 }
 
 //nolint
-func (tsm *trieStorageManager) storageProcessLoop(ctx context.Context, msh marshal.Marshalizer, hsh hashing.Hasher) {
+func (tsm *trieStorageManager) doCheckpintsAndSnapshots(ctx context.Context, msh marshal.Marshalizer, hsh hashing.Hasher) {
+	tsm.doProcessLoop(ctx, msh, hsh)
+	tsm.cleanupChans()
+}
+
+func (tsm *trieStorageManager) doProcessLoop(ctx context.Context, msh marshal.Marshalizer, hsh hashing.Hasher) {
 	for {
 		select {
 		case snapshotRequest := <-tsm.snapshotReq:
@@ -110,6 +115,21 @@ func (tsm *trieStorageManager) storageProcessLoop(ctx context.Context, msh marsh
 			tsm.takeCheckpoint(snapshotRequest, msh, hsh, ctx)
 		case <-ctx.Done():
 			log.Debug("trieStorageManager.storageProcessLoop go routine is closing...")
+			return
+		}
+	}
+}
+
+func (tsm *trieStorageManager) cleanupChans() {
+	<-tsm.closer.ChanClose()
+	//at this point we can not add new entries in the snapshot/checkpoint chans
+	for {
+		select {
+		case entry := <-tsm.snapshotReq:
+			tsm.finishOperation(entry, "trie snapshot finished on cleanup")
+		case entry := <-tsm.checkpointReq:
+			tsm.finishOperation(entry, "trie checkpoint finished on cleanup")
+		default:
 			return
 		}
 	}
@@ -305,14 +325,14 @@ func (tsm *trieStorageManager) safelyCloseChan(ch chan core.KeyValueHolder) {
 	}
 }
 
+func (tsm *trieStorageManager) finishOperation(snapshotEntry *snapshotsQueueEntry, message string) {
+	tsm.ExitPruningBufferingMode()
+	log.Debug(message, "rootHash", snapshotEntry.rootHash)
+	tsm.safelyCloseChan(snapshotEntry.leavesChan)
+}
+
 func (tsm *trieStorageManager) takeSnapshot(snapshotEntry *snapshotsQueueEntry, msh marshal.Marshalizer, hsh hashing.Hasher, ctx context.Context) {
-	defer func() {
-		tsm.ExitPruningBufferingMode()
-		log.Trace("trie snapshot finished", "rootHash", snapshotEntry.rootHash)
-		if snapshotEntry.leavesChan != nil {
-			close(snapshotEntry.leavesChan)
-		}
-	}()
+	defer tsm.finishOperation(snapshotEntry, "trie snapshot finished")
 
 	// use the main DB as that DB will certainly have all the trie nodes
 	// using a checkpoint DB is not safe because the process might contain an incomplete DB because the
@@ -341,13 +361,7 @@ func (tsm *trieStorageManager) takeSnapshot(snapshotEntry *snapshotsQueueEntry, 
 }
 
 func (tsm *trieStorageManager) takeCheckpoint(checkpointEntry *snapshotsQueueEntry, msh marshal.Marshalizer, hsh hashing.Hasher, ctx context.Context) {
-	defer func() {
-		tsm.ExitPruningBufferingMode()
-		log.Trace("trie checkpoint finished", "rootHash", checkpointEntry.rootHash)
-		if checkpointEntry.leavesChan != nil {
-			close(checkpointEntry.leavesChan)
-		}
-	}()
+	defer tsm.finishOperation(checkpointEntry, "trie checkpoint finished")
 
 	if tsm.isPresentInLastSnapshotDb(checkpointEntry.rootHash) {
 		log.Trace("checkpoint for rootHash already taken, skipping", "rootHash", checkpointEntry.rootHash)


### PR DESCRIPTION
- fixed OOM exceptions by correctly closing all involved channels when performing snapshot/checkpoint. The fix introduce a new method that consumes all remaining entries in the process channels *after* the component has been successfully closed. This will make all snapshot/checkpoint go routines started in accountsDB.go to finish and eventually close.
- fixed OOM exceptions by correctly using the throttler inside the user accounts syncer as to not allow starting of a large number of go routines