### PR TITLE
refactor peer mapper in node.go

### DIFF
--- a/integrationTests/consensus/testInitializer.go
+++ b/integrationTests/consensus/testInitializer.go
@@ -461,7 +461,6 @@ func createConsensusOnlyNode(
 		node.WithConsensusType(consensusType),
 		node.WithGenesisTime(time.Unix(startTime, 0)),
 		node.WithPeerDenialEvaluator(&mock.PeerDenialEvaluatorStub{}),
-		node.WithNetworkShardingCollector(networkShardingCollector),
 		node.WithRequestedItemsHandler(&mock.RequestedItemsHandlerStub{}),
 		node.WithValidatorSignatureSize(signatureSize),
 		node.WithPublicKeySize(publicKeySize),

--- a/integrationTests/consensus/testInitializer.go
+++ b/integrationTests/consensus/testInitializer.go
@@ -465,7 +465,6 @@ func createConsensusOnlyNode(
 		node.WithValidatorSignatureSize(signatureSize),
 		node.WithPublicKeySize(publicKeySize),
 		node.WithHardforkTrigger(&mock.HardforkTriggerStub{}),
-		node.WithNodeRedundancyHandler(&mock.RedundancyHandlerStub{}),
 	)
 
 	if err != nil {

--- a/integrationTests/testP2PNode.go
+++ b/integrationTests/testP2PNode.go
@@ -199,7 +199,6 @@ func (tP2pNode *TestP2PNode) initNode() {
 		node.WithInitialNodesPubKeys(pubkeys),
 		node.WithHardforkTrigger(hardforkTrigger),
 		node.WithPeerDenialEvaluator(&mock.PeerDenialEvaluatorStub{}),
-		node.WithNodeRedundancyHandler(redundancyHandler),
 	)
 	log.LogIfError(err)
 

--- a/integrationTests/testP2PNode.go
+++ b/integrationTests/testP2PNode.go
@@ -196,7 +196,6 @@ func (tP2pNode *TestP2PNode) initNode() {
 		node.WithProcessComponents(processComponents),
 		node.WithNetworkComponents(networkComponents),
 		node.WithDataComponents(dataComponents),
-		node.WithNetworkShardingCollector(tP2pNode.NetworkShardingUpdater),
 		node.WithInitialNodesPubKeys(pubkeys),
 		node.WithHardforkTrigger(hardforkTrigger),
 		node.WithPeerDenialEvaluator(&mock.PeerDenialEvaluatorStub{}),

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -2171,7 +2171,6 @@ func (tpn *TestProcessorNode) initNode() {
 		node.WithNetworkComponents(networkComponents),
 		node.WithStateComponents(stateComponents),
 		node.WithPeerDenialEvaluator(&mock.PeerDenialEvaluatorStub{}),
-		node.WithNetworkShardingCollector(tpn.NetworkShardingCollector),
 		node.WithTxAccumulator(txAccumulator),
 		node.WithHardforkTrigger(&mock.HardforkTriggerStub{}),
 		node.WithNodeRedundancyHandler(&mock.RedundancyHandlerStub{}),

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -2173,7 +2173,6 @@ func (tpn *TestProcessorNode) initNode() {
 		node.WithPeerDenialEvaluator(&mock.PeerDenialEvaluatorStub{}),
 		node.WithTxAccumulator(txAccumulator),
 		node.WithHardforkTrigger(&mock.HardforkTriggerStub{}),
-		node.WithNodeRedundancyHandler(&mock.RedundancyHandlerStub{}),
 	)
 	log.LogIfError(err)
 
@@ -2694,7 +2693,6 @@ func (tpn *TestProcessorNode) createHeartbeatWithHardforkTrigger(heartbeatPk str
 		node.WithCryptoComponents(cryptoComponents),
 		node.WithNetworkComponents(networkComponents),
 		node.WithProcessComponents(processComponents),
-		node.WithNodeRedundancyHandler(redundancyHandler),
 	)
 	log.LogIfError(err)
 

--- a/node/node.go
+++ b/node/node.go
@@ -74,8 +74,6 @@ type Node struct {
 	peerDenialEvaluator p2p.PeerDenialEvaluator
 	hardforkTrigger     HardforkTrigger
 
-	networkShardingCollector NetworkShardingCollector
-
 	consensusType string
 
 	currentSendingGoRoutines int32
@@ -1205,7 +1203,7 @@ func (n *Node) createPidInfo(p core.PeerID) core.QueryP2PPeerInfo {
 		IsBlacklisted: n.peerDenialEvaluator.IsDenied(p),
 	}
 
-	peerInfo := n.networkShardingCollector.GetPeerInfo(p)
+	peerInfo := n.processComponents.PeerShardMapper().GetPeerInfo(p)
 	result.PeerType = peerInfo.PeerType.String()
 	result.PeerSubType = peerInfo.PeerSubType.String()
 	if len(peerInfo.PkBytes) == 0 {

--- a/node/node.go
+++ b/node/node.go
@@ -23,7 +23,6 @@ import (
 	disabledSig "github.com/ElrondNetwork/elrond-go-crypto/signing/disabled/singlesig"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/common"
-	"github.com/ElrondNetwork/elrond-go/consensus"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/debug"
 	"github.com/ElrondNetwork/elrond-go/facade"
@@ -107,7 +106,6 @@ type Node struct {
 	closableComponents        []mainFactory.Closer
 	enableSignTxWithHashEpoch uint32
 	isInImportMode            bool
-	nodeRedundancyHandler     consensus.NodeRedundancyHandler
 }
 
 // ApplyOptions can set up different configurable options of a Node instance

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -3114,6 +3114,18 @@ func TestNode_ShouldWork(t *testing.T) {
 
 	pid1 := "pid1"
 	pid2 := "pid2"
+
+	processComponents := getDefaultProcessComponents()
+	processComponents.PeerMapper = &p2pmocks.NetworkShardingCollectorStub{
+		GetPeerInfoCalled: func(pid core.PeerID) core.P2PPeerInfo {
+			return core.P2PPeerInfo{
+				PeerType: 0,
+				ShardID:  0,
+				PkBytes:  pid.Bytes(),
+			}
+		},
+	}
+
 	networkComponents := getDefaultNetworkComponents()
 	networkComponents.Messenger = &p2pmocks.MessengerStub{
 		PeersCalled: func() []core.PeerID {
@@ -3130,15 +3142,7 @@ func TestNode_ShouldWork(t *testing.T) {
 
 	n, _ := node.NewNode(
 		node.WithNetworkComponents(networkComponents),
-		node.WithNetworkShardingCollector(&p2pmocks.NetworkShardingCollectorStub{
-			GetPeerInfoCalled: func(pid core.PeerID) core.P2PPeerInfo {
-				return core.P2PPeerInfo{
-					PeerType: 0,
-					ShardID:  0,
-					PkBytes:  pid.Bytes(),
-				}
-			},
-		}),
+		node.WithProcessComponents(processComponents),
 		node.WithCoreComponents(coreComponents),
 		node.WithPeerDenialEvaluator(&mock.PeerDenialEvaluatorStub{
 			IsDeniedCalled: func(pid core.PeerID) bool {

--- a/node/options.go
+++ b/node/options.go
@@ -253,17 +253,6 @@ func WithRequestedItemsHandler(requestedItemsHandler dataRetriever.RequestedItem
 	}
 }
 
-// WithNetworkShardingCollector sets up a network sharding updater for the Node
-func WithNetworkShardingCollector(networkShardingCollector NetworkShardingCollector) Option {
-	return func(n *Node) error {
-		if check.IfNil(networkShardingCollector) {
-			return ErrNilNetworkShardingCollector
-		}
-		n.networkShardingCollector = networkShardingCollector
-		return nil
-	}
-}
-
 // WithTxAccumulator sets up a transaction accumulator handler for the Node
 func WithTxAccumulator(accumulator core.Accumulator) Option {
 	return func(n *Node) error {

--- a/node/options.go
+++ b/node/options.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data/endProcess"
-	"github.com/ElrondNetwork/elrond-go/consensus"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/factory"
 	"github.com/ElrondNetwork/elrond-go/p2p"
@@ -338,17 +337,6 @@ func WithEnableSignTxWithHashEpoch(enableSignTxWithHashEpoch uint32) Option {
 func WithImportMode(importMode bool) Option {
 	return func(n *Node) error {
 		n.isInImportMode = importMode
-		return nil
-	}
-}
-
-// WithNodeRedundancyHandler sets up a node redundancy handler for the node
-func WithNodeRedundancyHandler(nodeRedundancyHandler consensus.NodeRedundancyHandler) Option {
-	return func(n *Node) error {
-		if check.IfNil(nodeRedundancyHandler) {
-			return ErrNilNodeRedundancyHandler
-		}
-		n.nodeRedundancyHandler = nodeRedundancyHandler
 		return nil
 	}
 }

--- a/node/options_test.go
+++ b/node/options_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/data/endProcess"
 	"github.com/ElrondNetwork/elrond-go/node/mock"
-	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -179,30 +178,6 @@ func TestWithPeerDenialEvaluator_OkHandlerShouldWork(t *testing.T) {
 	err := opt(node)
 
 	assert.True(t, node.peerDenialEvaluator == blackListHandler)
-	assert.Nil(t, err)
-}
-
-func TestWithNetworkShardingCollector_NilNetworkShardingCollectorShouldErr(t *testing.T) {
-	t.Parallel()
-
-	node, _ := NewNode()
-
-	opt := WithNetworkShardingCollector(nil)
-	err := opt(node)
-
-	assert.Equal(t, ErrNilNetworkShardingCollector, err)
-}
-
-func TestWithNetworkShardingCollector_OkHandlerShouldWork(t *testing.T) {
-	t.Parallel()
-
-	node, _ := NewNode()
-
-	networkShardingCollector := &p2pmocks.NetworkShardingCollectorStub{}
-	opt := WithNetworkShardingCollector(networkShardingCollector)
-	err := opt(node)
-
-	assert.True(t, node.networkShardingCollector == networkShardingCollector)
 	assert.Nil(t, err)
 }
 

--- a/node/options_test.go
+++ b/node/options_test.go
@@ -291,27 +291,3 @@ func TestWithSignTxWithHashEpoch_EnableSignTxWithHashEpochShouldWork(t *testing.
 	assert.Equal(t, epochEnable, node.enableSignTxWithHashEpoch)
 	assert.Nil(t, err)
 }
-
-func TestWithNodeRedundancyHandler_NilNodeRedundancyHandlerShouldErr(t *testing.T) {
-	t.Parallel()
-
-	node, _ := NewNode()
-
-	opt := WithNodeRedundancyHandler(nil)
-	err := opt(node)
-
-	assert.Equal(t, ErrNilNodeRedundancyHandler, err)
-}
-
-func TestWithNodeRedundancyHandler_OkNodeRedundancyHandlerShouldWork(t *testing.T) {
-	t.Parallel()
-
-	node, _ := NewNode()
-
-	nodeRedundancyHandler := &mock.NodeRedundancyHandlerStub{}
-	opt := WithNodeRedundancyHandler(nodeRedundancyHandler)
-	err := opt(node)
-
-	assert.Equal(t, nodeRedundancyHandler, node.nodeRedundancyHandler)
-	assert.Nil(t, err)
-}


### PR DESCRIPTION
inside `node.go` -> use network sharding collector (peer mapper) from `processComponents` instead of direct field