### PR TITLE
fix missing pprof endpoint

### DIFF
--- a/api/gin/common_test.go
+++ b/api/gin/common_test.go
@@ -6,7 +6,7 @@ import (
 
 	apiErrors "github.com/ElrondNetwork/elrond-go/api/errors"
 	"github.com/ElrondNetwork/elrond-go/config"
-	"github.com/ElrondNetwork/elrond-go/facade/disabled"
+	"github.com/ElrondNetwork/elrond-go/facade/initial"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +21,7 @@ func TestCommon_checkArgs(t *testing.T) {
 	err := checkArgs(args)
 	require.True(t, errors.Is(err, apiErrors.ErrCannotCreateGinWebServer))
 
-	args.Facade = disabled.NewDisabledNodeFacade("api interface")
+	args.Facade = initial.NewInitialNodeFacade("api interface", false)
 	err = checkArgs(args)
 	require.NoError(t, err)
 }

--- a/api/gin/webServer.go
+++ b/api/gin/webServer.go
@@ -36,7 +36,6 @@ type webServer struct {
 	antiFloodConfig config.WebServerAntifloodConfig
 	httpServer      shared.HttpServerCloser
 	groups          map[string]shared.GroupHandler
-	ginEngine       *gin.Engine
 	cancelFunc      func()
 }
 
@@ -118,7 +117,6 @@ func (ws *webServer) StartHttpServer() error {
 	}
 
 	ws.registerRoutes(engine)
-	ws.ginEngine = engine
 
 	server := &http.Server{Addr: ws.facade.RestApiInterface(), Handler: engine}
 	log.Debug("creating gin web sever", "interface", ws.facade.RestApiInterface())

--- a/api/gin/webServer.go
+++ b/api/gin/webServer.go
@@ -37,7 +37,6 @@ type webServer struct {
 	httpServer      shared.HttpServerCloser
 	groups          map[string]shared.GroupHandler
 	ginEngine       *gin.Engine
-	pprofEnabled    bool
 	cancelFunc      func()
 }
 
@@ -52,7 +51,6 @@ func NewGinWebServerHandler(args ArgsNewWebServer) (*webServer, error) {
 		facade:          args.Facade,
 		antiFloodConfig: args.AntiFloodConfig,
 		apiConfig:       args.ApiConfig,
-		pprofEnabled:    false,
 	}
 
 	return gws, nil
@@ -72,15 +70,6 @@ func (ws *webServer) UpdateFacade(facade shared.FacadeHandler) error {
 		if err != nil {
 			log.Error("cannot update facade for gin API group", "group name", groupName, "error", err)
 		}
-	}
-
-	shouldEnablePprofAfterUpdate := !ws.pprofEnabled &&
-		facade.PprofEnabled() &&
-		ws.ginEngine != nil
-
-	if shouldEnablePprofAfterUpdate {
-		log.Debug("registering pprof")
-		pprof.Register(ws.ginEngine)
 	}
 
 	return nil
@@ -223,7 +212,6 @@ func (ws *webServer) registerRoutes(ginRouter *gin.Engine) {
 	}
 
 	if ws.facade.PprofEnabled() {
-		ws.pprofEnabled = true
 		pprof.Register(ginRouter)
 	}
 }

--- a/facade/initial/disabledStatusMetrics.go
+++ b/facade/initial/disabledStatusMetrics.go
@@ -1,4 +1,4 @@
-package disabled
+package initial
 
 const responseKey = "error"
 const responseValue = "node is starting"

