### PR TITLE
EN-10523: Web server refactoring

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -105,3 +105,9 @@ var ErrNilHttpServer = errors.New("nil http server")
 
 // ErrCannotCreateGinWebServer signals that the gin web server cannot be created
 var ErrCannotCreateGinWebServer = errors.New("cannot create gin web server")
+
+// ErrNilFacadeHandler signals that a nil facade handler has been provided
+var ErrNilFacadeHandler = errors.New("nil facade handler")
+
+// ErrFacadeWrongTypeAssertion signals that a type conversion to a facade type failed
+var ErrFacadeWrongTypeAssertion = errors.New("facade - wrong type assertion")

--- a/api/groups/addressGroup.go
+++ b/api/groups/addressGroup.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data/api"
 	"github.com/ElrondNetwork/elrond-go-core/data/esdt"
 	"github.com/ElrondNetwork/elrond-go/api/errors"
@@ -69,7 +70,7 @@ type esdtNFTTokenData struct {
 
 // NewAddressGroup returns a new instance of addressGroup
 func NewAddressGroup(facade addressFacadeHandler) (*addressGroup, error) {
-	if facade == nil {
+	if check.IfNil(facade) {
 		return nil, fmt.Errorf("%w for address group", errors.ErrNilFacadeHandler)
 	}
 

--- a/api/groups/addressGroup.go
+++ b/api/groups/addressGroup.go
@@ -43,9 +43,9 @@ type addressFacadeHandler interface {
 }
 
 type addressGroup struct {
+	*baseGroup
 	facade    addressFacadeHandler
 	mutFacade sync.RWMutex
-	*baseGroup
 }
 
 type esdtTokenData struct {
@@ -68,14 +68,9 @@ type esdtNFTTokenData struct {
 }
 
 // NewAddressGroup returns a new instance of addressGroup
-func NewAddressGroup(facadeHandler interface{}) (*addressGroup, error) {
-	if facadeHandler == nil {
-		return nil, errors.ErrNilFacadeHandler
-	}
-
-	facade, ok := facadeHandler.(addressFacadeHandler)
-	if !ok {
-		return nil, fmt.Errorf("%w for address group", errors.ErrFacadeWrongTypeAssertion)
+func NewAddressGroup(facade addressFacadeHandler) (*addressGroup, error) {
+	if facade == nil {
+		return nil, fmt.Errorf("%w for address group", errors.ErrNilFacadeHandler)
 	}
 
 	ag := &addressGroup{
@@ -599,20 +594,7 @@ func (ag *addressGroup) getESDTNFTData(c *gin.Context) {
 		return
 	}
 
-	tokenData := esdtNFTTokenData{
-		TokenIdentifier: tokenIdentifier,
-		Balance:         esdtData.Value.String(),
-		Properties:      string(esdtData.Properties),
-	}
-	if esdtData.TokenMetaData != nil {
-		tokenData.Name = string(esdtData.TokenMetaData.Name)
-		tokenData.Nonce = esdtData.TokenMetaData.Nonce
-		tokenData.Creator = string(esdtData.TokenMetaData.Creator)
-		tokenData.Royalties = big.NewInt(int64(esdtData.TokenMetaData.Royalties)).String()
-		tokenData.Hash = esdtData.TokenMetaData.Hash
-		tokenData.URIs = esdtData.TokenMetaData.URIs
-		tokenData.Attributes = esdtData.TokenMetaData.Attributes
-	}
+	tokenData := buildTokenDataApiResponse(tokenIdentifier, esdtData)
 
 	c.JSON(
 		http.StatusOK,
@@ -654,20 +636,7 @@ func (ag *addressGroup) getAllESDTData(c *gin.Context) {
 
 	formattedTokens := make(map[string]*esdtNFTTokenData)
 	for tokenID, esdtData := range tokens {
-		tokenData := &esdtNFTTokenData{
-			TokenIdentifier: tokenID,
-			Balance:         esdtData.Value.String(),
-			Properties:      string(esdtData.Properties),
-		}
-		if esdtData.TokenMetaData != nil {
-			tokenData.Name = string(esdtData.TokenMetaData.Name)
-			tokenData.Nonce = esdtData.TokenMetaData.Nonce
-			tokenData.Creator = string(esdtData.TokenMetaData.Creator)
-			tokenData.Royalties = big.NewInt(int64(esdtData.TokenMetaData.Royalties)).String()
-			tokenData.Hash = esdtData.TokenMetaData.Hash
-			tokenData.URIs = esdtData.TokenMetaData.URIs
-			tokenData.Attributes = esdtData.TokenMetaData.Attributes
-		}
+		tokenData := buildTokenDataApiResponse(tokenID, esdtData)
 
 		formattedTokens[tokenID] = tokenData
 	}
@@ -682,6 +651,25 @@ func (ag *addressGroup) getAllESDTData(c *gin.Context) {
 	)
 }
 
+func buildTokenDataApiResponse(tokenIdentifier string, esdtData *esdt.ESDigitalToken) *esdtNFTTokenData {
+	tokenData := &esdtNFTTokenData{
+		TokenIdentifier: tokenIdentifier,
+		Balance:         esdtData.Value.String(),
+		Properties:      string(esdtData.Properties),
+	}
+	if esdtData.TokenMetaData != nil {
+		tokenData.Name = string(esdtData.TokenMetaData.Name)
+		tokenData.Nonce = esdtData.TokenMetaData.Nonce
+		tokenData.Creator = string(esdtData.TokenMetaData.Creator)
+		tokenData.Royalties = big.NewInt(int64(esdtData.TokenMetaData.Royalties)).String()
+		tokenData.Hash = esdtData.TokenMetaData.Hash
+		tokenData.URIs = esdtData.TokenMetaData.URIs
+		tokenData.Attributes = esdtData.TokenMetaData.Attributes
+	}
+
+	return tokenData
+}
+
 func (ag *addressGroup) getFacade() addressFacadeHandler {
 	ag.mutFacade.RLock()
 	defer ag.mutFacade.RUnlock()
@@ -694,14 +682,19 @@ func (ag *addressGroup) UpdateFacade(newFacade interface{}) error {
 	if newFacade == nil {
 		return errors.ErrNilFacadeHandler
 	}
-	castedFacade, ok := newFacade.(addressFacadeHandler)
+	castFacade, ok := newFacade.(addressFacadeHandler)
 	if !ok {
 		return fmt.Errorf("%w for address group", errors.ErrFacadeWrongTypeAssertion)
 	}
 
 	ag.mutFacade.Lock()
-	ag.facade = castedFacade
+	ag.facade = castFacade
 	ag.mutFacade.Unlock()
 
 	return nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (ag *addressGroup) IsInterfaceNil() bool {
+	return ag == nil
 }

--- a/api/groups/addressGroup.go
+++ b/api/groups/addressGroup.go
@@ -1,0 +1,707 @@
+package groups
+
+import (
+	"fmt"
+	"math/big"
+	"net/http"
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/data/api"
+	"github.com/ElrondNetwork/elrond-go-core/data/esdt"
+	"github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	getAccountPath            = "/:address"
+	getBalancePath            = "/:address/balance"
+	getUsernamePath           = "/:address/username"
+	getKeysPath               = "/:address/keys"
+	getKeyPath                = "/:address/key/:key"
+	getESDTTokensPath         = "/:address/esdt"
+	getESDTBalancePath        = "/:address/esdt/:tokenIdentifier"
+	getESDTTokensWithRolePath = "/:address/esdts-with-role/:role"
+	getESDTsRolesPath         = "/:address/esdts/roles"
+	getRegisteredNFTsPath     = "/:address/registered-nfts"
+	getESDTNFTDataPath        = "/:address/nft/:tokenIdentifier/nonce/:nonce"
+)
+
+type addressFacadeHandler interface {
+	GetBalance(address string) (*big.Int, error)
+	GetUsername(address string) (string, error)
+	GetValueForKey(address string, key string) (string, error)
+	GetAccount(address string) (api.AccountResponse, error)
+	GetESDTData(address string, key string, nonce uint64) (*esdt.ESDigitalToken, error)
+	GetESDTsRoles(address string) (map[string][]string, error)
+	GetNFTTokenIDsRegisteredByAddress(address string) ([]string, error)
+	GetESDTsWithRole(address string, role string) ([]string, error)
+	GetAllESDTTokens(address string) (map[string]*esdt.ESDigitalToken, error)
+	GetKeyValuePairs(address string) (map[string]string, error)
+	IsInterfaceNil() bool
+}
+
+type addressGroup struct {
+	facade    addressFacadeHandler
+	mutFacade sync.RWMutex
+	*baseGroup
+}
+
+type esdtTokenData struct {
+	TokenIdentifier string `json:"tokenIdentifier"`
+	Balance         string `json:"balance"`
+	Properties      string `json:"properties"`
+}
+
+type esdtNFTTokenData struct {
+	TokenIdentifier string   `json:"tokenIdentifier"`
+	Balance         string   `json:"balance"`
+	Properties      string   `json:"properties,omitempty"`
+	Name            string   `json:"name,omitempty"`
+	Nonce           uint64   `json:"nonce,omitempty"`
+	Creator         string   `json:"creator,omitempty"`
+	Royalties       string   `json:"royalties,omitempty"`
+	Hash            []byte   `json:"hash,omitempty"`
+	URIs            [][]byte `json:"uris,omitempty"`
+	Attributes      []byte   `json:"attributes,omitempty"`
+}
+
+// NewAddressGroup returns a new instance of addressGroup
+func NewAddressGroup(facadeHandler interface{}) (*addressGroup, error) {
+	if facadeHandler == nil {
+		return nil, errors.ErrNilFacadeHandler
+	}
+
+	facade, ok := facadeHandler.(addressFacadeHandler)
+	if !ok {
+		return nil, fmt.Errorf("%w for address group", errors.ErrFacadeWrongTypeAssertion)
+	}
+
+	ag := &addressGroup{
+		facade:    facade,
+		baseGroup: &baseGroup{},
+	}
+
+	endpoints := []*shared.EndpointHandlerData{
+		{
+			Path:    getAccountPath,
+			Method:  http.MethodGet,
+			Handler: ag.getAccount,
+		},
+		{
+			Path:    getBalancePath,
+			Method:  http.MethodGet,
+			Handler: ag.getBalance,
+		},
+		{
+			Path:    getUsernamePath,
+			Method:  http.MethodGet,
+			Handler: ag.getUsername,
+		},
+		{
+			Path:    getKeyPath,
+			Method:  http.MethodGet,
+			Handler: ag.getValueForKey,
+		},
+		{
+			Path:    getKeysPath,
+			Method:  http.MethodGet,
+			Handler: ag.getKeyValuePairs,
+		},
+		{
+			Path:    getESDTBalancePath,
+			Method:  http.MethodGet,
+			Handler: ag.getESDTBalance,
+		},
+		{
+			Path:    getESDTNFTDataPath,
+			Method:  http.MethodGet,
+			Handler: ag.getESDTNFTData,
+		},
+		{
+			Path:    getESDTTokensPath,
+			Method:  http.MethodGet,
+			Handler: ag.getAllESDTData,
+		},
+		{
+			Path:    getRegisteredNFTsPath,
+			Method:  http.MethodGet,
+			Handler: ag.getNFTTokenIDsRegisteredByAddress,
+		},
+		{
+			Path:    getESDTTokensWithRolePath,
+			Method:  http.MethodGet,
+			Handler: ag.getESDTTokensWithRole,
+		},
+		{
+			Path:    getESDTsRolesPath,
+			Method:  http.MethodGet,
+			Handler: ag.getESDTsRoles,
+		},
+	}
+	ag.endpoints = endpoints
+
+	return ag, nil
+}
+
+// addressGroup returns a response containing information about the account correlated with provided address
+func (ag *addressGroup) getAccount(c *gin.Context) {
+	addr := c.Param("address")
+	accountResponse, err := ag.getFacade().GetAccount(addr)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrCouldNotGetAccount.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	accountResponse.Address = addr
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"account": accountResponse},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// getBalance returns the balance for the address parameter
+func (ag *addressGroup) getBalance(c *gin.Context) {
+	addr := c.Param("address")
+	if addr == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetBalance.Error(), errors.ErrEmptyAddress.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	balance, err := ag.getFacade().GetBalance(addr)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetBalance.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"balance": balance.String()},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// getUsername returns the username for the address parameter
+func (ag *addressGroup) getUsername(c *gin.Context) {
+	addr := c.Param("address")
+	if addr == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetUsername.Error(), errors.ErrEmptyAddress.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	userName, err := ag.getFacade().GetUsername(addr)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetUsername.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"username": userName},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// getValueForKey returns the value for the given address and key
+func (ag *addressGroup) getValueForKey(c *gin.Context) {
+	addr := c.Param("address")
+	if addr == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetValueForKey.Error(), errors.ErrEmptyAddress.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	key := c.Param("key")
+	if key == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetValueForKey.Error(), errors.ErrEmptyKey.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	value, err := ag.getFacade().GetValueForKey(addr, key)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetValueForKey.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"value": value},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// addressGroup returns all the key-value pairs for the given address
+func (ag *addressGroup) getKeyValuePairs(c *gin.Context) {
+	addr := c.Param("address")
+	if addr == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetKeyValuePairs.Error(), errors.ErrEmptyAddress.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	value, err := ag.getFacade().GetKeyValuePairs(addr)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetKeyValuePairs.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"pairs": value},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// getESDTBalance returns the balance for the given address and esdt token
+func (ag *addressGroup) getESDTBalance(c *gin.Context) {
+	addr := c.Param("address")
+	if addr == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTBalance.Error(), errors.ErrEmptyAddress.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	tokenIdentifier := c.Param("tokenIdentifier")
+	if tokenIdentifier == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTBalance.Error(), errors.ErrEmptyTokenIdentifier.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	esdtData, err := ag.getFacade().GetESDTData(addr, tokenIdentifier, 0)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTBalance.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	tokenData := esdtTokenData{
+		TokenIdentifier: tokenIdentifier,
+		Balance:         esdtData.Value.String(),
+		Properties:      string(esdtData.Properties),
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"tokenData": tokenData},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// getESDTsRoles returns the token identifiers and roles for a given address
+func (ag *addressGroup) getESDTsRoles(c *gin.Context) {
+	addr := c.Param("address")
+	if addr == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetRolesForAccount.Error(), errors.ErrEmptyAddress.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	tokensRoles, err := ag.getFacade().GetESDTsRoles(addr)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetRolesForAccount.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"roles": tokensRoles},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// getESDTTokensWithRole returns the token identifiers where a given address has the given role
+func (ag *addressGroup) getESDTTokensWithRole(c *gin.Context) {
+	addr := c.Param("address")
+	if addr == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTBalance.Error(), errors.ErrEmptyAddress.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	role := c.Param("role")
+	if role == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTBalance.Error(), errors.ErrEmptyRole.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	if !core.IsValidESDTRole(role) {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("invalid role: %s", role),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	tokens, err := ag.getFacade().GetESDTsWithRole(addr, role)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTBalance.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"tokens": tokens},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// getNFTTokenIDsRegisteredByAddress returns the token identifiers of the tokens where a given address is the owner
+func (ag *addressGroup) getNFTTokenIDsRegisteredByAddress(c *gin.Context) {
+	addr := c.Param("address")
+	if addr == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTBalance.Error(), errors.ErrEmptyAddress.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	tokens, err := ag.getFacade().GetNFTTokenIDsRegisteredByAddress(addr)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTBalance.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"tokens": tokens},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// getESDTNFTData returns the nft data for the given token
+func (ag *addressGroup) getESDTNFTData(c *gin.Context) {
+	addr := c.Param("address")
+	if addr == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTNFTData.Error(), errors.ErrEmptyAddress.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	tokenIdentifier := c.Param("tokenIdentifier")
+	if tokenIdentifier == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTNFTData.Error(), errors.ErrEmptyTokenIdentifier.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	nonceAsStr := c.Param("nonce")
+	if nonceAsStr == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: errors.ErrNonceInvalid.Error(),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	nonceAsBigInt, okConvert := big.NewInt(0).SetString(nonceAsStr, 10)
+	if !okConvert {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: errors.ErrNonceInvalid.Error(),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	esdtData, err := ag.getFacade().GetESDTData(addr, tokenIdentifier, nonceAsBigInt.Uint64())
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTBalance.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	tokenData := esdtNFTTokenData{
+		TokenIdentifier: tokenIdentifier,
+		Balance:         esdtData.Value.String(),
+		Properties:      string(esdtData.Properties),
+	}
+	if esdtData.TokenMetaData != nil {
+		tokenData.Name = string(esdtData.TokenMetaData.Name)
+		tokenData.Nonce = esdtData.TokenMetaData.Nonce
+		tokenData.Creator = string(esdtData.TokenMetaData.Creator)
+		tokenData.Royalties = big.NewInt(int64(esdtData.TokenMetaData.Royalties)).String()
+		tokenData.Hash = esdtData.TokenMetaData.Hash
+		tokenData.URIs = esdtData.TokenMetaData.URIs
+		tokenData.Attributes = esdtData.TokenMetaData.Attributes
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"tokenData": tokenData},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// getAllESDTData returns the tokens list from this account
+func (ag *addressGroup) getAllESDTData(c *gin.Context) {
+	addr := c.Param("address")
+	if addr == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTTokens.Error(), errors.ErrEmptyAddress.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	tokens, err := ag.getFacade().GetAllESDTTokens(addr)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetESDTTokens.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	formattedTokens := make(map[string]*esdtNFTTokenData)
+	for tokenID, esdtData := range tokens {
+		tokenData := &esdtNFTTokenData{
+			TokenIdentifier: tokenID,
+			Balance:         esdtData.Value.String(),
+			Properties:      string(esdtData.Properties),
+		}
+		if esdtData.TokenMetaData != nil {
+			tokenData.Name = string(esdtData.TokenMetaData.Name)
+			tokenData.Nonce = esdtData.TokenMetaData.Nonce
+			tokenData.Creator = string(esdtData.TokenMetaData.Creator)
+			tokenData.Royalties = big.NewInt(int64(esdtData.TokenMetaData.Royalties)).String()
+			tokenData.Hash = esdtData.TokenMetaData.Hash
+			tokenData.URIs = esdtData.TokenMetaData.URIs
+			tokenData.Attributes = esdtData.TokenMetaData.Attributes
+		}
+
+		formattedTokens[tokenID] = tokenData
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"esdts": formattedTokens},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+func (ag *addressGroup) getFacade() addressFacadeHandler {
+	ag.mutFacade.RLock()
+	defer ag.mutFacade.RUnlock()
+
+	return ag.facade
+}
+
+// UpdateFacade will update the facade
+func (ag *addressGroup) UpdateFacade(newFacade interface{}) error {
+	if newFacade == nil {
+		return errors.ErrNilFacadeHandler
+	}
+	castedFacade, ok := newFacade.(addressFacadeHandler)
+	if !ok {
+		return fmt.Errorf("%w for address group", errors.ErrFacadeWrongTypeAssertion)
+	}
+
+	ag.mutFacade.Lock()
+	ag.facade = castedFacade
+	ag.mutFacade.Unlock()
+
+	return nil
+}

--- a/api/groups/addressGroup_test.go
+++ b/api/groups/addressGroup_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type AccountResponse struct {
+type accountResponse struct {
 	Account struct {
 		Address         string `json:"address"`
 		Nonce           uint64 `json:"nonce"`
@@ -138,13 +138,6 @@ func TestNewAddressGroup(t *testing.T) {
 	t.Run("nil facade", func(t *testing.T) {
 		hg, err := groups.NewAddressGroup(nil)
 		require.True(t, errors.Is(err, apiErrors.ErrNilFacadeHandler))
-		require.Nil(t, hg)
-	})
-
-	t.Run("wrong type assertion facade", func(t *testing.T) {
-		dummyStruct := struct{}{}
-		hg, err := groups.NewAddressGroup(dummyStruct)
-		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
 		require.Nil(t, hg)
 	})
 
@@ -449,7 +442,7 @@ func TestGetAccount_ReturnsSuccessfully(t *testing.T) {
 	response := shared.GenericAPIResponse{}
 	loadResponse(resp.Body, &response)
 	mapResponse := response.Data.(map[string]interface{})
-	accountResponse := AccountResponse{}
+	accountResponse := accountResponse{}
 
 	mapResponseBytes, _ := json.Marshal(&mapResponse)
 	_ = json.Unmarshal(mapResponseBytes, &accountResponse)

--- a/api/groups/addressGroup_test.go
+++ b/api/groups/addressGroup_test.go
@@ -1,0 +1,990 @@
+package groups_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/data/api"
+	"github.com/ElrondNetwork/elrond-go-core/data/esdt"
+	apiErrors "github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/groups"
+	"github.com/ElrondNetwork/elrond-go/api/mock"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type AccountResponse struct {
+	Account struct {
+		Address         string `json:"address"`
+		Nonce           uint64 `json:"nonce"`
+		Balance         string `json:"balance"`
+		Code            string `json:"code"`
+		CodeHash        []byte `json:"codeHash"`
+		RootHash        []byte `json:"rootHash"`
+		DeveloperReward string `json:"developerReward"`
+	} `json:"account"`
+}
+
+type valueForKeyResponseData struct {
+	Value string `json:"value"`
+}
+
+type valueForKeyResponse struct {
+	Data  valueForKeyResponseData `json:"data"`
+	Error string                  `json:"error"`
+	Code  string                  `json:"code"`
+}
+
+type esdtTokenData struct {
+	TokenIdentifier string `json:"tokenIdentifier"`
+	Balance         string `json:"balance"`
+	Properties      string `json:"properties"`
+}
+
+type esdtNFTTokenData struct {
+	TokenIdentifier string   `json:"tokenIdentifier"`
+	Balance         string   `json:"balance"`
+	Properties      string   `json:"properties"`
+	Name            string   `json:"name"`
+	Nonce           uint64   `json:"nonce"`
+	Creator         string   `json:"creator"`
+	Royalties       string   `json:"royalties"`
+	Hash            []byte   `json:"hash"`
+	URIs            [][]byte `json:"uris"`
+	Attributes      []byte   `json:"attributes"`
+}
+
+type esdtNFTResponseData struct {
+	esdtNFTTokenData `json:"tokenData"`
+}
+
+type esdtTokenResponseData struct {
+	esdtTokenData `json:"tokenData"`
+}
+
+type esdtsWithRoleResponseData struct {
+	Tokens []string `json:"tokens"`
+}
+
+type esdtsWithRoleResponse struct {
+	Data  esdtsWithRoleResponseData `json:"data"`
+	Error string                    `json:"error"`
+	Code  string                    `json:"code"`
+}
+
+type esdtTokenResponse struct {
+	Data  esdtTokenResponseData `json:"data"`
+	Error string                `json:"error"`
+	Code  string                `json:"code"`
+}
+
+type esdtNFTResponse struct {
+	Data  esdtNFTResponseData `json:"data"`
+	Error string              `json:"error"`
+	Code  string              `json:"code"`
+}
+
+type esdtTokensCompleteResponseData struct {
+	Tokens map[string]esdtNFTTokenData `json:"esdts"`
+}
+
+type esdtTokensCompleteResponse struct {
+	Data  esdtTokensCompleteResponseData `json:"data"`
+	Error string                         `json:"error"`
+	Code  string
+}
+
+type keyValuePairsResponseData struct {
+	Pairs map[string]string `json:"pairs"`
+}
+
+type keyValuePairsResponse struct {
+	Data  keyValuePairsResponseData `json:"data"`
+	Error string                    `json:"error"`
+	Code  string
+}
+
+type esdtRolesResponseData struct {
+	Roles map[string][]string `json:"roles"`
+}
+
+type esdtRolesResponse struct {
+	Data  esdtRolesResponseData `json:"data"`
+	Error string                `json:"error"`
+	Code  string
+}
+
+type usernameResponseData struct {
+	Username string `json:"username"`
+}
+
+type usernameResponse struct {
+	Data  usernameResponseData `json:"data"`
+	Error string               `json:"error"`
+	Code  string               `json:"code"`
+}
+
+func TestNewAddressGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil facade", func(t *testing.T) {
+		hg, err := groups.NewAddressGroup(nil)
+		require.True(t, errors.Is(err, apiErrors.ErrNilFacadeHandler))
+		require.Nil(t, hg)
+	})
+
+	t.Run("wrong type assertion facade", func(t *testing.T) {
+		dummyStruct := struct{}{}
+		hg, err := groups.NewAddressGroup(dummyStruct)
+		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
+		require.Nil(t, hg)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		hg, err := groups.NewAddressGroup(&mock.Facade{})
+		require.NoError(t, err)
+		require.NotNil(t, hg)
+	})
+}
+
+func TestAddressRoute_EmptyTrailReturns404(t *testing.T) {
+	t.Parallel()
+	facade := mock.Facade{}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/address", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+}
+
+func getValueForKey(dataFromResponse interface{}, key string) string {
+	dataMap, ok := dataFromResponse.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	valueI, okCast := dataMap[key]
+	if okCast {
+		return fmt.Sprintf("%v", valueI)
+	}
+	return ""
+}
+
+func TestGetBalance_WithCorrectAddressShouldNotReturnError(t *testing.T) {
+	t.Parallel()
+
+	amount := big.NewInt(10)
+	addr := "testAddress"
+	facade := mock.Facade{
+		BalanceHandler: func(s string) (i *big.Int, e error) {
+			return amount, nil
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/balance", addr), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	balanceStr := getValueForKey(response.Data, "balance")
+	balanceResponse, ok := big.NewInt(0).SetString(balanceStr, 10)
+	assert.True(t, ok)
+	assert.Equal(t, amount, balanceResponse)
+	assert.Equal(t, "", response.Error)
+}
+
+func TestGetBalance_WithWrongAddressShouldError(t *testing.T) {
+	t.Parallel()
+	otherAddress := "otherAddress"
+	facade := mock.Facade{
+		BalanceHandler: func(s string) (i *big.Int, e error) {
+			return big.NewInt(0), nil
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/balance", otherAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, "", response.Error)
+}
+
+func TestGetBalance_NodeGetBalanceReturnsError(t *testing.T) {
+	t.Parallel()
+	addr := "addr"
+	balanceError := errors.New("error")
+	facade := mock.Facade{
+		BalanceHandler: func(s string) (i *big.Int, e error) {
+			return nil, balanceError
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/balance", addr), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.Equal(t, fmt.Sprintf("%s: %s", apiErrors.ErrGetBalance.Error(), balanceError.Error()), response.Error)
+}
+
+func TestGetBalance_WithEmptyAddressShoudReturnError(t *testing.T) {
+	t.Parallel()
+	facade := mock.Facade{
+		BalanceHandler: func(s string) (i *big.Int, e error) {
+			return big.NewInt(0), errors.New("address was empty")
+		},
+	}
+
+	emptyAddress := ""
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/balance", emptyAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.NotEmpty(t, response)
+	assert.True(t, strings.Contains(response.Error,
+		fmt.Sprintf("%s: %s", apiErrors.ErrGetBalance.Error(), apiErrors.ErrEmptyAddress.Error()),
+	))
+}
+
+func TestGetValueForKey_NodeFailsShouldError(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		GetValueForKeyCalled: func(_ string, _ string) (string, error) {
+			return "", expectedErr
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/key/test", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	valueForKeyResponseObj := valueForKeyResponse{}
+	loadResponse(resp.Body, &valueForKeyResponseObj)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(valueForKeyResponseObj.Error, expectedErr.Error()))
+}
+
+func TestGetValueForKey_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	testValue := "value"
+	facade := mock.Facade{
+		GetValueForKeyCalled: func(_ string, _ string) (string, error) {
+			return testValue, nil
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/key/test", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	valueForKeyResponseObj := valueForKeyResponse{}
+	loadResponse(resp.Body, &valueForKeyResponseObj)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, testValue, valueForKeyResponseObj.Data.Value)
+}
+
+func TestGetUsername_NodeFailsShouldError(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		GetUsernameCalled: func(_ string) (string, error) {
+			return "", expectedErr
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/username", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	usernameResponseObj := usernameResponse{}
+	loadResponse(resp.Body, &usernameResponseObj)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(usernameResponseObj.Error, expectedErr.Error()))
+}
+
+func TestGetUsername_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	testUsername := "value"
+	facade := mock.Facade{
+		GetUsernameCalled: func(_ string) (string, error) {
+			return testUsername, nil
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/username", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	usernameResponseObj := usernameResponse{}
+	loadResponse(resp.Body, &usernameResponseObj)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, testUsername, usernameResponseObj.Data.Username)
+}
+
+func TestGetAccount_FailWhenFacadeGetAccountFails(t *testing.T) {
+	t.Parallel()
+
+	returnedError := "i am an error"
+	facade := mock.Facade{
+		GetAccountHandler: func(address string) (api.AccountResponse, error) {
+			return api.AccountResponse{}, errors.New(returnedError)
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/address/test", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.Empty(t, response.Data)
+	assert.NotEmpty(t, response.Error)
+	assert.True(t, strings.Contains(response.Error, fmt.Sprintf("%s: %s", apiErrors.ErrCouldNotGetAccount.Error(), returnedError)))
+}
+
+func TestGetAccount_ReturnsSuccessfully(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{
+		GetAccountHandler: func(address string) (api.AccountResponse, error) {
+			return api.AccountResponse{
+				Address:         "1234",
+				Balance:         big.NewInt(100).String(),
+				Nonce:           1,
+				DeveloperReward: big.NewInt(120).String(),
+			}, nil
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	reqAddress := "test"
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s", reqAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+	mapResponse := response.Data.(map[string]interface{})
+	accountResponse := AccountResponse{}
+
+	mapResponseBytes, _ := json.Marshal(&mapResponse)
+	_ = json.Unmarshal(mapResponseBytes, &accountResponse)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, reqAddress, accountResponse.Account.Address)
+	assert.Equal(t, uint64(1), accountResponse.Account.Nonce)
+	assert.Equal(t, "100", accountResponse.Account.Balance)
+	assert.Equal(t, "120", accountResponse.Account.DeveloperReward)
+	assert.Empty(t, response.Error)
+}
+
+func TestGetESDTBalance_NodeFailsShouldError(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		GetESDTDataCalled: func(_ string, _ string, _ uint64) (*esdt.ESDigitalToken, error) {
+			return nil, expectedErr
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/esdt/newToken", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	usernameResponseObj := usernameResponse{}
+	loadResponse(resp.Body, &usernameResponseObj)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(usernameResponseObj.Error, expectedErr.Error()))
+}
+
+func TestGetESDTBalance_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	testValue := big.NewInt(100).String()
+	testProperties := "frozen"
+	facade := mock.Facade{
+		GetESDTDataCalled: func(_ string, _ string, _ uint64) (*esdt.ESDigitalToken, error) {
+			return &esdt.ESDigitalToken{Value: big.NewInt(100), Properties: []byte(testProperties)}, nil
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/esdt/newToken", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	esdtBalanceResponseObj := esdtTokenResponse{}
+	loadResponse(resp.Body, &esdtBalanceResponseObj)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, testValue, esdtBalanceResponseObj.Data.Balance)
+	assert.Equal(t, testProperties, esdtBalanceResponseObj.Data.Properties)
+}
+
+func TestGetESDTNFTData_NodeFailsShouldError(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		GetESDTDataCalled: func(_ string, _ string, _ uint64) (*esdt.ESDigitalToken, error) {
+			return nil, expectedErr
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/nft/newToken/nonce/10", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	esdtResponseObj := esdtNFTResponse{}
+	loadResponse(resp.Body, &esdtResponseObj)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(esdtResponseObj.Error, expectedErr.Error()))
+}
+
+func TestGetESDTNFTData_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	testValue := big.NewInt(100).String()
+	testNonce := uint64(37)
+	testProperties := "frozen"
+	facade := mock.Facade{
+		GetESDTDataCalled: func(_ string, _ string, _ uint64) (*esdt.ESDigitalToken, error) {
+			return &esdt.ESDigitalToken{
+				Value:         big.NewInt(100),
+				Properties:    []byte(testProperties),
+				TokenMetaData: &esdt.MetaData{Nonce: testNonce, Creator: []byte(testAddress)}}, nil
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/nft/newToken/nonce/10", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	esdtResponseObj := esdtNFTResponse{}
+	loadResponse(resp.Body, &esdtResponseObj)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, testValue, esdtResponseObj.Data.Balance)
+	assert.Equal(t, testProperties, esdtResponseObj.Data.Properties)
+	assert.Equal(t, testAddress, esdtResponseObj.Data.Creator)
+	assert.Equal(t, testNonce, esdtResponseObj.Data.Nonce)
+}
+
+func TestGetESDTTokensWithRole_InvalidRoleShouldError(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		GetESDTsWithRoleCalled: func(_ string, _ string) ([]string, error) {
+			return nil, expectedErr
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/esdts-with-role/invalid", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	esdtResponseObj := esdtsWithRoleResponse{}
+	loadResponse(resp.Body, &esdtResponseObj)
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.True(t, strings.Contains(esdtResponseObj.Error, "invalid role"))
+}
+
+func TestGetESDTTokensWithRole_NodeFailsShouldError(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		GetESDTsWithRoleCalled: func(_ string, _ string) ([]string, error) {
+			return nil, expectedErr
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/esdts-with-role/ESDTRoleNFTCreate", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	esdtResponseObj := esdtsWithRoleResponse{}
+	loadResponse(resp.Body, &esdtResponseObj)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(esdtResponseObj.Error, expectedErr.Error()))
+}
+
+func TestGetESDTTokensWithRole_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedTokens := []string{"ABC-0o9i8u", "XYZ-r5y7i9"}
+	facade := mock.Facade{
+		GetESDTsWithRoleCalled: func(address string, role string) ([]string, error) {
+			return expectedTokens, nil
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/esdts-with-role/ESDTRoleNFTCreate", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	esdtResponseObj := esdtsWithRoleResponse{}
+	loadResponse(resp.Body, &esdtResponseObj)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, expectedTokens, esdtResponseObj.Data.Tokens)
+}
+
+func TestGetNFTTokenIDsRegisteredByAddress_NodeFailsShouldError(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		GetNFTTokenIDsRegisteredByAddressCalled: func(_ string) ([]string, error) {
+			return nil, expectedErr
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/registered-nfts", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	esdtResponseObj := esdtsWithRoleResponse{}
+	loadResponse(resp.Body, &esdtResponseObj)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(esdtResponseObj.Error, expectedErr.Error()))
+}
+
+func TestGetNFTTokenIDsRegisteredByAddress_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedTokens := []string{"ABC-0o9i8u", "XYZ-r5y7i9"}
+	facade := mock.Facade{
+		GetNFTTokenIDsRegisteredByAddressCalled: func(address string) ([]string, error) {
+			return expectedTokens, nil
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/registered-nfts", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	esdtResponseObj := esdtsWithRoleResponse{}
+	loadResponse(resp.Body, &esdtResponseObj)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, expectedTokens, esdtResponseObj.Data.Tokens)
+}
+
+func TestGetFullESDTTokens_NodeFailsShouldError(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		GetAllESDTTokensCalled: func(_ string) (map[string]*esdt.ESDigitalToken, error) {
+			return nil, expectedErr
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/esdt", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	esdtTokenResponseObj := esdtTokensCompleteResponse{}
+	loadResponse(resp.Body, &esdtTokenResponseObj)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(esdtTokenResponseObj.Error, expectedErr.Error()))
+}
+
+func TestGetFullESDTTokens_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	testValue1 := "token1"
+	testValue2 := "token2"
+	facade := mock.Facade{
+		GetAllESDTTokensCalled: func(address string) (map[string]*esdt.ESDigitalToken, error) {
+			tokens := make(map[string]*esdt.ESDigitalToken)
+			tokens[testValue1] = &esdt.ESDigitalToken{Value: big.NewInt(10)}
+			tokens[testValue2] = &esdt.ESDigitalToken{Value: big.NewInt(100)}
+			return tokens, nil
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/esdt", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	esdtTokenResponseObj := esdtTokensCompleteResponse{}
+	loadResponse(resp.Body, &esdtTokenResponseObj)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, 2, len(esdtTokenResponseObj.Data.Tokens))
+}
+
+func TestGetKeyValuePairs_WithEmptyAddressShoudReturnError(t *testing.T) {
+	t.Parallel()
+	facade := mock.Facade{}
+
+	emptyAddress := ""
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/keys", emptyAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.NotEmpty(t, response)
+	assert.True(t, strings.Contains(response.Error,
+		fmt.Sprintf("%s: %s", apiErrors.ErrGetKeyValuePairs.Error(), apiErrors.ErrEmptyAddress.Error()),
+	))
+}
+
+func TestGetKeyValuePairs_NodeFailsShouldError(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		GetKeyValuePairsCalled: func(_ string) (map[string]string, error) {
+			return nil, expectedErr
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/keys", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := &shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(response.Error, expectedErr.Error()))
+}
+
+func TestGetKeyValuePairs_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	pairs := map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	}
+	testAddress := "address"
+	facade := mock.Facade{
+		GetKeyValuePairsCalled: func(_ string) (map[string]string, error) {
+			return pairs, nil
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/keys", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := keyValuePairsResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, pairs, response.Data.Pairs)
+}
+
+func TestGetESDTsRoles_WithEmptyAddressShoudReturnError(t *testing.T) {
+	t.Parallel()
+	facade := mock.Facade{}
+
+	emptyAddress := ""
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/esdts/roles", emptyAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.NotEmpty(t, response)
+	assert.True(t, strings.Contains(response.Error,
+		fmt.Sprintf("%s: %s", apiErrors.ErrGetRolesForAccount.Error(), apiErrors.ErrEmptyAddress.Error()),
+	))
+}
+
+func TestGetESDTsRoles_NodeFailsShouldError(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		GetESDTsRolesCalled: func(_ string) (map[string][]string, error) {
+			return nil, expectedErr
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/esdts/roles", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := &shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(response.Error, expectedErr.Error()))
+}
+
+func TestGetESDTsRoles_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	roles := map[string][]string{
+		"token0": {"role0", "role1"},
+		"token1": {"role3", "role1"},
+	}
+	testAddress := "address"
+	facade := mock.Facade{
+		GetESDTsRolesCalled: func(_ string) (map[string][]string, error) {
+			return roles, nil
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/esdts/roles", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := esdtRolesResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, roles, response.Data.Roles)
+}
+
+func TestAddressGroup_UpdateFacade(t *testing.T) {
+	t.Parallel()
+
+	roles := map[string][]string{
+		"token0": {"role0", "role1"},
+		"token1": {"role3", "role1"},
+	}
+	testAddress := "address"
+	facade := mock.Facade{
+		GetESDTsRolesCalled: func(_ string) (map[string][]string, error) {
+			return roles, nil
+		},
+	}
+
+	addrGroup, err := groups.NewAddressGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/esdts/roles", testAddress), nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := esdtRolesResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, roles, response.Data.Roles)
+
+	newErr := errors.New("new error")
+	newFacade := mock.Facade{
+		GetESDTsRolesCalled: func(_ string) (map[string][]string, error) {
+			return nil, newErr
+		},
+	}
+	err = addrGroup.UpdateFacade(&newFacade)
+	require.NoError(t, err)
+
+	req, _ = http.NewRequest("GET", fmt.Sprintf("/address/%s/esdts/roles", testAddress), nil)
+	resp = httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response = esdtRolesResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(response.Error, newErr.Error()))
+}
+
+func getAddressRoutesConfig() config.ApiRoutesConfig {
+	return config.ApiRoutesConfig{
+		APIPackages: map[string]config.APIPackageConfig{
+			"address": {
+				Routes: []config.RouteConfig{
+					{Name: "/:address", Open: true},
+					{Name: "/:address/balance", Open: true},
+					{Name: "/:address/username", Open: true},
+					{Name: "/:address/keys", Open: true},
+					{Name: "/:address/key/:key", Open: true},
+					{Name: "/:address/esdt", Open: true},
+					{Name: "/:address/esdts/roles", Open: true},
+					{Name: "/:address/esdt/:tokenIdentifier", Open: true},
+					{Name: "/:address/nft/:tokenIdentifier/nonce/:nonce", Open: true},
+					{Name: "/:address/esdts-with-role/:role", Open: true},
+					{Name: "/:address/registered-nfts", Open: true},
+				},
+			},
+		},
+	}
+}

--- a/api/groups/baseGroup.go
+++ b/api/groups/baseGroup.go
@@ -1,0 +1,112 @@
+package groups
+
+import (
+	"strings"
+
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/gin-gonic/gin"
+)
+
+var log = logger.GetOrCreate("api/groups")
+
+type endpointProperties struct {
+	isOpen bool
+}
+
+type baseGroup struct {
+	endpoints []*shared.EndpointHandlerData
+}
+
+// GetEndpoints returns all the endpoints specific to the group
+func (bg *baseGroup) GetEndpoints() []*shared.EndpointHandlerData {
+	return bg.endpoints
+}
+
+// RegisterRoutes will register all the endpoints to the given web server
+func (bg *baseGroup) RegisterRoutes(
+	ws *gin.RouterGroup,
+	apiConfig config.ApiRoutesConfig,
+	additionalMiddlewares []shared.MiddlewareProcessor,
+) {
+	for _, handlerData := range bg.endpoints {
+		properties := getEndpointProperties(ws, handlerData.Path, apiConfig)
+
+		if !properties.isOpen {
+			log.Debug("endpoint is closed", "path", handlerData.Path)
+			continue
+		}
+
+		middlewares := make([]gin.HandlerFunc, 0)
+		for _, middleware := range additionalMiddlewares {
+			if middleware == nil ||
+				middleware.MiddlewareHandlerFunc() == nil ||
+				middleware.IsInterfaceNil() {
+				continue
+			}
+			middlewares = append(middlewares, middleware.MiddlewareHandlerFunc())
+		}
+
+		beforeSpecifiesMiddlewares, afterSpecificMiddlewares := extractSpecificMiddlewares(handlerData.AdditionalMiddlewares)
+		for _, specificMiddleware := range beforeSpecifiesMiddlewares {
+			middlewares = append(middlewares, specificMiddleware)
+		}
+		middlewares = append(middlewares, handlerData.Handler)
+		for _, specificMiddleware := range afterSpecificMiddlewares {
+			middlewares = append(middlewares, specificMiddleware)
+		}
+
+		ws.Handle(handlerData.Method, handlerData.Path, middlewares...)
+	}
+}
+
+func extractSpecificMiddlewares(middlewares []shared.AdditionalMiddleware) ([]gin.HandlerFunc, []gin.HandlerFunc) {
+	if len(middlewares) == 0 {
+		return nil, nil
+	}
+
+	beforeMiddlewares := make([]gin.HandlerFunc, 0)
+	afterMiddlewares := make([]gin.HandlerFunc, 0)
+	for _, middleware := range middlewares {
+		if middleware.Before {
+			beforeMiddlewares = append(beforeMiddlewares, middleware.Middleware)
+		} else {
+			afterMiddlewares = append(afterMiddlewares, middleware.Middleware)
+		}
+	}
+
+	return beforeMiddlewares, afterMiddlewares
+}
+
+func getEndpointProperties(ws *gin.RouterGroup, path string, apiConfig config.ApiRoutesConfig) endpointProperties {
+	basePath := ws.BasePath()
+
+	// ws.BasePath will return paths like /group or /v1.0/group so we need the last token after splitting by /
+	splitPath := strings.Split(basePath, "/")
+	basePath = splitPath[len(splitPath)-1]
+
+	group, ok := apiConfig.APIPackages[basePath]
+	if !ok {
+		return endpointProperties{
+			isOpen: false,
+		}
+	}
+
+	for _, route := range group.Routes {
+		if route.Name == path {
+			return endpointProperties{
+				isOpen: route.Open,
+			}
+		}
+	}
+
+	return endpointProperties{
+		isOpen: false,
+	}
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (bg *baseGroup) IsInterfaceNil() bool {
+	return bg == nil
+}

--- a/api/groups/blockGroup.go
+++ b/api/groups/blockGroup.go
@@ -24,20 +24,15 @@ type blockFacadeHandler interface {
 }
 
 type blockGroup struct {
+	*baseGroup
 	facade blockFacadeHandler
 	mutFacade sync.RWMutex
-	*baseGroup
 }
 
 // NewBlockGroup returns a new instance of blockGroup
-func NewBlockGroup(facadeHandler interface{}) (*blockGroup, error) {
-	if facadeHandler == nil {
-		return nil, errors.ErrNilFacadeHandler
-	}
-
-	facade, ok := facadeHandler.(blockFacadeHandler)
-	if !ok {
-		return nil, fmt.Errorf("%w for block group", errors.ErrFacadeWrongTypeAssertion)
+func NewBlockGroup(facade blockFacadeHandler) (*blockGroup, error) {
+	if facade == nil {
+		return nil, fmt.Errorf("%w for block group", errors.ErrNilFacadeHandler)
 	}
 
 	bg := &blockGroup{
@@ -161,14 +156,19 @@ func (bg *blockGroup) UpdateFacade(newFacade interface{}) error {
 	if newFacade == nil {
 		return errors.ErrNilFacadeHandler
 	}
-	castedFacade, ok := newFacade.(blockFacadeHandler)
+	castFacade, ok := newFacade.(blockFacadeHandler)
 	if !ok {
 		return errors.ErrFacadeWrongTypeAssertion
 	}
 
 	bg.mutFacade.Lock()
-	bg.facade = castedFacade
+	bg.facade = castFacade
 	bg.mutFacade.Unlock()
 
 	return nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (bg *blockGroup) IsInterfaceNil() bool {
+	return bg == nil
 }

--- a/api/groups/blockGroup.go
+++ b/api/groups/blockGroup.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data/api"
 	"github.com/ElrondNetwork/elrond-go/api/errors"
 	"github.com/ElrondNetwork/elrond-go/api/shared"
@@ -21,6 +22,7 @@ const (
 type blockFacadeHandler interface {
 	GetBlockByHash(hash string, withTxs bool) (*api.Block, error)
 	GetBlockByNonce(nonce uint64, withTxs bool) (*api.Block, error)
+	IsInterfaceNil() bool
 }
 
 type blockGroup struct {
@@ -31,7 +33,7 @@ type blockGroup struct {
 
 // NewBlockGroup returns a new instance of blockGroup
 func NewBlockGroup(facade blockFacadeHandler) (*blockGroup, error) {
-	if facade == nil {
+	if check.IfNil(facade) {
 		return nil, fmt.Errorf("%w for block group", errors.ErrNilFacadeHandler)
 	}
 

--- a/api/groups/blockGroup.go
+++ b/api/groups/blockGroup.go
@@ -1,0 +1,174 @@
+package groups
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go-core/data/api"
+	"github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	getBlockByNoncePath = "/by-nonce/:nonce"
+	getBlockByHashPath  = "/by-hash/:hash"
+)
+
+type blockFacadeHandler interface {
+	GetBlockByHash(hash string, withTxs bool) (*api.Block, error)
+	GetBlockByNonce(nonce uint64, withTxs bool) (*api.Block, error)
+}
+
+type blockGroup struct {
+	facade blockFacadeHandler
+	mutFacade sync.RWMutex
+	*baseGroup
+}
+
+// NewBlockGroup returns a new instance of blockGroup
+func NewBlockGroup(facadeHandler interface{}) (*blockGroup, error) {
+	if facadeHandler == nil {
+		return nil, errors.ErrNilFacadeHandler
+	}
+
+	facade, ok := facadeHandler.(blockFacadeHandler)
+	if !ok {
+		return nil, fmt.Errorf("%w for block group", errors.ErrFacadeWrongTypeAssertion)
+	}
+
+	bg := &blockGroup{
+		facade:    facade,
+		baseGroup: &baseGroup{},
+	}
+
+	endpoints := []*shared.EndpointHandlerData{
+		{
+			Path:    getBlockByNoncePath,
+			Method:  http.MethodGet,
+			Handler: bg.getBlockByNonce,
+		},
+		{
+			Path:    getBlockByHashPath,
+			Method:  http.MethodGet,
+			Handler: bg.getBlockByHash,
+		},
+	}
+	bg.endpoints = endpoints
+
+	return bg, nil
+}
+
+func (bg *blockGroup) getBlockByNonce(c *gin.Context) {
+	nonce, err := getQueryParamNonce(c)
+	if err != nil {
+		shared.RespondWithValidationError(
+			c, fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), errors.ErrInvalidBlockNonce.Error()),
+		)
+		return
+	}
+
+	withTxs, err := getQueryParamWithTxs(c)
+	if err != nil {
+		shared.RespondWithValidationError(
+			c, fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), errors.ErrInvalidQueryParameter.Error()),
+		)
+		return
+	}
+
+	start := time.Now()
+	block, err := bg.getFacade().GetBlockByNonce(nonce, withTxs)
+	log.Debug(fmt.Sprintf("GetBlockByNonce took %s", time.Since(start)))
+	if err != nil {
+		shared.RespondWith(
+			c,
+			http.StatusInternalServerError,
+			nil,
+			fmt.Sprintf("%s: %s", errors.ErrGetBlock.Error(), err.Error()),
+			shared.ReturnCodeInternalError,
+		)
+		return
+	}
+
+	shared.RespondWith(c, http.StatusOK, gin.H{"block": block}, "", shared.ReturnCodeSuccess)
+
+}
+
+func (bg *blockGroup) getBlockByHash(c *gin.Context) {
+	hash := c.Param("hash")
+	if hash == "" {
+		shared.RespondWithValidationError(
+			c, fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), errors.ErrValidationEmptyBlockHash.Error()),
+		)
+		return
+	}
+
+	withTxs, err := getQueryParamWithTxs(c)
+	if err != nil {
+		shared.RespondWithValidationError(
+			c, fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), errors.ErrInvalidBlockNonce.Error()),
+		)
+		return
+	}
+
+	start := time.Now()
+	block, err := bg.getFacade().GetBlockByHash(hash, withTxs)
+	log.Debug(fmt.Sprintf("GetBlockByHash took %s", time.Since(start)))
+	if err != nil {
+		shared.RespondWith(
+			c,
+			http.StatusInternalServerError,
+			nil,
+			fmt.Sprintf("%s: %s", errors.ErrGetBlock.Error(), err.Error()),
+			shared.ReturnCodeInternalError,
+		)
+		return
+	}
+
+	shared.RespondWith(c, http.StatusOK, gin.H{"block": block}, "", shared.ReturnCodeSuccess)
+}
+
+func getQueryParamWithTxs(c *gin.Context) (bool, error) {
+	withTxsStr := c.Request.URL.Query().Get("withTxs")
+	if withTxsStr == "" {
+		return false, nil
+	}
+
+	return strconv.ParseBool(withTxsStr)
+}
+
+func getQueryParamNonce(c *gin.Context) (uint64, error) {
+	nonceStr := c.Param("nonce")
+	if nonceStr == "" {
+		return 0, errors.ErrInvalidBlockNonce
+	}
+
+	return strconv.ParseUint(nonceStr, 10, 64)
+}
+
+func (bg *blockGroup) getFacade() blockFacadeHandler {
+	bg.mutFacade.RLock()
+	defer bg.mutFacade.RUnlock()
+
+	return bg.facade
+}
+
+// UpdateFacade will update the facade
+func (bg *blockGroup) UpdateFacade(newFacade interface{}) error {
+	if newFacade == nil {
+		return errors.ErrNilFacadeHandler
+	}
+	castedFacade, ok := newFacade.(blockFacadeHandler)
+	if !ok {
+		return errors.ErrFacadeWrongTypeAssertion
+	}
+
+	bg.mutFacade.Lock()
+	bg.facade = castedFacade
+	bg.mutFacade.Unlock()
+
+	return nil
+}

--- a/api/groups/blockGroup_test.go
+++ b/api/groups/blockGroup_test.go
@@ -25,13 +25,6 @@ func TestNewBlockGroup(t *testing.T) {
 		require.Nil(t, hg)
 	})
 
-	t.Run("wrong type assertion facade", func(t *testing.T) {
-		dummyStruct := struct {}{}
-		hg, err := groups.NewBlockGroup(dummyStruct)
-		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
-		require.Nil(t, hg)
-	})
-
 	t.Run("should work", func(t *testing.T) {
 		hg, err := groups.NewBlockGroup(&mock.Facade{})
 		require.NoError(t, err)

--- a/api/groups/blockGroup_test.go
+++ b/api/groups/blockGroup_test.go
@@ -1,0 +1,246 @@
+package groups_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/data/api"
+	apiErrors "github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/groups"
+	"github.com/ElrondNetwork/elrond-go/api/mock"
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBlockGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil facade", func(t *testing.T) {
+		hg, err := groups.NewBlockGroup(nil)
+		require.True(t, errors.Is(err, apiErrors.ErrNilFacadeHandler))
+		require.Nil(t, hg)
+	})
+
+	t.Run("wrong type assertion facade", func(t *testing.T) {
+		dummyStruct := struct {}{}
+		hg, err := groups.NewBlockGroup(dummyStruct)
+		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
+		require.Nil(t, hg)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		hg, err := groups.NewBlockGroup(&mock.Facade{})
+		require.NoError(t, err)
+		require.NotNil(t, hg)
+	})
+}
+
+type blockResponseData struct {
+	Block api.Block `json:"block"`
+}
+
+type blockResponse struct {
+	Data  blockResponseData `json:"data"`
+	Error string            `json:"error"`
+	Code  string            `json:"code"`
+}
+
+func TestGetBlockByNonce_EmptyNonceUrlParameterShouldErr(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{
+		GetBlockByNonceCalled: func(_ uint64, _ bool) (*api.Block, error) {
+			return &api.Block{}, nil
+		},
+	}
+
+	blockGroup, err := groups.NewBlockGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(blockGroup, "block", getBlockRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/block/by-nonce", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := blockResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+}
+
+func TestGetBlockByNonce_InvalidNonceShouldErr(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{
+		GetBlockByNonceCalled: func(_ uint64, _ bool) (*api.Block, error) {
+			return &api.Block{}, nil
+		},
+	}
+
+	blockGroup, err := groups.NewBlockGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(blockGroup, "block", getBlockRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/block/by-nonce/invalid", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := blockResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+
+	assert.True(t, strings.Contains(response.Error, apiErrors.ErrInvalidBlockNonce.Error()))
+}
+
+func TestGetBlockByNonce_FacadeErrorShouldErr(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("local err")
+	facade := mock.Facade{
+		GetBlockByNonceCalled: func(_ uint64, _ bool) (*api.Block, error) {
+			return nil, expectedErr
+		},
+	}
+
+	blockGroup, err := groups.NewBlockGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(blockGroup, "block", getBlockRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/block/by-nonce/37", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := blockResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+
+	assert.True(t, strings.Contains(response.Error, expectedErr.Error()))
+}
+
+func TestGetBlockByNonce_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	expectedBlock := api.Block{
+		Nonce: 37,
+		Round: 39,
+	}
+	facade := mock.Facade{
+		GetBlockByNonceCalled: func(_ uint64, _ bool) (*api.Block, error) {
+			return &expectedBlock, nil
+		},
+	}
+
+	blockGroup, err := groups.NewBlockGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(blockGroup, "block", getBlockRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/block/by-nonce/37", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := blockResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	assert.Equal(t, expectedBlock, response.Data.Block)
+}
+
+// ---- by hash
+
+func TestGetBlockByHash_NoHashUrlParameterShouldErr(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{
+		GetBlockByNonceCalled: func(_ uint64, _ bool) (*api.Block, error) {
+			return &api.Block{}, nil
+		},
+	}
+
+	blockGroup, err := groups.NewBlockGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(blockGroup, "block", getBlockRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/block/by-hash", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := blockResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+}
+
+func TestGetBlockByHash_FacadeErrorShouldErr(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("local err")
+	facade := mock.Facade{
+		GetBlockByHashCalled: func(_ string, _ bool) (*api.Block, error) {
+			return nil, expectedErr
+		},
+	}
+
+	blockGroup, err := groups.NewBlockGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(blockGroup, "block", getBlockRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/block/by-hash/hash", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := blockResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+
+	assert.True(t, strings.Contains(response.Error, expectedErr.Error()))
+}
+
+func TestGetBlockByHash_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	expectedBlock := api.Block{
+		Nonce: 37,
+		Round: 39,
+	}
+	facade := mock.Facade{
+		GetBlockByHashCalled: func(_ string, _ bool) (*api.Block, error) {
+			return &expectedBlock, nil
+		},
+	}
+
+	blockGroup, err := groups.NewBlockGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(blockGroup, "block", getBlockRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/block/by-hash/hash", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := blockResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	assert.Equal(t, expectedBlock, response.Data.Block)
+}
+
+func getBlockRoutesConfig() config.ApiRoutesConfig {
+	return config.ApiRoutesConfig{
+		APIPackages: map[string]config.APIPackageConfig{
+			"block": {
+				Routes: []config.RouteConfig{
+					{Name: "/by-nonce/:nonce", Open: true},
+					{Name: "/by-hash/:hash", Open: true},
+				},
+			},
+		},
+	}
+}

--- a/api/groups/common_test.go
+++ b/api/groups/common_test.go
@@ -1,0 +1,37 @@
+package groups_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func startWebServer(group shared.GroupHandler, path string, apiConfig config.ApiRoutesConfig) *gin.Engine {
+	ws := gin.New()
+	ws.Use(cors.Default())
+	routes := ws.Group(path)
+	group.RegisterRoutes(routes, apiConfig, nil)
+	return ws
+}
+
+func loadResponse(rsp io.Reader, destination interface{}) {
+	jsonParser := json.NewDecoder(rsp)
+	err := jsonParser.Decode(destination)
+	logError(err)
+}
+
+
+func logError(err error) {
+	if err != nil {
+		fmt.Println(err)
+	}
+}

--- a/api/groups/common_test.go
+++ b/api/groups/common_test.go
@@ -19,7 +19,7 @@ func startWebServer(group shared.GroupHandler, path string, apiConfig config.Api
 	ws := gin.New()
 	ws.Use(cors.Default())
 	routes := ws.Group(path)
-	group.RegisterRoutes(routes, apiConfig, nil)
+	group.RegisterRoutes(routes, apiConfig)
 	return ws
 }
 

--- a/api/groups/export_test.go
+++ b/api/groups/export_test.go
@@ -1,0 +1,11 @@
+package groups
+
+import "github.com/ElrondNetwork/elrond-go/process"
+
+const ExecManualTrigger = execManualTrigger
+const ExecBroadcastTrigger = execBroadcastTrigger
+
+// CreateSCQuery -
+func (vvg *vmValuesGroup) CreateSCQuery(request *VMValueRequest) (*process.SCQuery, error) {
+	return vvg.createSCQuery(request)
+}

--- a/api/groups/export_test.go
+++ b/api/groups/export_test.go
@@ -2,10 +2,18 @@ package groups
 
 import "github.com/ElrondNetwork/elrond-go/process"
 
+// ExecManualTrigger -
 const ExecManualTrigger = execManualTrigger
+
+// ExecBroadcastTrigger -
 const ExecBroadcastTrigger = execBroadcastTrigger
 
 // CreateSCQuery -
 func (vvg *vmValuesGroup) CreateSCQuery(request *VMValueRequest) (*process.SCQuery, error) {
 	return vvg.createSCQuery(request)
+}
+
+// VmValuesFacadeHandler exported the vm values facade handler interface for testing purposes
+type VmValuesFacadeHandler interface {
+	vmValuesFacadeHandler
 }

--- a/api/groups/hardforkGroup.go
+++ b/api/groups/hardforkGroup.go
@@ -1,0 +1,131 @@
+package groups
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	execManualTrigger    = "executed, trigger is affecting only the current node"
+	execBroadcastTrigger = "executed, trigger is affecting current node and will get broadcast to other peers"
+	triggerPath          = "/trigger"
+)
+
+type hardforkFacadeHandler interface {
+	Trigger(epoch uint32, withEarlyEndOfEpoch bool) error
+	IsSelfTrigger() bool
+	IsInterfaceNil() bool
+}
+
+type hardforkGroup struct {
+	facade hardforkFacadeHandler
+	mutFacade sync.RWMutex
+	*baseGroup
+}
+
+// NewHardforkGroup returns a new instance of hardforkFacadeHandler
+func NewHardforkGroup(facadeHandler interface{}) (*hardforkGroup, error) {
+	if facadeHandler == nil {
+		return nil, errors.ErrNilFacadeHandler
+	}
+
+	facade, ok := facadeHandler.(hardforkFacadeHandler)
+	if !ok {
+		return nil, fmt.Errorf("%w for hardfork group", errors.ErrFacadeWrongTypeAssertion)
+	}
+
+	hg := &hardforkGroup{
+		facade:    facade,
+		baseGroup: &baseGroup{},
+	}
+
+	endpoints := []*shared.EndpointHandlerData{
+		{
+			Path:    triggerPath,
+			Method:  http.MethodPost,
+			Handler: hg.triggerHandler,
+		},
+	}
+	hg.endpoints = endpoints
+
+	return hg, nil
+}
+
+// HarforkRequest represents the structure on which user input for triggering a hardfork will validate against
+type HarforkRequest struct {
+	Epoch               uint32 `form:"epoch" json:"epoch"`
+	WithEarlyEndOfEpoch bool   `form:"withEarlyEndOfEpoch" json:"withEarlyEndOfEpoch"`
+}
+
+// triggerHandler will receive a trigger request from the client and propagate it for processing
+func (hg *hardforkGroup) triggerHandler(c *gin.Context) {
+	var hr = HarforkRequest{}
+	err := c.ShouldBindJSON(&hr)
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), err.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	err = hg.getFacade().Trigger(hr.Epoch, hr.WithEarlyEndOfEpoch)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: err.Error(),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	status := execManualTrigger
+	if hg.getFacade().IsSelfTrigger() {
+		status = execBroadcastTrigger
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"status": status},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+func (hg *hardforkGroup) getFacade() hardforkFacadeHandler {
+	hg.mutFacade.RLock()
+	defer hg.mutFacade.RUnlock()
+
+	return hg.facade
+}
+
+// UpdateFacade will update the facade
+func (hg *hardforkGroup) UpdateFacade(newFacade interface{}) error {
+	if newFacade == nil {
+		return errors.ErrNilFacadeHandler
+	}
+	castedFacade, ok := newFacade.(hardforkFacadeHandler)
+	if !ok {
+		return errors.ErrFacadeWrongTypeAssertion
+	}
+
+	hg.mutFacade.Lock()
+	hg.facade = castedFacade
+	hg.mutFacade.Unlock()
+
+	return nil
+}

--- a/api/groups/hardforkGroup.go
+++ b/api/groups/hardforkGroup.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go/api/errors"
 	"github.com/ElrondNetwork/elrond-go/api/shared"
 	"github.com/gin-gonic/gin"
@@ -30,7 +31,7 @@ type hardforkGroup struct {
 
 // NewHardforkGroup returns a new instance of hardforkFacadeHandler
 func NewHardforkGroup(facade hardforkFacadeHandler) (*hardforkGroup, error) {
-	if facade == nil {
+	if check.IfNil(facade) {
 		return nil, fmt.Errorf("%w for hardfork group", errors.ErrNilFacadeHandler)
 	}
 

--- a/api/groups/hardforkGroup.go
+++ b/api/groups/hardforkGroup.go
@@ -23,20 +23,15 @@ type hardforkFacadeHandler interface {
 }
 
 type hardforkGroup struct {
+	*baseGroup
 	facade hardforkFacadeHandler
 	mutFacade sync.RWMutex
-	*baseGroup
 }
 
 // NewHardforkGroup returns a new instance of hardforkFacadeHandler
-func NewHardforkGroup(facadeHandler interface{}) (*hardforkGroup, error) {
-	if facadeHandler == nil {
-		return nil, errors.ErrNilFacadeHandler
-	}
-
-	facade, ok := facadeHandler.(hardforkFacadeHandler)
-	if !ok {
-		return nil, fmt.Errorf("%w for hardfork group", errors.ErrFacadeWrongTypeAssertion)
+func NewHardforkGroup(facade hardforkFacadeHandler) (*hardforkGroup, error) {
+	if facade == nil {
+		return nil, fmt.Errorf("%w for hardfork group", errors.ErrNilFacadeHandler)
 	}
 
 	hg := &hardforkGroup{
@@ -118,14 +113,19 @@ func (hg *hardforkGroup) UpdateFacade(newFacade interface{}) error {
 	if newFacade == nil {
 		return errors.ErrNilFacadeHandler
 	}
-	castedFacade, ok := newFacade.(hardforkFacadeHandler)
+	castFacade, ok := newFacade.(hardforkFacadeHandler)
 	if !ok {
 		return errors.ErrFacadeWrongTypeAssertion
 	}
 
 	hg.mutFacade.Lock()
-	hg.facade = castedFacade
+	hg.facade = castFacade
 	hg.mutFacade.Unlock()
 
 	return nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (hg *hardforkGroup) IsInterfaceNil() bool {
+	return hg == nil
 }

--- a/api/groups/hardforkGroup_test.go
+++ b/api/groups/hardforkGroup_test.go
@@ -1,0 +1,187 @@
+package groups_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	apiErrors "github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/groups"
+	"github.com/ElrondNetwork/elrond-go/api/hardfork"
+	"github.com/ElrondNetwork/elrond-go/api/mock"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+
+type TriggerResponse struct {
+	Status string `json:"status"`
+}
+
+func TestNewHardforkGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil facade", func(t *testing.T) {
+		hg, err := groups.NewHardforkGroup(nil)
+		require.True(t, errors.Is(err, apiErrors.ErrNilFacadeHandler))
+		require.Nil(t, hg)
+	})
+
+	t.Run("wrong type assertion facade", func(t *testing.T) {
+		dummyStruct := struct {}{}
+		hg, err := groups.NewHardforkGroup(dummyStruct)
+		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
+		require.Nil(t, hg)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		hg, err := groups.NewHardforkGroup(&mock.HardforkFacade{})
+		require.NoError(t, err)
+		require.NotNil(t, hg)
+	})
+}
+
+func TestTrigger_TriggerCanNotExecuteShouldErr(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("expected error")
+	hardforkFacade := &mock.HardforkFacade{
+		TriggerCalled: func(_ uint32, _ bool) error {
+			return expectedErr
+		},
+	}
+
+	hardforkGroup, err := groups.NewHardforkGroup(hardforkFacade)
+	require.NoError(t, err)
+
+	ws := startWebServer(hardforkGroup, "hardfork", getHardforkRoutesConfig())
+
+	hr := &hardfork.HarforkRequest{
+		Epoch: 4,
+	}
+
+	buffHr, _ := json.Marshal(hr)
+	req, _ := http.NewRequest("POST", "/hardfork/trigger", bytes.NewBuffer(buffHr))
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, resp.Code, http.StatusInternalServerError)
+	assert.Contains(t, response.Error, expectedErr.Error())
+}
+
+func TestTrigger_TriggerWrongRequestTypeShouldErr(t *testing.T) {
+	t.Parallel()
+
+	hardforkGroup, err := groups.NewHardforkGroup(&mock.HardforkFacade{})
+	require.NoError(t, err)
+
+	ws := startWebServer(hardforkGroup, "hardfork", getHardforkRoutesConfig())
+
+	req, _ := http.NewRequest("POST", "/hardfork/trigger", bytes.NewBuffer([]byte("wrong buffer")))
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	triggerResponse := TriggerResponse{}
+	loadResponse(resp.Body, &triggerResponse)
+
+	assert.Equal(t, resp.Code, http.StatusBadRequest)
+}
+
+func TestTrigger_ManualShouldWork(t *testing.T) {
+	t.Parallel()
+
+	recoveredEpoch := uint32(0)
+	hr := &hardfork.HarforkRequest{
+		Epoch: 4,
+	}
+	buffHr, _ := json.Marshal(hr)
+
+	hardforkFacade := &mock.HardforkFacade{
+		TriggerCalled: func(epoch uint32, _ bool) error {
+			atomic.StoreUint32(&recoveredEpoch, epoch)
+
+			return nil
+		},
+		IsSelfTriggerCalled: func() bool {
+			return false
+		},
+	}
+	hardforkGroup, err := groups.NewHardforkGroup(hardforkFacade)
+	require.NoError(t, err)
+
+	ws := startWebServer(hardforkGroup, "hardfork", getHardforkRoutesConfig())
+
+	req, _ := http.NewRequest("POST", "/hardfork/trigger", bytes.NewBuffer(buffHr))
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	triggerResponse := TriggerResponse{}
+	mapResponseData := response.Data.(map[string]interface{})
+	mapResponseBytes, _ := json.Marshal(&mapResponseData)
+	_ = json.Unmarshal(mapResponseBytes, &triggerResponse)
+
+	assert.Equal(t, resp.Code, http.StatusOK)
+	assert.Equal(t, groups.ExecManualTrigger, triggerResponse.Status)
+	assert.Equal(t, hr.Epoch, atomic.LoadUint32(&recoveredEpoch))
+}
+
+func TestTrigger_BroadcastShouldWork(t *testing.T) {
+	t.Parallel()
+
+	hardforkFacade := &mock.HardforkFacade{
+		TriggerCalled: func(_ uint32, _ bool) error {
+			return nil
+		},
+		IsSelfTriggerCalled: func() bool {
+			return true
+		},
+	}
+
+	hardforkGroup, err := groups.NewHardforkGroup(hardforkFacade)
+	require.NoError(t, err)
+
+	ws := startWebServer(hardforkGroup, "hardfork", getHardforkRoutesConfig())
+
+	hr := &hardfork.HarforkRequest{
+		Epoch: 4,
+	}
+	buffHr, _ := json.Marshal(hr)
+	req, _ := http.NewRequest("POST", "/hardfork/trigger", bytes.NewBuffer(buffHr))
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	triggerResponse := TriggerResponse{}
+	mapResponseData := response.Data.(map[string]interface{})
+	mapResponseBytes, _ := json.Marshal(&mapResponseData)
+	_ = json.Unmarshal(mapResponseBytes, &triggerResponse)
+
+	assert.Equal(t, resp.Code, http.StatusOK)
+	assert.Equal(t, groups.ExecBroadcastTrigger, triggerResponse.Status)
+}
+
+func getHardforkRoutesConfig() config.ApiRoutesConfig {
+	return config.ApiRoutesConfig{
+		APIPackages: map[string]config.APIPackageConfig{
+			"hardfork": {
+				Routes: []config.RouteConfig{
+					{Name: "/trigger", Open: true},
+				},
+			},
+		},
+	}
+}

--- a/api/groups/hardforkGroup_test.go
+++ b/api/groups/hardforkGroup_test.go
@@ -33,13 +33,6 @@ func TestNewHardforkGroup(t *testing.T) {
 		require.Nil(t, hg)
 	})
 
-	t.Run("wrong type assertion facade", func(t *testing.T) {
-		dummyStruct := struct {}{}
-		hg, err := groups.NewHardforkGroup(dummyStruct)
-		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
-		require.Nil(t, hg)
-	})
-
 	t.Run("should work", func(t *testing.T) {
 		hg, err := groups.NewHardforkGroup(&mock.HardforkFacade{})
 		require.NoError(t, err)

--- a/api/groups/networkGroup.go
+++ b/api/groups/networkGroup.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data/api"
 	"github.com/ElrondNetwork/elrond-go/api/errors"
 	"github.com/ElrondNetwork/elrond-go/api/shared"
@@ -44,7 +45,7 @@ type networkGroup struct {
 
 // NewNetworkGroup returns a new instance of networkGroup
 func NewNetworkGroup(facade networkFacadeHandler) (*networkGroup, error) {
-	if facade == nil {
+	if check.IfNil(facade) {
 		return nil, fmt.Errorf("%w for network group", errors.ErrNilFacadeHandler)
 	}
 

--- a/api/groups/networkGroup.go
+++ b/api/groups/networkGroup.go
@@ -1,0 +1,284 @@
+package groups
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/data/api"
+	"github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/ElrondNetwork/elrond-go/common"
+	"github.com/ElrondNetwork/elrond-go/node/external"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	getConfigPath        = "/config"
+	getStatusPath        = "/status"
+	economicsPath        = "/economics"
+	enableEpochsPath     = "/enable-epochs"
+	getESDTsPath         = "/esdts"
+	getFFTsPath          = "/esdt/fungible-tokens"
+	getSFTsPath          = "/esdt/semi-fungible-tokens"
+	getNFTsPath          = "/esdt/non-fungible-tokens"
+	directStakedInfoPath = "/direct-staked-info"
+	delegatedInfoPath    = "/delegated-info"
+)
+
+type networkFacadeHandler interface {
+	GetTotalStakedValue() (*api.StakeValues, error)
+	GetDirectStakedList() ([]*api.DirectStakedValue, error)
+	GetDelegatorsList() ([]*api.Delegator, error)
+	StatusMetrics() external.StatusMetricsHandler
+	GetAllIssuedESDTs(tokenType string) ([]string, error)
+	IsInterfaceNil() bool
+}
+
+type networkGroup struct {
+	facade    networkFacadeHandler
+	mutFacade sync.RWMutex
+	*baseGroup
+}
+
+// NewNetworkGroup returns a new instance of networkGroup
+func NewNetworkGroup(facadeHandler interface{}) (*networkGroup, error) {
+	if facadeHandler == nil {
+		return nil, errors.ErrNilFacadeHandler
+	}
+
+	facade, ok := facadeHandler.(networkFacadeHandler)
+	if !ok {
+		return nil, fmt.Errorf("%w for network group", errors.ErrFacadeWrongTypeAssertion)
+	}
+
+	ng := &networkGroup{
+		facade:    facade,
+		baseGroup: &baseGroup{},
+	}
+
+	endpoints := []*shared.EndpointHandlerData{
+		{
+			Path:    getConfigPath,
+			Method:  http.MethodGet,
+			Handler: ng.getNetworkConfig,
+		},
+		{
+			Path:    getStatusPath,
+			Method:  http.MethodGet,
+			Handler: ng.getNetworkStatus,
+		},
+		{
+			Path: economicsPath,
+			Method: http.MethodGet,
+			Handler: ng.economicsMetrics,
+		},
+		{
+			Path: enableEpochsPath,
+			Method: http.MethodGet,
+			Handler: ng.getEnableEpochs,
+		},
+		{
+			Path: getESDTsPath,
+			Method: http.MethodGet,
+			Handler: ng.getHandlerFuncForEsdt(""),
+		},
+		{
+			Path: getFFTsPath,
+			Method: http.MethodGet,
+			Handler: ng.getHandlerFuncForEsdt(core.FungibleESDT),
+		},
+		{
+			Path: getSFTsPath,
+			Method: http.MethodGet,
+			Handler: ng.getHandlerFuncForEsdt(core.SemiFungibleESDT),
+		},
+		{
+			Path: getNFTsPath,
+			Method: http.MethodGet,
+			Handler: ng.getHandlerFuncForEsdt(core.NonFungibleESDT),
+		},
+		{
+			Path: directStakedInfoPath,
+			Method: http.MethodGet,
+			Handler: ng.directStakedInfo,
+		},
+		{
+			Path: delegatedInfoPath,
+			Method: http.MethodGet,
+			Handler: ng.delegatedInfo,
+		},
+	}
+	ng.endpoints = endpoints
+
+	return ng, nil
+}
+
+// getNetworkConfig returns metrics related to the network configuration (shard independent)
+func (ng *networkGroup) getNetworkConfig(c *gin.Context) {
+	configMetrics := ng.getFacade().StatusMetrics().ConfigMetrics()
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"config": configMetrics},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// getEnableEpochs returns metrics related to the activation epochs of the network
+func (ng *networkGroup) getEnableEpochs(c *gin.Context) {
+	enableEpochsMetrics := ng.getFacade().StatusMetrics().EnableEpochsMetrics()
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"enableEpochs": enableEpochsMetrics},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// getNetworkStatus returns metrics related to the network status (shard specific)
+func (ng *networkGroup) getNetworkStatus(c *gin.Context) {
+	networkMetrics := ng.getFacade().StatusMetrics().NetworkMetrics()
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"status": networkMetrics},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// economicsMetrics is the endpoint that will return the economics data such as total supply
+func (ng *networkGroup) economicsMetrics(c *gin.Context) {
+	stakeValues, err := ng.getFacade().GetTotalStakedValue()
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: err.Error(),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	metrics := ng.getFacade().StatusMetrics().EconomicsMetrics()
+	metrics[common.MetricTotalBaseStakedValue] = stakeValues.BaseStaked.String()
+	metrics[common.MetricTopUpValue] = stakeValues.TopUp.String()
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"metrics": metrics},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+func (ng *networkGroup) getHandlerFuncForEsdt(tokenType string) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		tokens, err := ng.getFacade().GetAllIssuedESDTs(tokenType)
+		if err != nil {
+			c.JSON(
+				http.StatusInternalServerError,
+				shared.GenericAPIResponse{
+					Data:  nil,
+					Error: err.Error(),
+					Code:  shared.ReturnCodeInternalError,
+				},
+			)
+			return
+		}
+
+		c.JSON(
+			http.StatusOK,
+			shared.GenericAPIResponse{
+				Data:  gin.H{"tokens": tokens},
+				Error: "",
+				Code:  shared.ReturnCodeSuccess,
+			},
+		)
+	}
+}
+
+// directStakedInfo is the endpoint that will return the directed staked info list
+func (ng *networkGroup) directStakedInfo(c *gin.Context) {
+	directStakedList, err := ng.getFacade().GetDirectStakedList()
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: err.Error(),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"list": directStakedList},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// delegatedInfo is the endpoint that will return the delegated list
+func (ng *networkGroup) delegatedInfo(c *gin.Context) {
+	delegatedList, err := ng.getFacade().GetDelegatorsList()
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: err.Error(),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"list": delegatedList},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+func (ng *networkGroup) getFacade() networkFacadeHandler {
+	ng.mutFacade.RLock()
+	defer ng.mutFacade.RUnlock()
+
+	return ng.facade
+}
+
+// UpdateFacade will update the facade
+func (ng *networkGroup) UpdateFacade(newFacade interface{}) error {
+	if newFacade == nil {
+		return errors.ErrNilFacadeHandler
+	}
+	castedFacade, ok := newFacade.(networkFacadeHandler)
+	if !ok {
+		return errors.ErrFacadeWrongTypeAssertion
+	}
+
+	ng.mutFacade.Lock()
+	ng.facade = castedFacade
+	ng.mutFacade.Unlock()
+
+	return nil
+}

--- a/api/groups/networkGroup.go
+++ b/api/groups/networkGroup.go
@@ -37,20 +37,15 @@ type networkFacadeHandler interface {
 }
 
 type networkGroup struct {
+	*baseGroup
 	facade    networkFacadeHandler
 	mutFacade sync.RWMutex
-	*baseGroup
 }
 
 // NewNetworkGroup returns a new instance of networkGroup
-func NewNetworkGroup(facadeHandler interface{}) (*networkGroup, error) {
-	if facadeHandler == nil {
-		return nil, errors.ErrNilFacadeHandler
-	}
-
-	facade, ok := facadeHandler.(networkFacadeHandler)
-	if !ok {
-		return nil, fmt.Errorf("%w for network group", errors.ErrFacadeWrongTypeAssertion)
+func NewNetworkGroup(facade networkFacadeHandler) (*networkGroup, error) {
+	if facade == nil {
+		return nil, fmt.Errorf("%w for network group", errors.ErrNilFacadeHandler)
 	}
 
 	ng := &networkGroup{
@@ -271,14 +266,19 @@ func (ng *networkGroup) UpdateFacade(newFacade interface{}) error {
 	if newFacade == nil {
 		return errors.ErrNilFacadeHandler
 	}
-	castedFacade, ok := newFacade.(networkFacadeHandler)
+	castFacade, ok := newFacade.(networkFacadeHandler)
 	if !ok {
 		return errors.ErrFacadeWrongTypeAssertion
 	}
 
 	ng.mutFacade.Lock()
-	ng.facade = castedFacade
+	ng.facade = castFacade
 	ng.mutFacade.Unlock()
 
 	return nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (ng *networkGroup) IsInterfaceNil() bool {
+	return ng == nil
 }

--- a/api/groups/networkGroup_test.go
+++ b/api/groups/networkGroup_test.go
@@ -1,0 +1,434 @@
+package groups_test
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/data/api"
+	apiErrors "github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/groups"
+	"github.com/ElrondNetwork/elrond-go/api/mock"
+	"github.com/ElrondNetwork/elrond-go/common"
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/node/external"
+	"github.com/ElrondNetwork/elrond-go/statusHandler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNetworkGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil facade", func(t *testing.T) {
+		hg, err := groups.NewNetworkGroup(nil)
+		require.True(t, errors.Is(err, apiErrors.ErrNilFacadeHandler))
+		require.Nil(t, hg)
+	})
+
+	t.Run("wrong type assertion facade", func(t *testing.T) {
+		dummyStruct := struct {}{}
+		hg, err := groups.NewNetworkGroup(dummyStruct)
+		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
+		require.Nil(t, hg)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		hg, err := groups.NewNetworkGroup(&mock.Facade{})
+		require.NoError(t, err)
+		require.NotNil(t, hg)
+	})
+}
+
+type esdtTokensResponseData struct {
+	Tokens []string `json:"tokens"`
+}
+
+type esdtTokensResponse struct {
+	Data  esdtTokensResponseData `json:"data"`
+	Error string                 `json:"error"`
+	Code  string
+}
+
+func TestNetworkConfigMetrics_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	statusMetricsProvider := statusHandler.NewStatusMetrics()
+	key := common.MetricMinGasLimit
+	value := uint64(37)
+	statusMetricsProvider.SetUInt64Value(key, value)
+
+	facade := mock.Facade{}
+	facade.StatusMetricsHandler = func() external.StatusMetricsHandler {
+		return statusMetricsProvider
+	}
+
+	networkGroup, err := groups.NewNetworkGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(networkGroup, "network", getNetworkRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/network/config", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respStr := string(respBytes)
+	assert.Equal(t, resp.Code, http.StatusOK)
+
+	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, fmt.Sprintf("%d", value))
+	assert.True(t, keyAndValueFoundInResponse)
+}
+
+func TestNetworkStatusMetrics_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	statusMetricsProvider := statusHandler.NewStatusMetrics()
+	key := common.MetricEpochNumber
+	value := uint64(37)
+	statusMetricsProvider.SetUInt64Value(key, value)
+
+	facade := mock.Facade{}
+	facade.StatusMetricsHandler = func() external.StatusMetricsHandler {
+		return statusMetricsProvider
+	}
+
+	networkGroup, err := groups.NewNetworkGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(networkGroup, "network", getNetworkRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/network/status", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respStr := string(respBytes)
+	assert.Equal(t, resp.Code, http.StatusOK)
+
+	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, fmt.Sprintf("%d", value))
+	assert.True(t, keyAndValueFoundInResponse)
+}
+
+func TestEconomicsMetrics_ShouldWork(t *testing.T) {
+	statusMetricsProvider := statusHandler.NewStatusMetrics()
+	key := common.MetricTotalSupply
+	value := "12345"
+	statusMetricsProvider.SetStringValue(key, value)
+
+	facade := mock.Facade{
+		GetTotalStakedValueHandler: func() (*api.StakeValues, error) {
+			return &api.StakeValues{
+				BaseStaked: big.NewInt(100),
+				TopUp:      big.NewInt(20),
+			}, nil
+		},
+	}
+	facade.StatusMetricsHandler = func() external.StatusMetricsHandler {
+		return statusMetricsProvider
+	}
+
+	networkGroup, err := groups.NewNetworkGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(networkGroup, "network", getNetworkRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/network/economics", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respStr := string(respBytes)
+	assert.Equal(t, resp.Code, http.StatusOK)
+
+	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, value)
+	assert.True(t, keyAndValueFoundInResponse)
+}
+
+func TestEconomicsMetrics_CannotGetStakeValues(t *testing.T) {
+	statusMetricsProvider := statusHandler.NewStatusMetrics()
+	key := common.MetricTotalSupply
+	value := "12345"
+	statusMetricsProvider.SetStringValue(key, value)
+
+	localErr := fmt.Errorf("%s", "local error")
+	facade := mock.Facade{
+		GetTotalStakedValueHandler: func() (*api.StakeValues, error) {
+			return nil, localErr
+		},
+	}
+	facade.StatusMetricsHandler = func() external.StatusMetricsHandler {
+		return statusMetricsProvider
+	}
+
+	networkGroup, err := groups.NewNetworkGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(networkGroup, "network", getNetworkRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/network/economics", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	assert.Equal(t, resp.Code, http.StatusInternalServerError)
+}
+
+func TestGetAllIssuedESDTs_ShouldWork(t *testing.T) {
+	tokens := []string{"tokenA", "tokenB"}
+	facade := mock.Facade{
+		GetAllIssuedESDTsCalled: func(_ string) ([]string, error) {
+			return tokens, nil
+		},
+	}
+
+	networkGroup, err := groups.NewNetworkGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(networkGroup, "network", getNetworkRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/network/esdts", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := esdtTokensResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, resp.Code, http.StatusOK)
+
+	assert.Equal(t, tokens, response.Data.Tokens)
+}
+
+func TestGetAllIssuedESDTs_Error(t *testing.T) {
+	localErr := fmt.Errorf("%s", "local error")
+	facade := mock.Facade{
+		GetAllIssuedESDTsCalled: func(_ string) ([]string, error) {
+			return nil, localErr
+		},
+	}
+
+	networkGroup, err := groups.NewNetworkGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(networkGroup, "network", getNetworkRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/network/esdts", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	assert.Equal(t, resp.Code, http.StatusInternalServerError)
+}
+
+func TestDirectStakedInfo_ShouldWork(t *testing.T) {
+	stakedData1 := api.DirectStakedValue{
+		Address:    "addr1",
+		BaseStaked: "1111",
+		TopUp:      "2222",
+		Total:      "3333",
+	}
+	stakedData2 := api.DirectStakedValue{
+		Address:    "addr2",
+		BaseStaked: "4444",
+		TopUp:      "5555",
+		Total:      "9999",
+	}
+
+	facade := mock.Facade{
+		GetDirectStakedListHandler: func() ([]*api.DirectStakedValue, error) {
+			return []*api.DirectStakedValue{&stakedData1, &stakedData2}, nil
+		},
+	}
+
+	networkGroup, err := groups.NewNetworkGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(networkGroup, "network", getNetworkRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/network/direct-staked-info", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respStr := string(respBytes)
+	assert.Equal(t, resp.Code, http.StatusOK)
+
+	valuesFoundInResponse := directStakedFoundInResponse(respStr, stakedData1) && directStakedFoundInResponse(respStr, stakedData2)
+	assert.True(t, valuesFoundInResponse)
+}
+
+func directStakedFoundInResponse(response string, stakedData api.DirectStakedValue) bool {
+	return strings.Contains(response, stakedData.Address) && strings.Contains(response, stakedData.Total) &&
+		strings.Contains(response, stakedData.BaseStaked) && strings.Contains(response, stakedData.TopUp)
+}
+
+func TestDirectStakedInfo_CannotGetDirectStakedList(t *testing.T) {
+	expectedError := fmt.Errorf("%s", "expected error")
+	facade := mock.Facade{
+		GetDirectStakedListHandler: func() ([]*api.DirectStakedValue, error) {
+			return nil, expectedError
+		},
+	}
+
+	networkGroup, err := groups.NewNetworkGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(networkGroup, "network", getNetworkRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/network/direct-staked-info", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respStr := string(respBytes)
+
+	assert.Equal(t, resp.Code, http.StatusInternalServerError)
+	assert.True(t, strings.Contains(respStr, expectedError.Error()))
+}
+
+func TestDelegatedInfo_ShouldWork(t *testing.T) {
+	delegator1 := api.Delegator{
+		DelegatorAddress: "addr1",
+		DelegatedTo: []*api.DelegatedValue{
+			{
+				DelegationScAddress: "addr2",
+				Value:               "1111",
+			},
+			{
+				DelegationScAddress: "addr3",
+				Value:               "2222",
+			},
+		},
+		Total:         "3333",
+		TotalAsBigInt: big.NewInt(4444),
+	}
+
+	delegator2 := api.Delegator{
+		DelegatorAddress: "addr4",
+		DelegatedTo: []*api.DelegatedValue{
+			{
+				DelegationScAddress: "addr5",
+				Value:               "5555",
+			},
+			{
+				DelegationScAddress: "addr6",
+				Value:               "6666",
+			},
+		},
+		Total:         "12221",
+		TotalAsBigInt: big.NewInt(13331),
+	}
+
+	facade := mock.Facade{
+		GetDelegatorsListHandler: func() ([]*api.Delegator, error) {
+			return []*api.Delegator{&delegator1, &delegator2}, nil
+		},
+	}
+
+	networkGroup, err := groups.NewNetworkGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(networkGroup, "network", getNetworkRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/network/delegated-info", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respStr := string(respBytes)
+	assert.Equal(t, resp.Code, http.StatusOK)
+
+	valuesFoundInResponse := delegatorFoundInResponse(respStr, delegator1) && delegatorFoundInResponse(respStr, delegator2)
+	assert.True(t, valuesFoundInResponse)
+}
+
+func delegatorFoundInResponse(response string, delegator api.Delegator) bool {
+	if strings.Contains(response, delegator.TotalAsBigInt.String()) {
+		//we should have not encoded the total as big int
+		return false
+	}
+
+	found := strings.Contains(response, delegator.DelegatorAddress) && strings.Contains(response, delegator.Total)
+	for _, delegatedTo := range delegator.DelegatedTo {
+		found = found && strings.Contains(response, delegatedTo.Value) && strings.Contains(response, delegatedTo.DelegationScAddress)
+	}
+
+	return found
+}
+
+func TestDelegatedInfo_CannotGetDelegatedList(t *testing.T) {
+	expectedError := fmt.Errorf("%s", "expected error")
+	facade := mock.Facade{
+		GetDelegatorsListHandler: func() ([]*api.Delegator, error) {
+			return nil, expectedError
+		},
+	}
+
+	networkGroup, err := groups.NewNetworkGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(networkGroup, "network", getNetworkRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/network/delegated-info", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respStr := string(respBytes)
+
+	assert.Equal(t, resp.Code, http.StatusInternalServerError)
+	assert.True(t, strings.Contains(respStr, expectedError.Error()))
+}
+
+func TestGetEnableEpochs_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	statusMetrics := statusHandler.NewStatusMetrics()
+	key := common.MetricScDeployEnableEpoch
+	value := uint64(4)
+	statusMetrics.SetUInt64Value(key, value)
+
+	facade := mock.Facade{}
+	facade.StatusMetricsHandler = func() external.StatusMetricsHandler {
+		return statusMetrics
+	}
+
+	networkGroup, err := groups.NewNetworkGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(networkGroup, "network", getNetworkRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/network/enable-epochs", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respStr := string(respBytes)
+	assert.Equal(t, resp.Code, http.StatusOK)
+
+	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, strconv.FormatUint(value, 10))
+	assert.True(t, keyAndValueFoundInResponse)
+}
+
+func getNetworkRoutesConfig() config.ApiRoutesConfig {
+	return config.ApiRoutesConfig{
+		APIPackages: map[string]config.APIPackageConfig{
+			"network": {
+				Routes: []config.RouteConfig{
+					{Name: "/config", Open: true},
+					{Name: "/status", Open: true},
+					{Name: "/economics", Open: true},
+					{Name: "/esdts", Open: true},
+					{Name: "/total-staked", Open: true},
+					{Name: "/enable-epochs", Open: true},
+					{Name: "/direct-staked-info", Open: true},
+					{Name: "/delegated-info", Open: true},
+				},
+			},
+		},
+	}
+}
+

--- a/api/groups/networkGroup_test.go
+++ b/api/groups/networkGroup_test.go
@@ -32,13 +32,6 @@ func TestNewNetworkGroup(t *testing.T) {
 		require.Nil(t, hg)
 	})
 
-	t.Run("wrong type assertion facade", func(t *testing.T) {
-		dummyStruct := struct {}{}
-		hg, err := groups.NewNetworkGroup(dummyStruct)
-		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
-		require.Nil(t, hg)
-	})
-
 	t.Run("should work", func(t *testing.T) {
 		hg, err := groups.NewNetworkGroup(&mock.Facade{})
 		require.NoError(t, err)

--- a/api/groups/nodeGroup.go
+++ b/api/groups/nodeGroup.go
@@ -1,0 +1,266 @@
+package groups
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/ElrondNetwork/elrond-go/debug"
+	"github.com/ElrondNetwork/elrond-go/heartbeat/data"
+	"github.com/ElrondNetwork/elrond-go/node/external"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	pidQueryParam       = "pid"
+	debugPath           = "/debug"
+	heartbeatStatusPath = "/heartbeatstatus"
+	metricsPath         = "/metrics"
+	p2pStatusPath       = "/p2pstatus"
+	peerInfoPath        = "/peerinfo"
+	statusPath          = "/status"
+
+	// AccStateCheckpointsKey is used as a key for the number of account state checkpoints in the api response
+	AccStateCheckpointsKey = "erd_num_accounts_state_checkpoints"
+
+	// PeerStateCheckpointsKey is used as a key for the number of peer state checkpoints in the api response
+	PeerStateCheckpointsKey = "erd_num_peer_state_checkpoints"
+)
+
+type nodeFacadeHandler interface {
+	GetHeartbeats() ([]data.PubKeyHeartbeat, error)
+	StatusMetrics() external.StatusMetricsHandler
+	GetQueryHandler(name string) (debug.QueryHandler, error)
+	GetPeerInfo(pid string) ([]core.QueryP2PPeerInfo, error)
+	GetNumCheckpointsFromAccountState() uint32
+	GetNumCheckpointsFromPeerState() uint32
+	IsInterfaceNil() bool
+}
+
+// QueryDebugRequest represents the structure on which user input for querying a debug info will validate against
+type QueryDebugRequest struct {
+	Name   string `form:"name" json:"name"`
+	Search string `form:"search" json:"search"`
+}
+
+type nodeGroup struct {
+	facade    nodeFacadeHandler
+	mutFacade sync.RWMutex
+	*baseGroup
+}
+
+// NewNodeGroup returns a new instance of nodeGroup
+func NewNodeGroup(facadeHandler interface{}) (*nodeGroup, error) {
+	if facadeHandler == nil {
+		return nil, errors.ErrNilFacadeHandler
+	}
+
+	facade, ok := facadeHandler.(nodeFacadeHandler)
+	if !ok {
+		return nil, fmt.Errorf("%w for node group", errors.ErrFacadeWrongTypeAssertion)
+	}
+
+	ng := &nodeGroup{
+		facade:    facade,
+		baseGroup: &baseGroup{},
+	}
+
+	endpoints := []*shared.EndpointHandlerData{
+		{
+			Path:    heartbeatStatusPath,
+			Method:  http.MethodGet,
+			Handler: ng.heartbeatStatus,
+		},
+		{
+			Path:    statusPath,
+			Method:  http.MethodGet,
+			Handler: ng.statusMetrics,
+		},
+		{
+			Path:    p2pStatusPath,
+			Method:  http.MethodGet,
+			Handler: ng.p2pStatusMetrics,
+		},
+		{
+			Path:    metricsPath,
+			Method:  http.MethodGet,
+			Handler: ng.prometheusMetrics,
+		},
+		{
+			Path:    debugPath,
+			Method:  http.MethodPost,
+			Handler: ng.queryDebug,
+		},
+		{
+			Path:    peerInfoPath,
+			Method:  http.MethodGet,
+			Handler: ng.peerInfo,
+		},
+
+	}
+	ng.endpoints = endpoints
+
+	return ng, nil
+}
+
+// heartbeatStatus respond with the heartbeat status of the node
+func (ng *nodeGroup) heartbeatStatus(c *gin.Context) {
+	hbStatus, err := ng.getFacade().GetHeartbeats()
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: err.Error(),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"heartbeats": hbStatus},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// statusMetrics returns the node statistics exported by an StatusMetricsHandler without p2p statistics
+func (ng *nodeGroup) statusMetrics(c *gin.Context) {
+	nodeFacade := ng.getFacade()
+	details := nodeFacade.StatusMetrics().StatusMetricsMapWithoutP2P()
+	details[AccStateCheckpointsKey] = nodeFacade.GetNumCheckpointsFromAccountState()
+	details[PeerStateCheckpointsKey] = nodeFacade.GetNumCheckpointsFromPeerState()
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"metrics": details},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// p2pStatusMetrics returns the node's p2p statistics exported by a StatusMetricsHandler
+func (ng *nodeGroup) p2pStatusMetrics(c *gin.Context) {
+	details := ng.getFacade().StatusMetrics().StatusP2pMetricsMap()
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"metrics": details},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// queryDebug returns the debug information after the query has been interpreted
+func (ng *nodeGroup) queryDebug(c *gin.Context) {
+	var gtx = QueryDebugRequest{}
+	err := c.ShouldBindJSON(&gtx)
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), err.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	qh, err := ng.getFacade().GetQueryHandler(gtx.Name)
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrQueryError.Error(), err.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"result": qh.Query(gtx.Search)},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// peerInfo returns the information of a provided p2p peer ID
+func (ng *nodeGroup) peerInfo(c *gin.Context) {
+	queryVals := c.Request.URL.Query()
+	pids := queryVals[pidQueryParam]
+	pid := ""
+	if len(pids) > 0 {
+		pid = pids[0]
+	}
+
+	info, err := ng.getFacade().GetPeerInfo(pid)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetPidInfo.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"info": info},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// prometheusMetrics is the endpoint which will return the data in the way that prometheus expects them
+func (ng *nodeGroup) prometheusMetrics(c *gin.Context) {
+	metrics := ng.getFacade().StatusMetrics().StatusMetricsWithoutP2PPrometheusString()
+	c.String(
+		http.StatusOK,
+		metrics,
+	)
+}
+
+
+func (ng *nodeGroup) getFacade() nodeFacadeHandler {
+	ng.mutFacade.RLock()
+	defer ng.mutFacade.RUnlock()
+
+	return ng.facade
+}
+
+// UpdateFacade will update the facade
+func (ng *nodeGroup) UpdateFacade(newFacade interface{}) error {
+	if newFacade == nil {
+		return errors.ErrNilFacadeHandler
+	}
+	castedFacade, ok := newFacade.(nodeFacadeHandler)
+	if !ok {
+		return errors.ErrFacadeWrongTypeAssertion
+	}
+
+	ng.mutFacade.Lock()
+	ng.facade = castedFacade
+	ng.mutFacade.Unlock()
+
+	return nil
+}

--- a/api/groups/nodeGroup.go
+++ b/api/groups/nodeGroup.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go/api/errors"
 	"github.com/ElrondNetwork/elrond-go/api/shared"
 	"github.com/ElrondNetwork/elrond-go/debug"
@@ -54,7 +55,7 @@ type nodeGroup struct {
 
 // NewNodeGroup returns a new instance of nodeGroup
 func NewNodeGroup(facade nodeFacadeHandler) (*nodeGroup, error) {
-	if facade == nil {
+	if check.IfNil(facade) {
 		return nil, fmt.Errorf("%w for node group", errors.ErrNilFacadeHandler)
 	}
 

--- a/api/groups/nodeGroup.go
+++ b/api/groups/nodeGroup.go
@@ -47,20 +47,15 @@ type QueryDebugRequest struct {
 }
 
 type nodeGroup struct {
+	*baseGroup
 	facade    nodeFacadeHandler
 	mutFacade sync.RWMutex
-	*baseGroup
 }
 
 // NewNodeGroup returns a new instance of nodeGroup
-func NewNodeGroup(facadeHandler interface{}) (*nodeGroup, error) {
-	if facadeHandler == nil {
-		return nil, errors.ErrNilFacadeHandler
-	}
-
-	facade, ok := facadeHandler.(nodeFacadeHandler)
-	if !ok {
-		return nil, fmt.Errorf("%w for node group", errors.ErrFacadeWrongTypeAssertion)
+func NewNodeGroup(facade nodeFacadeHandler) (*nodeGroup, error) {
+	if facade == nil {
+		return nil, fmt.Errorf("%w for node group", errors.ErrNilFacadeHandler)
 	}
 
 	ng := &nodeGroup{
@@ -253,14 +248,19 @@ func (ng *nodeGroup) UpdateFacade(newFacade interface{}) error {
 	if newFacade == nil {
 		return errors.ErrNilFacadeHandler
 	}
-	castedFacade, ok := newFacade.(nodeFacadeHandler)
+	castFacade, ok := newFacade.(nodeFacadeHandler)
 	if !ok {
 		return errors.ErrFacadeWrongTypeAssertion
 	}
 
 	ng.mutFacade.Lock()
-	ng.facade = castedFacade
+	ng.facade = castFacade
 	ng.mutFacade.Unlock()
 
 	return nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (ng *nodeGroup) IsInterfaceNil() bool {
+	return ng == nil
 }

--- a/api/groups/nodeGroup_test.go
+++ b/api/groups/nodeGroup_test.go
@@ -39,13 +39,6 @@ func TestNewNodeGroup(t *testing.T) {
 		require.Nil(t, hg)
 	})
 
-	t.Run("wrong type assertion facade", func(t *testing.T) {
-		dummyStruct := struct {}{}
-		hg, err := groups.NewNodeGroup(dummyStruct)
-		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
-		require.Nil(t, hg)
-	})
-
 	t.Run("should work", func(t *testing.T) {
 		hg, err := groups.NewNodeGroup(&mock.Facade{})
 		require.NoError(t, err)
@@ -53,18 +46,18 @@ func TestNewNodeGroup(t *testing.T) {
 	})
 }
 
-type GeneralResponse struct {
+type generalResponse struct {
 	Message string `json:"message"`
 	Error   string `json:"error"`
 }
 
-type StatusResponse struct {
-	GeneralResponse
+type statusResponse struct {
+	generalResponse
 	Running bool `json:"running"`
 }
 
-type QueryResponse struct {
-	GeneralResponse
+type queryResponse struct {
+	generalResponse
 	Result []string `json:"result"`
 }
 
@@ -93,7 +86,7 @@ func TestHeartbeatstatus_FromFacadeErrors(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	statusRsp := StatusResponse{}
+	statusRsp := statusResponse{}
 	loadResponse(resp.Body, &statusRsp)
 
 	assert.Equal(t, resp.Code, http.StatusInternalServerError)
@@ -127,7 +120,7 @@ func TestHeartbeatstatus(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	statusRsp := StatusResponse{}
+	statusRsp := statusResponse{}
 	loadResponseAsString(resp.Body, &statusRsp)
 
 	assert.Equal(t, resp.Code, http.StatusOK)
@@ -235,7 +228,7 @@ func TestQueryDebug_GetQueryErrorsShouldErr(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	queryResponse := &GeneralResponse{}
+	queryResponse := &generalResponse{}
 	loadResponse(resp.Body, queryResponse)
 
 	assert.Equal(t, http.StatusBadRequest, resp.Code)
@@ -273,7 +266,7 @@ func TestQueryDebug_GetQueryShouldWork(t *testing.T) {
 	response := shared.GenericAPIResponse{}
 	loadResponse(resp.Body, &response)
 
-	queryResponse := QueryResponse{}
+	queryResponse := queryResponse{}
 	mapResponseData := response.Data.(map[string]interface{})
 	mapResponseDataBytes, _ := json.Marshal(mapResponseData)
 	_ = json.Unmarshal(mapResponseDataBytes, &queryResponse)
@@ -377,7 +370,7 @@ func TestPrometheusMetrics_ShouldWork(t *testing.T) {
 	assert.True(t, keyAndValueFoundInResponse)
 }
 
-func loadResponseAsString(rsp io.Reader, response *StatusResponse) {
+func loadResponseAsString(rsp io.Reader, response *statusResponse) {
 	buff, err := ioutil.ReadAll(rsp)
 	if err != nil {
 		logError(err)

--- a/api/groups/nodeGroup_test.go
+++ b/api/groups/nodeGroup_test.go
@@ -1,0 +1,406 @@
+package groups_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	apiErrors "github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/groups"
+	"github.com/ElrondNetwork/elrond-go/api/mock"
+	"github.com/ElrondNetwork/elrond-go/api/node"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/debug"
+	"github.com/ElrondNetwork/elrond-go/heartbeat/data"
+	"github.com/ElrondNetwork/elrond-go/node/external"
+	"github.com/ElrondNetwork/elrond-go/statusHandler"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNodeGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil facade", func(t *testing.T) {
+		hg, err := groups.NewNodeGroup(nil)
+		require.True(t, errors.Is(err, apiErrors.ErrNilFacadeHandler))
+		require.Nil(t, hg)
+	})
+
+	t.Run("wrong type assertion facade", func(t *testing.T) {
+		dummyStruct := struct {}{}
+		hg, err := groups.NewNodeGroup(dummyStruct)
+		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
+		require.Nil(t, hg)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		hg, err := groups.NewNodeGroup(&mock.Facade{})
+		require.NoError(t, err)
+		require.NotNil(t, hg)
+	})
+}
+
+type GeneralResponse struct {
+	Message string `json:"message"`
+	Error   string `json:"error"`
+}
+
+type StatusResponse struct {
+	GeneralResponse
+	Running bool `json:"running"`
+}
+
+type QueryResponse struct {
+	GeneralResponse
+	Result []string `json:"result"`
+}
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+//------- Heartbeatstatus
+
+func TestHeartbeatstatus_FromFacadeErrors(t *testing.T) {
+	t.Parallel()
+
+	errExpected := errors.New("expected error")
+	facade := mock.Facade{
+		GetHeartbeatsHandler: func() ([]data.PubKeyHeartbeat, error) {
+			return nil, errExpected
+		},
+	}
+
+	nodeGroup, err := groups.NewNodeGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(nodeGroup, "node", getNodeRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/node/heartbeatstatus", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	statusRsp := StatusResponse{}
+	loadResponse(resp.Body, &statusRsp)
+
+	assert.Equal(t, resp.Code, http.StatusInternalServerError)
+	assert.Equal(t, errExpected.Error(), statusRsp.Error)
+}
+
+func TestHeartbeatstatus(t *testing.T) {
+	t.Parallel()
+
+	hbStatus := []data.PubKeyHeartbeat{
+		{
+			PublicKey:       "pk1",
+			TimeStamp:       time.Now(),
+			MaxInactiveTime: data.Duration{Duration: 0},
+			IsActive:        true,
+			ReceivedShardID: uint32(0),
+		},
+	}
+	facade := mock.Facade{
+		GetHeartbeatsHandler: func() (heartbeats []data.PubKeyHeartbeat, e error) {
+			return hbStatus, nil
+		},
+	}
+
+	nodeGroup, err := groups.NewNodeGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(nodeGroup, "node", getNodeRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/node/heartbeatstatus", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	statusRsp := StatusResponse{}
+	loadResponseAsString(resp.Body, &statusRsp)
+
+	assert.Equal(t, resp.Code, http.StatusOK)
+	assert.NotEqual(t, "", statusRsp.Message)
+}
+
+func TestStatusMetrics_ShouldDisplayNonP2pMetrics(t *testing.T) {
+	statusMetricsProvider := statusHandler.NewStatusMetrics()
+	key := "test-details-key"
+	value := "test-details-value"
+	statusMetricsProvider.SetStringValue(key, value)
+
+	p2pKey := "a_p2p_specific_key"
+	statusMetricsProvider.SetStringValue(p2pKey, "p2p value")
+	numCheckpoints := 2
+
+	facade := mock.Facade{}
+	facade.StatusMetricsHandler = func() external.StatusMetricsHandler {
+		return statusMetricsProvider
+	}
+	facade.GetNumCheckpointsFromPeerStateCalled = func() uint32 {
+		return uint32(numCheckpoints)
+	}
+	facade.GetNumCheckpointsFromAccountStateCalled = func() uint32 {
+		return uint32(numCheckpoints)
+	}
+
+	nodeGroup, err := groups.NewNodeGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(nodeGroup, "node", getNodeRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/node/status", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respStr := string(respBytes)
+	assert.Equal(t, resp.Code, http.StatusOK)
+
+	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, value)
+	assert.True(t, keyAndValueFoundInResponse)
+	assert.False(t, strings.Contains(respStr, p2pKey))
+
+	keyAndValueFoundInResponse = strings.Contains(respStr, node.AccStateCheckpointsKey) && strings.Contains(respStr, strconv.Itoa(numCheckpoints))
+	assert.True(t, keyAndValueFoundInResponse)
+
+	keyAndValueFoundInResponse = strings.Contains(respStr, node.PeerStateCheckpointsKey) && strings.Contains(respStr, strconv.Itoa(numCheckpoints))
+	assert.True(t, keyAndValueFoundInResponse)
+}
+
+func TestP2PStatusMetrics_ShouldDisplayNonP2pMetrics(t *testing.T) {
+	statusMetricsProvider := statusHandler.NewStatusMetrics()
+	key := "test-details-key"
+	value := "test-details-value"
+	statusMetricsProvider.SetStringValue(key, value)
+
+	p2pKey := "a_p2p_specific_key"
+	p2pValue := "p2p value"
+	statusMetricsProvider.SetStringValue(p2pKey, p2pValue)
+
+	facade := mock.Facade{}
+	facade.StatusMetricsHandler = func() external.StatusMetricsHandler {
+		return statusMetricsProvider
+	}
+
+	nodeGroup, err := groups.NewNodeGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(nodeGroup, "node", getNodeRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/node/p2pstatus", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respStr := string(respBytes)
+	assert.Equal(t, resp.Code, http.StatusOK)
+
+	keyAndValueFoundInResponse := strings.Contains(respStr, p2pKey) && strings.Contains(respStr, p2pValue)
+	assert.True(t, keyAndValueFoundInResponse)
+
+	assert.False(t, strings.Contains(respStr, key))
+}
+
+func TestQueryDebug_GetQueryErrorsShouldErr(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		GetQueryHandlerCalled: func(name string) (handler debug.QueryHandler, err error) {
+			return nil, expectedErr
+		},
+	}
+
+	qdr := &node.QueryDebugRequest{}
+	jsonStr, _ := json.Marshal(qdr)
+
+	nodeGroup, err := groups.NewNodeGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(nodeGroup, "node", getNodeRoutesConfig())
+
+	req, _ := http.NewRequest("POST", "/node/debug", bytes.NewBuffer(jsonStr))
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	queryResponse := &GeneralResponse{}
+	loadResponse(resp.Body, queryResponse)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Contains(t, queryResponse.Error, expectedErr.Error())
+}
+
+func TestQueryDebug_GetQueryShouldWork(t *testing.T) {
+	t.Parallel()
+
+	str1 := "aaa"
+	str2 := "bbb"
+	facade := mock.Facade{
+		GetQueryHandlerCalled: func(name string) (handler debug.QueryHandler, err error) {
+			return &mock.QueryHandlerStub{
+					QueryCalled: func(search string) []string {
+						return []string{str1, str2}
+					},
+				},
+				nil
+		},
+	}
+
+	qdr := &node.QueryDebugRequest{}
+	jsonStr, _ := json.Marshal(qdr)
+
+	nodeGroup, err := groups.NewNodeGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(nodeGroup, "node", getNodeRoutesConfig())
+
+	req, _ := http.NewRequest("POST", "/node/debug", bytes.NewBuffer(jsonStr))
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	queryResponse := QueryResponse{}
+	mapResponseData := response.Data.(map[string]interface{})
+	mapResponseDataBytes, _ := json.Marshal(mapResponseData)
+	_ = json.Unmarshal(mapResponseDataBytes, &queryResponse)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Contains(t, queryResponse.Result, str1)
+	assert.Contains(t, queryResponse.Result, str2)
+}
+
+func TestPeerInfo_PeerInfoErrorsShouldErr(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		GetPeerInfoCalled: func(pid string) ([]core.QueryP2PPeerInfo, error) {
+			return nil, expectedErr
+		},
+	}
+	pid := "pid1"
+
+	nodeGroup, err := groups.NewNodeGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(nodeGroup, "node", getNodeRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/node/peerinfo?pid="+pid, nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := &shared.GenericAPIResponse{}
+	loadResponse(resp.Body, response)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(response.Error, expectedErr.Error()))
+}
+
+func TestPeerInfo_PeerInfoShouldWork(t *testing.T) {
+	t.Parallel()
+
+	pidProvided := "16Uiu2HAmRCVXdXqt8BXfhrzotczHMXXvgHPd7iwGWvS53JT1xdw6"
+	val := core.QueryP2PPeerInfo{
+		Pid: pidProvided,
+	}
+	facade := mock.Facade{
+		GetPeerInfoCalled: func(pid string) ([]core.QueryP2PPeerInfo, error) {
+			if pid == pidProvided {
+				return []core.QueryP2PPeerInfo{val}, nil
+			}
+
+			assert.Fail(t, "should have received the pid")
+			return nil, nil
+		},
+	}
+
+	nodeGroup, err := groups.NewNodeGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(nodeGroup, "node", getNodeRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/node/peerinfo?pid="+pidProvided, nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := &shared.GenericAPIResponse{}
+	loadResponse(resp.Body, response)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, "", response.Error)
+
+	responseInfo, ok := response.Data.(map[string]interface{})
+	require.True(t, ok)
+
+	assert.NotNil(t, responseInfo["info"])
+}
+
+func TestPrometheusMetrics_ShouldWork(t *testing.T) {
+	statusMetricsProvider := statusHandler.NewStatusMetrics()
+	key := "test-key"
+	value := uint64(37)
+	statusMetricsProvider.SetUInt64Value(key, value)
+
+	facade := mock.Facade{}
+	facade.StatusMetricsHandler = func() external.StatusMetricsHandler {
+		return statusMetricsProvider
+	}
+
+	nodeGroup, err := groups.NewNodeGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(nodeGroup, "node", getNodeRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/node/metrics", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respStr := string(respBytes)
+	assert.Equal(t, resp.Code, http.StatusOK)
+
+	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, fmt.Sprintf("%d", value))
+	assert.True(t, keyAndValueFoundInResponse)
+}
+
+func loadResponseAsString(rsp io.Reader, response *StatusResponse) {
+	buff, err := ioutil.ReadAll(rsp)
+	if err != nil {
+		logError(err)
+		return
+	}
+
+	response.Message = string(buff)
+}
+
+func getNodeRoutesConfig() config.ApiRoutesConfig {
+	return config.ApiRoutesConfig{
+		APIPackages: map[string]config.APIPackageConfig{
+			"node": {
+				Routes: []config.RouteConfig{
+					{Name: "/status", Open: true},
+					{Name: "/metrics", Open: true},
+					{Name: "/heartbeatstatus", Open: true},
+					{Name: "/p2pstatus", Open: true},
+					{Name: "/debug", Open: true},
+					{Name: "/peerinfo", Open: true},
+				},
+			},
+		},
+	}
+}
+

--- a/api/groups/proofGroup.go
+++ b/api/groups/proofGroup.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go/api/errors"
 	"github.com/ElrondNetwork/elrond-go/api/middleware"
 	"github.com/ElrondNetwork/elrond-go/api/shared"
@@ -27,6 +28,7 @@ type proofFacadeHandler interface {
 	GetProofCurrentRootHash(address string) ([][]byte, []byte, error)
 	VerifyProof(rootHash string, address string, proof [][]byte) (bool, error)
 	GetThrottlerForEndpoint(endpoint string) (core.Throttler, bool)
+	IsInterfaceNil() bool
 }
 
 type proofGroup struct {
@@ -37,7 +39,7 @@ type proofGroup struct {
 
 // NewProofGroup returns a new instance of proofGroup
 func NewProofGroup(facade proofFacadeHandler) (*proofGroup, error) {
-	if facade == nil {
+	if check.IfNil(facade) {
 		return nil, fmt.Errorf("%w for proof group", errors.ErrNilFacadeHandler)
 	}
 

--- a/api/groups/proofGroup.go
+++ b/api/groups/proofGroup.go
@@ -1,0 +1,286 @@
+package groups
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/middleware"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	getProofCurrentRootHashEndpoint = "/proof/address/:address"
+	getProofEndpoint                = "/proof/root-hash/:roothash/address/:address"
+	verifyProofEndpoint             = "/proof/verify"
+
+	getProofCurrentRootHashPath = "/address/:address"
+	getProofPath                = "/root-hash/:roothash/address/:address"
+	verifyProofPath             = "/verify"
+)
+
+type proofFacadeHandler interface {
+	GetProof(rootHash string, address string) ([][]byte, error)
+	GetProofCurrentRootHash(address string) ([][]byte, []byte, error)
+	VerifyProof(rootHash string, address string, proof [][]byte) (bool, error)
+	GetThrottlerForEndpoint(endpoint string) (core.Throttler, bool)
+}
+
+type proofGroup struct {
+	facade    proofFacadeHandler
+	mutFacade sync.RWMutex
+	*baseGroup
+}
+
+// NewProofGroup returns a new instance of proofGroup
+func NewProofGroup(facadeHandler interface{}) (*proofGroup, error) {
+	if facadeHandler == nil {
+		return nil, errors.ErrNilFacadeHandler
+	}
+
+	facade, ok := facadeHandler.(proofFacadeHandler)
+	if !ok {
+		return nil, fmt.Errorf("%w for proof group", errors.ErrFacadeWrongTypeAssertion)
+	}
+
+	pg := &proofGroup{
+		facade:    facade,
+		baseGroup: &baseGroup{},
+	}
+
+	endpoints := []*shared.EndpointHandlerData{
+		{
+			Path:    getProofPath,
+			Method:  http.MethodGet,
+			Handler: pg.getProof,
+			AdditionalMiddlewares: []shared.AdditionalMiddleware{
+				{
+					Middleware: middleware.CreateEndpointThrottlerFromFacade(getProofEndpoint, facade),
+					Before:     true,
+				},
+			},
+		},
+		{
+			Path:    getProofCurrentRootHashPath,
+			Method:  http.MethodGet,
+			Handler: pg.getProofCurrentRootHash,
+			AdditionalMiddlewares: []shared.AdditionalMiddleware{
+				{
+					Middleware: middleware.CreateEndpointThrottlerFromFacade(getProofCurrentRootHashEndpoint, facade),
+					Before:     true,
+				},
+			},
+		},
+		{
+			Path:    verifyProofPath,
+			Method:  http.MethodPost,
+			Handler: pg.verifyProof,
+			AdditionalMiddlewares: []shared.AdditionalMiddleware{
+				{
+					Middleware: middleware.CreateEndpointThrottlerFromFacade(verifyProofEndpoint, facade),
+					Before:     true,
+				},
+			},
+		},
+	}
+	pg.endpoints = endpoints
+
+	return pg, nil
+}
+
+// VerifyProofRequest represents the parameters needed to verify a Merkle proof
+type VerifyProofRequest struct {
+	RootHash string   `json:"roothash"`
+	Address  string   `json:"address"`
+	Proof    []string `json:"proof"`
+}
+
+// getProof will receive a rootHash and an address from the client, and it will return the Merkle proof
+func (pg *proofGroup) getProof(c *gin.Context) {
+	rootHash := c.Param("roothash")
+	if rootHash == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), errors.ErrValidationEmptyRootHash.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	address := c.Param("address")
+	if address == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), errors.ErrValidationEmptyAddress.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	proof, err := pg.getFacade().GetProof(rootHash, address)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetProof.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	hexProof := make([]string, 0)
+	for _, byteProof := range proof {
+		hexProof = append(hexProof, hex.EncodeToString(byteProof))
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"proof": hexProof},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// getProofCurrentRootHash will receive an address from the client, and it will return the
+// Merkle proof for the current root hash
+func (pg *proofGroup) getProofCurrentRootHash(c *gin.Context) {
+	address := c.Param("address")
+	if address == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), errors.ErrValidationEmptyAddress.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	proof, rootHash, err := pg.getFacade().GetProofCurrentRootHash(address)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetProof.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	hexProof := make([]string, 0)
+	for _, byteProof := range proof {
+		hexProof = append(hexProof, hex.EncodeToString(byteProof))
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data: gin.H{
+				"proof":    hexProof,
+				"rootHash": hex.EncodeToString(rootHash),
+			},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// verifyProof will receive a rootHash, an address and a Merkle proof from the client,
+// and it will verify the proof
+func (pg *proofGroup) verifyProof(c *gin.Context) {
+	var verifyProofParams = &VerifyProofRequest{}
+	err := c.ShouldBindJSON(&verifyProofParams)
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), err.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	proof := make([][]byte, 0)
+	for _, hexProof := range verifyProofParams.Proof {
+		bytesProof, err := hex.DecodeString(hexProof)
+		if err != nil {
+			c.JSON(
+				http.StatusBadRequest,
+				shared.GenericAPIResponse{
+					Data:  nil,
+					Error: fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), err.Error()),
+					Code:  shared.ReturnCodeRequestError,
+				},
+			)
+			return
+		}
+
+		proof = append(proof, bytesProof)
+	}
+
+	var proofOk bool
+	proofOk, err = pg.getFacade().VerifyProof(verifyProofParams.RootHash, verifyProofParams.Address, proof)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrVerifyProof.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"ok": proofOk},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+func (pg *proofGroup) getFacade() proofFacadeHandler {
+	pg.mutFacade.RLock()
+	defer pg.mutFacade.RUnlock()
+
+	return pg.facade
+}
+
+// UpdateFacade will update the facade
+func (pg *proofGroup) UpdateFacade(newFacade interface{}) error {
+	if newFacade == nil {
+		return errors.ErrNilFacadeHandler
+	}
+	castedFacade, ok := newFacade.(proofFacadeHandler)
+	if !ok {
+		return errors.ErrFacadeWrongTypeAssertion
+	}
+
+	pg.mutFacade.Lock()
+	pg.facade = castedFacade
+	pg.mutFacade.Unlock()
+
+	return nil
+}

--- a/api/groups/proofGroup_test.go
+++ b/api/groups/proofGroup_test.go
@@ -30,13 +30,6 @@ func TestNewProofGroup(t *testing.T) {
 		require.Nil(t, hg)
 	})
 
-	t.Run("wrong type assertion facade", func(t *testing.T) {
-		dummyStruct := struct {}{}
-		hg, err := groups.NewProofGroup(dummyStruct)
-		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
-		require.Nil(t, hg)
-	})
-
 	t.Run("should work", func(t *testing.T) {
 		hg, err := groups.NewProofGroup(&mock.Facade{})
 		require.NoError(t, err)

--- a/api/groups/proofGroup_test.go
+++ b/api/groups/proofGroup_test.go
@@ -1,0 +1,322 @@
+package groups_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	apiErrors "github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/groups"
+	"github.com/ElrondNetwork/elrond-go/api/mock"
+	"github.com/ElrondNetwork/elrond-go/api/proof"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewProofGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil facade", func(t *testing.T) {
+		hg, err := groups.NewProofGroup(nil)
+		require.True(t, errors.Is(err, apiErrors.ErrNilFacadeHandler))
+		require.Nil(t, hg)
+	})
+
+	t.Run("wrong type assertion facade", func(t *testing.T) {
+		dummyStruct := struct {}{}
+		hg, err := groups.NewProofGroup(dummyStruct)
+		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
+		require.Nil(t, hg)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		hg, err := groups.NewProofGroup(&mock.Facade{})
+		require.NoError(t, err)
+		require.NotNil(t, hg)
+	})
+}
+
+func TestGetProof_GetProofError(t *testing.T) {
+	t.Parallel()
+
+	getProofErr := fmt.Errorf("GetProof error")
+	facade := &mock.Facade{
+		GetProofCalled: func(rootHash string, address string) ([][]byte, error) {
+			return nil, getProofErr
+		},
+	}
+
+	proofGroup, err := groups.NewProofGroup(facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(proofGroup, "proof", getProofRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/proof/root-hash/roothash/address/addr", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, shared.ReturnCodeInternalError, response.Code)
+	assert.True(t, strings.Contains(response.Error, apiErrors.ErrGetProof.Error()))
+}
+
+func TestGetProof(t *testing.T) {
+	t.Parallel()
+
+	validProof := [][]byte{[]byte("valid"), []byte("proof")}
+	facade := &mock.Facade{
+		GetProofCalled: func(rootHash string, address string) ([][]byte, error) {
+			assert.Equal(t, "roothash", rootHash)
+			assert.Equal(t, "addr", address)
+			return validProof, nil
+		},
+	}
+
+	proofGroup, err := groups.NewProofGroup(facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(proofGroup, "proof", getProofRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/proof/root-hash/roothash/address/addr", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, shared.ReturnCodeSuccess, response.Code)
+
+	responseMap, ok := response.Data.(map[string]interface{})
+	assert.True(t, ok)
+
+	proofs, ok := responseMap["proof"].([]interface{})
+	assert.True(t, ok)
+
+	proof1 := proofs[0].(string)
+	proof2 := proofs[1].(string)
+
+	assert.Equal(t, hex.EncodeToString([]byte("valid")), proof1)
+	assert.Equal(t, hex.EncodeToString([]byte("proof")), proof2)
+}
+
+func TestGetProofCurrentRootHash_GetProofError(t *testing.T) {
+	t.Parallel()
+
+	getProofErr := fmt.Errorf("GetProof error")
+	facade := &mock.Facade{
+		GetProofCurrentRootHashCalled: func(address string) ([][]byte, []byte, error) {
+			return nil, nil, getProofErr
+		},
+	}
+
+	proofGroup, err := groups.NewProofGroup(facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(proofGroup, "proof", getProofRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/proof/address/addr", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, shared.ReturnCodeInternalError, response.Code)
+	assert.True(t, strings.Contains(response.Error, apiErrors.ErrGetProof.Error()))
+}
+
+func TestGetProofCurrentRootHash(t *testing.T) {
+	t.Parallel()
+
+	validProof := [][]byte{[]byte("valid"), []byte("proof")}
+	rootHash := []byte("rootHash")
+	facade := &mock.Facade{
+		GetProofCurrentRootHashCalled: func(address string) ([][]byte, []byte, error) {
+			assert.Equal(t, "addr", address)
+			return validProof, rootHash, nil
+		},
+	}
+
+	proofGroup, err := groups.NewProofGroup(facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(proofGroup, "proof", getProofRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/proof/address/addr", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, shared.ReturnCodeSuccess, response.Code)
+
+	responseMap, ok := response.Data.(map[string]interface{})
+	assert.True(t, ok)
+
+	proofs, ok := responseMap["proof"].([]interface{})
+	assert.True(t, ok)
+
+	proof1 := proofs[0].(string)
+	proof2 := proofs[1].(string)
+
+	assert.Equal(t, hex.EncodeToString([]byte("valid")), proof1)
+	assert.Equal(t, hex.EncodeToString([]byte("proof")), proof2)
+
+	rh, ok := responseMap["rootHash"].(string)
+	assert.True(t, ok)
+	assert.Equal(t, hex.EncodeToString(rootHash), rh)
+}
+
+func TestVerifyProof_BadRequestShouldErr(t *testing.T) {
+	t.Parallel()
+
+	proofGroup, err := groups.NewProofGroup(&mock.Facade{})
+	require.NoError(t, err)
+
+	ws := startWebServer(proofGroup, "proof", getProofRoutesConfig())
+
+	req, _ := http.NewRequest("POST", "/proof/verify", bytes.NewBuffer([]byte("invalid bytes")))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, shared.ReturnCodeRequestError, response.Code)
+	assert.True(t, strings.Contains(response.Error, apiErrors.ErrValidation.Error()))
+}
+
+func TestVerifyProof_VerifyProofErr(t *testing.T) {
+	t.Parallel()
+
+	verifyProfErr := fmt.Errorf("VerifyProof err")
+	facade := &mock.Facade{
+		VerifyProofCalled: func(rootHash string, address string, proof [][]byte) (bool, error) {
+			return false, verifyProfErr
+		},
+	}
+
+	varifyProofParams := proof.VerifyProofRequest{
+		RootHash: "rootHash",
+		Address:  "address",
+		Proof:    []string{hex.EncodeToString([]byte("valid")), hex.EncodeToString([]byte("proof"))},
+	}
+	verifyProofBytes, _ := json.Marshal(varifyProofParams)
+
+	proofGroup, err := groups.NewProofGroup(facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(proofGroup, "proof", getProofRoutesConfig())
+
+	req, _ := http.NewRequest("POST", "/proof/verify", bytes.NewBuffer(verifyProofBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, shared.ReturnCodeInternalError, response.Code)
+	assert.True(t, strings.Contains(response.Error, apiErrors.ErrVerifyProof.Error()))
+}
+
+func TestVerifyProof_VerifyProofCanNotDecodeProof(t *testing.T) {
+	t.Parallel()
+
+	facade := &mock.Facade{}
+
+	varifyProofParams := proof.VerifyProofRequest{
+		RootHash: "rootHash",
+		Address:  "address",
+		Proof:    []string{"invalid", "hex"},
+	}
+	verifyProofBytes, _ := json.Marshal(varifyProofParams)
+
+	proofGroup, err := groups.NewProofGroup(facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(proofGroup, "proof", getProofRoutesConfig())
+
+	req, _ := http.NewRequest("POST", "/proof/verify", bytes.NewBuffer(verifyProofBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, shared.ReturnCodeRequestError, response.Code)
+	assert.True(t, strings.Contains(response.Error, apiErrors.ErrValidation.Error()))
+}
+
+func TestVerifyProof(t *testing.T) {
+	t.Parallel()
+
+	rootHash := "rootHash"
+	address := "address"
+	validProof := []string{hex.EncodeToString([]byte("valid")), hex.EncodeToString([]byte("proof"))}
+	varifyProofParams := proof.VerifyProofRequest{
+		RootHash: rootHash,
+		Address:  address,
+		Proof:    validProof,
+	}
+	verifyProofBytes, _ := json.Marshal(varifyProofParams)
+
+	facade := &mock.Facade{
+		VerifyProofCalled: func(rH string, addr string, proof [][]byte) (bool, error) {
+			assert.Equal(t, rootHash, rH)
+			assert.Equal(t, address, addr)
+			for i := range proof {
+				assert.Equal(t, validProof[i], hex.EncodeToString(proof[i]))
+			}
+
+			return true, nil
+		},
+	}
+
+	proofGroup, err := groups.NewProofGroup(facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(proofGroup, "proof", getProofRoutesConfig())
+
+	req, _ := http.NewRequest("POST", "/proof/verify", bytes.NewBuffer(verifyProofBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, shared.ReturnCodeSuccess, response.Code)
+
+	responseMap, ok := response.Data.(map[string]interface{})
+	assert.True(t, ok)
+
+	isValid, ok := responseMap["ok"].(bool)
+	assert.True(t, ok)
+	assert.True(t, isValid)
+}
+
+
+func getProofRoutesConfig() config.ApiRoutesConfig {
+	return config.ApiRoutesConfig{
+		APIPackages: map[string]config.APIPackageConfig{
+			"proof": {
+				Routes: []config.RouteConfig{
+					{Name: "/root-hash/:roothash/address/:address", Open: true},
+					{Name: "/address/:address", Open: true},
+					{Name: "/verify", Open: true},
+				},
+			},
+		},
+	}
+}
+

--- a/api/groups/transactionGroup.go
+++ b/api/groups/transactionGroup.go
@@ -1,0 +1,578 @@
+package groups
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"net/http"
+	"strconv"
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
+	"github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/middleware"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	txSimData "github.com/ElrondNetwork/elrond-go/process/txsimulator/data"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	sendTransactionEndpoint          = "/transaction/send"
+	simulateTransactionEndpoint      = "/transaction/simulate"
+	sendMultipleTransactionsEndpoint = "/transaction/send-multiple"
+	getTransactionEndpoint           = "/transaction/:hash"
+	sendTransactionPath              = "/send"
+	simulateTransactionPath          = "/simulate"
+	costPath                         = "/cost"
+	sendMultiplePath                 = "/send-multiple"
+	getTransactionPath               = "/:txhash"
+
+	queryParamWithResults    = "withResults"
+	queryParamCheckSignature = "checkSignature"
+)
+
+// transactionFacadeHandler interface defines methods that can be used by the gin webserver
+type transactionFacadeHandler interface {
+	CreateTransaction(nonce uint64, value string, receiver string, receiverUsername []byte, sender string, senderUsername []byte, gasPrice uint64,
+		gasLimit uint64, data []byte, signatureHex string, chainID string, version uint32, options uint32) (*transaction.Transaction, []byte, error)
+	ValidateTransaction(tx *transaction.Transaction) error
+	ValidateTransactionForSimulation(tx *transaction.Transaction, checkSignature bool) error
+	SendBulkTransactions([]*transaction.Transaction) (uint64, error)
+	SimulateTransactionExecution(tx *transaction.Transaction) (*txSimData.SimulationResults, error)
+	GetTransaction(hash string, withResults bool) (*transaction.ApiTransactionResult, error)
+	ComputeTransactionGasLimit(tx *transaction.Transaction) (*transaction.CostResponse, error)
+	EncodeAddressPubkey(pk []byte) (string, error)
+	GetThrottlerForEndpoint(endpoint string) (core.Throttler, bool)
+	IsInterfaceNil() bool
+}
+
+type transactionGroup struct {
+	facade    transactionFacadeHandler
+	mutFacade sync.RWMutex
+	*baseGroup
+}
+
+// NewTransactionGroup returns a new instance of transactionGroup
+func NewTransactionGroup(facadeHandler interface{}) (*transactionGroup, error) {
+	if facadeHandler == nil {
+		return nil, errors.ErrNilFacadeHandler
+	}
+
+	facade, ok := facadeHandler.(transactionFacadeHandler)
+	if !ok {
+		return nil, fmt.Errorf("%w for transaction group", errors.ErrFacadeWrongTypeAssertion)
+	}
+
+	tg := &transactionGroup{
+		facade:    facade,
+		baseGroup: &baseGroup{},
+	}
+
+	endpoints := []*shared.EndpointHandlerData{
+		{
+			Path:    sendTransactionPath,
+			Method:  http.MethodPost,
+			Handler: tg.sendTransaction,
+			AdditionalMiddlewares: []shared.AdditionalMiddleware{
+				{
+					Middleware: middleware.CreateEndpointThrottlerFromFacade(sendTransactionEndpoint, facade),
+					Before:     true,
+				},
+			},
+		},
+		{
+			Path:    simulateTransactionPath,
+			Method:  http.MethodPost,
+			Handler: tg.simulateTransaction,
+			AdditionalMiddlewares: []shared.AdditionalMiddleware{
+				{
+					Middleware: middleware.CreateEndpointThrottlerFromFacade(simulateTransactionEndpoint, facade),
+					Before:     true,
+				},
+			},
+		},
+		{
+			Path:    costPath,
+			Method:  http.MethodPost,
+			Handler: tg.computeTransactionGasLimit,
+		},
+		{
+			Path:    sendMultiplePath,
+			Method:  http.MethodPost,
+			Handler: tg.sendMultipleTransactions,
+			AdditionalMiddlewares: []shared.AdditionalMiddleware{
+				{
+					Middleware: middleware.CreateEndpointThrottlerFromFacade(sendMultipleTransactionsEndpoint, facade),
+					Before:     true,
+				},
+			},
+		},
+		{
+			Path:    getTransactionPath,
+			Method:  http.MethodGet,
+			Handler: tg.getTransaction,
+			AdditionalMiddlewares: []shared.AdditionalMiddleware{
+				{
+					Middleware: middleware.CreateEndpointThrottlerFromFacade(getTransactionEndpoint, facade),
+					Before:     true,
+				},
+			},
+		},
+	}
+	tg.endpoints = endpoints
+
+	return tg, nil
+}
+
+// TxRequest represents the structure on which user input for generating a new transaction will validate against
+type TxRequest struct {
+	Sender   string   `form:"sender" json:"sender"`
+	Receiver string   `form:"receiver" json:"receiver"`
+	Value    *big.Int `form:"value" json:"value"`
+	Data     string   `form:"data" json:"data"`
+}
+
+// MultipleTxRequest represents the structure on which user input for generating a bulk of transactions will validate against
+type MultipleTxRequest struct {
+	Receiver string   `form:"receiver" json:"receiver"`
+	Value    *big.Int `form:"value" json:"value"`
+	TxCount  int      `form:"txCount" json:"txCount"`
+}
+
+// SendTxRequest represents the structure that maps and validates user input for publishing a new transaction
+type SendTxRequest struct {
+	Sender           string `form:"sender" json:"sender"`
+	Receiver         string `form:"receiver" json:"receiver"`
+	SenderUsername   []byte `json:"senderUsername,omitempty"`
+	ReceiverUsername []byte `json:"receiverUsername,omitempty"`
+	Value            string `form:"value" json:"value"`
+	Data             []byte `form:"data" json:"data"`
+	Nonce            uint64 `form:"nonce" json:"nonce"`
+	GasPrice         uint64 `form:"gasPrice" json:"gasPrice"`
+	GasLimit         uint64 `form:"gasLimit" json:"gasLimit"`
+	Signature        string `form:"signature" json:"signature"`
+	ChainID          string `form:"chainID" json:"chainID"`
+	Version          uint32 `form:"version" json:"version"`
+	Options          uint32 `json:"options,omitempty"`
+}
+
+// TxResponse represents the structure on which the response will be validated against
+type TxResponse struct {
+	SendTxRequest
+	ShardID     uint32 `json:"shardId"`
+	Hash        string `json:"hash"`
+	BlockNumber uint64 `json:"blockNumber"`
+	BlockHash   string `json:"blockHash"`
+	Timestamp   uint64 `json:"timestamp"`
+}
+
+// simulateTransaction will receive a transaction from the client and will simulate it's execution and return the results
+func (tg *transactionGroup) simulateTransaction(c *gin.Context) {
+	var gtx = SendTxRequest{}
+	err := c.ShouldBindJSON(&gtx)
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), err.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	checkSignature, err := getQueryParameterCheckSignature(c)
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: errors.ErrValidation.Error(),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	tx, txHash, err := tg.getFacade().CreateTransaction(
+		gtx.Nonce,
+		gtx.Value,
+		gtx.Receiver,
+		gtx.ReceiverUsername,
+		gtx.Sender,
+		gtx.SenderUsername,
+		gtx.GasPrice,
+		gtx.GasLimit,
+		gtx.Data,
+		gtx.Signature,
+		gtx.ChainID,
+		gtx.Version,
+		gtx.Options,
+	)
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrTxGenerationFailed.Error(), err.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	err = tg.getFacade().ValidateTransactionForSimulation(tx, checkSignature)
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrTxGenerationFailed.Error(), err.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	executionResults, err := tg.getFacade().SimulateTransactionExecution(tx)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: err.Error(),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	executionResults.Hash = hex.EncodeToString(txHash)
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"result": executionResults},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// sendTransaction will receive a transaction from the client and propagate it for processing
+func (tg *transactionGroup) sendTransaction(c *gin.Context) {
+	var gtx = SendTxRequest{}
+	err := c.ShouldBindJSON(&gtx)
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), err.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	tx, txHash, err := tg.getFacade().CreateTransaction(
+		gtx.Nonce,
+		gtx.Value,
+		gtx.Receiver,
+		gtx.ReceiverUsername,
+		gtx.Sender,
+		gtx.SenderUsername,
+		gtx.GasPrice,
+		gtx.GasLimit,
+		gtx.Data,
+		gtx.Signature,
+		gtx.ChainID,
+		gtx.Version,
+		gtx.Options,
+	)
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrTxGenerationFailed.Error(), err.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	err = tg.getFacade().ValidateTransaction(tx)
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrTxGenerationFailed.Error(), err.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	_, err = tg.getFacade().SendBulkTransactions([]*transaction.Transaction{tx})
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: err.Error(),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	txHexHash := hex.EncodeToString(txHash)
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"txHash": txHexHash},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// sendMultipleTransactions will receive a number of transactions and will propagate them for processing
+func (tg *transactionGroup) sendMultipleTransactions(c *gin.Context) {
+	var gtx []SendTxRequest
+	err := c.ShouldBindJSON(&gtx)
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), err.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	var (
+		txs    []*transaction.Transaction
+		tx     *transaction.Transaction
+		txHash []byte
+	)
+
+	txsHashes := make(map[int]string)
+	for idx, receivedTx := range gtx {
+		tx, txHash, err = tg.getFacade().CreateTransaction(
+			receivedTx.Nonce,
+			receivedTx.Value,
+			receivedTx.Receiver,
+			receivedTx.ReceiverUsername,
+			receivedTx.Sender,
+			receivedTx.SenderUsername,
+			receivedTx.GasPrice,
+			receivedTx.GasLimit,
+			receivedTx.Data,
+			receivedTx.Signature,
+			receivedTx.ChainID,
+			receivedTx.Version,
+			receivedTx.Options,
+		)
+		if err != nil {
+			continue
+		}
+
+		err = tg.getFacade().ValidateTransaction(tx)
+		if err != nil {
+			continue
+		}
+
+		txs = append(txs, tx)
+		txsHashes[idx] = hex.EncodeToString(txHash)
+	}
+
+	numOfSentTxs, err := tg.getFacade().SendBulkTransactions(txs)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: err.Error(),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data: gin.H{
+				"txsSent":   numOfSentTxs,
+				"txsHashes": txsHashes,
+			},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// getTransaction returns transaction details for a given txhash
+func (tg *transactionGroup) getTransaction(c *gin.Context) {
+	txhash := c.Param("txhash")
+	if txhash == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), errors.ErrValidationEmptyTxHash.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	withResults, err := getQueryParamWithResults(c)
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: errors.ErrValidation.Error(),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	tx, err := tg.getFacade().GetTransaction(txhash, withResults)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetTransaction.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"transaction": tx},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// computeTransactionGasLimit returns how many gas units a transaction wil consume
+func (tg *transactionGroup) computeTransactionGasLimit(c *gin.Context) {
+	var gtx SendTxRequest
+	err := c.ShouldBindJSON(&gtx)
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrValidation.Error(), err.Error()),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	tx, _, err := tg.getFacade().CreateTransaction(
+		gtx.Nonce,
+		gtx.Value,
+		gtx.Receiver,
+		gtx.ReceiverUsername,
+		gtx.Sender,
+		gtx.SenderUsername,
+		gtx.GasPrice,
+		gtx.GasLimit,
+		gtx.Data,
+		gtx.Signature,
+		gtx.ChainID,
+		gtx.Version,
+		gtx.Options,
+	)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: err.Error(),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	cost, err := tg.getFacade().ComputeTransactionGasLimit(tx)
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: err.Error(),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  cost,
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+func getQueryParamWithResults(c *gin.Context) (bool, error) {
+	withResultsStr := c.Request.URL.Query().Get(queryParamWithResults)
+	if withResultsStr == "" {
+		return false, nil
+	}
+
+	return strconv.ParseBool(withResultsStr)
+}
+
+func getQueryParameterCheckSignature(c *gin.Context) (bool, error) {
+	bypassSignatureStr := c.Request.URL.Query().Get(queryParamCheckSignature)
+	if bypassSignatureStr == "" {
+		return true, nil
+	}
+
+	return strconv.ParseBool(bypassSignatureStr)
+}
+
+func (tg *transactionGroup) getFacade() transactionFacadeHandler {
+	tg.mutFacade.RLock()
+	defer tg.mutFacade.RUnlock()
+
+	return tg.facade
+}
+
+// UpdateFacade will update the facade
+func (tg *transactionGroup) UpdateFacade(newFacade interface{}) error {
+	if newFacade == nil {
+		return errors.ErrNilFacadeHandler
+	}
+	castedFacade, ok := newFacade.(transactionFacadeHandler)
+	if !ok {
+		return errors.ErrFacadeWrongTypeAssertion
+	}
+
+	tg.mutFacade.Lock()
+	tg.facade = castedFacade
+	tg.mutFacade.Unlock()
+
+	return nil
+}

--- a/api/groups/transactionGroup.go
+++ b/api/groups/transactionGroup.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/elrond-go/api/errors"
 	"github.com/ElrondNetwork/elrond-go/api/middleware"
@@ -55,7 +56,7 @@ type transactionGroup struct {
 
 // NewTransactionGroup returns a new instance of transactionGroup
 func NewTransactionGroup(facade transactionFacadeHandler) (*transactionGroup, error) {
-	if facade == nil {
+	if check.IfNil(facade) {
 		return nil, fmt.Errorf("%w for transaction group", errors.ErrNilFacadeHandler)
 	}
 

--- a/api/groups/transactionGroup_test.go
+++ b/api/groups/transactionGroup_test.go
@@ -34,13 +34,6 @@ func TestNewTransactionGroup(t *testing.T) {
 		require.Nil(t, hg)
 	})
 
-	t.Run("wrong type assertion facade", func(t *testing.T) {
-		dummyStruct := struct {}{}
-		hg, err := groups.NewTransactionGroup(dummyStruct)
-		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
-		require.Nil(t, hg)
-	})
-
 	t.Run("should work", func(t *testing.T) {
 		hg, err := groups.NewTransactionGroup(&mock.Facade{})
 		require.NoError(t, err)

--- a/api/groups/transactionGroup_test.go
+++ b/api/groups/transactionGroup_test.go
@@ -1,0 +1,850 @@
+package groups_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	dataTx "github.com/ElrondNetwork/elrond-go-core/data/transaction"
+	apiErrors "github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/groups"
+	"github.com/ElrondNetwork/elrond-go/api/mock"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/ElrondNetwork/elrond-go/api/transaction"
+	"github.com/ElrondNetwork/elrond-go/config"
+	txSimData "github.com/ElrondNetwork/elrond-go/process/txsimulator/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTransactionGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil facade", func(t *testing.T) {
+		hg, err := groups.NewTransactionGroup(nil)
+		require.True(t, errors.Is(err, apiErrors.ErrNilFacadeHandler))
+		require.Nil(t, hg)
+	})
+
+	t.Run("wrong type assertion facade", func(t *testing.T) {
+		dummyStruct := struct {}{}
+		hg, err := groups.NewTransactionGroup(dummyStruct)
+		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
+		require.Nil(t, hg)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		hg, err := groups.NewTransactionGroup(&mock.Facade{})
+		require.NoError(t, err)
+		require.NotNil(t, hg)
+	})
+}
+
+type transactionResponseData struct {
+	TxResp *transaction.TxResponse `json:"transaction,omitempty"`
+}
+
+type transactionResponse struct {
+	Data  transactionResponseData `json:"data"`
+	Error string                  `json:"error"`
+	Code  string                  `json:"code"`
+}
+
+type sendMultipleTxsResponseData struct {
+	TxsSent   int      `json:"txsSent"`
+	TxsHashes []string `json:"txsHashes"`
+}
+
+type sendMultipleTxsResponse struct {
+	Data  sendMultipleTxsResponseData `json:"data"`
+	Error string                      `json:"error"`
+	Code  string                      `json:"code"`
+}
+
+type simulateTxResponse struct {
+	Data  interface{} `json:"data"`
+	Error string      `json:"error"`
+	Code  string      `json:"code"`
+}
+
+type sendSingleTxResponseData struct {
+	TxHash string `json:"txHash"`
+}
+
+type sendSingleTxResponse struct {
+	Data  sendSingleTxResponseData `json:"data"`
+	Error string                   `json:"error"`
+	Code  string                   `json:"code"`
+}
+
+type transactionCostResponseData struct {
+	Cost uint64 `json:"txGasUnits"`
+}
+
+type transactionCostResponse struct {
+	Data  transactionCostResponseData `json:"data"`
+	Error string                      `json:"error"`
+	Code  string                      `json:"code"`
+}
+
+func TestGetTransaction_WithCorrectHashShouldReturnTransaction(t *testing.T) {
+	sender := "sender"
+	receiver := "receiver"
+	value := "10"
+	txData := []byte("data")
+	hash := "hash"
+	facade := mock.Facade{
+		GetTransactionHandler: func(hash string, withEvents bool) (i *dataTx.ApiTransactionResult, e error) {
+			return &dataTx.ApiTransactionResult{
+				Sender:   sender,
+				Receiver: receiver,
+				Data:     txData,
+				Value:    value,
+			}, nil
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/transaction/"+hash, nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := transactionResponse{}
+	loadResponse(resp.Body, &response)
+
+	txResp := response.Data.TxResp
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, sender, txResp.Sender)
+	assert.Equal(t, receiver, txResp.Receiver)
+	assert.Equal(t, value, txResp.Value)
+	assert.Equal(t, txData, txResp.Data)
+}
+
+func TestGetTransaction_WithUnknownHashShouldReturnNil(t *testing.T) {
+	sender := "sender"
+	receiver := "receiver"
+	value := "10"
+	txData := []byte("data")
+	wrongHash := "wronghash"
+	facade := mock.Facade{
+		GetTransactionHandler: func(hash string, withEvents bool) (*dataTx.ApiTransactionResult, error) {
+			if hash == wrongHash {
+				return nil, errors.New("local error")
+			}
+			return &dataTx.ApiTransactionResult{
+				Sender:   sender,
+				Receiver: receiver,
+				Data:     txData,
+				Value:    value,
+			}, nil
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/transaction/"+wrongHash, nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	txResp := transactionResponse{}
+	loadResponse(resp.Body, &txResp)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.Empty(t, txResp.Data)
+}
+
+func TestGetTransaction_ErrorWithExceededNumGoRoutines(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{
+		GetThrottlerForEndpointCalled: func(_ string) (core.Throttler, bool) {
+			return &mock.ThrottlerStub{
+				CanProcessCalled: func() bool { return false },
+			}, true
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/transaction/eeee", nil)
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	txResp := transactionResponse{}
+	loadResponse(resp.Body, &txResp)
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.Code)
+	assert.True(t, strings.Contains(txResp.Error, apiErrors.ErrTooManyRequests.Error()))
+	assert.Equal(t, string(shared.ReturnCodeSystemBusy), txResp.Code)
+	assert.Empty(t, txResp.Data)
+}
+
+func TestSendTransaction_ErrorWithExceededNumGoRoutines(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{
+		GetThrottlerForEndpointCalled: func(_ string) (core.Throttler, bool) {
+			return &mock.ThrottlerStub{
+				CanProcessCalled: func() bool { return false },
+			}, true
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	tx := transaction.SendTxRequest{}
+
+	jsonBytes, _ := json.Marshal(tx)
+	req, _ := http.NewRequest("POST", "/transaction/send", bytes.NewBuffer(jsonBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	txResp := sendSingleTxResponse{}
+	loadResponse(resp.Body, &txResp)
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.Code)
+	assert.True(t, strings.Contains(txResp.Error, apiErrors.ErrTooManyRequests.Error()))
+	assert.Equal(t, string(shared.ReturnCodeSystemBusy), txResp.Code)
+	assert.Empty(t, txResp.Data)
+}
+
+func TestSendTransaction_WrongParametersShouldErrorOnValidation(t *testing.T) {
+	t.Parallel()
+	sender := "sender"
+	receiver := "receiver"
+	value := "ishouldbeint"
+	data := "data"
+
+	facade := mock.Facade{}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	jsonStr := fmt.Sprintf(`{"sender":"%s", "receiver":"%s", "value":%s, "data":"%s"}`,
+		sender,
+		receiver,
+		value,
+		data,
+	)
+
+	req, _ := http.NewRequest("POST", "/transaction/send", bytes.NewBuffer([]byte(jsonStr)))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	txResp := sendSingleTxResponse{}
+	loadResponse(resp.Body, &txResp)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Contains(t, txResp.Error, apiErrors.ErrValidation.Error())
+	assert.Empty(t, txResp.Data)
+}
+
+func TestSendTransaction_ErrorWhenFacadeSendTransactionError(t *testing.T) {
+	t.Parallel()
+	sender := "sender"
+	receiver := "receiver"
+	value := big.NewInt(10)
+	data := "data"
+	signature := "aabbccdd"
+	errorString := "send transaction error"
+
+	facade := mock.Facade{
+		CreateTransactionHandler: func(nonce uint64, value string, receiver string, receiverUsername []byte, sender string, senderUsername []byte, gasPrice uint64, gasLimit uint64, data []byte, signatureHex string, chainID string, version uint32, options uint32) (*dataTx.Transaction, []byte, error) {
+			return nil, nil, nil
+		},
+		SendBulkTransactionsHandler: func(txs []*dataTx.Transaction) (u uint64, err error) {
+			return 0, errors.New(errorString)
+		},
+		ValidateTransactionHandler: func(tx *dataTx.Transaction) error {
+			return nil
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	jsonStr := fmt.Sprintf(`{"sender":"%s", "receiver":"%s", "value":"%s", "signature":"%s", "data":"%s"}`,
+		sender,
+		receiver,
+		value,
+		signature,
+		data,
+	)
+
+	req, _ := http.NewRequest("POST", "/transaction/send", bytes.NewBuffer([]byte(jsonStr)))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	txResp := sendSingleTxResponse{}
+	loadResponse(resp.Body, &txResp)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.Contains(t, txResp.Error, errorString)
+	assert.Empty(t, txResp.Data)
+}
+
+func TestSendTransaction_ReturnsSuccessfully(t *testing.T) {
+	t.Parallel()
+	nonce := uint64(1)
+	sender := "sender"
+	receiver := "receiver"
+	value := big.NewInt(10)
+	data := "data"
+	signature := "aabbccdd"
+	hexTxHash := "deadbeef"
+
+	facade := mock.Facade{
+		CreateTransactionHandler: func(nonce uint64, value string, receiver string, receiverUsername []byte, sender string, senderUsername []byte, gasPrice uint64, gasLimit uint64, data []byte, signatureHex string, chainID string, version uint32, options uint32) (*dataTx.Transaction, []byte, error) {
+			txHash, _ := hex.DecodeString(hexTxHash)
+			return nil, txHash, nil
+		},
+		SendBulkTransactionsHandler: func(txs []*dataTx.Transaction) (u uint64, err error) {
+			return 1, nil
+		},
+		ValidateTransactionHandler: func(tx *dataTx.Transaction) error {
+			return nil
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	jsonStr := fmt.Sprintf(
+		`{"nonce": %d, "sender": "%s", "receiver": "%s", "value": "%s", "signature": "%s", "data": "%s"}`,
+		nonce,
+		sender,
+		receiver,
+		value,
+		signature,
+		data,
+	)
+
+	req, _ := http.NewRequest("POST", "/transaction/send", bytes.NewBuffer([]byte(jsonStr)))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := sendSingleTxResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Empty(t, response.Error)
+	assert.Equal(t, hexTxHash, response.Data.TxHash)
+}
+
+func TestSendMultipleTransactions_ErrorWithExceededNumGoRoutines(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{
+		GetThrottlerForEndpointCalled: func(_ string) (core.Throttler, bool) {
+			return &mock.ThrottlerStub{
+				CanProcessCalled: func() bool { return false },
+			}, true
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	tx0 := transaction.SendTxRequest{}
+	txs := []*transaction.SendTxRequest{&tx0}
+
+	jsonBytes, _ := json.Marshal(txs)
+	req, _ := http.NewRequest("POST", "/transaction/send-multiple", bytes.NewBuffer(jsonBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	txResp := sendMultipleTxsResponse{}
+	loadResponse(resp.Body, &txResp)
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.Code)
+	assert.True(t, strings.Contains(txResp.Error, apiErrors.ErrTooManyRequests.Error()))
+	assert.Equal(t, string(shared.ReturnCodeSystemBusy), txResp.Code)
+	assert.Empty(t, txResp.Data)
+}
+
+func TestSendMultipleTransactions_WrongPayloadShouldErrorOnValidation(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	jsonStr := `{"wrong": json}`
+
+	req, _ := http.NewRequest("POST", "/transaction/send-multiple", bytes.NewBuffer([]byte(jsonStr)))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	txResp := sendMultipleTxsResponse{}
+	loadResponse(resp.Body, &txResp)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Contains(t, txResp.Error, apiErrors.ErrValidation.Error())
+	assert.Empty(t, txResp.Data)
+}
+
+func TestSendMultipleTransactions_OkPayloadShouldWork(t *testing.T) {
+	t.Parallel()
+
+	createTxWasCalled := false
+	sendBulkTxsWasCalled := false
+
+	facade := mock.Facade{
+		CreateTransactionHandler: func(nonce uint64, value string, receiver string, receiverUsername []byte, sender string, senderUsername []byte, gasPrice uint64, gasLimit uint64, data []byte, signatureHex string, chainID string, version uint32, options uint32) (*dataTx.Transaction, []byte, error) {
+			createTxWasCalled = true
+			return &dataTx.Transaction{}, make([]byte, 0), nil
+		},
+		SendBulkTransactionsHandler: func(txs []*dataTx.Transaction) (u uint64, e error) {
+			sendBulkTxsWasCalled = true
+			return 0, nil
+		},
+		ValidateTransactionHandler: func(tx *dataTx.Transaction) error {
+			return nil
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	tx0 := transaction.SendTxRequest{
+		Sender:    "sender1",
+		Receiver:  "receiver1",
+		Value:     "100",
+		Data:      make([]byte, 0),
+		Nonce:     0,
+		GasPrice:  0,
+		GasLimit:  0,
+		Signature: "",
+	}
+	tx1 := tx0
+	tx1.Sender = "sender2"
+	txs := []*transaction.SendTxRequest{&tx0, &tx1}
+
+	jsonBytes, _ := json.Marshal(txs)
+
+	req, _ := http.NewRequest("POST", "/transaction/send-multiple", bytes.NewBuffer(jsonBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	txCostResp := sendMultipleTxsResponse{}
+	loadResponse(resp.Body, &txCostResp)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.True(t, createTxWasCalled)
+	assert.True(t, sendBulkTxsWasCalled)
+}
+
+func TestComputeTransactionGasLimit(t *testing.T) {
+	t.Parallel()
+
+	expectedGasLimit := uint64(37)
+
+	facade := mock.Facade{
+		CreateTransactionHandler: func(nonce uint64, value string, receiver string, receiverUsername []byte, sender string, senderUsername []byte, gasPrice uint64, gasLimit uint64, data []byte, signatureHex string, chainID string, version uint32, options uint32) (*dataTx.Transaction, []byte, error) {
+			return &dataTx.Transaction{}, nil, nil
+		},
+		ComputeTransactionGasLimitHandler: func(tx *dataTx.Transaction) (*dataTx.CostResponse, error) {
+			return &dataTx.CostResponse{
+				GasUnits:      expectedGasLimit,
+				ReturnMessage: "",
+			}, nil
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	tx0 := transaction.SendTxRequest{
+		Sender:    "sender1",
+		Receiver:  "receiver1",
+		Value:     "100",
+		Data:      make([]byte, 0),
+		Nonce:     0,
+		GasPrice:  0,
+		GasLimit:  0,
+		Signature: "",
+	}
+
+	jsonBytes, _ := json.Marshal(tx0)
+
+	req, _ := http.NewRequest("POST", "/transaction/cost", bytes.NewBuffer(jsonBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	txCostResp := transactionCostResponse{}
+	loadResponse(resp.Body, &txCostResp)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, expectedGasLimit, txCostResp.Data.Cost)
+}
+
+func TestSimulateTransaction_BadRequestShouldErr(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	req, _ := http.NewRequest("POST", "/transaction/simulate", bytes.NewBuffer([]byte("invalid bytes")))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	simulateResponse := simulateTxResponse{}
+	loadResponse(resp.Body, &simulateResponse)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+}
+
+func TestSimulateTransaction_CreateErrorsShouldErr(t *testing.T) {
+	t.Parallel()
+
+	processTxWasCalled := false
+
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		SimulateTransactionExecutionHandler: func(tx *dataTx.Transaction) (*txSimData.SimulationResults, error) {
+			processTxWasCalled = true
+			return &txSimData.SimulationResults{
+				Status:     "ok",
+				FailReason: "no reason",
+				ScResults:  nil,
+				Receipts:   nil,
+				Hash:       "hash",
+			}, nil
+		},
+		CreateTransactionHandler: func(nonce uint64, value string, receiver string, receiverUsername []byte, sender string, senderUsername []byte, gasPrice uint64, gasLimit uint64, data []byte, signatureHex string, chainID string, version uint32, options uint32) (*dataTx.Transaction, []byte, error) {
+			return nil, nil, expectedErr
+		},
+		ValidateTransactionForSimulationHandler: func(tx *dataTx.Transaction, bypassSignature bool) error {
+			return nil
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	tx := transaction.SendTxRequest{
+		Sender:    "sender1",
+		Receiver:  "receiver1",
+		Value:     "100",
+		Data:      make([]byte, 0),
+		Nonce:     0,
+		GasPrice:  0,
+		GasLimit:  0,
+		Signature: "",
+	}
+	jsonBytes, _ := json.Marshal(tx)
+
+	req, _ := http.NewRequest("POST", "/transaction/simulate", bytes.NewBuffer(jsonBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	simulateResponse := simulateTxResponse{}
+	loadResponse(resp.Body, &simulateResponse)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.False(t, processTxWasCalled)
+	assert.Contains(t, simulateResponse.Error, expectedErr.Error())
+}
+
+func TestSimulateTransaction_ValidateErrorsShouldErr(t *testing.T) {
+	t.Parallel()
+
+	processTxWasCalled := false
+
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		SimulateTransactionExecutionHandler: func(tx *dataTx.Transaction) (*txSimData.SimulationResults, error) {
+			processTxWasCalled = true
+			return &txSimData.SimulationResults{
+				Status:     "ok",
+				FailReason: "no reason",
+				ScResults:  nil,
+				Receipts:   nil,
+				Hash:       "hash",
+			}, nil
+		},
+		CreateTransactionHandler: func(nonce uint64, value string, receiver string, receiverUsername []byte, sender string, senderUsername []byte, gasPrice uint64, gasLimit uint64, data []byte, signatureHex string, chainID string, version uint32, options uint32) (*dataTx.Transaction, []byte, error) {
+			return &dataTx.Transaction{}, []byte("hash"), nil
+		},
+		ValidateTransactionForSimulationHandler: func(tx *dataTx.Transaction, bypassSignature bool) error {
+			return expectedErr
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	tx := transaction.SendTxRequest{
+		Sender:    "sender1",
+		Receiver:  "receiver1",
+		Value:     "100",
+		Data:      make([]byte, 0),
+		Nonce:     0,
+		GasPrice:  0,
+		GasLimit:  0,
+		Signature: "",
+	}
+	jsonBytes, _ := json.Marshal(tx)
+
+	req, _ := http.NewRequest("POST", "/transaction/simulate", bytes.NewBuffer(jsonBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	simulateResponse := simulateTxResponse{}
+	loadResponse(resp.Body, &simulateResponse)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.False(t, processTxWasCalled)
+	assert.Contains(t, simulateResponse.Error, expectedErr.Error())
+}
+
+func TestSimulateTransaction_CannotParseParameterShouldErr(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	tx := transaction.SendTxRequest{
+		Sender:    "sender1",
+		Receiver:  "receiver1",
+		Value:     "100",
+		Data:      make([]byte, 0),
+		Nonce:     0,
+		GasPrice:  0,
+		GasLimit:  0,
+		Signature: "",
+	}
+	jsonBytes, _ := json.Marshal(tx)
+
+	req, _ := http.NewRequest("POST", "/transaction/simulate?checkSignature=tttt", bytes.NewBuffer(jsonBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	simulateResponse := simulateTxResponse{}
+	loadResponse(resp.Body, &simulateResponse)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Equal(t, apiErrors.ErrValidation.Error(), simulateResponse.Error)
+}
+
+func TestSimulateTransaction_UseQueryParameterShouldWork(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{
+		ValidateTransactionForSimulationHandler: func(tx *dataTx.Transaction, bypassSignature bool) error {
+			assert.True(t, bypassSignature)
+			return nil
+		},
+		CreateTransactionHandler: func(nonce uint64, value string, receiver string, receiverUsername []byte, sender string, senderUsername []byte, gasPrice uint64, gasLimit uint64, data []byte, signatureHex string, chainID string, version uint32, options uint32) (*dataTx.Transaction, []byte, error) {
+			return &dataTx.Transaction{}, []byte("hash"), nil
+		},
+		SimulateTransactionExecutionHandler: func(tx *dataTx.Transaction) (*txSimData.SimulationResults, error) {
+			return &txSimData.SimulationResults{}, nil
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	tx := transaction.SendTxRequest{
+		Sender:    "sender1",
+		Receiver:  "receiver1",
+		Value:     "100",
+		Data:      make([]byte, 0),
+		Nonce:     0,
+		GasPrice:  0,
+		GasLimit:  0,
+		Signature: "",
+	}
+	jsonBytes, _ := json.Marshal(tx)
+
+	req, _ := http.NewRequest("POST", "/transaction/simulate?bypassSignature=true", bytes.NewBuffer(jsonBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	simulateResponse := simulateTxResponse{}
+	loadResponse(resp.Body, &simulateResponse)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+}
+
+func TestSimulateTransaction_ProcessErrorsShouldErr(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("expected error")
+	facade := mock.Facade{
+		SimulateTransactionExecutionHandler: func(tx *dataTx.Transaction) (*txSimData.SimulationResults, error) {
+			return nil, expectedErr
+		},
+		CreateTransactionHandler: func(nonce uint64, value string, receiver string, receiverUsername []byte, sender string, senderUsername []byte, gasPrice uint64, gasLimit uint64, data []byte, signatureHex string, chainID string, version uint32, options uint32) (*dataTx.Transaction, []byte, error) {
+			return &dataTx.Transaction{}, []byte("hash"), nil
+		},
+		ValidateTransactionForSimulationHandler: func(tx *dataTx.Transaction, bypassSignature bool) error {
+			return nil
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	tx := transaction.SendTxRequest{
+		Sender:    "sender1",
+		Receiver:  "receiver1",
+		Value:     "100",
+		Data:      make([]byte, 0),
+		Nonce:     0,
+		GasPrice:  0,
+		GasLimit:  0,
+		Signature: "",
+	}
+	jsonBytes, _ := json.Marshal(tx)
+
+	req, _ := http.NewRequest("POST", "/transaction/simulate", bytes.NewBuffer(jsonBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	simulateResponse := simulateTxResponse{}
+	loadResponse(resp.Body, &simulateResponse)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.Contains(t, simulateResponse.Error, expectedErr.Error())
+}
+
+func TestSimulateTransaction(t *testing.T) {
+	t.Parallel()
+
+	processTxWasCalled := false
+
+	facade := mock.Facade{
+		SimulateTransactionExecutionHandler: func(tx *dataTx.Transaction) (*txSimData.SimulationResults, error) {
+			processTxWasCalled = true
+			return &txSimData.SimulationResults{
+				Status:     "ok",
+				FailReason: "no reason",
+				ScResults:  nil,
+				Receipts:   nil,
+				Hash:       "hash",
+			}, nil
+		},
+		CreateTransactionHandler: func(nonce uint64, value string, receiver string, receiverUsername []byte, sender string, senderUsername []byte, gasPrice uint64, gasLimit uint64, data []byte, signatureHex string, chainID string, version uint32, options uint32) (*dataTx.Transaction, []byte, error) {
+			return &dataTx.Transaction{}, []byte("hash"), nil
+		},
+		ValidateTransactionForSimulationHandler: func(tx *dataTx.Transaction, bypassSignature bool) error {
+			return nil
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	tx := transaction.SendTxRequest{
+		Sender:    "sender1",
+		Receiver:  "receiver1",
+		Value:     "100",
+		Data:      make([]byte, 0),
+		Nonce:     0,
+		GasPrice:  0,
+		GasLimit:  0,
+		Signature: "",
+	}
+	jsonBytes, _ := json.Marshal(tx)
+
+	req, _ := http.NewRequest("POST", "/transaction/simulate", bytes.NewBuffer(jsonBytes))
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	simulateResponse := simulateTxResponse{}
+	loadResponse(resp.Body, &simulateResponse)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.True(t, processTxWasCalled)
+	assert.Equal(t, string(shared.ReturnCodeSuccess), simulateResponse.Code)
+}
+
+func getTransactionRoutesConfig() config.ApiRoutesConfig {
+	return config.ApiRoutesConfig{
+		APIPackages: map[string]config.APIPackageConfig{
+			"transaction": {
+				Routes: []config.RouteConfig{
+					{Name: "/send", Open: true},
+					{Name: "/send-multiple", Open: true},
+					{Name: "/cost", Open: true},
+					{Name: "/:txhash", Open: true},
+					{Name: "/:txhash/status", Open: true},
+					{Name: "/simulate", Open: true},
+				},
+			},
+		},
+	}
+}
+

--- a/api/groups/validatorGroup.go
+++ b/api/groups/validatorGroup.go
@@ -19,20 +19,15 @@ type validatorFacadeHandler interface {
 }
 
 type validatorGroup struct {
+	*baseGroup
 	facade    validatorFacadeHandler
 	mutFacade sync.RWMutex
-	*baseGroup
 }
 
 // NewValidatorGroup returns a new instance of validatorGroup
-func NewValidatorGroup(facadeHandler interface{}) (*validatorGroup, error) {
-	if facadeHandler == nil {
-		return nil, errors.ErrNilFacadeHandler
-	}
-
-	facade, ok := facadeHandler.(validatorFacadeHandler)
-	if !ok {
-		return nil, fmt.Errorf("%w for validator group", errors.ErrFacadeWrongTypeAssertion)
+func NewValidatorGroup(facade validatorFacadeHandler) (*validatorGroup, error) {
+	if facade == nil {
+		return nil, fmt.Errorf("%w for validator group", errors.ErrNilFacadeHandler)
 	}
 
 	ng := &validatorGroup{
@@ -89,14 +84,19 @@ func (vg *validatorGroup) UpdateFacade(newFacade interface{}) error {
 	if newFacade == nil {
 		return errors.ErrNilFacadeHandler
 	}
-	castedFacade, ok := newFacade.(validatorFacadeHandler)
+	castFacade, ok := newFacade.(validatorFacadeHandler)
 	if !ok {
 		return errors.ErrFacadeWrongTypeAssertion
 	}
 
 	vg.mutFacade.Lock()
-	vg.facade = castedFacade
+	vg.facade = castFacade
 	vg.mutFacade.Unlock()
 
 	return nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (vg *validatorGroup) IsInterfaceNil() bool {
+	return vg == nil
 }

--- a/api/groups/validatorGroup.go
+++ b/api/groups/validatorGroup.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go/api/errors"
 	"github.com/ElrondNetwork/elrond-go/api/shared"
 	"github.com/ElrondNetwork/elrond-go/state"
@@ -26,7 +27,7 @@ type validatorGroup struct {
 
 // NewValidatorGroup returns a new instance of validatorGroup
 func NewValidatorGroup(facade validatorFacadeHandler) (*validatorGroup, error) {
-	if facade == nil {
+	if check.IfNil(facade) {
 		return nil, fmt.Errorf("%w for validator group", errors.ErrNilFacadeHandler)
 	}
 

--- a/api/groups/validatorGroup.go
+++ b/api/groups/validatorGroup.go
@@ -1,0 +1,102 @@
+package groups
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/ElrondNetwork/elrond-go/state"
+	"github.com/gin-gonic/gin"
+)
+
+const statisticsPath = "/statistics"
+
+type validatorFacadeHandler interface {
+	ValidatorStatisticsApi() (map[string]*state.ValidatorApiResponse, error)
+	IsInterfaceNil() bool
+}
+
+type validatorGroup struct {
+	facade    validatorFacadeHandler
+	mutFacade sync.RWMutex
+	*baseGroup
+}
+
+// NewValidatorGroup returns a new instance of validatorGroup
+func NewValidatorGroup(facadeHandler interface{}) (*validatorGroup, error) {
+	if facadeHandler == nil {
+		return nil, errors.ErrNilFacadeHandler
+	}
+
+	facade, ok := facadeHandler.(validatorFacadeHandler)
+	if !ok {
+		return nil, fmt.Errorf("%w for validator group", errors.ErrFacadeWrongTypeAssertion)
+	}
+
+	ng := &validatorGroup{
+		facade:    facade,
+		baseGroup: &baseGroup{},
+	}
+
+	endpoints := []*shared.EndpointHandlerData{
+		{
+			Path:    statisticsPath,
+			Method:  http.MethodGet,
+			Handler: ng.statistics,
+		},
+	}
+	ng.endpoints = endpoints
+
+	return ng, nil
+}
+
+// statistics will return the validation statistics for all validators
+func (vg *validatorGroup) statistics(c *gin.Context) {
+	valStats, err := vg.getFacade().ValidatorStatisticsApi()
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: err.Error(),
+				Code:  shared.ReturnCodeRequestError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"statistics": valStats},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+func (vg *validatorGroup) getFacade() validatorFacadeHandler {
+	vg.mutFacade.RLock()
+	defer vg.mutFacade.RUnlock()
+
+	return vg.facade
+}
+
+// UpdateFacade will update the facade
+func (vg *validatorGroup) UpdateFacade(newFacade interface{}) error {
+	if newFacade == nil {
+		return errors.ErrNilFacadeHandler
+	}
+	castedFacade, ok := newFacade.(validatorFacadeHandler)
+	if !ok {
+		return errors.ErrFacadeWrongTypeAssertion
+	}
+
+	vg.mutFacade.Lock()
+	vg.facade = castedFacade
+	vg.mutFacade.Unlock()
+
+	return nil
+}

--- a/api/groups/validatorGroup_test.go
+++ b/api/groups/validatorGroup_test.go
@@ -1,0 +1,126 @@
+package groups_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	apiErrors "github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/groups"
+	"github.com/ElrondNetwork/elrond-go/api/mock"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewValidatorGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil facade", func(t *testing.T) {
+		hg, err := groups.NewValidatorGroup(nil)
+		require.True(t, errors.Is(err, apiErrors.ErrNilFacadeHandler))
+		require.Nil(t, hg)
+	})
+
+	t.Run("wrong type assertion facade", func(t *testing.T) {
+		dummyStruct := struct{}{}
+		hg, err := groups.NewValidatorGroup(dummyStruct)
+		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
+		require.Nil(t, hg)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		hg, err := groups.NewValidatorGroup(&mock.Facade{})
+		require.NoError(t, err)
+		require.NotNil(t, hg)
+	})
+}
+
+type ValidatorStatisticsResponse struct {
+	Result map[string]*state.ValidatorApiResponse `json:"statistics"`
+	Error  string                                 `json:"error"`
+}
+
+func TestValidatorStatistics_ErrorWhenFacadeFails(t *testing.T) {
+	t.Parallel()
+
+	errStr := "error in facade"
+
+	facade := mock.Facade{
+		ValidatorStatisticsHandler: func() (map[string]*state.ValidatorApiResponse, error) {
+			return nil, errors.New(errStr)
+		},
+	}
+
+	validatorGroup, err := groups.NewValidatorGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(validatorGroup, "validator", getValidatorRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/validator/statistics", nil)
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := ValidatorStatisticsResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Contains(t, response.Error, errStr)
+}
+
+func TestValidatorStatistics_ReturnsSuccessfully(t *testing.T) {
+	t.Parallel()
+
+	mapToReturn := make(map[string]*state.ValidatorApiResponse)
+	mapToReturn["test"] = &state.ValidatorApiResponse{
+		NumLeaderSuccess:    5,
+		NumLeaderFailure:    2,
+		NumValidatorSuccess: 7,
+		NumValidatorFailure: 3,
+	}
+
+	facade := mock.Facade{
+		ValidatorStatisticsHandler: func() (map[string]*state.ValidatorApiResponse, error) {
+			return mapToReturn, nil
+		},
+	}
+
+	validatorGroup, err := groups.NewValidatorGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(validatorGroup, "validator", getValidatorRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/validator/statistics", nil)
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	validatorStatistics := ValidatorStatisticsResponse{}
+	mapResponseData := response.Data.(map[string]interface{})
+	mapResponseDataBytes, _ := json.Marshal(mapResponseData)
+	_ = json.Unmarshal(mapResponseDataBytes, &validatorStatistics)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	assert.Equal(t, validatorStatistics.Result, mapToReturn)
+}
+
+func getValidatorRoutesConfig() config.ApiRoutesConfig {
+	return config.ApiRoutesConfig{
+		APIPackages: map[string]config.APIPackageConfig{
+			"validator": {
+				Routes: []config.RouteConfig{
+					{Name: "/statistics", Open: true},
+				},
+			},
+		},
+	}
+}

--- a/api/groups/validatorGroup_test.go
+++ b/api/groups/validatorGroup_test.go
@@ -26,13 +26,6 @@ func TestNewValidatorGroup(t *testing.T) {
 		require.Nil(t, hg)
 	})
 
-	t.Run("wrong type assertion facade", func(t *testing.T) {
-		dummyStruct := struct{}{}
-		hg, err := groups.NewValidatorGroup(dummyStruct)
-		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
-		require.Nil(t, hg)
-	})
-
 	t.Run("should work", func(t *testing.T) {
 		hg, err := groups.NewValidatorGroup(&mock.Facade{})
 		require.NoError(t, err)

--- a/api/groups/vmValuesGroup.go
+++ b/api/groups/vmValuesGroup.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data/vm"
 	"github.com/ElrondNetwork/elrond-go/api/errors"
 	"github.com/ElrondNetwork/elrond-go/api/shared"
@@ -36,7 +37,7 @@ type vmValuesGroup struct {
 
 // NewVmValuesGroup returns a new instance of vmValuesGroup
 func NewVmValuesGroup(facade vmValuesFacadeHandler) (*vmValuesGroup, error) {
-	if facade == nil {
+	if check.IfNil(facade) {
 		return nil, fmt.Errorf("%w for vm values group", errors.ErrNilFacadeHandler)
 	}
 

--- a/api/groups/vmValuesGroup.go
+++ b/api/groups/vmValuesGroup.go
@@ -1,0 +1,244 @@
+package groups
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"net/http"
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go-core/data/vm"
+	"github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/ElrondNetwork/elrond-go/process"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	hexPath    = "/hex"
+	stringPath = "/string"
+	intPath    = "/int"
+	queryPath  = "/query"
+)
+
+// NewVmValuesGroup returns a new instance of vmValuesGroup
+func NewVmValuesGroup(facadeHandler interface{}) (*vmValuesGroup, error) {
+	if facadeHandler == nil {
+		return nil, errors.ErrNilFacadeHandler
+	}
+
+	facade, ok := facadeHandler.(vmValuesFacadeHandler)
+	if !ok {
+		return nil, fmt.Errorf("%w for vmValues group", errors.ErrFacadeWrongTypeAssertion)
+	}
+
+	vvg := &vmValuesGroup{
+		facade:    facade,
+		baseGroup: &baseGroup{},
+	}
+
+	endpoints := []*shared.EndpointHandlerData{
+		{
+			Path:    hexPath,
+			Method:  http.MethodPost,
+			Handler: vvg.getHex,
+		},
+		{
+			Path:    stringPath,
+			Method:  http.MethodPost,
+			Handler: vvg.getString,
+		},
+		{
+			Path:    intPath,
+			Method:  http.MethodPost,
+			Handler: vvg.getInt,
+		},
+		{
+			Path:    queryPath,
+			Method:  http.MethodPost,
+			Handler: vvg.executeQuery,
+		},
+	}
+	vvg.endpoints = endpoints
+
+	return vvg, nil
+}
+
+type vmValuesFacadeHandler interface {
+	ExecuteSCQuery(*process.SCQuery) (*vm.VMOutputApi, error)
+	DecodeAddressPubkey(pk string) ([]byte, error)
+	IsInterfaceNil() bool
+}
+
+type vmValuesGroup struct {
+	facade    vmValuesFacadeHandler
+	mutFacade sync.RWMutex
+	*baseGroup
+}
+
+// VMValueRequest represents the structure on which user input for generating a new transaction will validate against
+type VMValueRequest struct {
+	ScAddress  string   `form:"scAddress" json:"scAddress"`
+	FuncName   string   `form:"funcName" json:"funcName"`
+	CallerAddr string   `form:"caller" json:"caller"`
+	CallValue  string   `form:"value" json:"value"`
+	Args       []string `form:"args"  json:"args"`
+}
+
+// getHex returns the data as bytes, hex-encoded
+func (vvg *vmValuesGroup) getHex(context *gin.Context) {
+	vvg.doGetVMValue(context, vm.AsHex)
+}
+
+// getString returns the data as string
+func (vvg *vmValuesGroup) getString(context *gin.Context) {
+	vvg.doGetVMValue(context, vm.AsString)
+}
+
+// getInt returns the data as big int
+func (vvg *vmValuesGroup) getInt(context *gin.Context) {
+	vvg.doGetVMValue(context, vm.AsBigIntString)
+}
+
+func (vvg *vmValuesGroup) doGetVMValue(context *gin.Context, asType vm.ReturnDataKind) {
+	vmOutput, execErrMsg, err := vvg.doExecuteQuery(context)
+
+	if err != nil {
+		vvg.returnBadRequest(context, "doGetVMValue", err)
+		return
+	}
+
+	returnData, err := vmOutput.GetFirstReturnData(asType)
+	if err != nil {
+		execErrMsg += " " + err.Error()
+	}
+
+	vvg.returnOkResponse(context, returnData, execErrMsg)
+}
+
+// executeQuery returns the data as string
+func (vvg *vmValuesGroup) executeQuery(context *gin.Context) {
+	vmOutput, execErrMsg, err := vvg.doExecuteQuery(context)
+	if err != nil {
+		vvg.returnBadRequest(context, "executeQuery", err)
+		return
+	}
+
+	vvg.returnOkResponse(context, vmOutput, execErrMsg)
+}
+
+func (vvg *vmValuesGroup) doExecuteQuery(context *gin.Context) (*vm.VMOutputApi, string, error) {
+	request := VMValueRequest{}
+	err := context.ShouldBindJSON(&request)
+	if err != nil {
+		return nil, "", errors.ErrInvalidJSONRequest
+	}
+
+	command, err := vvg.createSCQuery(&request)
+	if err != nil {
+		return nil, "", err
+	}
+
+	vmOutputApi, err := vvg.getFacade().ExecuteSCQuery(command)
+	if err != nil {
+		return nil, "", err
+	}
+
+	vmExecErrMsg := ""
+	if len(vmOutputApi.ReturnCode) > 0 && vmOutputApi.ReturnCode != vmcommon.Ok.String() {
+		vmExecErrMsg = vmOutputApi.ReturnCode + ":" + vmOutputApi.ReturnMessage
+	}
+
+	return vmOutputApi, vmExecErrMsg, nil
+}
+
+func (vvg *vmValuesGroup) createSCQuery(request *VMValueRequest) (*process.SCQuery, error) {
+	decodedAddress, err := vvg.getFacade().DecodeAddressPubkey(request.ScAddress)
+	if err != nil {
+		return nil, fmt.Errorf("'%s' is not a valid address: %s", request.ScAddress, err.Error())
+	}
+
+	arguments := make([][]byte, len(request.Args))
+	var argBytes []byte
+	for i, arg := range request.Args {
+		argBytes, err = hex.DecodeString(arg)
+		if err != nil {
+			return nil, fmt.Errorf("'%s' is not a valid hex string: %s", arg, err.Error())
+		}
+
+		arguments[i] = append(arguments[i], argBytes...)
+	}
+
+	scQuery := &process.SCQuery{
+		ScAddress: decodedAddress,
+		FuncName:  request.FuncName,
+		Arguments: arguments,
+	}
+
+	if len(request.CallerAddr) > 0 {
+		callerAddress, errDecodeCaller := vvg.getFacade().DecodeAddressPubkey(request.CallerAddr)
+		if errDecodeCaller != nil {
+			return nil, errDecodeCaller
+		}
+
+		scQuery.CallerAddr = callerAddress
+	}
+
+	if len(request.CallValue) > 0 {
+		callValue, ok := big.NewInt(0).SetString(request.CallValue, 10)
+		if !ok {
+			return nil, fmt.Errorf("non numeric call value provided: %s", request.CallValue)
+		}
+		scQuery.CallValue = callValue
+	}
+
+	return scQuery, nil
+}
+
+func (vvg *vmValuesGroup) returnBadRequest(context *gin.Context, errScope string, err error) {
+	message := fmt.Sprintf("%s: %s", errScope, err)
+	context.JSON(
+		http.StatusBadRequest,
+		shared.GenericAPIResponse{
+			Data:  nil,
+			Error: message,
+			Code:  shared.ReturnCodeRequestError,
+		},
+	)
+}
+
+func (vvg *vmValuesGroup) returnOkResponse(context *gin.Context, data interface{}, errorMsg string) {
+	context.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"data": data},
+			Error: errorMsg,
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+func (vvg *vmValuesGroup) getFacade() vmValuesFacadeHandler {
+	vvg.mutFacade.RLock()
+	defer vvg.mutFacade.RUnlock()
+
+	return vvg.facade
+}
+
+// UpdateFacade will update the facade
+func (vvg *vmValuesGroup) UpdateFacade(newFacade interface{}) error {
+	if newFacade == nil {
+		return errors.ErrNilFacadeHandler
+	}
+	castedFacade, ok := newFacade.(vmValuesFacadeHandler)
+	if !ok {
+		return errors.ErrFacadeWrongTypeAssertion
+	}
+
+	vvg.mutFacade.Lock()
+	vvg.facade = castedFacade
+	vvg.mutFacade.Unlock()
+
+	return nil
+}

--- a/api/groups/vmValuesGroup_test.go
+++ b/api/groups/vmValuesGroup_test.go
@@ -1,0 +1,355 @@
+package groups_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/data/vm"
+	apiErrors "github.com/ElrondNetwork/elrond-go/api/errors"
+	"github.com/ElrondNetwork/elrond-go/api/groups"
+	"github.com/ElrondNetwork/elrond-go/api/mock"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/process"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewVmValuesGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil facade", func(t *testing.T) {
+		hg, err := groups.NewVmValuesGroup(nil)
+		require.True(t, errors.Is(err, apiErrors.ErrNilFacadeHandler))
+		require.Nil(t, hg)
+	})
+
+	t.Run("wrong type assertion facade", func(t *testing.T) {
+		dummyStruct := struct{}{}
+		hg, err := groups.NewVmValuesGroup(dummyStruct)
+		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
+		require.Nil(t, hg)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		hg, err := groups.NewVmValuesGroup(&mock.Facade{})
+		require.NoError(t, err)
+		require.NotNil(t, hg)
+	})
+}
+
+type simpleResponse struct {
+	Data  string `json:"data"`
+	Error string `json:"error"`
+}
+
+type vmOutputResponse struct {
+	Data  *vmcommon.VMOutput `json:"data"`
+	Error string             `json:"error"`
+}
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+const DummyScAddress = "00000000000000000500fabd9501b7e5353de57a4e319857c2fb99089770720a"
+
+func TestGetHex_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	valueBuff, _ := hex.DecodeString("DEADBEEF")
+
+	facade := mock.Facade{
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
+			return &vm.VMOutputApi{
+				ReturnData: [][]byte{valueBuff},
+			}, nil
+		},
+	}
+
+	request := groups.VMValueRequest{
+		ScAddress: DummyScAddress,
+		FuncName:  "function",
+		Args:      []string{},
+	}
+
+	response := simpleResponse{}
+	statusCode := doPost(t, &facade, "/vm-values/hex", request, &response)
+
+	require.Equal(t, http.StatusOK, statusCode)
+	require.Equal(t, "", response.Error)
+	require.Equal(t, hex.EncodeToString(valueBuff), response.Data)
+}
+
+func TestGetString_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	valueBuff := "DEADBEEF"
+
+	facade := mock.Facade{
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
+			return &vm.VMOutputApi{
+				ReturnData: [][]byte{[]byte(valueBuff)},
+			}, nil
+		},
+	}
+
+	request := groups.VMValueRequest{
+		ScAddress: DummyScAddress,
+		FuncName:  "function",
+		Args:      []string{},
+	}
+
+	response := simpleResponse{}
+	statusCode := doPost(t, &facade, "/vm-values/string", request, &response)
+
+	require.Equal(t, http.StatusOK, statusCode)
+	require.Equal(t, "", response.Error)
+	require.Equal(t, valueBuff, response.Data)
+}
+
+func TestGetInt_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	value := "1234567"
+
+	facade := mock.Facade{
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
+			returnData := big.NewInt(0)
+			returnData.SetString(value, 10)
+			return &vm.VMOutputApi{
+				ReturnData: [][]byte{returnData.Bytes()},
+			}, nil
+		},
+	}
+
+	request := groups.VMValueRequest{
+		ScAddress: DummyScAddress,
+		FuncName:  "function",
+		Args:      []string{},
+	}
+
+	response := simpleResponse{}
+	statusCode := doPost(t, &facade, "/vm-values/int", request, &response)
+
+	require.Equal(t, http.StatusOK, statusCode)
+	require.Equal(t, "", response.Error)
+	require.Equal(t, value, response.Data)
+}
+
+func TestQuery_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
+
+			return &vm.VMOutputApi{
+				ReturnData: [][]byte{big.NewInt(42).Bytes()},
+			}, nil
+		},
+	}
+
+	request := groups.VMValueRequest{
+		ScAddress: DummyScAddress,
+		FuncName:  "function",
+		Args:      []string{},
+	}
+
+	response := vmOutputResponse{}
+	statusCode := doPost(t, &facade, "/vm-values/query", request, &response)
+
+	require.Equal(t, http.StatusOK, statusCode)
+	require.Equal(t, "", response.Error)
+	require.Equal(t, int64(42), big.NewInt(0).SetBytes(response.Data.ReturnData[0]).Int64())
+}
+
+func TestCreateSCQuery_ArgumentIsNotHexShouldErr(t *testing.T) {
+	request := groups.VMValueRequest{
+		ScAddress: DummyScAddress,
+		FuncName:  "function",
+		Args:      []string{"bad arg"},
+	}
+
+	group, _ := groups.NewVmValuesGroup(&mock.Facade{})
+	_, err := group.CreateSCQuery(&request)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "'bad arg' is not a valid hex string")
+}
+
+func TestAllRoutes_FacadeErrorsShouldErr(t *testing.T) {
+	t.Parallel()
+
+	errExpected := errors.New("some random error")
+	facade := mock.Facade{
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
+			return nil, errExpected
+		},
+	}
+
+	request := groups.VMValueRequest{
+		ScAddress: DummyScAddress,
+		FuncName:  "function",
+		Args:      []string{},
+	}
+
+	requireErrorOnAllRoutes(t, &facade, request, errExpected)
+}
+
+func TestAllRoutes_WhenBadAddressShouldErr(t *testing.T) {
+	t.Parallel()
+
+	errExpected := errors.New("not a valid address")
+	facade := mock.Facade{
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
+			return &vm.VMOutputApi{}, nil
+		},
+	}
+
+	request := groups.VMValueRequest{
+		ScAddress: "DUMMY",
+		FuncName:  "function",
+		Args:      []string{},
+	}
+
+	requireErrorOnAllRoutes(t, &facade, request, errExpected)
+}
+
+func TestAllRoutes_WhenBadArgumentsShouldErr(t *testing.T) {
+	t.Parallel()
+
+	errExpected := errors.New("not a valid hex string")
+	facade := mock.Facade{
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
+			return &vm.VMOutputApi{}, nil
+		},
+	}
+
+	request := groups.VMValueRequest{
+		ScAddress: DummyScAddress,
+		FuncName:  "function",
+		Args:      []string{"AA", "ZZ"},
+	}
+
+	requireErrorOnAllRoutes(t, &facade, request, errExpected)
+}
+
+func TestAllRoutes_WhenNoVMReturnDataShouldErr(t *testing.T) {
+	t.Parallel()
+
+	errExpected := errors.New("no return data")
+	facade := &mock.Facade{
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
+			return &vm.VMOutputApi{}, nil
+		},
+	}
+
+	request := groups.VMValueRequest{
+		ScAddress: DummyScAddress,
+		FuncName:  "function",
+		Args:      []string{},
+	}
+
+	response := simpleResponse{}
+
+	statusCode := doPost(t, facade, "/vm-values/hex", request, &response)
+	require.Equal(t, http.StatusOK, statusCode)
+	require.Contains(t, response.Error, errExpected.Error())
+
+	statusCode = doPost(t, facade, "/vm-values/string", request, &response)
+	require.Equal(t, http.StatusOK, statusCode)
+	require.Contains(t, response.Error, errExpected.Error())
+
+	statusCode = doPost(t, facade, "/vm-values/int", request, &response)
+	require.Equal(t, http.StatusOK, statusCode)
+	require.Contains(t, response.Error, errExpected.Error())
+}
+
+func TestAllRoutes_WhenBadJsonShouldErr(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{
+		ExecuteSCQueryHandler: func(query *process.SCQuery) (vmOutput *vm.VMOutputApi, e error) {
+			return &vm.VMOutputApi{}, nil
+		},
+	}
+
+	requireErrorOnGetSingleValueRoutes(t, &facade, []byte("dummy"), apiErrors.ErrInvalidJSONRequest)
+}
+
+func doPost(t *testing.T, facade interface{}, url string, request interface{}, response interface{}) int {
+	// Serialize if not already
+	requestAsBytes, ok := request.([]byte)
+	if !ok {
+		requestAsBytes, _ = json.Marshal(request)
+	}
+
+	group, err := groups.NewVmValuesGroup(facade)
+	require.NoError(t, err)
+
+	server := startWebServer(group, "vm-values", getVmValuesRoutesConfig())
+
+	httpRequest, _ := http.NewRequest("POST", url, bytes.NewBuffer(requestAsBytes))
+
+	responseRecorder := httptest.NewRecorder()
+	server.ServeHTTP(responseRecorder, httpRequest)
+
+	responseI := shared.GenericAPIResponse{}
+	loadResponse(responseRecorder.Body, &responseI)
+	if responseI.Error == "" {
+		responseDataMap := responseI.Data.(map[string]interface{})
+		responseDataMapBytes, _ := json.Marshal(responseDataMap)
+		_ = json.Unmarshal(responseDataMapBytes, response)
+	} else {
+		resp := response.(*simpleResponse)
+		resp.Error = responseI.Error
+	}
+
+	return responseRecorder.Code
+}
+
+func requireErrorOnAllRoutes(t *testing.T, facade interface{}, request interface{}, errExpected error) {
+	requireErrorOnGetSingleValueRoutes(t, facade, request, errExpected)
+
+	response := simpleResponse{}
+	statusCode := doPost(t, facade, "/vm-values/query", request, &response)
+	require.Equal(t, http.StatusBadRequest, statusCode)
+	require.Contains(t, response.Error, errExpected.Error())
+}
+
+func requireErrorOnGetSingleValueRoutes(t *testing.T, facade interface{}, request interface{}, errExpected error) {
+	response := simpleResponse{}
+
+	statusCode := doPost(t, facade, "/vm-values/hex", request, &response)
+	require.Equal(t, http.StatusBadRequest, statusCode)
+	require.Contains(t, response.Error, errExpected.Error())
+
+	statusCode = doPost(t, facade, "/vm-values/string", request, &response)
+	require.Equal(t, http.StatusBadRequest, statusCode)
+	require.Contains(t, response.Error, errExpected.Error())
+
+	statusCode = doPost(t, facade, "/vm-values/int", request, &response)
+	require.Equal(t, http.StatusBadRequest, statusCode)
+	require.Contains(t, response.Error, errExpected.Error())
+}
+
+func getVmValuesRoutesConfig() config.ApiRoutesConfig {
+	return config.ApiRoutesConfig{
+		APIPackages: map[string]config.APIPackageConfig{
+			"vm-values": {
+				Routes: []config.RouteConfig{
+					{Name: "/hex", Open: true},
+					{Name: "/string", Open: true},
+					{Name: "/int", Open: true},
+					{Name: "/query", Open: true},
+				},
+			},
+		},
+	}
+}

--- a/api/groups/vmValuesGroup_test.go
+++ b/api/groups/vmValuesGroup_test.go
@@ -31,13 +31,6 @@ func TestNewVmValuesGroup(t *testing.T) {
 		require.Nil(t, hg)
 	})
 
-	t.Run("wrong type assertion facade", func(t *testing.T) {
-		dummyStruct := struct{}{}
-		hg, err := groups.NewVmValuesGroup(dummyStruct)
-		require.True(t, errors.Is(err, apiErrors.ErrFacadeWrongTypeAssertion))
-		require.Nil(t, hg)
-	})
-
 	t.Run("should work", func(t *testing.T) {
 		hg, err := groups.NewVmValuesGroup(&mock.Facade{})
 		require.NoError(t, err)
@@ -59,7 +52,7 @@ func init() {
 	gin.SetMode(gin.TestMode)
 }
 
-const DummyScAddress = "00000000000000000500fabd9501b7e5353de57a4e319857c2fb99089770720a"
+const dummyScAddress = "00000000000000000500fabd9501b7e5353de57a4e319857c2fb99089770720a"
 
 func TestGetHex_ShouldWork(t *testing.T) {
 	t.Parallel()
@@ -75,7 +68,7 @@ func TestGetHex_ShouldWork(t *testing.T) {
 	}
 
 	request := groups.VMValueRequest{
-		ScAddress: DummyScAddress,
+		ScAddress: dummyScAddress,
 		FuncName:  "function",
 		Args:      []string{},
 	}
@@ -102,7 +95,7 @@ func TestGetString_ShouldWork(t *testing.T) {
 	}
 
 	request := groups.VMValueRequest{
-		ScAddress: DummyScAddress,
+		ScAddress: dummyScAddress,
 		FuncName:  "function",
 		Args:      []string{},
 	}
@@ -131,7 +124,7 @@ func TestGetInt_ShouldWork(t *testing.T) {
 	}
 
 	request := groups.VMValueRequest{
-		ScAddress: DummyScAddress,
+		ScAddress: dummyScAddress,
 		FuncName:  "function",
 		Args:      []string{},
 	}
@@ -157,7 +150,7 @@ func TestQuery_ShouldWork(t *testing.T) {
 	}
 
 	request := groups.VMValueRequest{
-		ScAddress: DummyScAddress,
+		ScAddress: dummyScAddress,
 		FuncName:  "function",
 		Args:      []string{},
 	}
@@ -172,7 +165,7 @@ func TestQuery_ShouldWork(t *testing.T) {
 
 func TestCreateSCQuery_ArgumentIsNotHexShouldErr(t *testing.T) {
 	request := groups.VMValueRequest{
-		ScAddress: DummyScAddress,
+		ScAddress: dummyScAddress,
 		FuncName:  "function",
 		Args:      []string{"bad arg"},
 	}
@@ -194,7 +187,7 @@ func TestAllRoutes_FacadeErrorsShouldErr(t *testing.T) {
 	}
 
 	request := groups.VMValueRequest{
-		ScAddress: DummyScAddress,
+		ScAddress: dummyScAddress,
 		FuncName:  "function",
 		Args:      []string{},
 	}
@@ -232,7 +225,7 @@ func TestAllRoutes_WhenBadArgumentsShouldErr(t *testing.T) {
 	}
 
 	request := groups.VMValueRequest{
-		ScAddress: DummyScAddress,
+		ScAddress: dummyScAddress,
 		FuncName:  "function",
 		Args:      []string{"AA", "ZZ"},
 	}
@@ -251,7 +244,7 @@ func TestAllRoutes_WhenNoVMReturnDataShouldErr(t *testing.T) {
 	}
 
 	request := groups.VMValueRequest{
-		ScAddress: DummyScAddress,
+		ScAddress: dummyScAddress,
 		FuncName:  "function",
 		Args:      []string{},
 	}
@@ -290,7 +283,10 @@ func doPost(t *testing.T, facade interface{}, url string, request interface{}, r
 		requestAsBytes, _ = json.Marshal(request)
 	}
 
-	group, err := groups.NewVmValuesGroup(facade)
+	vmValuesFacade, ok := facade.(groups.VmValuesFacadeHandler)
+	require.True(t, ok)
+
+	group, err := groups.NewVmValuesGroup(vmValuesFacade)
 	require.NoError(t, err)
 
 	server := startWebServer(group, "vm-values", getVmValuesRoutesConfig())

--- a/api/middleware/endpointThrottler.go
+++ b/api/middleware/endpointThrottler.go
@@ -69,7 +69,7 @@ func CreateEndpointThrottler(throttlerName string) gin.HandlerFunc {
 	}
 }
 
-// CreateEndpointThrottler will create a middleware-type of handler to be used in conjunction with special
+// CreateEndpointThrottlerFromFacade will create a middleware-type of handler to be used in conjunction with special
 // REST API end points that need to be better protected
 func CreateEndpointThrottlerFromFacade(throttlerName string, facade interface{}) gin.HandlerFunc {
 	return func(c *gin.Context) {

--- a/api/middleware/endpointThrottler.go
+++ b/api/middleware/endpointThrottler.go
@@ -68,3 +68,46 @@ func CreateEndpointThrottler(throttlerName string) gin.HandlerFunc {
 		c.Next()
 	}
 }
+
+// CreateEndpointThrottler will create a middleware-type of handler to be used in conjunction with special
+// REST API end points that need to be better protected
+func CreateEndpointThrottlerFromFacade(throttlerName string, facade interface{}) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		tg, ok := facade.(throttlerGetter)
+		if !ok {
+			c.AbortWithStatusJSON(
+				http.StatusInternalServerError,
+				shared.GenericAPIResponse{
+					Data:  nil,
+					Error: errors.ErrInvalidAppContext.Error(),
+					Code:  shared.ReturnCodeInternalError,
+				},
+			)
+			return
+		}
+
+		endpointThrottler, ok := tg.GetThrottlerForEndpoint(throttlerName)
+		if !ok {
+			c.Next()
+			return
+		}
+
+		if !endpointThrottler.CanProcess() {
+			c.AbortWithStatusJSON(
+				http.StatusTooManyRequests,
+				shared.GenericAPIResponse{
+					Data:  nil,
+					Error: fmt.Sprintf("%s for endpoint %s", errors.ErrTooManyRequests.Error(), throttlerName),
+					Code:  shared.ReturnCodeSystemBusy,
+				},
+			)
+			return
+		}
+
+		endpointThrottler.StartProcessing()
+		defer endpointThrottler.EndProcessing()
+
+		c.Next()
+	}
+}
+

--- a/api/shared/interface.go
+++ b/api/shared/interface.go
@@ -42,7 +42,6 @@ type GroupHandler interface {
 	RegisterRoutes(
 		ws *gin.RouterGroup,
 		apiConfig config.ApiRoutesConfig,
-		additionalMiddlewares []MiddlewareProcessor,
 	)
 	IsInterfaceNil() bool
 }

--- a/api/shared/interface.go
+++ b/api/shared/interface.go
@@ -1,6 +1,9 @@
 package shared
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/gin-gonic/gin"
+)
 
 // HttpServerCloser defines the basic actions of starting and closing that a web server should be able to do
 type HttpServerCloser interface {
@@ -30,5 +33,16 @@ type UpgradeableHttpServerHandler interface {
 	GetHttpServer() HttpServerCloser
 	SetHttpServer(httpServer HttpServerCloser) error
 	Close() error
+	IsInterfaceNil() bool
+}
+
+// GroupHandler defines the actions needed to be performed by an gin API group
+type GroupHandler interface {
+	UpdateFacade(newFacade interface{}) error
+	RegisterRoutes(
+		ws *gin.RouterGroup,
+		apiConfig config.ApiRoutesConfig,
+		additionalMiddlewares []MiddlewareProcessor,
+	)
 	IsInterfaceNil() bool
 }

--- a/api/shared/shared.go
+++ b/api/shared/shared.go
@@ -6,6 +6,20 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// AdditionalMiddleware holds the data needed for adding a middleware to an API endpoint
+type AdditionalMiddleware struct {
+	Middleware gin.HandlerFunc
+	Before bool
+}
+
+// EndpointHandlerData holds the items needed for creating a new gin HTTP endpoint
+type EndpointHandlerData struct {
+	Path    string
+	Method  string
+	Handler gin.HandlerFunc
+	AdditionalMiddlewares []AdditionalMiddleware
+}
+
 // GenericAPIResponse defines the structure of all responses on API endpoints
 type GenericAPIResponse struct {
 	Data  interface{} `json:"data"`

--- a/api/shared/shared.go
+++ b/api/shared/shared.go
@@ -6,17 +6,28 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// MiddlewarePosition is the type that specifies the position of a middleware relative to the base endpoint handler
+type MiddlewarePosition bool
+
+const (
+	// Before indicates that the middleware should be used before the base endpoint handler
+	Before MiddlewarePosition = true
+
+	// After indicates that the middleware should be used after the base endpoint handler
+	After MiddlewarePosition = false
+)
+
 // AdditionalMiddleware holds the data needed for adding a middleware to an API endpoint
 type AdditionalMiddleware struct {
 	Middleware gin.HandlerFunc
-	Before bool
+	Position   MiddlewarePosition
 }
 
 // EndpointHandlerData holds the items needed for creating a new gin HTTP endpoint
 type EndpointHandlerData struct {
-	Path    string
-	Method  string
-	Handler gin.HandlerFunc
+	Path                  string
+	Method                string
+	Handler               gin.HandlerFunc
 	AdditionalMiddlewares []AdditionalMiddleware
 }
 


### PR DESCRIPTION
What has been done:
- refactored API routes handler: from exported, state-less functions to methods of structures;
- eliminate the `facade` that was set in gin's context -> instead, have it as a member in structures;
- copied and adapted all the endpoints and their unit tests.

What's left to do:
- integrate the new structures inside API starter;
- remove old routes handlers;
- integrate in nodeRunner the new version -> the gin server shouldn't be restarted anymore.