### PR TITLE
Merkle Proof API refactor

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -97,6 +97,9 @@ var ErrValidationEmptyRootHash = errors.New("rootHash is empty")
 // ErrValidationEmptyAddress signals that an empty address was provided
 var ErrValidationEmptyAddress = errors.New("address is empty")
 
+// ErrValidationEmptyKey signals that an empty key was provided
+var ErrValidationEmptyKey = errors.New("key is empty")
+
 // ErrGetProof signals an error happening when trying to compute a Merkle proof
 var ErrGetProof = errors.New("getting proof failed")
 

--- a/api/mock/facade.go
+++ b/api/mock/facade.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/esdt"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/elrond-go-core/data/vm"
+	"github.com/ElrondNetwork/elrond-go/api/shared"
 	"github.com/ElrondNetwork/elrond-go/debug"
 	"github.com/ElrondNetwork/elrond-go/heartbeat/data"
 	"github.com/ElrondNetwork/elrond-go/node/external"
@@ -56,8 +57,9 @@ type Facade struct {
 	GetAllIssuedESDTsCalled                 func(tokenType string) ([]string, error)
 	GetDirectStakedListHandler              func() ([]*api.DirectStakedValue, error)
 	GetDelegatorsListHandler                func() ([]*api.Delegator, error)
-	GetProofCalled                          func(string, string) ([][]byte, error)
-	GetProofCurrentRootHashCalled           func(string) ([][]byte, []byte, error)
+	GetProofCalled                          func(string, string) (*shared.GetProofResponse, error)
+	GetProofCurrentRootHashCalled           func(string) (*shared.GetProofResponse, error)
+	GetProofDataTrieCalled                  func(string, string, string) (*shared.GetProofResponse, *shared.GetProofResponse, error)
 	VerifyProofCalled                       func(string, string, [][]byte) (bool, error)
 	GetTokenSupplyCalled                    func(token string) (string, error)
 }
@@ -72,7 +74,7 @@ func (f *Facade) GetTokenSupply(token string) (string, error) {
 }
 
 // GetProof -
-func (f *Facade) GetProof(rootHash string, address string) ([][]byte, error) {
+func (f *Facade) GetProof(rootHash string, address string) (*shared.GetProofResponse, error) {
 	if f.GetProofCalled != nil {
 		return f.GetProofCalled(rootHash, address)
 	}
@@ -81,9 +83,18 @@ func (f *Facade) GetProof(rootHash string, address string) ([][]byte, error) {
 }
 
 // GetProofCurrentRootHash -
-func (f *Facade) GetProofCurrentRootHash(address string) ([][]byte, []byte, error) {
+func (f *Facade) GetProofCurrentRootHash(address string) (*shared.GetProofResponse, error) {
 	if f.GetProofCurrentRootHashCalled != nil {
 		return f.GetProofCurrentRootHashCalled(address)
+	}
+
+	return nil, nil
+}
+
+// GetProofDataTrie -
+func (f *Facade) GetProofDataTrie(rootHash string, address string, key string) (*shared.GetProofResponse, *shared.GetProofResponse, error) {
+	if f.GetProofDataTrieCalled != nil {
+		return f.GetProofDataTrieCalled(rootHash, address, key)
 	}
 
 	return nil, nil, nil

--- a/api/shared/shared.go
+++ b/api/shared/shared.go
@@ -28,6 +28,13 @@ const ReturnCodeRequestError ReturnCode = "bad_request"
 // ReturnCodeSystemBusy defines a request which hasn't been executed successfully due to too many requests
 const ReturnCodeSystemBusy ReturnCode = "system_busy"
 
+// GetProofResponse is a struct that stores the response of a GetProof request
+type GetProofResponse struct {
+	Proof    [][]byte
+	Value    []byte
+	RootHash string
+}
+
 // RespondWith will respond with the generic API response
 func RespondWith(c *gin.Context, status int, dataField interface{}, err string, code ReturnCode) {
 	c.JSON(

--- a/cmd/node/config/api.toml
+++ b/cmd/node/config/api.toml
@@ -179,6 +179,9 @@
         # /proof/root-hash/:roothash/address/:address will compute and return the proof in JSON format
         { Name = "/root-hash/:roothash/address/:address", Open = true },
 
+        # /proof/root-hash/:roothash/address/:address/key/:key will compute and return the proof in JSON format
+        { Name = "/root-hash/:roothash/address/:address/key/:key", Open = true },
+
         # /proof/address/:address will compute and return the proof and root hash in JSON format
         { Name = "/address/:address", Open = true },
 

--- a/facade/errors.go
+++ b/facade/errors.go
@@ -31,3 +31,6 @@ var ErrNilBlockchain = errors.New("nil blockchain")
 
 // ErrNilBlockHeader signals that the current block header is nil
 var ErrNilBlockHeader = errors.New("nil block header")
+
+// ErrNilMarshalizer signals that an operation has been attempted to or with a nil Marshalizer implementation
+var ErrNilMarshalizer = errors.New("nil Marshalizer")

--- a/integrationTests/state/stateTrie/stateTrie_test.go
+++ b/integrationTests/state/stateTrie/stateTrie_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	dataTx "github.com/ElrondNetwork/elrond-go-core/data/transaction"
-	"github.com/ElrondNetwork/elrond-go-crypto"
+	crypto "github.com/ElrondNetwork/elrond-go-crypto"
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/integrationTests"

--- a/integrationTests/testProcessorNodeWithTestWebServer.go
+++ b/integrationTests/testProcessorNodeWithTestWebServer.go
@@ -89,6 +89,7 @@ func createFacadeArg(tpn *TestProcessorNode) nodeFacade.ArgNodeFacade {
 		AccountsState:   tpn.AccntState,
 		PeerState:       tpn.PeerState,
 		Blockchain:      tpn.BlockChain,
+		Marshalizer:     TestMarshalizer,
 	}
 }
 

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -467,6 +467,7 @@ func (nr *nodeRunner) createApiFacade(
 		AccountsState:   currentNode.stateComponents.AccountsAdapter(),
 		PeerState:       currentNode.stateComponents.PeerAccounts(),
 		Blockchain:      currentNode.dataComponents.Blockchain(),
+		Marshalizer:     currentNode.coreComponents.InternalMarshalizer(),
 	}
 
 	ef, err := facade.NewNodeFacade(argNodeFacade)


### PR DESCRIPTION
Added a new endpoint that returns the proof for an account, and the proof for a given key from the data trie, all in a single call.

For tessting, check that the following endpoints work on a node:
"/proof/address/:address"
"/proof/root-hash/:roothash/address/:address"
"/proof/root-hash/:roothash/address/:address/key/:key"
"/proof/verify"