### PR TITLE
Fix health record creation error

### DIFF
--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -189,14 +189,22 @@ func (nr *nodeRunner) shuffleOutStatsAndGC() {
 		log.Debug("node statistics after running GC", statistics.GetRuntimeStatistics()...)
 	}
 
-	if debugConfig.DoProfileOnShuffleOut {
-		log.Debug("running profile job")
-		parentPath := filepath.Join(nr.configs.FlagsConfig.WorkingDir, nr.configs.GeneralConfig.Health.FolderPath)
-		var stats runtime.MemStats
-		runtime.ReadMemStats(&stats)
-		err := health.WriteMemoryUseInfo(stats, time.Now(), parentPath, "softrestart")
-		log.LogIfError(err)
+	nr.doProfileOnShuffleOut()
+}
+
+func (nr *nodeRunner) doProfileOnShuffleOut() {
+	debugConfig := nr.configs.GeneralConfig.Debug.ShuffleOut
+	shouldDoProfile := debugConfig.DoProfileOnShuffleOut && nr.configs.FlagsConfig.UseHealthService
+	if !shouldDoProfile {
+		return
 	}
+
+	log.Debug("running profile job")
+	parentPath := filepath.Join(nr.configs.FlagsConfig.WorkingDir, nr.configs.GeneralConfig.Health.FolderPath)
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	err := health.WriteMemoryUseInfo(stats, time.Now(), parentPath, "softrestart")
+	log.LogIfError(err)
 }
 
 func (nr *nodeRunner) executeOneComponentCreationCycle(


### PR DESCRIPTION
- fix health record creation error on shuffle out & with health service deactivated

Testing scenario: start a regular internal testnet using the `master` branch and **without** the `-use-health-service` on the node start line. After upgrade & some shuffle out processes, when grepping the logs for `ERROR` you will find some lines like
` open /home/xxx/elrond-nodes/node-0/health-records/mem__softrestart__xxx__xxx_MB.pprof: no such file or directory`
(this is just to prove the `master` branch has the wrong code)
Repeat these steps with this branch. Should no longer find `ERROR` messages. Then reactivate the `-use-health-service` flag and give it a proper #all-in scenario.