### PR TITLE
Fix trie sync timeout when the node is building the list of data tries to be synced

### DIFF
--- a/state/syncer/userAccountsSyncer.go
+++ b/state/syncer/userAccountsSyncer.go
@@ -220,6 +220,8 @@ func (u *userAccountsSyncer) findAllAccountRootHashes(mainTrie common.Trie) ([][
 
 	rootHashes := make([][]byte, 0)
 	for leaf := range leavesChannel {
+		u.resetTimeoutHandlerWatchdog()
+
 		account := state.NewEmptyUserAccount()
 		err = u.marshalizer.Unmarshal(account, leaf.Value())
 		if err != nil {
@@ -234,4 +236,10 @@ func (u *userAccountsSyncer) findAllAccountRootHashes(mainTrie common.Trie) ([][
 	}
 
 	return rootHashes, nil
+}
+
+// resetTimeoutHandlerWatchdog this method should be called whenever the syncer is doing something other than
+// requesting trie nodes as to prevent the sync process being terminated prematurely.
+func (u *userAccountsSyncer) resetTimeoutHandlerWatchdog() {
+	u.timeoutHandler.ResetWatchdog()
 }


### PR DESCRIPTION
- fixed trie sync timeout false positive trigger by resetting the watchdog when the node builds up its list of data tries to be synced