--- a/facade/initial/disabledStatusMetrics_test.go
+++ b/facade/initial/disabledStatusMetrics_test.go
@@ -1,4 +1,4 @@
-package disabled
+package initial
 
 import (
 	"testing"

--- a/facade/initial/initialNodeFacade.go
+++ b/facade/initial/initialNodeFacade.go
@@ -1,4 +1,4 @@
-package disabled
+package initial
 
 import (
 	"errors"
@@ -21,87 +21,89 @@ import (
 var errNodeStarting = errors.New("node is starting")
 var emptyString = ""
 
-// disabledNodeFacade represents a facade with no functionality
-type disabledNodeFacade struct {
+// initialNodeFacade represents a facade with no functionality
+type initialNodeFacade struct {
 	apiInterface         string
 	statusMetricsHandler external.StatusMetricsHandler
+	pprofEnabled         bool
 }
 
-// NewDisabledNodeFacade is the disabled implementation of the facade interface
-func NewDisabledNodeFacade(apiInterface string) *disabledNodeFacade {
-	return &disabledNodeFacade{
+// NewInitialNodeFacade is the initial implementation of the facade interface
+func NewInitialNodeFacade(apiInterface string, pprofEnabled bool) *initialNodeFacade {
+	return &initialNodeFacade{
 		apiInterface:         apiInterface,
 		statusMetricsHandler: NewDisabledStatusMetricsHandler(),
+		pprofEnabled:         pprofEnabled,
 	}
 }
 
 // GetProof -
-func (nf *disabledNodeFacade) GetProof(_ string, _ string) ([][]byte, error) {
+func (inf *initialNodeFacade) GetProof(_ string, _ string) ([][]byte, error) {
 	return nil, errNodeStarting
 }
 
 // GetProofCurrentRootHash -
-func (nf *disabledNodeFacade) GetProofCurrentRootHash(_ string) ([][]byte, []byte, error) {
+func (inf *initialNodeFacade) GetProofCurrentRootHash(_ string) ([][]byte, []byte, error) {
 	return nil, nil, errNodeStarting
 }
 
 // VerifyProof -
-func (nf *disabledNodeFacade) VerifyProof(_ string, _ string, _ [][]byte) (bool, error) {
+func (inf *initialNodeFacade) VerifyProof(_ string, _ string, _ [][]byte) (bool, error) {
 	return false, errNodeStarting
 }
 
 // SetSyncer does nothing
-func (nf *disabledNodeFacade) SetSyncer(_ ntp.SyncTimer) {
+func (inf *initialNodeFacade) SetSyncer(_ ntp.SyncTimer) {
 }
 
 // RestAPIServerDebugMode returns false
 //TODO: remove in the future
-func (nf *disabledNodeFacade) RestAPIServerDebugMode() bool {
+func (inf *initialNodeFacade) RestAPIServerDebugMode() bool {
 	return false
 }
 
 // RestApiInterface returns empty string
-func (nf *disabledNodeFacade) RestApiInterface() string {
-	return nf.apiInterface
+func (inf *initialNodeFacade) RestApiInterface() string {
+	return inf.apiInterface
 }
 
 // GetBalance returns nil and error
-func (nf *disabledNodeFacade) GetBalance(_ string) (*big.Int, error) {
+func (inf *initialNodeFacade) GetBalance(_ string) (*big.Int, error) {
 	return nil, errNodeStarting
 }
 
 // GetUsername returns empty string and error
-func (nf *disabledNodeFacade) GetUsername(_ string) (string, error) {
+func (inf *initialNodeFacade) GetUsername(_ string) (string, error) {
 	return emptyString, errNodeStarting
 }
 
 // GetValueForKey returns an empty string and error
-func (nf *disabledNodeFacade) GetValueForKey(_ string, _ string) (string, error) {
+func (inf *initialNodeFacade) GetValueForKey(_ string, _ string) (string, error) {
 	return emptyString, errNodeStarting
 }
 
 // GetESDTBalance returns empty strings and error
-func (nf *disabledNodeFacade) GetESDTBalance(_ string, _ string) (string, string, error) {
+func (inf *initialNodeFacade) GetESDTBalance(_ string, _ string) (string, string, error) {
 	return emptyString, emptyString, errNodeStarting
 }
 
 // GetAllESDTTokens returns nil and error
-func (nf *disabledNodeFacade) GetAllESDTTokens(_ string) (map[string]*esdt.ESDigitalToken, error) {
+func (inf *initialNodeFacade) GetAllESDTTokens(_ string) (map[string]*esdt.ESDigitalToken, error) {
 	return nil, errNodeStarting
 }
 
 // GetNFTTokenIDsRegisteredByAddress returns nil and error
-func (nf *disabledNodeFacade) GetNFTTokenIDsRegisteredByAddress(_ string) ([]string, error) {
+func (inf *initialNodeFacade) GetNFTTokenIDsRegisteredByAddress(_ string) ([]string, error) {
 	return nil, errNodeStarting
 }
 
 // GetESDTsWithRole returns nil and error
-func (nf *disabledNodeFacade) GetESDTsWithRole(_ string, _ string) ([]string, error) {
+func (inf *initialNodeFacade) GetESDTsWithRole(_ string, _ string) ([]string, error) {
 	return nil, errNodeStarting
 }
 
 // CreateTransaction return nil and error
-func (nf *disabledNodeFacade) CreateTransaction(
+func (inf *initialNodeFacade) CreateTransaction(
 	_ uint64,
 	_ string,
 	_ string,
@@ -119,176 +121,176 @@ func (nf *disabledNodeFacade) CreateTransaction(
 }
 
 // ValidateTransaction returns error
-func (nf *disabledNodeFacade) ValidateTransaction(_ *transaction.Transaction) error {
+func (inf *initialNodeFacade) ValidateTransaction(_ *transaction.Transaction) error {
 	return errNodeStarting
 }
 
 // ValidateTransactionForSimulation returns error
-func (nf *disabledNodeFacade) ValidateTransactionForSimulation(_ *transaction.Transaction, _ bool) error {
+func (inf *initialNodeFacade) ValidateTransactionForSimulation(_ *transaction.Transaction, _ bool) error {
 	return errNodeStarting
 }
 
 // ValidatorStatisticsApi returns nil and error
-func (nf *disabledNodeFacade) ValidatorStatisticsApi() (map[string]*state.ValidatorApiResponse, error) {
+func (inf *initialNodeFacade) ValidatorStatisticsApi() (map[string]*state.ValidatorApiResponse, error) {
 	return nil, errNodeStarting
 }
 
 // SendBulkTransactions returns 0 and error
-func (nf *disabledNodeFacade) SendBulkTransactions(_ []*transaction.Transaction) (uint64, error) {
+func (inf *initialNodeFacade) SendBulkTransactions(_ []*transaction.Transaction) (uint64, error) {
 	return uint64(0), errNodeStarting
 }
 
 // SimulateTransactionExecution returns nil and error
-func (nf *disabledNodeFacade) SimulateTransactionExecution(_ *transaction.Transaction) (*txSimData.SimulationResults, error) {
+func (inf *initialNodeFacade) SimulateTransactionExecution(_ *transaction.Transaction) (*txSimData.SimulationResults, error) {
 	return nil, errNodeStarting
 }
 
 // GetTransaction returns nil and error
-func (nf *disabledNodeFacade) GetTransaction(_ string, _ bool) (*transaction.ApiTransactionResult, error) {
+func (inf *initialNodeFacade) GetTransaction(_ string, _ bool) (*transaction.ApiTransactionResult, error) {
 	return nil, errNodeStarting
 }
 
 // ComputeTransactionGasLimit returns 0 and error
-func (nf *disabledNodeFacade) ComputeTransactionGasLimit(_ *transaction.Transaction) (*transaction.CostResponse, error) {
+func (inf *initialNodeFacade) ComputeTransactionGasLimit(_ *transaction.Transaction) (*transaction.CostResponse, error) {
 	return nil, errNodeStarting
 }
 
 // GetAccount returns nil and error
-func (nf *disabledNodeFacade) GetAccount(_ string) (api.AccountResponse, error) {
+func (inf *initialNodeFacade) GetAccount(_ string) (api.AccountResponse, error) {
 	return api.AccountResponse{}, errNodeStarting
 }
 
 // GetCode returns nil and error
-func (nf *disabledNodeFacade) GetCode(_ []byte) []byte {
+func (inf *initialNodeFacade) GetCode(_ []byte) []byte {
 	return nil
 }
 
 // DirectTrigger returns error
-func (nf *disabledNodeFacade) DirectTrigger(_ uint32, _ bool) error {
+func (inf *initialNodeFacade) DirectTrigger(_ uint32, _ bool) error {
 	return errNodeStarting
 }
 
 // GetHeartbeats returns nil and error
-func (nf *disabledNodeFacade) GetHeartbeats() ([]data.PubKeyHeartbeat, error) {
+func (inf *initialNodeFacade) GetHeartbeats() ([]data.PubKeyHeartbeat, error) {
 	return nil, errNodeStarting
 }
 
 // StatusMetrics will returns nil
-func (nf *disabledNodeFacade) StatusMetrics() external.StatusMetricsHandler {
-	return nf.statusMetricsHandler
+func (inf *initialNodeFacade) StatusMetrics() external.StatusMetricsHandler {
+	return inf.statusMetricsHandler
 }
 
 // GetTotalStakedValue returns nil and error
-func (nf *disabledNodeFacade) GetTotalStakedValue() (*api.StakeValues, error) {
+func (inf *initialNodeFacade) GetTotalStakedValue() (*api.StakeValues, error) {
 	return nil, errNodeStarting
 }
 
 // ExecuteSCQuery returns nil and error
-func (nf *disabledNodeFacade) ExecuteSCQuery(_ *process.SCQuery) (*vm.VMOutputApi, error) {
+func (inf *initialNodeFacade) ExecuteSCQuery(_ *process.SCQuery) (*vm.VMOutputApi, error) {
 	return nil, errNodeStarting
 }
 
 // PprofEnabled returns false
-func (nf *disabledNodeFacade) PprofEnabled() bool {
-	return false
+func (inf *initialNodeFacade) PprofEnabled() bool {
+	return inf.pprofEnabled
 }
 
 // Trigger returns error
-func (nf *disabledNodeFacade) Trigger(_ uint32, _ bool) error {
+func (inf *initialNodeFacade) Trigger(_ uint32, _ bool) error {
 	return errNodeStarting
 }
 
 // IsSelfTrigger returns false
-func (nf *disabledNodeFacade) IsSelfTrigger() bool {
+func (inf *initialNodeFacade) IsSelfTrigger() bool {
 	return false
 }
 
 // EncodeAddressPubkey returns empty string and error
-func (nf *disabledNodeFacade) EncodeAddressPubkey(_ []byte) (string, error) {
+func (inf *initialNodeFacade) EncodeAddressPubkey(_ []byte) (string, error) {
 	return emptyString, errNodeStarting
 }
 
 // DecodeAddressPubkey returns nil and error
-func (nf *disabledNodeFacade) DecodeAddressPubkey(_ string) ([]byte, error) {
+func (inf *initialNodeFacade) DecodeAddressPubkey(_ string) ([]byte, error) {
 	return nil, errNodeStarting
 }
 
 // GetQueryHandler returns nil and error
-func (nf *disabledNodeFacade) GetQueryHandler(_ string) (debug.QueryHandler, error) {
+func (inf *initialNodeFacade) GetQueryHandler(_ string) (debug.QueryHandler, error) {
 	return nil, errNodeStarting
 }
 
 // GetPeerInfo returns nil and error
-func (nf *disabledNodeFacade) GetPeerInfo(_ string) ([]core.QueryP2PPeerInfo, error) {
+func (inf *initialNodeFacade) GetPeerInfo(_ string) ([]core.QueryP2PPeerInfo, error) {
 	return nil, errNodeStarting
 }
 
 // GetThrottlerForEndpoint returns nil and false
-func (nf *disabledNodeFacade) GetThrottlerForEndpoint(_ string) (core.Throttler, bool) {
+func (inf *initialNodeFacade) GetThrottlerForEndpoint(_ string) (core.Throttler, bool) {
 	return nil, false
 }
 
 // GetBlockByHash return nil and error
-func (nf *disabledNodeFacade) GetBlockByHash(_ string, _ bool) (*api.Block, error) {
+func (inf *initialNodeFacade) GetBlockByHash(_ string, _ bool) (*api.Block, error) {
 	return nil, errNodeStarting
 }
 
 // GetBlockByNonce returns nil and error
-func (nf *disabledNodeFacade) GetBlockByNonce(_ uint64, _ bool) (*api.Block, error) {
+func (inf *initialNodeFacade) GetBlockByNonce(_ uint64, _ bool) (*api.Block, error) {
 	return nil, errNodeStarting
 }
 
 // Close returns error
-func (nf *disabledNodeFacade) Close() error {
+func (inf *initialNodeFacade) Close() error {
 	return errNodeStarting
 }
 
 // GetNumCheckpointsFromAccountState returns 0
-func (nf *disabledNodeFacade) GetNumCheckpointsFromAccountState() uint32 {
+func (inf *initialNodeFacade) GetNumCheckpointsFromAccountState() uint32 {
 	return uint32(0)
 }
 
 // GetNumCheckpointsFromPeerState returns 0
-func (nf *disabledNodeFacade) GetNumCheckpointsFromPeerState() uint32 {
+func (inf *initialNodeFacade) GetNumCheckpointsFromPeerState() uint32 {
 	return uint32(0)
 }
 
 // GetKeyValuePairs nil map
-func (nf *disabledNodeFacade) GetKeyValuePairs(_ string) (map[string]string, error) {
+func (inf *initialNodeFacade) GetKeyValuePairs(_ string) (map[string]string, error) {
 	return nil, nil
 }
 
 // GetDirectStakedList returns empty slice
-func (nf *disabledNodeFacade) GetDirectStakedList() ([]*api.DirectStakedValue, error) {
+func (inf *initialNodeFacade) GetDirectStakedList() ([]*api.DirectStakedValue, error) {
 	return make([]*api.DirectStakedValue, 0), nil
 }
 
 // GetDelegatorsList returns empty slice
-func (nf *disabledNodeFacade) GetDelegatorsList() ([]*api.Delegator, error) {
+func (inf *initialNodeFacade) GetDelegatorsList() ([]*api.Delegator, error) {
 	return make([]*api.Delegator, 0), nil
 }
 
 // GetESDTData returns nil and error
-func (nf *disabledNodeFacade) GetESDTData(_ string, _ string, _ uint64) (*esdt.ESDigitalToken, error) {
+func (inf *initialNodeFacade) GetESDTData(_ string, _ string, _ uint64) (*esdt.ESDigitalToken, error) {
 	return nil, errNodeStarting
 }
 
 // GetESDTsRoles return nil and error
-func (nf *disabledNodeFacade) GetESDTsRoles(_ string) (map[string][]string, error) {
+func (inf *initialNodeFacade) GetESDTsRoles(_ string) (map[string][]string, error) {
 	return nil, errNodeStarting
 }
 
 // GetAllIssuedESDTs returns nil and error
-func (nf *disabledNodeFacade) GetAllIssuedESDTs(_ string) ([]string, error) {
+func (inf *initialNodeFacade) GetAllIssuedESDTs(_ string) ([]string, error) {
 	return nil, errNodeStarting
 }
 
 // GetTokenSupply returns nil and error
-func (nf *disabledNodeFacade) GetTokenSupply(_ string) (string, error) {
+func (inf *initialNodeFacade) GetTokenSupply(_ string) (string, error) {
 	return "", errNodeStarting
 }
 
 // IsInterfaceNil returns true if there is no value under the interface
-func (nf *disabledNodeFacade) IsInterfaceNil() bool {
-	return nf == nil
+func (inf *initialNodeFacade) IsInterfaceNil() bool {
+	return inf == nil
 }

--- a/facade/initial/initialNodeFacade.go
+++ b/facade/initial/initialNodeFacade.go
@@ -257,17 +257,17 @@ func (inf *initialNodeFacade) GetNumCheckpointsFromPeerState() uint32 {
 
 // GetKeyValuePairs nil map
 func (inf *initialNodeFacade) GetKeyValuePairs(_ string) (map[string]string, error) {
-	return nil, nil
+	return nil, errNodeStarting
 }
 
 // GetDirectStakedList returns empty slice
 func (inf *initialNodeFacade) GetDirectStakedList() ([]*api.DirectStakedValue, error) {
-	return make([]*api.DirectStakedValue, 0), nil
+	return nil, errNodeStarting
 }
 
 // GetDelegatorsList returns empty slice
 func (inf *initialNodeFacade) GetDelegatorsList() ([]*api.Delegator, error) {
-	return make([]*api.Delegator, 0), nil
+	return nil, errNodeStarting
 }
 
 // GetESDTData returns nil and error

--- a/facade/initial/initialNodeFacade_test.go
+++ b/facade/initial/initialNodeFacade_test.go
@@ -1,4 +1,4 @@
-package disabled
+package initial
 
 import (
 	"fmt"
@@ -19,7 +19,7 @@ func TestDisabledNodeFacade_AllMethodsShouldNotPanic(t *testing.T) {
 	}()
 
 	apiInterface := "127.0.0.1:7799"
-	dnf := NewDisabledNodeFacade(apiInterface)
+	dnf := NewInitialNodeFacade(apiInterface, true)
 
 	dnf.SetSyncer(nil)
 	b := dnf.RestAPIServerDebugMode()

--- a/facade/initial/initialNodeFacade_test.go
+++ b/facade/initial/initialNodeFacade_test.go
@@ -19,127 +19,175 @@ func TestDisabledNodeFacade_AllMethodsShouldNotPanic(t *testing.T) {
 	}()
 
 	apiInterface := "127.0.0.1:7799"
-	dnf := NewInitialNodeFacade(apiInterface, true)
+	inf := NewInitialNodeFacade(apiInterface, true)
 
-	dnf.SetSyncer(nil)
-	b := dnf.RestAPIServerDebugMode()
-	assert.Equal(t, false, b)
-	s1 := dnf.RestApiInterface()
+	inf.SetSyncer(nil)
+	b := inf.RestAPIServerDebugMode()
+	assert.False(t, b)
+	s1 := inf.RestApiInterface()
 	assert.Equal(t, apiInterface, s1)
-	s1, s2, err := dnf.GetESDTBalance("", "")
+	s1, s2, err := inf.GetESDTBalance("", "")
 	assert.Equal(t, emptyString, s1+s2)
 	assert.Equal(t, errNodeStarting, err)
-	v, err := dnf.GetBalance("")
+	v, err := inf.GetBalance("")
 	assert.Nil(t, v)
 	assert.Equal(t, errNodeStarting, err)
 
-	s1, err = dnf.GetUsername("")
+	s1, err = inf.GetUsername("")
 	assert.Equal(t, emptyString, s1)
 	assert.Equal(t, errNodeStarting, err)
 
-	s1, err = dnf.GetValueForKey("", "")
+	s1, err = inf.GetValueForKey("", "")
 	assert.Equal(t, emptyString, s1)
 	assert.Equal(t, errNodeStarting, err)
 
-	s3, err := dnf.GetAllESDTTokens("")
+	s3, err := inf.GetAllESDTTokens("")
 	assert.Nil(t, s3)
 	assert.Equal(t, errNodeStarting, err)
 
-	n1, n2, err := dnf.CreateTransaction(uint64(0), "", "", []byte{0}, "",
+	n1, n2, err := inf.CreateTransaction(uint64(0), "", "", []byte{0}, "",
 		[]byte{0}, uint64(0), uint64(0), []byte{0}, "", "", uint32(0), uint32(0))
 	assert.Nil(t, n1)
 	assert.Nil(t, n2)
 	assert.Equal(t, errNodeStarting, err)
 
-	err = dnf.ValidateTransaction(nil)
+	err = inf.ValidateTransaction(nil)
 	assert.Equal(t, errNodeStarting, err)
 
-	err = dnf.ValidateTransactionForSimulation(nil, false)
+	err = inf.ValidateTransactionForSimulation(nil, false)
 	assert.Equal(t, errNodeStarting, err)
 
-	v1, err := dnf.ValidatorStatisticsApi()
+	v1, err := inf.ValidatorStatisticsApi()
 	assert.Nil(t, v1)
 	assert.Equal(t, errNodeStarting, err)
 
-	u1, err := dnf.SendBulkTransactions(nil)
+	u1, err := inf.SendBulkTransactions(nil)
 	assert.Equal(t, uint64(0), u1)
 	assert.Equal(t, errNodeStarting, err)
 
-	u2, err := dnf.SimulateTransactionExecution(nil)
+	u2, err := inf.SimulateTransactionExecution(nil)
 	assert.Nil(t, u2)
 	assert.Equal(t, errNodeStarting, err)
 
-	t1, err := dnf.GetTransaction("", false)
+	t1, err := inf.GetTransaction("", false)
 	assert.Nil(t, t1)
 	assert.Equal(t, errNodeStarting, err)
 
-	resp, err := dnf.ComputeTransactionGasLimit(nil)
+	resp, err := inf.ComputeTransactionGasLimit(nil)
 	assert.Nil(t, resp)
 	assert.Equal(t, errNodeStarting, err)
 
-	uac, err := dnf.GetAccount("")
+	uac, err := inf.GetAccount("")
 	assert.Equal(t, api.AccountResponse{}, uac)
 	assert.Equal(t, errNodeStarting, err)
 
-	hi, err := dnf.GetHeartbeats()
+	hi, err := inf.GetHeartbeats()
 	assert.Nil(t, hi)
 	assert.NotNil(t, errNodeStarting, err)
 
-	sm := dnf.StatusMetrics()
+	sm := inf.StatusMetrics()
 	assert.NotNil(t, sm)
 
-	vo, err := dnf.ExecuteSCQuery(nil)
+	vo, err := inf.ExecuteSCQuery(nil)
 	assert.Nil(t, vo)
 	assert.Equal(t, errNodeStarting, err)
 
-	b = dnf.PprofEnabled()
-	assert.Equal(t, false, b)
+	b = inf.PprofEnabled()
+	assert.True(t, b)
 
-	err = dnf.Trigger(0, false)
+	err = inf.Trigger(0, false)
 	assert.Equal(t, errNodeStarting, err)
 
-	b = dnf.IsSelfTrigger()
-	assert.Equal(t, false, b)
+	b = inf.IsSelfTrigger()
+	assert.False(t, b)
 
-	s1, err = dnf.EncodeAddressPubkey(nil)
+	s1, err = inf.EncodeAddressPubkey(nil)
 	assert.Equal(t, emptyString, s1)
 	assert.Equal(t, errNodeStarting, err)
 
-	ba, err := dnf.DecodeAddressPubkey("")
+	ba, err := inf.DecodeAddressPubkey("")
 	assert.Nil(t, ba)
 	assert.Equal(t, errNodeStarting, err)
 
-	qh, err := dnf.GetQueryHandler("")
+	qh, err := inf.GetQueryHandler("")
 	assert.Nil(t, qh)
 	assert.Equal(t, errNodeStarting, err)
 
-	qp, err := dnf.GetPeerInfo("")
+	qp, err := inf.GetPeerInfo("")
 	assert.Nil(t, qp)
 	assert.Equal(t, errNodeStarting, err)
 
-	th, b := dnf.GetThrottlerForEndpoint("")
+	th, b := inf.GetThrottlerForEndpoint("")
 	assert.Nil(t, th)
-	assert.Equal(t, false, b)
+	assert.False(t, b)
 
-	ab, err := dnf.GetBlockByHash("", false)
+	ab, err := inf.GetBlockByHash("", false)
 	assert.Nil(t, ab)
 	assert.Equal(t, errNodeStarting, err)
 
-	c := dnf.GetCode(nil)
+	c := inf.GetCode(nil)
 	assert.Nil(t, c)
 
-	ab, err = dnf.GetBlockByNonce(0, false)
+	ab, err = inf.GetBlockByNonce(0, false)
 	assert.Nil(t, ab)
 	assert.Equal(t, errNodeStarting, err)
 
-	err = dnf.Close()
+	err = inf.Close()
 	assert.Equal(t, errNodeStarting, err)
 
-	u32 := dnf.GetNumCheckpointsFromAccountState()
+	u32 := inf.GetNumCheckpointsFromAccountState()
 	assert.Equal(t, uint32(0), u32)
 
-	u32 = dnf.GetNumCheckpointsFromPeerState()
+	u32 = inf.GetNumCheckpointsFromPeerState()
 	assert.Equal(t, uint32(0), u32)
 
-	assert.False(t, check.IfNil(dnf))
+	proof, err := inf.GetProof("", "")
+	assert.Nil(t, proof)
+	assert.Equal(t, errNodeStarting, err)
+
+	proof, rootHash, err := inf.GetProofCurrentRootHash("")
+	assert.Nil(t, proof)
+	assert.Nil(t, rootHash)
+	assert.Equal(t, errNodeStarting, err)
+
+	b, err = inf.VerifyProof("", "", nil)
+	assert.False(t, b)
+	assert.Equal(t, errNodeStarting, err)
+
+	sa, err := inf.GetNFTTokenIDsRegisteredByAddress("")
+	assert.Nil(t, sa)
+	assert.Equal(t, errNodeStarting, err)
+
+	sa, err = inf.GetESDTsWithRole("", "")
+	assert.Nil(t, sa)
+	assert.Equal(t, errNodeStarting, err)
+
+	err = inf.DirectTrigger(0, true)
+	assert.Equal(t, errNodeStarting, err)
+
+	asv, err := inf.GetDirectStakedList()
+	assert.Nil(t, asv)
+	assert.Equal(t, errNodeStarting, err)
+
+	mss, err := inf.GetKeyValuePairs("")
+	assert.Nil(t, mss)
+	assert.Equal(t, errNodeStarting, err)
+
+	ds, err := inf.GetDelegatorsList()
+	assert.Nil(t, ds)
+	assert.Equal(t, errNodeStarting, err)
+
+	mssa, err := inf.GetESDTsRoles("")
+	assert.Nil(t, mssa)
+	assert.Equal(t, errNodeStarting, err)
+
+	sa, err = inf.GetAllIssuedESDTs("")
+	assert.Nil(t, sa)
+	assert.Equal(t, errNodeStarting, err)
+
+	s1, err = inf.GetTokenSupply("")
+	assert.Empty(t, s1)
+	assert.Equal(t, errNodeStarting, err)
+
+	assert.False(t, check.IfNil(inf))
 }

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	dbLookupFactory "github.com/ElrondNetwork/elrond-go/dblookupext/factory"
 	"github.com/ElrondNetwork/elrond-go/facade"
-	"github.com/ElrondNetwork/elrond-go/facade/disabled"
+	"github.com/ElrondNetwork/elrond-go/facade/initial"
 	mainFactory "github.com/ElrondNetwork/elrond-go/factory"
 	"github.com/ElrondNetwork/elrond-go/genesis/parsing"
 	"github.com/ElrondNetwork/elrond-go/health"
@@ -491,7 +491,7 @@ func (nr *nodeRunner) createApiFacade(
 
 func (nr *nodeRunner) createHttpServer() (shared.UpgradeableHttpServerHandler, error) {
 	httpServerArgs := gin.ArgsNewWebServer{
-		Facade:          disabled.NewDisabledNodeFacade(nr.configs.FlagsConfig.RestApiInterface),
+		Facade:          initial.NewInitialNodeFacade(nr.configs.FlagsConfig.RestApiInterface, nr.configs.FlagsConfig.EnablePprof),
 		ApiConfig:       *nr.configs.ApiRoutesConfig,
 		AntiFloodConfig: nr.configs.GeneralConfig.Antiflood.WebServer,
 	}


### PR DESCRIPTION
After merging `feat/web-server-refactor` - the pprof route was missing. This PR adds it back.

Testing procedure:
- start a testnet with the `--profile-mode` added to nodes
- `go tool pprof <node-ip>:<node-port>/debug/pprof/goroutine` - should work and not return 404 code