### PR TITLE
Fixed connect to seeders print + main print

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -74,6 +74,7 @@ func main() {
 
 	err := app.Run(os.Args)
 	if err != nil {
+		log.Error(err.Error())
 		os.Exit(1)
 	}
 }

--- a/p2p/libp2p/discovery/continuousKadDhtDiscoverer.go
+++ b/p2p/libp2p/discovery/continuousKadDhtDiscoverer.go
@@ -253,7 +253,7 @@ func (ckdd *ContinuousKadDhtDiscoverer) tryConnectToSeeder(
 
 func printConnectionErrorToSeeder(peer string, err error) {
 	if errors.Is(err, p2p.ErrUnwantedPeer) {
-		log.Trace("error connecting to seeder",
+		log.Trace("tryConnectToSeeder: unwanted peer",
 			"seeder", peer,
 			"error", err.Error(),
 		)

--- a/p2p/libp2p/discovery/optimizedKadDhtDiscoverer.go
+++ b/p2p/libp2p/discovery/optimizedKadDhtDiscoverer.go
@@ -180,7 +180,7 @@ func (okdd *optimizedKadDhtDiscoverer) tryToReconnectAtLeastToASeeder(ctx contex
 	for _, seederAddress := range okdd.initialPeersList {
 		err := okdd.connectToSeeder(ctx, seederAddress)
 		if err != nil {
-			log.Debug("error connecting to seeder", "seeder", seederAddress, "error", err.Error())
+			printConnectionErrorToSeeder(seederAddress, err)
 		} else {
 			connectedToOneSeeder = true
 		}


### PR DESCRIPTION
- fixed connect to seeders print
- added missing log print on node start error

Testing scenario:
1. build the node binary from `master` branch and run it in a new folder **without** the config folders. The node will close itself without printing any messages. Repeat the step from this branch: should see a log print error message.

2.a. run node (with configs) from `master` branch (no seeder, nothing else and log level `-log-level *:DEBUG`). You should see the log debug print `error connecting to seeder` (this is correct). 
2.b. Now, change in the p2p.toml file, place these seeders:
```
    InitialPeerList = [
        "/dns4/gondor.mainnet.elrond.com/tcp/10000/p2p/16Uiu2HAmQihd2Di6JrDCRf6bnxXEmgfFy8C3S7WDnq7WNXscfkrG",
        "/dns4/isengard.mainnet.elrond.com/tcp/10000/p2p/16Uiu2HAkxWoEwkkxMfUgi2CkxjWkZ7cccjvh4V57gxUQQC6c45N6",
        "/ip4/188.166.192.50/tcp/10000/p2p/16Uiu2HAmT2rqgzWYnFe7YL4poyjXvKhGtrwkhaAibSDFCjGATDZ7",
        "/ip4/188.166.203.198/tcp/10000/p2p/16Uiu2HAmJeuEEczm6kLyBKAJQobVn7ARmGFQ5mPrbNVsjdhJz9s1",
    ]
``` 
you can still see the log print as debug stating `error connecting to seeder` and mentioning something about an unwanted peer.
2.c. re-run the same scenario with the same steps (run the node with `-log-level *:DEBUG,p2p:TRACE`) and for scenario 2a. you will see the print as log debug. For repeating 2b., you will see a TRACE message stating `tryConnectToSeeder: unwanted peer` and no log debug `error connecting to seeder`.


