### PR TITLE
backward compatibility fix on edge case

### DIFF
--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -108,6 +108,9 @@
     # BuiltInFunctionOnMetaEnableEpoch represents the epoch when built in function processing on metachain is enabled
     BuiltInFunctionOnMetaEnableEpoch = 5
 
+    # SaveAccountsIfErrorDisableEpoch represents the epoch when save accounts if error is disabled
+    SaveAccountsIfErrorDisableEpoch = 5
+
     # MaxNodesChangeEnableEpoch holds configuration for changing the maximum number of nodes and the enabling epoch
     MaxNodesChangeEnableEpoch = [
         { EpochEnable = 0, MaxNumNodes = 36, NodesToShufflePerShard = 4 },

--- a/config/epochConfig.go
+++ b/config/epochConfig.go
@@ -49,6 +49,7 @@ type EnableEpochs struct {
 	GlobalMintBurnDisableEpoch                  uint32
 	ESDTTransferRoleEnableEpoch                 uint32
 	BuiltInFunctionOnMetaEnableEpoch            uint32
+	SaveAccountsIfErrorDisableEpoch             uint32
 }
 
 // GasScheduleByEpochs represents a gas schedule toml entry that will be applied from the provided epoch

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -913,6 +913,7 @@ func createFullArgumentsForSystemSCProcessing(stakingV2EnableEpoch uint32, trieS
 		DataPool:           testDataPool,
 		CompiledSCPool:     testDataPool.SmartContracts(),
 		NilCompiledSCStore: true,
+		EpochNotifier:      epochNotifier,
 	}
 
 	gasSchedule := arwenConfig.MakeGasMapForTests()

--- a/factory/apiResolverFactory.go
+++ b/factory/apiResolverFactory.go
@@ -250,19 +250,21 @@ func createScQueryElement(
 	scStorage := args.generalConfig.SmartContractsStorageForSCQuery
 	scStorage.DB.FilePath += fmt.Sprintf("%d", args.index)
 	argsHook := hooks.ArgBlockChainHook{
-		Accounts:           args.stateComponents.AccountsAdapter(),
-		PubkeyConv:         args.coreComponents.AddressPubKeyConverter(),
-		StorageService:     args.dataComponents.StorageService(),
-		BlockChain:         args.dataComponents.Blockchain(),
-		ShardCoordinator:   args.processComponents.ShardCoordinator(),
-		Marshalizer:        args.coreComponents.InternalMarshalizer(),
-		Uint64Converter:    args.coreComponents.Uint64ByteSliceConverter(),
-		BuiltInFunctions:   builtInFuncs,
-		DataPool:           args.dataComponents.Datapool(),
-		ConfigSCStorage:    scStorage,
-		CompiledSCPool:     smartContractsCache,
-		WorkingDir:         args.workingDir,
-		NilCompiledSCStore: true,
+		Accounts:                        args.stateComponents.AccountsAdapter(),
+		PubkeyConv:                      args.coreComponents.AddressPubKeyConverter(),
+		StorageService:                  args.dataComponents.StorageService(),
+		BlockChain:                      args.dataComponents.Blockchain(),
+		ShardCoordinator:                args.processComponents.ShardCoordinator(),
+		Marshalizer:                     args.coreComponents.InternalMarshalizer(),
+		Uint64Converter:                 args.coreComponents.Uint64ByteSliceConverter(),
+		BuiltInFunctions:                builtInFuncs,
+		DataPool:                        args.dataComponents.Datapool(),
+		ConfigSCStorage:                 scStorage,
+		CompiledSCPool:                  smartContractsCache,
+		WorkingDir:                      args.workingDir,
+		NilCompiledSCStore:              true,
+		EpochNotifier:                   args.coreComponents.EpochNotifier(),
+		SaveAccountsIfErrorDisableEpoch: args.epochConfig.EnableEpochs.SaveAccountsIfErrorDisableEpoch,
 	}
 
 	if args.processComponents.ShardCoordinator().SelfId() == core.MetachainShardId {

--- a/factory/blockProcessorCreator.go
+++ b/factory/blockProcessorCreator.go
@@ -115,19 +115,21 @@ func (pcf *processComponentsFactory) newShardBlockProcessor(
 	}
 
 	argsHook := hooks.ArgBlockChainHook{
-		Accounts:           pcf.state.AccountsAdapter(),
-		PubkeyConv:         pcf.coreData.AddressPubKeyConverter(),
-		StorageService:     pcf.data.StorageService(),
-		BlockChain:         pcf.data.Blockchain(),
-		ShardCoordinator:   pcf.bootstrapComponents.ShardCoordinator(),
-		Marshalizer:        pcf.coreData.InternalMarshalizer(),
-		Uint64Converter:    pcf.coreData.Uint64ByteSliceConverter(),
-		BuiltInFunctions:   builtInFuncs,
-		DataPool:           pcf.data.Datapool(),
-		CompiledSCPool:     pcf.data.Datapool().SmartContracts(),
-		WorkingDir:         pcf.workingDir,
-		NilCompiledSCStore: false,
-		ConfigSCStorage:    pcf.config.SmartContractsStorage,
+		Accounts:                        pcf.state.AccountsAdapter(),
+		PubkeyConv:                      pcf.coreData.AddressPubKeyConverter(),
+		StorageService:                  pcf.data.StorageService(),
+		BlockChain:                      pcf.data.Blockchain(),
+		ShardCoordinator:                pcf.bootstrapComponents.ShardCoordinator(),
+		Marshalizer:                     pcf.coreData.InternalMarshalizer(),
+		Uint64Converter:                 pcf.coreData.Uint64ByteSliceConverter(),
+		BuiltInFunctions:                builtInFuncs,
+		DataPool:                        pcf.data.Datapool(),
+		CompiledSCPool:                  pcf.data.Datapool().SmartContracts(),
+		WorkingDir:                      pcf.workingDir,
+		NilCompiledSCStore:              false,
+		ConfigSCStorage:                 pcf.config.SmartContractsStorage,
+		EpochNotifier:                   pcf.epochNotifier,
+		SaveAccountsIfErrorDisableEpoch: pcf.epochConfig.EnableEpochs.SaveAccountsIfErrorDisableEpoch,
 	}
 
 	esdtTransferParser, err := parsers.NewESDTTransferParser(pcf.coreData.InternalMarshalizer())
@@ -450,19 +452,21 @@ func (pcf *processComponentsFactory) newMetaBlockProcessor(
 	}
 
 	argsHook := hooks.ArgBlockChainHook{
-		Accounts:           pcf.state.AccountsAdapter(),
-		PubkeyConv:         pcf.coreData.AddressPubKeyConverter(),
-		StorageService:     pcf.data.StorageService(),
-		BlockChain:         pcf.data.Blockchain(),
-		ShardCoordinator:   pcf.bootstrapComponents.ShardCoordinator(),
-		Marshalizer:        pcf.coreData.InternalMarshalizer(),
-		Uint64Converter:    pcf.coreData.Uint64ByteSliceConverter(),
-		BuiltInFunctions:   builtInFuncs,
-		DataPool:           pcf.data.Datapool(),
-		CompiledSCPool:     pcf.data.Datapool().SmartContracts(),
-		ConfigSCStorage:    pcf.config.SmartContractsStorage,
-		WorkingDir:         pcf.workingDir,
-		NilCompiledSCStore: false,
+		Accounts:                        pcf.state.AccountsAdapter(),
+		PubkeyConv:                      pcf.coreData.AddressPubKeyConverter(),
+		StorageService:                  pcf.data.StorageService(),
+		BlockChain:                      pcf.data.Blockchain(),
+		ShardCoordinator:                pcf.bootstrapComponents.ShardCoordinator(),
+		Marshalizer:                     pcf.coreData.InternalMarshalizer(),
+		Uint64Converter:                 pcf.coreData.Uint64ByteSliceConverter(),
+		BuiltInFunctions:                builtInFuncs,
+		DataPool:                        pcf.data.Datapool(),
+		CompiledSCPool:                  pcf.data.Datapool().SmartContracts(),
+		ConfigSCStorage:                 pcf.config.SmartContractsStorage,
+		WorkingDir:                      pcf.workingDir,
+		NilCompiledSCStore:              false,
+		EpochNotifier:                   pcf.epochNotifier,
+		SaveAccountsIfErrorDisableEpoch: pcf.epochConfig.EnableEpochs.SaveAccountsIfErrorDisableEpoch,
 	}
 
 	argsNewVMContainer := metachain.ArgsNewVMContainerFactory{

--- a/factory/blockProcessorCreator.go
+++ b/factory/blockProcessorCreator.go
@@ -259,6 +259,7 @@ func (pcf *processComponentsFactory) newShardBlockProcessor(
 		EpochNotifier:                         pcf.epochNotifier,
 		StakingV2EnableEpoch:                  pcf.epochConfig.EnableEpochs.StakingV2EnableEpoch,
 		BuiltInFunctionOnMetachainEnableEpoch: pcf.epochConfig.EnableEpochs.BuiltInFunctionOnMetaEnableEpoch,
+		ReloadAccountAfterSnapshotEnableEpoch: pcf.epochConfig.EnableEpochs.SaveAccountsIfErrorDisableEpoch,
 		VMOutputCacher:                        txcache.NewDisabledCache(),
 		ArwenChangeLocker:                     arwenChangeLocker,
 
@@ -586,6 +587,7 @@ func (pcf *processComponentsFactory) newMetaBlockProcessor(
 		EpochNotifier:                         pcf.epochNotifier,
 		StakingV2EnableEpoch:                  pcf.epochConfig.EnableEpochs.StakingV2EnableEpoch,
 		BuiltInFunctionOnMetachainEnableEpoch: pcf.epochConfig.EnableEpochs.BuiltInFunctionOnMetaEnableEpoch,
+		ReloadAccountAfterSnapshotEnableEpoch: pcf.epochConfig.EnableEpochs.SaveAccountsIfErrorDisableEpoch,
 		VMOutputCacher:                        txcache.NewDisabledCache(),
 		ArwenChangeLocker:                     arwenChangeLocker,
 

--- a/genesis/process/genesisBlockCreator.go
+++ b/genesis/process/genesisBlockCreator.go
@@ -407,18 +407,19 @@ func (gbc *genesisBlockCreator) computeDNSAddresses() error {
 
 	builtInFuncs := vmcommonBuiltInFunctions.NewBuiltInFunctionContainer()
 	argsHook := hooks.ArgBlockChainHook{
-		Accounts:           gbc.arg.Accounts,
-		PubkeyConv:         gbc.arg.Core.AddressPubKeyConverter(),
-		StorageService:     gbc.arg.Data.StorageService(),
-		BlockChain:         gbc.arg.Data.Blockchain(),
-		ShardCoordinator:   gbc.arg.ShardCoordinator,
-		Marshalizer:        gbc.arg.Core.InternalMarshalizer(),
-		Uint64Converter:    gbc.arg.Core.Uint64ByteSliceConverter(),
-		BuiltInFunctions:   builtInFuncs,
-		DataPool:           gbc.arg.Data.Datapool(),
-		CompiledSCPool:     gbc.arg.Data.Datapool().SmartContracts(),
-		NilCompiledSCStore: true,
-		EpochNotifier:      forking.NewGenericEpochNotifier(),
+		Accounts:                        gbc.arg.Accounts,
+		PubkeyConv:                      gbc.arg.Core.AddressPubKeyConverter(),
+		StorageService:                  gbc.arg.Data.StorageService(),
+		BlockChain:                      gbc.arg.Data.Blockchain(),
+		ShardCoordinator:                gbc.arg.ShardCoordinator,
+		Marshalizer:                     gbc.arg.Core.InternalMarshalizer(),
+		Uint64Converter:                 gbc.arg.Core.Uint64ByteSliceConverter(),
+		BuiltInFunctions:                builtInFuncs,
+		DataPool:                        gbc.arg.Data.Datapool(),
+		CompiledSCPool:                  gbc.arg.Data.Datapool().SmartContracts(),
+		NilCompiledSCStore:              true,
+		EpochNotifier:                   forking.NewGenericEpochNotifier(),
+		SaveAccountsIfErrorDisableEpoch: unreachableEpoch,
 	}
 	blockChainHook, err := hooks.NewBlockChainHookImpl(argsHook)
 	if err != nil {

--- a/genesis/process/genesisBlockCreator.go
+++ b/genesis/process/genesisBlockCreator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
+	"github.com/ElrondNetwork/elrond-go/common/forking"
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/blockchain"
@@ -417,6 +418,7 @@ func (gbc *genesisBlockCreator) computeDNSAddresses() error {
 		DataPool:           gbc.arg.Data.Datapool(),
 		CompiledSCPool:     gbc.arg.Data.Datapool().SmartContracts(),
 		NilCompiledSCStore: true,
+		EpochNotifier:      forking.NewGenericEpochNotifier(),
 	}
 	blockChainHook, err := hooks.NewBlockChainHookImpl(argsHook)
 	if err != nil {

--- a/genesis/process/metaGenesisBlockCreator.go
+++ b/genesis/process/metaGenesisBlockCreator.go
@@ -371,6 +371,7 @@ func createProcessorsForMetaGenesisBlock(arg ArgsGenesisBlockCreator, enableEpoc
 		ReturnDataToLastTransferEnableEpoch:   enableEpochs.ReturnDataToLastTransferEnableEpoch,
 		SenderInOutTransferEnableEpoch:        enableEpochs.SenderInOutTransferEnableEpoch,
 		BuiltInFunctionOnMetachainEnableEpoch: enableEpochs.BuiltInFunctionOnMetaEnableEpoch,
+		ReloadAccountAfterSnapshotEnableEpoch: enableEpochs.SaveAccountsIfErrorDisableEpoch,
 		IsGenesisProcessing:                   true,
 		StakingV2EnableEpoch:                  arg.EpochConfig.EnableEpochs.StakingV2EnableEpoch,
 		ArwenChangeLocker:                     &sync.RWMutex{}, // local Locker as to not interfere with the rest of the components

--- a/genesis/process/metaGenesisBlockCreator.go
+++ b/genesis/process/metaGenesisBlockCreator.go
@@ -248,18 +248,19 @@ func createProcessorsForMetaGenesisBlock(arg ArgsGenesisBlockCreator, enableEpoc
 	epochNotifier.CheckEpoch(temporaryMetaHeader)
 
 	argsHook := hooks.ArgBlockChainHook{
-		Accounts:           arg.Accounts,
-		PubkeyConv:         arg.Core.AddressPubKeyConverter(),
-		StorageService:     arg.Data.StorageService(),
-		BlockChain:         arg.Data.Blockchain(),
-		ShardCoordinator:   arg.ShardCoordinator,
-		Marshalizer:        arg.Core.InternalMarshalizer(),
-		Uint64Converter:    arg.Core.Uint64ByteSliceConverter(),
-		BuiltInFunctions:   builtInFuncs,
-		DataPool:           arg.Data.Datapool(),
-		CompiledSCPool:     arg.Data.Datapool().SmartContracts(),
-		NilCompiledSCStore: true,
-		EpochNotifier:      epochNotifier,
+		Accounts:                        arg.Accounts,
+		PubkeyConv:                      arg.Core.AddressPubKeyConverter(),
+		StorageService:                  arg.Data.StorageService(),
+		BlockChain:                      arg.Data.Blockchain(),
+		ShardCoordinator:                arg.ShardCoordinator,
+		Marshalizer:                     arg.Core.InternalMarshalizer(),
+		Uint64Converter:                 arg.Core.Uint64ByteSliceConverter(),
+		BuiltInFunctions:                builtInFuncs,
+		DataPool:                        arg.Data.Datapool(),
+		CompiledSCPool:                  arg.Data.Datapool().SmartContracts(),
+		NilCompiledSCStore:              true,
+		EpochNotifier:                   epochNotifier,
+		SaveAccountsIfErrorDisableEpoch: unreachableEpoch,
 	}
 
 	pubKeyVerifier, err := disabled.NewMessageSignVerifier(arg.BlockSignKeyGen)

--- a/genesis/process/metaGenesisBlockCreator.go
+++ b/genesis/process/metaGenesisBlockCreator.go
@@ -240,6 +240,13 @@ func saveGenesisMetaToStorage(
 
 func createProcessorsForMetaGenesisBlock(arg ArgsGenesisBlockCreator, enableEpochs config.EnableEpochs) (*genesisProcessors, error) {
 	builtInFuncs := vmcommonBuiltInFunctions.NewBuiltInFunctionContainer()
+	epochNotifier := forking.NewGenericEpochNotifier()
+	temporaryMetaHeader := &block.MetaBlock{
+		Epoch:     arg.StartEpochNum,
+		TimeStamp: arg.GenesisTime,
+	}
+	epochNotifier.CheckEpoch(temporaryMetaHeader)
+
 	argsHook := hooks.ArgBlockChainHook{
 		Accounts:           arg.Accounts,
 		PubkeyConv:         arg.Core.AddressPubKeyConverter(),
@@ -252,14 +259,8 @@ func createProcessorsForMetaGenesisBlock(arg ArgsGenesisBlockCreator, enableEpoc
 		DataPool:           arg.Data.Datapool(),
 		CompiledSCPool:     arg.Data.Datapool().SmartContracts(),
 		NilCompiledSCStore: true,
+		EpochNotifier:      epochNotifier,
 	}
-
-	epochNotifier := forking.NewGenericEpochNotifier()
-	temporaryMetaHeader := &block.MetaBlock{
-		Epoch:     arg.StartEpochNum,
-		TimeStamp: arg.GenesisTime,
-	}
-	epochNotifier.CheckEpoch(temporaryMetaHeader)
 
 	pubKeyVerifier, err := disabled.NewMessageSignVerifier(arg.BlockSignKeyGen)
 	if err != nil {

--- a/genesis/process/shardGenesisBlockCreator.go
+++ b/genesis/process/shardGenesisBlockCreator.go
@@ -298,6 +298,7 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, enableEpo
 		DataPool:           arg.Data.Datapool(),
 		CompiledSCPool:     arg.Data.Datapool().SmartContracts(),
 		NilCompiledSCStore: true,
+		EpochNotifier:      epochNotifier,
 	}
 	esdtTransferParser, err := parsers.NewESDTTransferParser(arg.Core.InternalMarshalizer())
 	if err != nil {

--- a/genesis/process/shardGenesisBlockCreator.go
+++ b/genesis/process/shardGenesisBlockCreator.go
@@ -60,6 +60,7 @@ func createGenesisConfig() config.EnableEpochs {
 		RelayedTransactionsV2EnableEpoch:            unreachableEpoch,
 		BuiltInFunctionOnMetaEnableEpoch:            unreachableEpoch,
 		IncrementSCRNonceInMultiTransferEnableEpoch: unreachableEpoch,
+		SaveAccountsIfErrorDisableEpoch:             unreachableEpoch,
 	}
 }
 
@@ -287,18 +288,19 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, enableEpo
 	}
 
 	argsHook := hooks.ArgBlockChainHook{
-		Accounts:           arg.Accounts,
-		PubkeyConv:         arg.Core.AddressPubKeyConverter(),
-		StorageService:     arg.Data.StorageService(),
-		BlockChain:         arg.Data.Blockchain(),
-		ShardCoordinator:   arg.ShardCoordinator,
-		Marshalizer:        arg.Core.InternalMarshalizer(),
-		Uint64Converter:    arg.Core.Uint64ByteSliceConverter(),
-		BuiltInFunctions:   builtInFuncs,
-		DataPool:           arg.Data.Datapool(),
-		CompiledSCPool:     arg.Data.Datapool().SmartContracts(),
-		NilCompiledSCStore: true,
-		EpochNotifier:      epochNotifier,
+		Accounts:                        arg.Accounts,
+		PubkeyConv:                      arg.Core.AddressPubKeyConverter(),
+		StorageService:                  arg.Data.StorageService(),
+		BlockChain:                      arg.Data.Blockchain(),
+		ShardCoordinator:                arg.ShardCoordinator,
+		Marshalizer:                     arg.Core.InternalMarshalizer(),
+		Uint64Converter:                 arg.Core.Uint64ByteSliceConverter(),
+		BuiltInFunctions:                builtInFuncs,
+		DataPool:                        arg.Data.Datapool(),
+		CompiledSCPool:                  arg.Data.Datapool().SmartContracts(),
+		NilCompiledSCStore:              true,
+		EpochNotifier:                   epochNotifier,
+		SaveAccountsIfErrorDisableEpoch: unreachableEpoch,
 	}
 	esdtTransferParser, err := parsers.NewESDTTransferParser(arg.Core.InternalMarshalizer())
 	if err != nil {

--- a/genesis/process/shardGenesisBlockCreator.go
+++ b/genesis/process/shardGenesisBlockCreator.go
@@ -422,6 +422,7 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, enableEpo
 		ReturnDataToLastTransferEnableEpoch:   enableEpochs.ReturnDataToLastTransferEnableEpoch,
 		SenderInOutTransferEnableEpoch:        enableEpochs.SenderInOutTransferEnableEpoch,
 		BuiltInFunctionOnMetachainEnableEpoch: enableEpochs.BuiltInFunctionOnMetaEnableEpoch,
+		ReloadAccountAfterSnapshotEnableEpoch: enableEpochs.SaveAccountsIfErrorDisableEpoch,
 		IsGenesisProcessing:                   true,
 		StakingV2EnableEpoch:                  arg.EpochConfig.EnableEpochs.StakingV2EnableEpoch,
 		VMOutputCacher:                        txcache.NewDisabledCache(),

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -801,6 +801,7 @@ func (tpn *TestProcessorNode) createFullSCQueryService() {
 		DataPool:           tpn.DataPool,
 		CompiledSCPool:     smartContractsCache,
 		NilCompiledSCStore: true,
+		EpochNotifier:      tpn.EpochNotifier,
 	}
 
 	if tpn.ShardCoordinator.SelfId() == core.MetachainShardId {
@@ -1376,6 +1377,7 @@ func (tpn *TestProcessorNode) initInnerProcessors(gasMap map[string]map[string]u
 		DataPool:           tpn.DataPool,
 		CompiledSCPool:     tpn.DataPool.SmartContracts(),
 		NilCompiledSCStore: true,
+		EpochNotifier:      tpn.EpochNotifier,
 	}
 	esdtTransferParser, _ := parsers.NewESDTTransferParser(TestMarshalizer)
 	maxGasLimitPerBlock := uint64(0xFFFFFFFFFFFFFFFF)
@@ -1568,6 +1570,7 @@ func (tpn *TestProcessorNode) initMetaInnerProcessors() {
 		DataPool:           tpn.DataPool,
 		CompiledSCPool:     tpn.DataPool.SmartContracts(),
 		NilCompiledSCStore: true,
+		EpochNotifier:      tpn.EpochNotifier,
 	}
 
 	var signVerifier vm.MessageSignVerifier

--- a/integrationTests/vm/arwen/utils.go
+++ b/integrationTests/vm/arwen/utils.go
@@ -252,6 +252,7 @@ func (context *TestContext) initVMAndBlockchainHook() {
 				MaxBatchSize:      100,
 			},
 		},
+		EpochNotifier: context.EpochNotifier,
 	}
 
 	vmFactoryConfig := config.VirtualMachineConfig{

--- a/integrationTests/vm/testInitializer.go
+++ b/integrationTests/vm/testInitializer.go
@@ -416,6 +416,7 @@ func CreateTxProcessorWithOneSCExecutorMockVM(
 		CompiledSCPool:     datapool.SmartContracts(),
 		NilCompiledSCStore: true,
 		ConfigSCStorage:    *defaultStorageConfig(),
+		EpochNotifier:      globalEpochNotifier,
 	}
 
 	blockChainHook, _ := hooks.NewBlockChainHookImpl(args)
@@ -513,6 +514,7 @@ func CreateOneSCExecutorMockVM(accnts state.AccountsAdapter) vmcommon.VMExecutio
 		CompiledSCPool:     datapool.SmartContracts(),
 		NilCompiledSCStore: true,
 		ConfigSCStorage:    *defaultStorageConfig(),
+		EpochNotifier:      globalEpochNotifier,
 	}
 	blockChainHook, _ := hooks.NewBlockChainHookImpl(args)
 	vm, _ := mock.NewOneSCExecutorMockVM(blockChainHook, testHasher)
@@ -560,6 +562,7 @@ func CreateVMAndBlockchainHookAndDataPool(
 		CompiledSCPool:     datapool.SmartContracts(),
 		NilCompiledSCStore: true,
 		ConfigSCStorage:    *defaultStorageConfig(),
+		EpochNotifier:      globalEpochNotifier,
 	}
 
 	esdtTransferParser, _ := parsers.NewESDTTransferParser(testMarshalizer)
@@ -630,6 +633,7 @@ func CreateVMAndBlockchainHookMeta(
 		DataPool:           datapool,
 		CompiledSCPool:     datapool.SmartContracts(),
 		NilCompiledSCStore: true,
+		EpochNotifier:      globalEpochNotifier,
 	}
 
 	economicsData, err := createEconomicsData(0)

--- a/integrationTests/vm/txsFee/builtInFunctions_test.go
+++ b/integrationTests/vm/txsFee/builtInFunctions_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
+	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/vm"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/vm/txsFee/utils"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -265,4 +266,29 @@ func TestBuildInFunctionSaveKeyValue_WrongDestination(t *testing.T) {
 	//Should not reference builtInFunctions.ErrNilSCDestAccount as that might change and this test will still pass.
 	requiredData := hex.EncodeToString([]byte("nil destination SC account"))
 	require.Equal(t, "@"+requiredData, string(intermediateTxs[0].GetData()))
+}
+
+func TestBuildInFunctionSaveKeyValue_NotEnoughGasFor3rdSave(t *testing.T) {
+	shardCoord, _ := sharding.NewMultiShardCoordinator(2, 0)
+
+	testContext, err := vm.CreatePreparedTxProcessorWithVMsShardCoordinatorAndEpochConfig(vm.ArgEnableEpoch{}, shardCoord, config.EnableEpochs{SaveAccountsIfErrorDisableEpoch: 5})
+	require.Nil(t, err)
+	defer testContext.Close()
+
+	sndAddr := []byte("12345678901234567890123456789112")
+
+	senderBalance := big.NewInt(100000)
+	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
+
+	txData := []byte(core.BuiltInFunctionSaveKeyValue + "@01000000@02000000@03000000@04000000@05000000@06000000")
+	gasLimit := uint64(len(txData) + 20)
+	gasPrice := uint64(10)
+
+	tx := vm.CreateTransaction(0, big.NewInt(0), sndAddr, sndAddr, gasPrice, gasLimit, txData)
+	retCode, err := testContext.TxProcessor.ProcessTransaction(tx)
+	require.Equal(t, vmcommon.UserError, retCode)
+	require.Equal(t, process.ErrFailedTransaction, err)
+
+	intermediateTxs := testContext.GetIntermediateTransactions(t)
+	require.True(t, len(intermediateTxs) > 1)
 }

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -146,7 +146,7 @@ func printEnableEpochs(configs *config.Configs) {
 	log.Debug(readEpochFor("contract global mint and burn"), "epoch", enableEpochs.GlobalMintBurnDisableEpoch)
 	log.Debug(readEpochFor("contract transfer role"), "epoch", enableEpochs.ESDTTransferRoleEnableEpoch)
 	log.Debug(readEpochFor("built in functions on metachain"), "epoch", enableEpochs.BuiltInFunctionOnMetaEnableEpoch)
-
+	log.Debug(readEpochFor("built in functions save accounts if error disabled"), "epoch", enableEpochs.SaveAccountsIfErrorDisableEpoch)
 	gasSchedule := configs.EpochConfig.GasSchedule
 
 	log.Debug(readEpochFor("gas schedule directories paths"), "epoch", gasSchedule.GasScheduleByEpochs)

--- a/process/factory/metachain/vmContainerFactory_test.go
+++ b/process/factory/metachain/vmContainerFactory_test.go
@@ -42,6 +42,7 @@ func createMockVMAccountsArguments() hooks.ArgBlockChainHook {
 		DataPool:           datapool,
 		CompiledSCPool:     datapool.SmartContracts(),
 		NilCompiledSCStore: true,
+		EpochNotifier:      &mock.EpochNotifierStub{},
 	}
 	return arguments
 }

--- a/process/factory/shard/vmContainerFactory_test.go
+++ b/process/factory/shard/vmContainerFactory_test.go
@@ -45,6 +45,7 @@ func createMockVMAccountsArguments() hooks.ArgBlockChainHook {
 		DataPool:           datapool,
 		CompiledSCPool:     datapool.SmartContracts(),
 		NilCompiledSCStore: true,
+		EpochNotifier:      &mock.EpochNotifierStub{},
 	}
 	return arguments
 }

--- a/process/smartContract/hooks/blockChainHook.go
+++ b/process/smartContract/hooks/blockChainHook.go
@@ -661,7 +661,7 @@ func (bh *BlockChainHookImpl) RevertToSnapshot(snapshot int) error {
 // EpochConfirmed is called whenever a new epoch is confirmed
 func (bh *BlockChainHookImpl) EpochConfirmed(epoch uint32, _ uint64) {
 	bh.flagSaveAccountsIfError.Toggle(epoch < bh.saveAccountsIfErrorDisableEpoch)
-	log.Debug("blockchain hook: built in functions save accounts if error", "enabled", bh.flagSaveAccountsIfError.IsSet())
+	log.Debug("blockchain hook: built in functions save accounts always", "enabled", bh.flagSaveAccountsIfError.IsSet())
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/process/smartContract/hooks/blockChainHook.go
+++ b/process/smartContract/hooks/blockChainHook.go
@@ -661,7 +661,7 @@ func (bh *BlockChainHookImpl) RevertToSnapshot(snapshot int) error {
 // EpochConfirmed is called whenever a new epoch is confirmed
 func (bh *BlockChainHookImpl) EpochConfirmed(epoch uint32, _ uint64) {
 	bh.flagSaveAccountsIfError.Toggle(epoch < bh.saveAccountsIfErrorDisableEpoch)
-	log.Debug("blockchain hook: save accounts if error", "enabled", bh.flagSaveAccountsIfError.IsSet())
+	log.Debug("blockchain hook: built in functions save accounts if error", "enabled", bh.flagSaveAccountsIfError.IsSet())
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/process/smartContract/hooks/blockChainHook.go
+++ b/process/smartContract/hooks/blockChainHook.go
@@ -374,9 +374,9 @@ func (bh *BlockChainHookImpl) ProcessBuiltInFunction(input *vmcommon.ContractCal
 	vmOutput, err := function.ProcessBuiltinFunction(sndAccount, dstAccount, input)
 	if err != nil {
 		if bh.flagSaveAccountsIfError.IsSet() {
-			err = bh.saveAccounts(input, sndAccount, dstAccount)
-			if err != nil {
-				return nil, err
+			errSave := bh.saveAccounts(input, sndAccount, dstAccount)
+			if errSave != nil {
+				return nil, errSave
 			}
 		}
 

--- a/process/smartContract/hooks/blockChainHook_test.go
+++ b/process/smartContract/hooks/blockChainHook_test.go
@@ -42,6 +42,7 @@ func createMockVMAccountsArguments() hooks.ArgBlockChainHook {
 		DataPool:           datapool,
 		CompiledSCPool:     datapool.SmartContracts(),
 		NilCompiledSCStore: true,
+		EpochNotifier:      &mock.EpochNotifierStub{},
 	}
 	return arguments
 }


### PR DESCRIPTION
backward compatibility fix on edge case.

Current code running on mainnet, does save account even if execution fails later. This means the account will get an empty hash instead of a NIL one. This results in roothash missmatch. This PR fixes the issue.