### PR TITLE
fix logs delegation contract

### DIFF
--- a/vm/systemSmartContracts/logs.go
+++ b/vm/systemSmartContracts/logs.go
@@ -58,6 +58,8 @@ func (d *delegation) getFundForLogEntry(activeFund []byte) *big.Int {
 	fund, err := d.getFund(activeFund)
 	if err != nil {
 		log.Warn("d.getFundForLogEntry cannot get fund", "error", err.Error())
+
+		return big.NewInt(0)
 	}
 
 	return fund.Value


### PR DESCRIPTION
Bugfix: Do not display `log.Warn` when delegator.ActiveFund is empty 