### PR TITLE
Fixed the node redundancy mechanism

### DIFF
--- a/factory/processComponents.go
+++ b/factory/processComponents.go
@@ -506,10 +506,19 @@ func (pcf *processComponentsFactory) Create() (*processComponents, error) {
 		return nil, err
 	}
 
+	observerBLSPrivateKey, observerBLSPublicKey := pcf.crypto.BlockSignKeyGen().GeneratePair()
+	observerBLSPublicKeyBuff, err := observerBLSPublicKey.ToByteArray()
+	if err != nil {
+		return nil, fmt.Errorf("error generating observerBLSPublicKeyBuff, %w", err)
+	} else {
+		log.Debug("generated BLS private key for redundancy handler. This key will be used on heartbeat messages "+
+			"if the node is in backup mode and the main node is active", "hex public key", observerBLSPublicKeyBuff)
+	}
+
 	nodeRedundancyArg := redundancy.ArgNodeRedundancy{
 		RedundancyLevel:    pcf.prefConfigs.RedundancyLevel,
 		Messenger:          pcf.network.NetworkMessenger(),
-		ObserverPrivateKey: pcf.crypto.PrivateKey(),
+		ObserverPrivateKey: observerBLSPrivateKey,
 	}
 	nodeRedundancyHandler, err := redundancy.NewNodeRedundancy(nodeRedundancyArg)
 	if err != nil {

--- a/factory/processComponentsHandler_test.go
+++ b/factory/processComponentsHandler_test.go
@@ -130,6 +130,7 @@ func TestManagedProcessComponents_Create_ShouldWork(t *testing.T) {
 	nodeSkBytes, err := cryptoComponents.PrivateKey().ToByteArray()
 	require.Nil(t, err)
 	observerSkBytes, err := managedProcessComponents.NodeRedundancyHandler().ObserverPrivateKey().ToByteArray()
+	require.Nil(t, err)
 	require.NotEqual(t, nodeSkBytes, observerSkBytes)
 }
 

--- a/factory/processComponentsHandler_test.go
+++ b/factory/processComponentsHandler_test.go
@@ -126,6 +126,11 @@ func TestManagedProcessComponents_Create_ShouldWork(t *testing.T) {
 	require.False(t, check.IfNil(managedProcessComponents.FallbackHeaderValidator()))
 	require.False(t, check.IfNil(managedProcessComponents.PeerShardMapper()))
 	require.False(t, check.IfNil(managedProcessComponents.ShardCoordinator()))
+
+	nodeSkBytes, err := cryptoComponents.PrivateKey().ToByteArray()
+	require.Nil(t, err)
+	observerSkBytes, err := managedProcessComponents.NodeRedundancyHandler().ObserverPrivateKey().ToByteArray()
+	require.NotEqual(t, nodeSkBytes, observerSkBytes)
 }
 
 func TestManagedProcessComponents_Close(t *testing.T) {


### PR DESCRIPTION
- fixed the node redundancy mechanism by providing a new private key

Testing scenario:
1. Start a new testnet, choose a validator node (we call this node A). Store its validatorKey.pem. 
2. Stop another node (doesn't matter the node - we will call it B). Provide it with the stored public key file (node's A key). 
3. Change the B's prefs.toml file, set the `RedundancyLevel` value to 1. 
4. Start the B node. Grep the log by the `broadcasting message heartbeat message` message. Should not use the public key from the provided file (should not broadcast A's public key), but a random BLS key (you can find this random key by grepping on `generated BLS private key for redundancy handler`).
5. Stop node A for ~30 rounds. Grep node B's log for `broadcasting message heartbeat message`, should find A's public key for a couple of times. 
6. Start node A. Node B should no longer broadcast the public key of the A node.