### PR TITLE
Refactor slash proof to use HeaderInfo instead InterceptedHeader

### DIFF
--- a/process/errors.go
+++ b/process/errors.go
@@ -902,6 +902,9 @@ var ErrNilRoundDetectorCache = errors.New("round detector cache is nil")
 // ErrNilRoundHeadersCache signals that a nil round headers cache has been provided
 var ErrNilRoundHeadersCache = errors.New("round headers cache is nil")
 
+// ErrNilSlashResult signals that a nil slash result has been provided
+var ErrNilSlashResult = errors.New("slash result is nil")
+
 // ErrInvalidProof signals that an invalid proof has been provided
 var ErrInvalidProof = errors.New("an invalid proof has been provided")
 

--- a/process/slash/common.go
+++ b/process/slash/common.go
@@ -1,20 +1,30 @@
 package slash
 
 import (
+	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/block/interceptedBlocks"
 )
+
+// HeaderInfo contains a HeaderHandler and its associated hash
+type HeaderInfo struct {
+	Header data.HeaderHandler
+	Hash   []byte
+}
+
+// HeaderInfoList defines a list of HeaderInfo
+type HeaderInfoList []HeaderInfo
 
 // SlashingResult contains the slashable data as well as the severity(slashing level)
 // for a possible malicious validator
 type SlashingResult struct {
 	SlashingLevel ThreatLevel
-	Data          []process.InterceptedData
+	Data          HeaderInfoList
 }
 
 type slashingHeaders struct {
 	slashingLevel ThreatLevel
-	headers       []*interceptedBlocks.InterceptedHeader
+	headers       HeaderInfoList
 }
 
 // IsIndexSetInBitmap - checks if a bit is set(1) in the given bitmap

--- a/process/slash/common.go
+++ b/process/slash/common.go
@@ -13,7 +13,7 @@ type HeaderInfo struct {
 }
 
 // HeaderInfoList defines a list of HeaderInfo
-type HeaderInfoList []HeaderInfo
+type HeaderInfoList []*HeaderInfo
 
 // SlashingResult contains the slashable data as well as the severity(slashing level)
 // for a possible malicious validator

--- a/process/slash/common.go
+++ b/process/slash/common.go
@@ -19,12 +19,7 @@ type HeaderInfoList []*HeaderInfo
 // for a possible malicious validator
 type SlashingResult struct {
 	SlashingLevel ThreatLevel
-	Data          HeaderInfoList
-}
-
-type slashingHeaders struct {
-	slashingLevel ThreatLevel
-	headers       HeaderInfoList
+	Headers       HeaderInfoList
 }
 
 // IsIndexSetInBitmap - checks if a bit is set(1) in the given bitmap

--- a/process/slash/common.go
+++ b/process/slash/common.go
@@ -2,8 +2,6 @@ package slash
 
 import (
 	"github.com/ElrondNetwork/elrond-go-core/data"
-	"github.com/ElrondNetwork/elrond-go/process"
-	"github.com/ElrondNetwork/elrond-go/process/block/interceptedBlocks"
 )
 
 // HeaderInfo contains a HeaderHandler and its associated hash
@@ -35,18 +33,4 @@ func IsIndexSetInBitmap(index uint32, bitmap []byte) bool {
 	bitPos := index % 8
 	mask := uint8(1 << bitPos)
 	return (byteInMap & mask) != 0
-}
-
-func convertInterceptedDataToInterceptedHeaders(data []process.InterceptedData) ([]*interceptedBlocks.InterceptedHeader, error) {
-	headers := make([]*interceptedBlocks.InterceptedHeader, 0, len(data))
-
-	for _, d := range data {
-		header, castOk := d.(*interceptedBlocks.InterceptedHeader)
-		if !castOk {
-			return nil, process.ErrCannotCastInterceptedDataToHeader
-		}
-		headers = append(headers, header)
-	}
-
-	return headers, nil
 }

--- a/process/slash/detector/baseSlashingDetector.go
+++ b/process/slash/detector/baseSlashingDetector.go
@@ -30,12 +30,12 @@ func absDiff(x, y uint64) uint64 {
 	return x - y
 }
 
-func computeSlashLevelBasedOnHeadersCount(data []process.InterceptedData) slash.ThreatLevel {
+func computeSlashLevelBasedOnHeadersCount(headers slash.HeaderInfoList) slash.ThreatLevel {
 	ret := slash.Low
 
-	if len(data) == minSlashableNoOfHeaders {
+	if len(headers) == minSlashableNoOfHeaders {
 		ret = slash.Medium
-	} else if len(data) >= minSlashableNoOfHeaders+1 {
+	} else if len(headers) >= minSlashableNoOfHeaders+1 {
 		ret = slash.High
 	}
 

--- a/process/slash/detector/baseSlashingDetector.go
+++ b/process/slash/detector/baseSlashingDetector.go
@@ -2,7 +2,6 @@ package detector
 
 import (
 	"github.com/ElrondNetwork/elrond-go/process"
-	"github.com/ElrondNetwork/elrond-go/process/block/interceptedBlocks"
 	"github.com/ElrondNetwork/elrond-go/process/slash"
 )
 
@@ -42,7 +41,7 @@ func computeSlashLevelBasedOnHeadersCount(headers slash.HeaderInfoList) slash.Th
 	return ret
 }
 
-func checkSlashLevelBasedOnHeadersCount(headers []*interceptedBlocks.InterceptedHeader, level slash.ThreatLevel) error {
+func checkSlashLevelBasedOnHeadersCount(headers slash.HeaderInfoList, level slash.ThreatLevel) error {
 	if level < slash.Medium || level > slash.High {
 		return process.ErrInvalidSlashLevel
 	}

--- a/process/slash/detector/interface.go
+++ b/process/slash/detector/interface.go
@@ -2,7 +2,7 @@ package detector
 
 import (
 	"github.com/ElrondNetwork/elrond-go-core/data"
-	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/process/slash"
 )
 
 // RoundDetectorCache defines what a round-based(per validator data) cache should do.
@@ -12,9 +12,9 @@ type RoundDetectorCache interface {
 	// irrelevant(obsolete) to be cached, an error should be returned.
 	// If the cache is full, it should have an eviction mechanism to always remove
 	// the oldest round entry
-	Add(round uint64, pubKey []byte, data process.InterceptedData) error
+	Add(round uint64, pubKey []byte, header slash.HeaderInfo) error
 	// GetData returns all cached data for a public key, in a given round
-	GetData(round uint64, pubKey []byte) []process.InterceptedData
+	GetData(round uint64, pubKey []byte) slash.HeaderInfoList
 	// GetPubKeys returns all cached public keys in a given round
 	GetPubKeys(round uint64) [][]byte
 	// IsInterfaceNil checks if the interface is nil

--- a/process/slash/detector/interface.go
+++ b/process/slash/detector/interface.go
@@ -12,8 +12,8 @@ type RoundDetectorCache interface {
 	// If the cache is full, it should have an eviction mechanism to always remove
 	// the oldest round entry
 	Add(round uint64, pubKey []byte, header *slash.HeaderInfo) error
-	// GetData returns all cached data for a public key, in a given round
-	GetData(round uint64, pubKey []byte) slash.HeaderInfoList
+	// GetHeaders returns all cached headers for a public key, in a given round
+	GetHeaders(round uint64, pubKey []byte) slash.HeaderInfoList
 	// GetPubKeys returns all cached public keys in a given round
 	GetPubKeys(round uint64) [][]byte
 	// IsInterfaceNil checks if the interface is nil

--- a/process/slash/detector/interface.go
+++ b/process/slash/detector/interface.go
@@ -1,7 +1,6 @@
 package detector
 
 import (
-	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go/process/slash"
 )
 
@@ -28,7 +27,7 @@ type HeadersCache interface {
 	// round is irrelevant(obsolete) to be cached, an error should be returned.
 	// If the cache is full, it should have an eviction mechanism
 	// to always remove the oldest round entry
-	Add(round uint64, hash []byte, header data.HeaderHandler) error
+	Add(round uint64, header *slash.HeaderInfo) error
 	// IsInterfaceNil checks if the interface is nil
 	IsInterfaceNil() bool
 }

--- a/process/slash/detector/interface.go
+++ b/process/slash/detector/interface.go
@@ -12,7 +12,7 @@ type RoundDetectorCache interface {
 	// irrelevant(obsolete) to be cached, an error should be returned.
 	// If the cache is full, it should have an eviction mechanism to always remove
 	// the oldest round entry
-	Add(round uint64, pubKey []byte, header slash.HeaderInfo) error
+	Add(round uint64, pubKey []byte, header *slash.HeaderInfo) error
 	// GetData returns all cached data for a public key, in a given round
 	GetData(round uint64, pubKey []byte) slash.HeaderInfoList
 	// GetPubKeys returns all cached public keys in a given round

--- a/process/slash/detector/multipleHeaderProposalsDetector.go
+++ b/process/slash/detector/multipleHeaderProposalsDetector.go
@@ -100,7 +100,7 @@ func (mhp *multipleHeaderProposalsDetector) getProposerPubKey(header data.Header
 }
 
 func (mhp *multipleHeaderProposalsDetector) getSlashingResult(currRound uint64, proposerPubKey []byte) *slash.SlashingResult {
-	proposedHeaders := mhp.cache.GetData(currRound, proposerPubKey)
+	proposedHeaders := mhp.cache.GetHeaders(currRound, proposerPubKey)
 	if len(proposedHeaders) >= 2 {
 		return &slash.SlashingResult{
 			SlashingLevel: mhp.computeSlashLevel(proposedHeaders),

--- a/process/slash/detector/multipleHeaderProposalsDetector.go
+++ b/process/slash/detector/multipleHeaderProposalsDetector.go
@@ -69,7 +69,7 @@ func (mhp *multipleHeaderProposalsDetector) VerifyData(data process.InterceptedD
 		return nil, err
 	}
 
-	err = mhp.cache.Add(round, proposer, slash.HeaderInfo{Header: header, Hash: interceptedHeader.Hash()})
+	err = mhp.cache.Add(round, proposer, &slash.HeaderInfo{Header: header, Hash: interceptedHeader.Hash()})
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func (mhp *multipleHeaderProposalsDetector) checkProposedHeaders(headers slash.H
 }
 
 func (mhp *multipleHeaderProposalsDetector) checkHeaderHasSameProposerAndRound(
-	headerInfo slash.HeaderInfo,
+	headerInfo *slash.HeaderInfo,
 	round uint64,
 	proposer []byte,
 ) error {

--- a/process/slash/detector/multipleHeaderProposalsDetector.go
+++ b/process/slash/detector/multipleHeaderProposalsDetector.go
@@ -138,24 +138,24 @@ func (mhp *multipleHeaderProposalsDetector) ValidateProof(proof slash.SlashingPr
 }
 
 // TODO: Add different logic here once slashing threat levels are clearly defined
-func (mhp *multipleHeaderProposalsDetector) checkSlashLevel(headers []*interceptedBlocks.InterceptedHeader, level slash.ThreatLevel) error {
+func (mhp *multipleHeaderProposalsDetector) checkSlashLevel(headers slash.HeaderInfoList, level slash.ThreatLevel) error {
 	return checkSlashLevelBasedOnHeadersCount(headers, level)
 }
 
-func (mhp *multipleHeaderProposalsDetector) checkProposedHeaders(headers []*interceptedBlocks.InterceptedHeader) error {
+func (mhp *multipleHeaderProposalsDetector) checkProposedHeaders(headers slash.HeaderInfoList) error {
 	if len(headers) < minSlashableNoOfHeaders {
 		return process.ErrNotEnoughHeadersProvided
 	}
 
 	hashes := make(map[string]struct{})
-	round := headers[0].HeaderHandler().GetRound()
-	proposer, err := mhp.getProposerPubKey(headers[0].HeaderHandler())
+	round := headers[0].Header.GetRound()
+	proposer, err := mhp.getProposerPubKey(headers[0].Header)
 	if err != nil {
 		return err
 	}
 
 	for _, header := range headers {
-		hash := string(header.Hash())
+		hash := string(header.Hash)
 		if _, exists := hashes[hash]; exists {
 			return process.ErrHeadersNotDifferentHashes
 		}
@@ -172,15 +172,15 @@ func (mhp *multipleHeaderProposalsDetector) checkProposedHeaders(headers []*inte
 }
 
 func (mhp *multipleHeaderProposalsDetector) checkHeaderHasSameProposerAndRound(
-	header *interceptedBlocks.InterceptedHeader,
+	headerInfo slash.HeaderInfo,
 	round uint64,
 	proposer []byte,
 ) error {
-	if header.HeaderHandler().GetRound() != round {
+	if headerInfo.Header.GetRound() != round {
 		return process.ErrHeadersNotSameRound
 	}
 
-	currProposer, err := mhp.getProposerPubKey(header.HeaderHandler())
+	currProposer, err := mhp.getProposerPubKey(headerInfo.Header)
 	if err != nil {
 		return err
 	}

--- a/process/slash/detector/multipleHeaderProposalsDetector.go
+++ b/process/slash/detector/multipleHeaderProposalsDetector.go
@@ -104,7 +104,7 @@ func (mhp *multipleHeaderProposalsDetector) getSlashingResult(currRound uint64, 
 	if len(proposedHeaders) >= 2 {
 		return &slash.SlashingResult{
 			SlashingLevel: mhp.computeSlashLevel(proposedHeaders),
-			Data:          proposedHeaders,
+			Headers:       proposedHeaders,
 		}
 	}
 

--- a/process/slash/detector/multipleHeaderProposalsDetector.go
+++ b/process/slash/detector/multipleHeaderProposalsDetector.go
@@ -69,7 +69,7 @@ func (mhp *multipleHeaderProposalsDetector) VerifyData(data process.InterceptedD
 		return nil, err
 	}
 
-	err = mhp.cache.Add(round, proposer, interceptedHeader)
+	err = mhp.cache.Add(round, proposer, slash.HeaderInfo{Header: header, Hash: interceptedHeader.Hash()})
 	if err != nil {
 		return nil, err
 	}
@@ -112,8 +112,8 @@ func (mhp *multipleHeaderProposalsDetector) getSlashingResult(currRound uint64, 
 }
 
 // TODO: Add different logic here once slashing threat levels are clearly defined
-func (mhp *multipleHeaderProposalsDetector) computeSlashLevel(data []process.InterceptedData) slash.ThreatLevel {
-	return computeSlashLevelBasedOnHeadersCount(data)
+func (mhp *multipleHeaderProposalsDetector) computeSlashLevel(headers slash.HeaderInfoList) slash.ThreatLevel {
+	return computeSlashLevelBasedOnHeadersCount(headers)
 }
 
 // ValidateProof - validates if the given proof is valid.

--- a/process/slash/detector/multipleHeaderProposalsDetector_test.go
+++ b/process/slash/detector/multipleHeaderProposalsDetector_test.go
@@ -318,7 +318,7 @@ func TestMultipleHeaderProposalsDetector_ValidateProof_MultipleProposalProof_Dif
 		proof, _ := slash.NewMultipleProposalProof(
 			&slash.SlashingResult{
 				SlashingLevel: level,
-				Data:          data,
+				Headers:       data,
 			},
 		)
 
@@ -443,7 +443,7 @@ func TestMultipleHeaderProposalsDetector_ValidateProof_MultipleProposalProof_Dif
 		proof, _ := slash.NewMultipleProposalProof(
 			&slash.SlashingResult{
 				SlashingLevel: level,
-				Data:          data,
+				Headers:       data,
 			},
 		)
 		err := sd.ValidateProof(proof)

--- a/process/slash/detector/multipleHeaderSigningDetector.go
+++ b/process/slash/detector/multipleHeaderSigningDetector.go
@@ -152,7 +152,7 @@ func (mhs *multipleHeaderSigningDetector) getSlashingResult(round uint64) map[st
 	slashingData := make(map[string]slash.SlashingResult)
 
 	for _, validator := range mhs.slashingCache.GetPubKeys(round) {
-		signedHeaders := mhs.slashingCache.GetData(round, validator)
+		signedHeaders := mhs.slashingCache.GetHeaders(round, validator)
 		if len(signedHeaders) > 1 {
 			slashingData[string(validator)] = slash.SlashingResult{
 				SlashingLevel: mhs.computeSlashLevel(signedHeaders),

--- a/process/slash/detector/multipleHeaderSigningDetector.go
+++ b/process/slash/detector/multipleHeaderSigningDetector.go
@@ -135,7 +135,10 @@ func (mhs *multipleHeaderSigningDetector) cacheSigners(interceptedHeader *interc
 	bitmap := header.GetPubKeysBitmap()
 	for idx, validator := range group {
 		if slash.IsIndexSetInBitmap(uint32(idx), bitmap) {
-			err = mhs.slashingCache.Add(header.GetRound(), validator.PubKey(), interceptedHeader)
+			err = mhs.slashingCache.Add(
+				header.GetRound(),
+				validator.PubKey(),
+				slash.HeaderInfo{Header: header, Hash: interceptedHeader.Hash()})
 			if err != nil {
 				return err
 			}
@@ -162,8 +165,8 @@ func (mhs *multipleHeaderSigningDetector) getSlashingResult(round uint64) map[st
 }
 
 // TODO: Add different logic here once slashing threat levels are clearly defined
-func (mhs *multipleHeaderSigningDetector) computeSlashLevel(data []process.InterceptedData) slash.ThreatLevel {
-	return computeSlashLevelBasedOnHeadersCount(data)
+func (mhs *multipleHeaderSigningDetector) computeSlashLevel(headers slash.HeaderInfoList) slash.ThreatLevel {
+	return computeSlashLevelBasedOnHeadersCount(headers)
 }
 
 // ValidateProof - validates the given proof

--- a/process/slash/detector/multipleHeaderSigningDetector.go
+++ b/process/slash/detector/multipleHeaderSigningDetector.go
@@ -196,28 +196,28 @@ func (mhs *multipleHeaderSigningDetector) ValidateProof(proof slash.SlashingProo
 }
 
 // TODO: Add different logic here once slashing threat levels are clearly defined
-func (mhs *multipleHeaderSigningDetector) checkSlashLevel(headers []*interceptedBlocks.InterceptedHeader, level slash.ThreatLevel) error {
+func (mhs *multipleHeaderSigningDetector) checkSlashLevel(headers slash.HeaderInfoList, level slash.ThreatLevel) error {
 	return checkSlashLevelBasedOnHeadersCount(headers, level)
 }
 
-func (mhs *multipleHeaderSigningDetector) checkSignedHeaders(pubKey []byte, headers []*interceptedBlocks.InterceptedHeader) error {
+func (mhs *multipleHeaderSigningDetector) checkSignedHeaders(pubKey []byte, headers slash.HeaderInfoList) error {
 	if len(headers) < minSlashableNoOfHeaders {
 		return process.ErrNotEnoughHeadersProvided
 	}
 
 	hashes := make(map[string]struct{})
-	round := headers[0].HeaderHandler().GetRound()
-	for _, header := range headers {
-		if header.HeaderHandler().GetRound() != round {
+	round := headers[0].Header.GetRound()
+	for _, headerInfo := range headers {
+		if headerInfo.Header.GetRound() != round {
 			return process.ErrHeadersNotSameRound
 		}
 
-		hash, err := mhs.checkHash(header.HeaderHandler(), hashes)
+		hash, err := mhs.checkHash(headerInfo.Header, hashes)
 		if err != nil {
 			return err
 		}
 
-		if !mhs.signedHeader(pubKey, header.HeaderHandler()) {
+		if !mhs.signedHeader(pubKey, headerInfo.Header) {
 			return process.ErrHeaderNotSignedByValidator
 		}
 		hashes[hash] = struct{}{}

--- a/process/slash/detector/multipleHeaderSigningDetector.go
+++ b/process/slash/detector/multipleHeaderSigningDetector.go
@@ -83,7 +83,7 @@ func (mhs *multipleHeaderSigningDetector) VerifyData(interceptedData process.Int
 		return nil, err
 	}
 
-	err = mhs.headersCache.Add(round, headerHash, header)
+	err = mhs.headersCache.Add(round, &slash.HeaderInfo{Header: header, Hash: headerHash})
 	if err != nil {
 		return nil, err
 	}

--- a/process/slash/detector/multipleHeaderSigningDetector.go
+++ b/process/slash/detector/multipleHeaderSigningDetector.go
@@ -138,7 +138,7 @@ func (mhs *multipleHeaderSigningDetector) cacheSigners(interceptedHeader *interc
 			err = mhs.slashingCache.Add(
 				header.GetRound(),
 				validator.PubKey(),
-				slash.HeaderInfo{Header: header, Hash: interceptedHeader.Hash()})
+				&slash.HeaderInfo{Header: header, Hash: interceptedHeader.Hash()})
 			if err != nil {
 				return err
 			}

--- a/process/slash/detector/multipleHeaderSigningDetector.go
+++ b/process/slash/detector/multipleHeaderSigningDetector.go
@@ -156,7 +156,7 @@ func (mhs *multipleHeaderSigningDetector) getSlashingResult(round uint64) map[st
 		if len(signedHeaders) > 1 {
 			slashingData[string(validator)] = slash.SlashingResult{
 				SlashingLevel: mhs.computeSlashLevel(signedHeaders),
-				Data:          signedHeaders,
+				Headers:       signedHeaders,
 			}
 		}
 	}

--- a/process/slash/detector/multipleHeaderSigningDetector_test.go
+++ b/process/slash/detector/multipleHeaderSigningDetector_test.go
@@ -377,8 +377,8 @@ func TestMultipleHeaderSigningDetector_ValidateProof_SignedHeadersHaveDifferentR
 		&slashMocks.RoundDetectorCacheStub{},
 		&slashMocks.HeadersCacheStub{})
 
-	h1 := slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h1")}
-	h2 := slash.HeaderInfo{Header: &block.Header{Round: 2, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h2")}
+	h1 := &slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h1")}
+	h2 := &slash.HeaderInfo{Header: &block.Header{Round: 2, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h2")}
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Medium,
@@ -410,8 +410,8 @@ func TestMultipleHeaderSigningDetector_ValidateProof_InvalidMarshaller_ExpectErr
 		&slashMocks.RoundDetectorCacheStub{},
 		&slashMocks.HeadersCacheStub{})
 
-	h1 := slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h1")}
-	h2 := slash.HeaderInfo{Header: &block.Header{Round: 2, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h2")}
+	h1 := &slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h1")}
+	h2 := &slash.HeaderInfo{Header: &block.Header{Round: 2, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h2")}
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Medium,
@@ -438,8 +438,8 @@ func TestMultipleHeaderSigningDetector_ValidateProof_SignedHeadersHaveSameHash_E
 		&slashMocks.RoundDetectorCacheStub{},
 		&slashMocks.HeadersCacheStub{})
 
-	h1 := slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h1")}
-	h2 := slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h2")}
+	h1 := &slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h1")}
+	h2 := &slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h2")}
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Medium,
@@ -466,8 +466,8 @@ func TestMultipleHeaderSigningDetector_ValidateProof_HeadersNotSignedByTheSameVa
 		&slashMocks.RoundDetectorCacheStub{},
 		&slashMocks.HeadersCacheStub{})
 
-	h1 := slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h1")}
-	h2 := slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x2)}}, Hash: []byte("h2")}
+	h1 := &slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h1")}
+	h2 := &slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x2)}}, Hash: []byte("h2")}
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Medium,
@@ -490,8 +490,8 @@ func TestMultipleHeaderSigningDetector_ValidateProof_InvalidSlashLevel_ExpectErr
 		&slashMocks.RoundDetectorCacheStub{},
 		&slashMocks.HeadersCacheStub{})
 
-	h1 := slash.HeaderInfo{Header: &block.Header{Round: 1}, Hash: []byte("h")}
-	h2 := slash.HeaderInfo{Header: &block.Header{Round: 1}, Hash: []byte("h")}
+	h1 := &slash.HeaderInfo{Header: &block.Header{Round: 1}, Hash: []byte("h")}
+	h2 := &slash.HeaderInfo{Header: &block.Header{Round: 1}, Hash: []byte("h")}
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Low,

--- a/process/slash/detector/multipleHeaderSigningDetector_test.go
+++ b/process/slash/detector/multipleHeaderSigningDetector_test.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
@@ -172,7 +171,7 @@ func TestMultipleHeaderSigningDetector_VerifyData_SameHeaderData_DifferentSigner
 		&mock.MarshalizerMock{},
 		&slashMocks.RoundDetectorCacheStub{},
 		&slashMocks.HeadersCacheStub{
-			AddCalled: func(round uint64, hash []byte, header data.HeaderHandler) error {
+			AddCalled: func(round uint64, header *slash.HeaderInfo) error {
 				return process.ErrHeadersNotDifferentHashes
 			},
 		})
@@ -241,7 +240,7 @@ func TestMultipleHeaderSigningDetector_VerifyData_ValidateProof(t *testing.T) {
 		},
 	)
 
-	slashCache := detector.NewRoundValidatorDataCache(3)
+	slashCache := detector.NewRoundValidatorHeaderCache(3)
 	headersCache := detector.NewRoundHeadersCache(3)
 	ssd, _ := detector.NewMultipleHeaderSigningDetector(
 		&mockEpochStart.NodesCoordinatorStub{

--- a/process/slash/detector/multipleHeaderSigningDetector_test.go
+++ b/process/slash/detector/multipleHeaderSigningDetector_test.go
@@ -282,8 +282,8 @@ func TestMultipleHeaderSigningDetector_VerifyData_ValidateProof(t *testing.T) {
 	require.Equal(t, slash.Medium, res.GetLevel(pk0))
 
 	require.Len(t, res.GetHeaders(pk0), 2)
-	require.Equal(t, []byte("rnd1"), res.GetHeaders(pk0)[0].HeaderHandler().GetPrevRandSeed())
-	require.Equal(t, []byte("rnd2"), res.GetHeaders(pk0)[1].HeaderHandler().GetPrevRandSeed())
+	require.Equal(t, []byte("rnd1"), res.GetHeaders(pk0)[0].Header.GetPrevRandSeed())
+	require.Equal(t, []byte("rnd2"), res.GetHeaders(pk0)[1].Header.GetPrevRandSeed())
 
 	// For 3rd header(same round): v0, v1 signed =>
 	// 1. v0 signed 3 headers this round(current and previous 2 headers)
@@ -302,13 +302,13 @@ func TestMultipleHeaderSigningDetector_VerifyData_ValidateProof(t *testing.T) {
 	require.Equal(t, slash.Medium, res.GetLevel(pk1))
 
 	require.Len(t, res.GetHeaders(pk0), 3)
-	require.Equal(t, []byte("rnd1"), res.GetHeaders(pk0)[0].HeaderHandler().GetPrevRandSeed())
-	require.Equal(t, []byte("rnd2"), res.GetHeaders(pk0)[1].HeaderHandler().GetPrevRandSeed())
-	require.Equal(t, []byte("rnd3"), res.GetHeaders(pk0)[2].HeaderHandler().GetPrevRandSeed())
+	require.Equal(t, []byte("rnd1"), res.GetHeaders(pk0)[0].Header.GetPrevRandSeed())
+	require.Equal(t, []byte("rnd2"), res.GetHeaders(pk0)[1].Header.GetPrevRandSeed())
+	require.Equal(t, []byte("rnd3"), res.GetHeaders(pk0)[2].Header.GetPrevRandSeed())
 
 	require.Len(t, res.GetHeaders(pk1), 2)
-	require.Equal(t, []byte("rnd1"), res.GetHeaders(pk1)[0].HeaderHandler().GetPrevRandSeed())
-	require.Equal(t, []byte("rnd3"), res.GetHeaders(pk1)[1].HeaderHandler().GetPrevRandSeed())
+	require.Equal(t, []byte("rnd1"), res.GetHeaders(pk1)[0].Header.GetPrevRandSeed())
+	require.Equal(t, []byte("rnd3"), res.GetHeaders(pk1)[1].Header.GetPrevRandSeed())
 
 	// 4th header(same round) == 2nd header, but validators are changed within group =>
 	// no slashing, because headers do not have different hash (without signatures). This
@@ -354,7 +354,7 @@ func TestMultipleHeaderSigningDetector_ValidateProof_NotEnoughHeaders_ExpectErro
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Medium,
-			Data:          []process.InterceptedData{},
+			Data:          slash.HeaderInfoList{},
 		},
 	})
 
@@ -377,12 +377,12 @@ func TestMultipleHeaderSigningDetector_ValidateProof_SignedHeadersHaveDifferentR
 		&slashMocks.RoundDetectorCacheStub{},
 		&slashMocks.HeadersCacheStub{})
 
-	h1 := slashMocks.CreateInterceptedHeaderData(&block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}})
-	h2 := slashMocks.CreateInterceptedHeaderData(&block.Header{Round: 2, PubKeysBitmap: []byte{byte(0x1)}})
+	h1 := slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h1")}
+	h2 := slash.HeaderInfo{Header: &block.Header{Round: 2, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h2")}
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Medium,
-			Data:          []process.InterceptedData{h1, h2},
+			Data:          slash.HeaderInfoList{h1, h2},
 		},
 	})
 
@@ -410,12 +410,12 @@ func TestMultipleHeaderSigningDetector_ValidateProof_InvalidMarshaller_ExpectErr
 		&slashMocks.RoundDetectorCacheStub{},
 		&slashMocks.HeadersCacheStub{})
 
-	h1 := slashMocks.CreateInterceptedHeaderData(&block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}})
-	h2 := slashMocks.CreateInterceptedHeaderData(&block.Header{Round: 2, PubKeysBitmap: []byte{byte(0x1)}})
+	h1 := slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h1")}
+	h2 := slash.HeaderInfo{Header: &block.Header{Round: 2, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h2")}
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Medium,
-			Data:          []process.InterceptedData{h1, h2},
+			Data:          slash.HeaderInfoList{h1, h2},
 		},
 	})
 
@@ -438,12 +438,12 @@ func TestMultipleHeaderSigningDetector_ValidateProof_SignedHeadersHaveSameHash_E
 		&slashMocks.RoundDetectorCacheStub{},
 		&slashMocks.HeadersCacheStub{})
 
-	h1 := slashMocks.CreateInterceptedHeaderData(&block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}})
-	h2 := slashMocks.CreateInterceptedHeaderData(&block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}})
+	h1 := slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h1")}
+	h2 := slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h2")}
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Medium,
-			Data:          []process.InterceptedData{h1, h2},
+			Data:          slash.HeaderInfoList{h1, h2},
 		},
 	})
 
@@ -466,12 +466,12 @@ func TestMultipleHeaderSigningDetector_ValidateProof_HeadersNotSignedByTheSameVa
 		&slashMocks.RoundDetectorCacheStub{},
 		&slashMocks.HeadersCacheStub{})
 
-	h1 := slashMocks.CreateInterceptedHeaderData(&block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}})
-	h2 := slashMocks.CreateInterceptedHeaderData(&block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x2)}})
+	h1 := slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x1)}}, Hash: []byte("h1")}
+	h2 := slash.HeaderInfo{Header: &block.Header{Round: 1, PubKeysBitmap: []byte{byte(0x2)}}, Hash: []byte("h2")}
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Medium,
-			Data:          []process.InterceptedData{h1, h2},
+			Data:          slash.HeaderInfoList{h1, h2},
 		},
 	})
 
@@ -490,12 +490,12 @@ func TestMultipleHeaderSigningDetector_ValidateProof_InvalidSlashLevel_ExpectErr
 		&slashMocks.RoundDetectorCacheStub{},
 		&slashMocks.HeadersCacheStub{})
 
-	h1 := slashMocks.CreateInterceptedHeaderData(&block.Header{Round: 1})
-	h2 := slashMocks.CreateInterceptedHeaderData(&block.Header{Round: 1})
+	h1 := slash.HeaderInfo{Header: &block.Header{Round: 1}, Hash: []byte("h")}
+	h2 := slash.HeaderInfo{Header: &block.Header{Round: 1}, Hash: []byte("h")}
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Low,
-			Data:          []process.InterceptedData{h1, h2},
+			Data:          slash.HeaderInfoList{h1, h2},
 		},
 	})
 

--- a/process/slash/detector/multipleHeaderSigningDetector_test.go
+++ b/process/slash/detector/multipleHeaderSigningDetector_test.go
@@ -353,7 +353,7 @@ func TestMultipleHeaderSigningDetector_ValidateProof_NotEnoughHeaders_ExpectErro
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Medium,
-			Data:          slash.HeaderInfoList{},
+			Headers:       slash.HeaderInfoList{},
 		},
 	})
 
@@ -381,7 +381,7 @@ func TestMultipleHeaderSigningDetector_ValidateProof_SignedHeadersHaveDifferentR
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Medium,
-			Data:          slash.HeaderInfoList{h1, h2},
+			Headers:       slash.HeaderInfoList{h1, h2},
 		},
 	})
 
@@ -414,7 +414,7 @@ func TestMultipleHeaderSigningDetector_ValidateProof_InvalidMarshaller_ExpectErr
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Medium,
-			Data:          slash.HeaderInfoList{h1, h2},
+			Headers:       slash.HeaderInfoList{h1, h2},
 		},
 	})
 
@@ -442,7 +442,7 @@ func TestMultipleHeaderSigningDetector_ValidateProof_SignedHeadersHaveSameHash_E
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Medium,
-			Data:          slash.HeaderInfoList{h1, h2},
+			Headers:       slash.HeaderInfoList{h1, h2},
 		},
 	})
 
@@ -470,7 +470,7 @@ func TestMultipleHeaderSigningDetector_ValidateProof_HeadersNotSignedByTheSameVa
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Medium,
-			Data:          slash.HeaderInfoList{h1, h2},
+			Headers:       slash.HeaderInfoList{h1, h2},
 		},
 	})
 
@@ -494,7 +494,7 @@ func TestMultipleHeaderSigningDetector_ValidateProof_InvalidSlashLevel_ExpectErr
 	proof, _ := slash.NewMultipleSigningProof(map[string]slash.SlashingResult{
 		"pubKey": {
 			SlashingLevel: slash.Low,
-			Data:          slash.HeaderInfoList{h1, h2},
+			Headers:       slash.HeaderInfoList{h1, h2},
 		},
 	})
 

--- a/process/slash/detector/roundHeadersCache.go
+++ b/process/slash/detector/roundHeadersCache.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"sync"
 
-	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/slash"
 )
@@ -29,11 +28,11 @@ func NewRoundHeadersCache(maxRounds uint64) *roundHeadersCache {
 
 // Add adds a header-hash in cache, in a given round.
 // It has an eviction mechanism which always removes the oldest round entry when cache is full
-func (rhc *roundHeadersCache) Add(round uint64, hash []byte, header data.HeaderHandler) error {
+func (rhc *roundHeadersCache) Add(round uint64, header *slash.HeaderInfo) error {
 	rhc.cacheMutex.Lock()
 	defer rhc.cacheMutex.Unlock()
 
-	if rhc.contains(round, hash) {
+	if rhc.contains(round, header.Hash) {
 		return process.ErrHeadersNotDifferentHashes
 	}
 
@@ -49,7 +48,7 @@ func (rhc *roundHeadersCache) Add(round uint64, hash []byte, header data.HeaderH
 		rhc.oldestRound = round
 	}
 
-	rhc.cache[round] = append(rhc.cache[round], &slash.HeaderInfo{Hash: hash, Header: header})
+	rhc.cache[round] = append(rhc.cache[round], header)
 	return nil
 }
 

--- a/process/slash/detector/roundHeadersCache.go
+++ b/process/slash/detector/roundHeadersCache.go
@@ -49,7 +49,7 @@ func (rhc *roundHeadersCache) Add(round uint64, hash []byte, header data.HeaderH
 		rhc.oldestRound = round
 	}
 
-	rhc.cache[round] = append(rhc.cache[round], slash.HeaderInfo{Hash: hash, Header: header})
+	rhc.cache[round] = append(rhc.cache[round], &slash.HeaderInfo{Hash: hash, Header: header})
 	return nil
 }
 

--- a/process/slash/detector/roundHeadersCache.go
+++ b/process/slash/detector/roundHeadersCache.go
@@ -7,16 +7,11 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/process/slash"
 )
 
-type headerInfoList []headerInfo
-type headerInfo struct {
-	hash   []byte
-	header data.HeaderHandler
-}
-
 type roundHeadersCache struct {
-	cache       map[uint64]headerInfoList
+	cache       map[uint64]slash.HeaderInfoList
 	cacheMutex  sync.RWMutex
 	oldestRound uint64
 	cacheSize   uint64
@@ -25,7 +20,7 @@ type roundHeadersCache struct {
 // NewRoundHeadersCache creates an instance of roundHeadersCache, which is a header-hash-based cache
 func NewRoundHeadersCache(maxRounds uint64) *roundHeadersCache {
 	return &roundHeadersCache{
-		cache:       make(map[uint64]headerInfoList),
+		cache:       make(map[uint64]slash.HeaderInfoList),
 		cacheMutex:  sync.RWMutex{},
 		oldestRound: math.MaxUint64,
 		cacheSize:   maxRounds,
@@ -54,7 +49,7 @@ func (rhc *roundHeadersCache) Add(round uint64, hash []byte, header data.HeaderH
 		rhc.oldestRound = round
 	}
 
-	rhc.cache[round] = append(rhc.cache[round], headerInfo{hash: hash, header: header})
+	rhc.cache[round] = append(rhc.cache[round], slash.HeaderInfo{Hash: hash, Header: header})
 	return nil
 }
 
@@ -65,7 +60,7 @@ func (rhc *roundHeadersCache) contains(round uint64, hash []byte) bool {
 	}
 
 	for _, currData := range hashHeaderList {
-		if bytes.Equal(currData.hash, hash) {
+		if bytes.Equal(currData.Hash, hash) {
 			return true
 		}
 	}

--- a/process/slash/detector/roundHeadersCache_test.go
+++ b/process/slash/detector/roundHeadersCache_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/process/slash"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/stretchr/testify/require"
 )
@@ -13,16 +14,16 @@ func TestRoundDataCache_Add_OneRound_FourHeaders(t *testing.T) {
 
 	dataCache := NewRoundHeadersCache(1)
 
-	err := dataCache.Add(1, []byte("hash1"), &testscommon.HeaderHandlerStub{TimestampField: 1})
+	err := dataCache.Add(1, &slash.HeaderInfo{Header: &testscommon.HeaderHandlerStub{TimestampField: 1}, Hash: []byte("hash1")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(1, []byte("hash1"), &testscommon.HeaderHandlerStub{TimestampField: 2})
+	err = dataCache.Add(1, &slash.HeaderInfo{Header: &testscommon.HeaderHandlerStub{TimestampField: 2}, Hash: []byte("hash1")})
 	require.Equal(t, process.ErrHeadersNotDifferentHashes, err)
 
-	err = dataCache.Add(1, []byte("hash2"), &testscommon.HeaderHandlerStub{TimestampField: 3})
+	err = dataCache.Add(1, &slash.HeaderInfo{Header: &testscommon.HeaderHandlerStub{TimestampField: 3}, Hash: []byte("hash2")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(1, []byte("hash3"), &testscommon.HeaderHandlerStub{TimestampField: 4})
+	err = dataCache.Add(1, &slash.HeaderInfo{Header: &testscommon.HeaderHandlerStub{TimestampField: 4}, Hash: []byte("hash3")})
 	require.Nil(t, err)
 
 	require.Len(t, dataCache.cache, 1)
@@ -44,10 +45,10 @@ func TestRoundDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldestRoundInC
 
 	dataCache := NewRoundHeadersCache(2)
 
-	err := dataCache.Add(1, []byte("hash1"), &testscommon.HeaderHandlerStub{TimestampField: 1})
+	err := dataCache.Add(1, &slash.HeaderInfo{Header: &testscommon.HeaderHandlerStub{TimestampField: 1}, Hash: []byte("hash1")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(2, []byte("hash2"), &testscommon.HeaderHandlerStub{TimestampField: 2})
+	err = dataCache.Add(2, &slash.HeaderInfo{Header: &testscommon.HeaderHandlerStub{TimestampField: 2}, Hash: []byte("hash2")})
 	require.Nil(t, err)
 
 	require.Len(t, dataCache.cache, 2)
@@ -60,7 +61,7 @@ func TestRoundDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldestRoundInC
 	require.Equal(t, []byte("hash2"), dataCache.cache[2][0].Hash)
 	require.Equal(t, uint64(2), dataCache.cache[2][0].Header.GetTimeStamp())
 
-	err = dataCache.Add(0, []byte("hash0"), &testscommon.HeaderHandlerStub{})
+	err = dataCache.Add(0, &slash.HeaderInfo{Header: &testscommon.HeaderHandlerStub{}, Hash: []byte("hash0")})
 	require.Equal(t, process.ErrHeaderRoundNotRelevant, err)
 
 	require.Len(t, dataCache.cache, 2)
@@ -73,7 +74,7 @@ func TestRoundDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldestRoundInC
 	require.Equal(t, []byte("hash2"), dataCache.cache[2][0].Hash)
 	require.Equal(t, uint64(2), dataCache.cache[2][0].Header.GetTimeStamp())
 
-	err = dataCache.Add(3, []byte("hash3"), &testscommon.HeaderHandlerStub{TimestampField: 3})
+	err = dataCache.Add(3, &slash.HeaderInfo{Header: &testscommon.HeaderHandlerStub{TimestampField: 3}, Hash: []byte("hash3")})
 	require.Nil(t, err)
 
 	require.Len(t, dataCache.cache, 2)
@@ -86,7 +87,7 @@ func TestRoundDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldestRoundInC
 	require.Equal(t, []byte("hash3"), dataCache.cache[3][0].Hash)
 	require.Equal(t, uint64(3), dataCache.cache[3][0].Header.GetTimeStamp())
 
-	err = dataCache.Add(4, []byte("hash4"), &testscommon.HeaderHandlerStub{TimestampField: 4})
+	err = dataCache.Add(4, &slash.HeaderInfo{Header: &testscommon.HeaderHandlerStub{TimestampField: 4}, Hash: []byte("hash4")})
 	require.Nil(t, err)
 
 	require.Len(t, dataCache.cache, 2)
@@ -105,13 +106,13 @@ func TestRoundDataCache_Contains(t *testing.T) {
 
 	dataCache := NewRoundHeadersCache(2)
 
-	err := dataCache.Add(1, []byte("hash1"), &testscommon.HeaderHandlerStub{TimestampField: 1})
+	err := dataCache.Add(1, &slash.HeaderInfo{Header: &testscommon.HeaderHandlerStub{TimestampField: 1}, Hash: []byte("hash1")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(1, []byte("hash2"), &testscommon.HeaderHandlerStub{TimestampField: 2})
+	err = dataCache.Add(1, &slash.HeaderInfo{Header: &testscommon.HeaderHandlerStub{TimestampField: 2}, Hash: []byte("hash2")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(2, []byte("hash3"), &testscommon.HeaderHandlerStub{TimestampField: 3})
+	err = dataCache.Add(2, &slash.HeaderInfo{Header: &testscommon.HeaderHandlerStub{TimestampField: 3}, Hash: []byte("hash3")})
 	require.Nil(t, err)
 
 	require.True(t, dataCache.contains(1, []byte("hash1")))
@@ -123,7 +124,7 @@ func TestRoundDataCache_Contains(t *testing.T) {
 }
 
 func TestRoundValidatorsDataCache_IsInterfaceNil(t *testing.T) {
-	cache := NewRoundValidatorDataCache(1)
+	cache := NewRoundValidatorHeaderCache(1)
 	require.False(t, cache.IsInterfaceNil())
 	cache = nil
 	require.True(t, cache.IsInterfaceNil())

--- a/process/slash/detector/roundHeadersCache_test.go
+++ b/process/slash/detector/roundHeadersCache_test.go
@@ -28,14 +28,14 @@ func TestRoundDataCache_Add_OneRound_FourHeaders(t *testing.T) {
 	require.Len(t, dataCache.cache, 1)
 	require.Len(t, dataCache.cache[1], 3)
 
-	require.Equal(t, []byte("hash1"), dataCache.cache[1][0].hash)
-	require.Equal(t, uint64(1), dataCache.cache[1][0].header.GetTimeStamp())
+	require.Equal(t, []byte("hash1"), dataCache.cache[1][0].Hash)
+	require.Equal(t, uint64(1), dataCache.cache[1][0].Header.GetTimeStamp())
 
-	require.Equal(t, []byte("hash2"), dataCache.cache[1][1].hash)
-	require.Equal(t, uint64(3), dataCache.cache[1][1].header.GetTimeStamp())
+	require.Equal(t, []byte("hash2"), dataCache.cache[1][1].Hash)
+	require.Equal(t, uint64(3), dataCache.cache[1][1].Header.GetTimeStamp())
 
-	require.Equal(t, []byte("hash3"), dataCache.cache[1][2].hash)
-	require.Equal(t, uint64(4), dataCache.cache[1][2].header.GetTimeStamp())
+	require.Equal(t, []byte("hash3"), dataCache.cache[1][2].Hash)
+	require.Equal(t, uint64(4), dataCache.cache[1][2].Header.GetTimeStamp())
 
 }
 
@@ -54,11 +54,11 @@ func TestRoundDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldestRoundInC
 	require.Len(t, dataCache.cache[1], 1)
 	require.Len(t, dataCache.cache[2], 1)
 
-	require.Equal(t, []byte("hash1"), dataCache.cache[1][0].hash)
-	require.Equal(t, uint64(1), dataCache.cache[1][0].header.GetTimeStamp())
+	require.Equal(t, []byte("hash1"), dataCache.cache[1][0].Hash)
+	require.Equal(t, uint64(1), dataCache.cache[1][0].Header.GetTimeStamp())
 
-	require.Equal(t, []byte("hash2"), dataCache.cache[2][0].hash)
-	require.Equal(t, uint64(2), dataCache.cache[2][0].header.GetTimeStamp())
+	require.Equal(t, []byte("hash2"), dataCache.cache[2][0].Hash)
+	require.Equal(t, uint64(2), dataCache.cache[2][0].Header.GetTimeStamp())
 
 	err = dataCache.Add(0, []byte("hash0"), &testscommon.HeaderHandlerStub{})
 	require.Equal(t, process.ErrHeaderRoundNotRelevant, err)
@@ -67,11 +67,11 @@ func TestRoundDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldestRoundInC
 	require.Len(t, dataCache.cache[1], 1)
 	require.Len(t, dataCache.cache[2], 1)
 
-	require.Equal(t, []byte("hash1"), dataCache.cache[1][0].hash)
-	require.Equal(t, uint64(1), dataCache.cache[1][0].header.GetTimeStamp())
+	require.Equal(t, []byte("hash1"), dataCache.cache[1][0].Hash)
+	require.Equal(t, uint64(1), dataCache.cache[1][0].Header.GetTimeStamp())
 
-	require.Equal(t, []byte("hash2"), dataCache.cache[2][0].hash)
-	require.Equal(t, uint64(2), dataCache.cache[2][0].header.GetTimeStamp())
+	require.Equal(t, []byte("hash2"), dataCache.cache[2][0].Hash)
+	require.Equal(t, uint64(2), dataCache.cache[2][0].Header.GetTimeStamp())
 
 	err = dataCache.Add(3, []byte("hash3"), &testscommon.HeaderHandlerStub{TimestampField: 3})
 	require.Nil(t, err)
@@ -80,11 +80,11 @@ func TestRoundDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldestRoundInC
 	require.Len(t, dataCache.cache[2], 1)
 	require.Len(t, dataCache.cache[3], 1)
 
-	require.Equal(t, []byte("hash2"), dataCache.cache[2][0].hash)
-	require.Equal(t, uint64(2), dataCache.cache[2][0].header.GetTimeStamp())
+	require.Equal(t, []byte("hash2"), dataCache.cache[2][0].Hash)
+	require.Equal(t, uint64(2), dataCache.cache[2][0].Header.GetTimeStamp())
 
-	require.Equal(t, []byte("hash3"), dataCache.cache[3][0].hash)
-	require.Equal(t, uint64(3), dataCache.cache[3][0].header.GetTimeStamp())
+	require.Equal(t, []byte("hash3"), dataCache.cache[3][0].Hash)
+	require.Equal(t, uint64(3), dataCache.cache[3][0].Header.GetTimeStamp())
 
 	err = dataCache.Add(4, []byte("hash4"), &testscommon.HeaderHandlerStub{TimestampField: 4})
 	require.Nil(t, err)
@@ -93,11 +93,11 @@ func TestRoundDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldestRoundInC
 	require.Len(t, dataCache.cache[3], 1)
 	require.Len(t, dataCache.cache[4], 1)
 
-	require.Equal(t, []byte("hash3"), dataCache.cache[3][0].hash)
-	require.Equal(t, uint64(3), dataCache.cache[3][0].header.GetTimeStamp())
+	require.Equal(t, []byte("hash3"), dataCache.cache[3][0].Hash)
+	require.Equal(t, uint64(3), dataCache.cache[3][0].Header.GetTimeStamp())
 
-	require.Equal(t, []byte("hash4"), dataCache.cache[4][0].hash)
-	require.Equal(t, uint64(4), dataCache.cache[4][0].header.GetTimeStamp())
+	require.Equal(t, []byte("hash4"), dataCache.cache[4][0].Hash)
+	require.Equal(t, uint64(4), dataCache.cache[4][0].Header.GetTimeStamp())
 }
 
 func TestRoundDataCache_Contains(t *testing.T) {

--- a/process/slash/detector/roundValidatorsDataCache.go
+++ b/process/slash/detector/roundValidatorsDataCache.go
@@ -31,7 +31,7 @@ func NewRoundValidatorDataCache(maxRounds uint64) *roundValidatorsDataCache {
 
 // Add adds in cache an intercepted data for a public key, in a given round.
 // It has an eviction mechanism which always removes the oldest round entry when cache is full
-func (rdc *roundValidatorsDataCache) Add(round uint64, pubKey []byte, headerInfo slash.HeaderInfo) error {
+func (rdc *roundValidatorsDataCache) Add(round uint64, pubKey []byte, headerInfo *slash.HeaderInfo) error {
 	pubKeyStr := string(pubKey)
 	rdc.cacheMutex.Lock()
 	defer rdc.cacheMutex.Unlock()
@@ -62,7 +62,7 @@ func (rdc *roundValidatorsDataCache) Add(round uint64, pubKey []byte, headerInfo
 	return nil
 }
 
-func (rdc *roundValidatorsDataCache) contains(round uint64, pubKey []byte, headerInfo slash.HeaderInfo) bool {
+func (rdc *roundValidatorsDataCache) contains(round uint64, pubKey []byte, headerInfo *slash.HeaderInfo) bool {
 	validatorsMap, exists := rdc.cache[round]
 	if !exists {
 		return false

--- a/process/slash/detector/roundValidatorsDataCache_test.go
+++ b/process/slash/detector/roundValidatorsDataCache_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/process/slash"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/stretchr/testify/require"
 )
@@ -12,11 +13,7 @@ func TestRoundProposerDataCache_Add_OneRound_TwoProposers_FourInterceptedData(t 
 	t.Parallel()
 	dataCache := NewRoundValidatorDataCache(1)
 
-	err := dataCache.Add(1, []byte("proposer1"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash1")
-		},
-	})
+	err := dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
 
 	err = dataCache.Add(1, []byte("proposer1"), &testscommon.InterceptedDataStub{

--- a/process/slash/detector/roundValidatorsDataCache_test.go
+++ b/process/slash/detector/roundValidatorsDataCache_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/slash"
-	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,25 +15,13 @@ func TestRoundProposerDataCache_Add_OneRound_TwoProposers_FourInterceptedData(t 
 	err := dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(1, []byte("proposer1"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash1")
-		},
-	})
+	err = dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Equal(t, process.ErrHeadersNotDifferentHashes, err)
 
-	err = dataCache.Add(1, []byte("proposer1"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash2")
-		},
-	})
+	err = dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(1, []byte("proposer2"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash3")
-		},
-	})
+	err = dataCache.Add(1, []byte("proposer2"), slash.HeaderInfo{Hash: []byte("hash3")})
 	require.Nil(t, err)
 
 	// One round
@@ -44,30 +31,22 @@ func TestRoundProposerDataCache_Add_OneRound_TwoProposers_FourInterceptedData(t 
 
 	// First proposer: proposed two headers
 	require.Len(t, dataCache.cache[1]["proposer1"], 2)
-	require.Equal(t, dataCache.cache[1]["proposer1"][0].Hash(), []byte("hash1"))
-	require.Equal(t, dataCache.cache[1]["proposer1"][1].Hash(), []byte("hash2"))
+	require.Equal(t, dataCache.cache[1]["proposer1"][0].Hash, []byte("hash1"))
+	require.Equal(t, dataCache.cache[1]["proposer1"][1].Hash, []byte("hash2"))
 
 	// Second proposer: proposed one header
 	require.Len(t, dataCache.cache[1]["proposer2"], 1)
-	require.Equal(t, dataCache.cache[1]["proposer2"][0].Hash(), []byte("hash3"))
+	require.Equal(t, dataCache.cache[1]["proposer2"][0].Hash, []byte("hash3"))
 }
 
 func TestRoundProposerDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldestRoundInCacheRemoved(t *testing.T) {
 	t.Parallel()
 	dataCache := NewRoundValidatorDataCache(2)
 
-	err := dataCache.Add(1, []byte("proposer1"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash1")
-		},
-	})
+	err := dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(2, []byte("proposer2"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash2")
-		},
-	})
+	err = dataCache.Add(2, []byte("proposer2"), slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
 	require.Len(t, dataCache.cache, 2)
@@ -76,14 +55,10 @@ func TestRoundProposerDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldest
 	require.Len(t, dataCache.cache[1]["proposer1"], 1)
 	require.Len(t, dataCache.cache[2]["proposer2"], 1)
 
-	require.Equal(t, dataCache.cache[1]["proposer1"][0].Hash(), []byte("hash1"))
-	require.Equal(t, dataCache.cache[2]["proposer2"][0].Hash(), []byte("hash2"))
+	require.Equal(t, dataCache.cache[1]["proposer1"][0].Hash, []byte("hash1"))
+	require.Equal(t, dataCache.cache[2]["proposer2"][0].Hash, []byte("hash2"))
 
-	err = dataCache.Add(0, []byte("proposer3"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash3")
-		},
-	})
+	err = dataCache.Add(0, []byte("proposer3"), slash.HeaderInfo{Hash: []byte("hash3")})
 	require.Equal(t, process.ErrHeaderRoundNotRelevant, err)
 
 	require.Len(t, dataCache.cache, 2)
@@ -92,14 +67,10 @@ func TestRoundProposerDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldest
 	require.Len(t, dataCache.cache[1]["proposer1"], 1)
 	require.Len(t, dataCache.cache[2]["proposer2"], 1)
 
-	require.Equal(t, dataCache.cache[1]["proposer1"][0].Hash(), []byte("hash1"))
-	require.Equal(t, dataCache.cache[2]["proposer2"][0].Hash(), []byte("hash2"))
+	require.Equal(t, dataCache.cache[1]["proposer1"][0].Hash, []byte("hash1"))
+	require.Equal(t, dataCache.cache[2]["proposer2"][0].Hash, []byte("hash2"))
 
-	err = dataCache.Add(3, []byte("proposer3"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash3")
-		},
-	})
+	err = dataCache.Add(3, []byte("proposer3"), slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
 
 	require.Len(t, dataCache.cache, 2)
@@ -108,14 +79,10 @@ func TestRoundProposerDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldest
 	require.Len(t, dataCache.cache[2]["proposer2"], 1)
 	require.Len(t, dataCache.cache[3]["proposer3"], 1)
 
-	require.Equal(t, dataCache.cache[2]["proposer2"][0].Hash(), []byte("hash2"))
-	require.Equal(t, dataCache.cache[3]["proposer3"][0].Hash(), []byte("hash3"))
+	require.Equal(t, dataCache.cache[2]["proposer2"][0].Hash, []byte("hash2"))
+	require.Equal(t, dataCache.cache[3]["proposer3"][0].Hash, []byte("hash3"))
 
-	err = dataCache.Add(4, []byte("proposer4"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash4")
-		},
-	})
+	err = dataCache.Add(4, []byte("proposer4"), slash.HeaderInfo{Hash: []byte("hash4")})
 	require.Nil(t, err)
 
 	require.Len(t, dataCache.cache, 2)
@@ -124,56 +91,40 @@ func TestRoundProposerDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldest
 	require.Len(t, dataCache.cache[3]["proposer3"], 1)
 	require.Len(t, dataCache.cache[4]["proposer4"], 1)
 
-	require.Equal(t, dataCache.cache[3]["proposer3"][0].Hash(), []byte("hash3"))
-	require.Equal(t, dataCache.cache[4]["proposer4"][0].Hash(), []byte("hash4"))
+	require.Equal(t, dataCache.cache[3]["proposer3"][0].Hash, []byte("hash3"))
+	require.Equal(t, dataCache.cache[4]["proposer4"][0].Hash, []byte("hash4"))
 }
 
 func TestRoundProposerDataCache_GetData(t *testing.T) {
 	t.Parallel()
 	dataCache := NewRoundValidatorDataCache(3)
 
-	err := dataCache.Add(1, []byte("proposer1"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash1")
-		},
-	})
+	err := dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(1, []byte("proposer1"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash2")
-		},
-	})
+	err = dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(2, []byte("proposer1"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash2")
-		},
-	})
+	err = dataCache.Add(2, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(2, []byte("proposer2"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash3")
-		},
-	})
+	err = dataCache.Add(2, []byte("proposer2"), slash.HeaderInfo{Hash: []byte("hash3")})
 	require.Nil(t, err)
 
 	require.Len(t, dataCache.cache, 2)
 
 	data1 := dataCache.GetData(1, []byte("proposer1"))
 	require.Len(t, data1, 2)
-	require.Equal(t, data1[0].Hash(), []byte("hash1"))
-	require.Equal(t, data1[1].Hash(), []byte("hash2"))
+	require.Equal(t, data1[0].Hash, []byte("hash1"))
+	require.Equal(t, data1[1].Hash, []byte("hash2"))
 
 	data1 = dataCache.GetData(2, []byte("proposer1"))
 	require.Len(t, data1, 1)
-	require.Equal(t, data1[0].Hash(), []byte("hash2"))
+	require.Equal(t, data1[0].Hash, []byte("hash2"))
 
 	data2 := dataCache.GetData(2, []byte("proposer2"))
 	require.Len(t, data2, 1)
-	require.Equal(t, data2[0].Hash(), []byte("hash3"))
+	require.Equal(t, data2[0].Hash, []byte("hash3"))
 
 	data3 := dataCache.GetData(444, []byte("this proposer is not cached"))
 	require.Nil(t, data3)
@@ -183,32 +134,16 @@ func TestRoundProposerDataCache_GetValidators(t *testing.T) {
 	t.Parallel()
 	dataCache := NewRoundValidatorDataCache(2)
 
-	err := dataCache.Add(1, []byte("proposer1"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash1")
-		},
-	})
+	err := dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(1, []byte("proposer1"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash2")
-		},
-	})
+	err = dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(1, []byte("proposer2"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash2")
-		},
-	})
+	err = dataCache.Add(1, []byte("proposer2"), slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(2, []byte("proposer2"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash2")
-		},
-	})
+	err = dataCache.Add(2, []byte("proposer2"), slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
 	require.Len(t, dataCache.cache, 2)
@@ -227,42 +162,19 @@ func TestRoundProposerDataCache_Contains(t *testing.T) {
 	t.Parallel()
 	dataCache := NewRoundValidatorDataCache(2)
 
-	err := dataCache.Add(1, []byte("proposer1"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash1")
-		},
-	})
+	err := dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(1, []byte("proposer1"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash2")
-		},
-	})
+	err = dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(2, []byte("proposer2"), &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash3")
-		},
-	})
+	err = dataCache.Add(2, []byte("proposer2"), slash.HeaderInfo{Hash: []byte("hash3")})
 	require.Nil(t, err)
 
-	expectedData1 := &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash1")
-		},
-	}
-	expectedData2 := &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash2")
-		},
-	}
-	expectedData3 := &testscommon.InterceptedDataStub{
-		HashCalled: func() []byte {
-			return []byte("hash3")
-		},
-	}
+	expectedData1 := slash.HeaderInfo{Hash: []byte("hash1")}
+	expectedData2 := slash.HeaderInfo{Hash: []byte("hash2")}
+	expectedData3 := slash.HeaderInfo{Hash: []byte("hash3")}
+
 	require.True(t, dataCache.contains(1, []byte("proposer1"), expectedData1))
 	require.True(t, dataCache.contains(1, []byte("proposer1"), expectedData2))
 	require.True(t, dataCache.contains(2, []byte("proposer2"), expectedData3))

--- a/process/slash/detector/roundValidatorsDataCache_test.go
+++ b/process/slash/detector/roundValidatorsDataCache_test.go
@@ -12,16 +12,16 @@ func TestRoundProposerDataCache_Add_OneRound_TwoProposers_FourInterceptedData(t 
 	t.Parallel()
 	dataCache := NewRoundValidatorDataCache(1)
 
-	err := dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash1")})
+	err := dataCache.Add(1, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash1")})
+	err = dataCache.Add(1, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Equal(t, process.ErrHeadersNotDifferentHashes, err)
 
-	err = dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash2")})
+	err = dataCache.Add(1, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(1, []byte("proposer2"), slash.HeaderInfo{Hash: []byte("hash3")})
+	err = dataCache.Add(1, []byte("proposer2"), &slash.HeaderInfo{Hash: []byte("hash3")})
 	require.Nil(t, err)
 
 	// One round
@@ -43,10 +43,10 @@ func TestRoundProposerDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldest
 	t.Parallel()
 	dataCache := NewRoundValidatorDataCache(2)
 
-	err := dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash1")})
+	err := dataCache.Add(1, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(2, []byte("proposer2"), slash.HeaderInfo{Hash: []byte("hash2")})
+	err = dataCache.Add(2, []byte("proposer2"), &slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
 	require.Len(t, dataCache.cache, 2)
@@ -58,7 +58,7 @@ func TestRoundProposerDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldest
 	require.Equal(t, dataCache.cache[1]["proposer1"][0].Hash, []byte("hash1"))
 	require.Equal(t, dataCache.cache[2]["proposer2"][0].Hash, []byte("hash2"))
 
-	err = dataCache.Add(0, []byte("proposer3"), slash.HeaderInfo{Hash: []byte("hash3")})
+	err = dataCache.Add(0, []byte("proposer3"), &slash.HeaderInfo{Hash: []byte("hash3")})
 	require.Equal(t, process.ErrHeaderRoundNotRelevant, err)
 
 	require.Len(t, dataCache.cache, 2)
@@ -70,7 +70,7 @@ func TestRoundProposerDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldest
 	require.Equal(t, dataCache.cache[1]["proposer1"][0].Hash, []byte("hash1"))
 	require.Equal(t, dataCache.cache[2]["proposer2"][0].Hash, []byte("hash2"))
 
-	err = dataCache.Add(3, []byte("proposer3"), slash.HeaderInfo{Hash: []byte("hash1")})
+	err = dataCache.Add(3, []byte("proposer3"), &slash.HeaderInfo{Hash: []byte("hash3")})
 	require.Nil(t, err)
 
 	require.Len(t, dataCache.cache, 2)
@@ -82,7 +82,7 @@ func TestRoundProposerDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldest
 	require.Equal(t, dataCache.cache[2]["proposer2"][0].Hash, []byte("hash2"))
 	require.Equal(t, dataCache.cache[3]["proposer3"][0].Hash, []byte("hash3"))
 
-	err = dataCache.Add(4, []byte("proposer4"), slash.HeaderInfo{Hash: []byte("hash4")})
+	err = dataCache.Add(4, []byte("proposer4"), &slash.HeaderInfo{Hash: []byte("hash4")})
 	require.Nil(t, err)
 
 	require.Len(t, dataCache.cache, 2)
@@ -99,16 +99,16 @@ func TestRoundProposerDataCache_GetData(t *testing.T) {
 	t.Parallel()
 	dataCache := NewRoundValidatorDataCache(3)
 
-	err := dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash1")})
+	err := dataCache.Add(1, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash2")})
+	err = dataCache.Add(1, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(2, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash2")})
+	err = dataCache.Add(2, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(2, []byte("proposer2"), slash.HeaderInfo{Hash: []byte("hash3")})
+	err = dataCache.Add(2, []byte("proposer2"), &slash.HeaderInfo{Hash: []byte("hash3")})
 	require.Nil(t, err)
 
 	require.Len(t, dataCache.cache, 2)
@@ -134,16 +134,16 @@ func TestRoundProposerDataCache_GetValidators(t *testing.T) {
 	t.Parallel()
 	dataCache := NewRoundValidatorDataCache(2)
 
-	err := dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash1")})
+	err := dataCache.Add(1, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash2")})
+	err = dataCache.Add(1, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(1, []byte("proposer2"), slash.HeaderInfo{Hash: []byte("hash2")})
+	err = dataCache.Add(1, []byte("proposer2"), &slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(2, []byte("proposer2"), slash.HeaderInfo{Hash: []byte("hash2")})
+	err = dataCache.Add(2, []byte("proposer2"), &slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
 	require.Len(t, dataCache.cache, 2)
@@ -162,18 +162,18 @@ func TestRoundProposerDataCache_Contains(t *testing.T) {
 	t.Parallel()
 	dataCache := NewRoundValidatorDataCache(2)
 
-	err := dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash1")})
+	err := dataCache.Add(1, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(1, []byte("proposer1"), slash.HeaderInfo{Hash: []byte("hash2")})
+	err = dataCache.Add(1, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash2")})
 	require.Nil(t, err)
 
-	err = dataCache.Add(2, []byte("proposer2"), slash.HeaderInfo{Hash: []byte("hash3")})
+	err = dataCache.Add(2, []byte("proposer2"), &slash.HeaderInfo{Hash: []byte("hash3")})
 	require.Nil(t, err)
 
-	expectedData1 := slash.HeaderInfo{Hash: []byte("hash1")}
-	expectedData2 := slash.HeaderInfo{Hash: []byte("hash2")}
-	expectedData3 := slash.HeaderInfo{Hash: []byte("hash3")}
+	expectedData1 := &slash.HeaderInfo{Hash: []byte("hash1")}
+	expectedData2 := &slash.HeaderInfo{Hash: []byte("hash2")}
+	expectedData3 := &slash.HeaderInfo{Hash: []byte("hash3")}
 
 	require.True(t, dataCache.contains(1, []byte("proposer1"), expectedData1))
 	require.True(t, dataCache.contains(1, []byte("proposer1"), expectedData2))

--- a/process/slash/detector/roundValidatorsHeadersCache.go
+++ b/process/slash/detector/roundValidatorsHeadersCache.go
@@ -99,8 +99,8 @@ func (rdc *roundValidatorsHeadersCache) updateOldestRound() {
 	rdc.oldestRound = min
 }
 
-// GetData returns all cached data for a public key, in a given round
-func (rdc *roundValidatorsHeadersCache) GetData(round uint64, pubKey []byte) slash.HeaderInfoList {
+// GetHeaders returns all cached data for a public key, in a given round
+func (rdc *roundValidatorsHeadersCache) GetHeaders(round uint64, pubKey []byte) slash.HeaderInfoList {
 	pubKeyStr := string(pubKey)
 	rdc.cacheMutex.RLock()
 	defer rdc.cacheMutex.RUnlock()

--- a/process/slash/detector/roundValidatorsHeadersCache_test.go
+++ b/process/slash/detector/roundValidatorsHeadersCache_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestRoundProposerDataCache_Add_OneRound_TwoProposers_FourInterceptedData(t *testing.T) {
 	t.Parallel()
-	dataCache := NewRoundValidatorDataCache(1)
+	dataCache := NewRoundValidatorHeaderCache(1)
 
 	err := dataCache.Add(1, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
@@ -41,7 +41,7 @@ func TestRoundProposerDataCache_Add_OneRound_TwoProposers_FourInterceptedData(t 
 
 func TestRoundProposerDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldestRoundInCacheRemoved(t *testing.T) {
 	t.Parallel()
-	dataCache := NewRoundValidatorDataCache(2)
+	dataCache := NewRoundValidatorHeaderCache(2)
 
 	err := dataCache.Add(1, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
@@ -97,7 +97,7 @@ func TestRoundProposerDataCache_Add_CacheSizeTwo_FourEntriesInCache_ExpectOldest
 
 func TestRoundProposerDataCache_GetData(t *testing.T) {
 	t.Parallel()
-	dataCache := NewRoundValidatorDataCache(3)
+	dataCache := NewRoundValidatorHeaderCache(3)
 
 	err := dataCache.Add(1, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
@@ -132,7 +132,7 @@ func TestRoundProposerDataCache_GetData(t *testing.T) {
 
 func TestRoundProposerDataCache_GetValidators(t *testing.T) {
 	t.Parallel()
-	dataCache := NewRoundValidatorDataCache(2)
+	dataCache := NewRoundValidatorHeaderCache(2)
 
 	err := dataCache.Add(1, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
@@ -160,7 +160,7 @@ func TestRoundProposerDataCache_GetValidators(t *testing.T) {
 
 func TestRoundProposerDataCache_Contains(t *testing.T) {
 	t.Parallel()
-	dataCache := NewRoundValidatorDataCache(2)
+	dataCache := NewRoundValidatorHeaderCache(2)
 
 	err := dataCache.Add(1, []byte("proposer1"), &slash.HeaderInfo{Hash: []byte("hash1")})
 	require.Nil(t, err)
@@ -171,19 +171,19 @@ func TestRoundProposerDataCache_Contains(t *testing.T) {
 	err = dataCache.Add(2, []byte("proposer2"), &slash.HeaderInfo{Hash: []byte("hash3")})
 	require.Nil(t, err)
 
-	expectedData1 := &slash.HeaderInfo{Hash: []byte("hash1")}
-	expectedData2 := &slash.HeaderInfo{Hash: []byte("hash2")}
-	expectedData3 := &slash.HeaderInfo{Hash: []byte("hash3")}
+	hash1 := []byte("hash1")
+	hash2 := []byte("hash2")
+	hash3 := []byte("hash3")
 
-	require.True(t, dataCache.contains(1, []byte("proposer1"), expectedData1))
-	require.True(t, dataCache.contains(1, []byte("proposer1"), expectedData2))
-	require.True(t, dataCache.contains(2, []byte("proposer2"), expectedData3))
+	require.True(t, dataCache.contains(1, []byte("proposer1"), hash1))
+	require.True(t, dataCache.contains(1, []byte("proposer1"), hash2))
+	require.True(t, dataCache.contains(2, []byte("proposer2"), hash3))
 
-	require.False(t, dataCache.contains(1, []byte("proposer1"), expectedData3))
-	require.False(t, dataCache.contains(2, []byte("proposer1"), expectedData1))
-	require.False(t, dataCache.contains(1, []byte("proposer2"), expectedData3))
-	require.False(t, dataCache.contains(1, []byte("proposer2"), expectedData2))
-	require.False(t, dataCache.contains(3, []byte("proposer1"), expectedData1))
+	require.False(t, dataCache.contains(1, []byte("proposer1"), hash3))
+	require.False(t, dataCache.contains(2, []byte("proposer1"), hash1))
+	require.False(t, dataCache.contains(1, []byte("proposer2"), hash3))
+	require.False(t, dataCache.contains(1, []byte("proposer2"), hash2))
+	require.False(t, dataCache.contains(3, []byte("proposer1"), hash1))
 }
 
 func TestRoundHeadersCache_IsInterfaceNil(t *testing.T) {

--- a/process/slash/detector/roundValidatorsHeadersCache_test.go
+++ b/process/slash/detector/roundValidatorsHeadersCache_test.go
@@ -113,20 +113,20 @@ func TestRoundProposerDataCache_GetData(t *testing.T) {
 
 	require.Len(t, dataCache.cache, 2)
 
-	data1 := dataCache.GetData(1, []byte("proposer1"))
+	data1 := dataCache.GetHeaders(1, []byte("proposer1"))
 	require.Len(t, data1, 2)
 	require.Equal(t, data1[0].Hash, []byte("hash1"))
 	require.Equal(t, data1[1].Hash, []byte("hash2"))
 
-	data1 = dataCache.GetData(2, []byte("proposer1"))
+	data1 = dataCache.GetHeaders(2, []byte("proposer1"))
 	require.Len(t, data1, 1)
 	require.Equal(t, data1[0].Hash, []byte("hash2"))
 
-	data2 := dataCache.GetData(2, []byte("proposer2"))
+	data2 := dataCache.GetHeaders(2, []byte("proposer2"))
 	require.Len(t, data2, 1)
 	require.Equal(t, data2[0].Hash, []byte("hash3"))
 
-	data3 := dataCache.GetData(444, []byte("this proposer is not cached"))
+	data3 := dataCache.GetHeaders(444, []byte("this proposer is not cached"))
 	require.Nil(t, data3)
 }
 

--- a/process/slash/interface.go
+++ b/process/slash/interface.go
@@ -3,7 +3,6 @@ package slash
 import (
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go/process"
-	"github.com/ElrondNetwork/elrond-go/process/block/interceptedBlocks"
 )
 
 // SlashingProofHandler - contains a proof for a slashing event and can be wrapped in a transaction
@@ -19,7 +18,7 @@ type MultipleProposalProofHandler interface {
 	// multiple colluding parties should have a higher level
 	GetLevel() ThreatLevel
 	//GetHeaders - returns the slashable proposed Data
-	GetHeaders() []*interceptedBlocks.InterceptedHeader
+	GetHeaders() HeaderInfoList
 }
 
 // MultipleSigningProofHandler contains proof data for a multiple header signing slashing event
@@ -30,7 +29,7 @@ type MultipleSigningProofHandler interface {
 	// GetLevel - returns the slashing level for a given validator
 	GetLevel(pubKey []byte) ThreatLevel
 	// GetHeaders - returns the slashable signed headers proposed by a given validator
-	GetHeaders(pubKey []byte) []*interceptedBlocks.InterceptedHeader
+	GetHeaders(pubKey []byte) HeaderInfoList
 }
 
 // SlashingDetector - checks for slashable events and generates proofs to be used for slash

--- a/process/slash/multipleHeaderProposalProof_test.go
+++ b/process/slash/multipleHeaderProposalProof_test.go
@@ -1,0 +1,66 @@
+package slash_test
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/process/slash"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMultipleProposalProof(t *testing.T) {
+	tests := []struct {
+		args        func() *slash.SlashingResult
+		expectedErr error
+	}{
+		{
+			args: func() *slash.SlashingResult {
+				return nil
+			},
+			expectedErr: process.ErrNilSlashResult,
+		},
+		{
+			args: func() *slash.SlashingResult {
+				return &slash.SlashingResult{SlashingLevel: slash.Medium, Headers: nil}
+			},
+			expectedErr: process.ErrNilHeaderHandler,
+		},
+		{
+			args: func() *slash.SlashingResult {
+				return &slash.SlashingResult{SlashingLevel: slash.Medium, Headers: slash.HeaderInfoList{}}
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, currTest := range tests {
+		_, err := slash.NewMultipleProposalProof(currTest.args())
+		require.Equal(t, currTest.expectedErr, err)
+	}
+}
+
+func TestMultipleProposalProof_GetHeaders_GetLevel_GetType(t *testing.T) {
+	h1 := &slash.HeaderInfo{
+		Header: &testscommon.HeaderHandlerStub{TimestampField: 1},
+		Hash:   []byte("h1"),
+	}
+	h2 := &slash.HeaderInfo{
+		Header: &testscommon.HeaderHandlerStub{TimestampField: 2},
+		Hash:   []byte("h2"),
+	}
+
+	slashRes := &slash.SlashingResult{
+		SlashingLevel: slash.Medium,
+		Headers:       slash.HeaderInfoList{h1, h2}}
+
+	proof, err := slash.NewMultipleProposalProof(slashRes)
+	require.Nil(t, err)
+
+	require.Equal(t, slash.MultipleProposal, proof.GetType())
+	require.Equal(t, slash.Medium, proof.GetLevel())
+
+	require.Len(t, proof.GetHeaders(), 2)
+	require.Contains(t, proof.GetHeaders(), h1)
+	require.Contains(t, proof.GetHeaders(), h2)
+}

--- a/process/slash/multipleHeaderProposalsProof.go
+++ b/process/slash/multipleHeaderProposalsProof.go
@@ -6,7 +6,7 @@ type multipleProposalProof struct {
 	slashableHeaders *SlashingResult
 }
 
-// NewMultipleProposalProof - creates a new double block proposal slashing proof with a level, type and data
+// NewMultipleProposalProof - creates a new multiple block proposal slashing proof with a level, type and headers
 func NewMultipleProposalProof(slashResult *SlashingResult) (MultipleProposalProofHandler, error) {
 	if slashResult == nil {
 		return nil, process.ErrNilSlashResult

--- a/process/slash/multipleHeaderProposalsProof.go
+++ b/process/slash/multipleHeaderProposalsProof.go
@@ -1,13 +1,22 @@
 package slash
 
+import "github.com/ElrondNetwork/elrond-go/process"
+
 type multipleProposalProof struct {
 	slashableHeaders *SlashingResult
 }
 
 // NewMultipleProposalProof - creates a new double block proposal slashing proof with a level, type and data
-func NewMultipleProposalProof(slashableData *SlashingResult) (MultipleProposalProofHandler, error) {
+func NewMultipleProposalProof(slashResult *SlashingResult) (MultipleProposalProofHandler, error) {
+	if slashResult == nil {
+		return nil, process.ErrNilSlashResult
+	}
+	if slashResult.Headers == nil {
+		return nil, process.ErrNilHeaderHandler
+	}
+
 	return &multipleProposalProof{
-		slashableHeaders: slashableData,
+		slashableHeaders: slashResult,
 	}, nil
 }
 
@@ -23,5 +32,5 @@ func (mpp *multipleProposalProof) GetType() SlashingType {
 
 // GetHeaders - returns the slashing proofs headers
 func (mpp *multipleProposalProof) GetHeaders() HeaderInfoList {
-	return mpp.slashableHeaders.Data
+	return mpp.slashableHeaders.Headers
 }

--- a/process/slash/multipleHeaderProposalsProof.go
+++ b/process/slash/multipleHeaderProposalsProof.go
@@ -1,31 +1,19 @@
 package slash
 
-import (
-	"github.com/ElrondNetwork/elrond-go/process/block/interceptedBlocks"
-)
-
 type multipleProposalProof struct {
-	slashableHeaders slashingHeaders
+	slashableHeaders *SlashingResult
 }
 
 // NewMultipleProposalProof - creates a new double block proposal slashing proof with a level, type and data
 func NewMultipleProposalProof(slashableData *SlashingResult) (MultipleProposalProofHandler, error) {
-	headers, err := convertInterceptedDataToInterceptedHeaders(slashableData.Data)
-	if err != nil {
-		return nil, err
-	}
-
 	return &multipleProposalProof{
-		slashableHeaders: slashingHeaders{
-			slashingLevel: slashableData.SlashingLevel,
-			headers:       headers,
-		},
+		slashableHeaders: slashableData,
 	}, nil
 }
 
 // GetLevel - returns the slashing proof threat level
 func (mpp *multipleProposalProof) GetLevel() ThreatLevel {
-	return mpp.slashableHeaders.slashingLevel
+	return mpp.slashableHeaders.SlashingLevel
 }
 
 // GetType - returns MultipleProposal
@@ -34,6 +22,6 @@ func (mpp *multipleProposalProof) GetType() SlashingType {
 }
 
 // GetHeaders - returns the slashing proofs headers
-func (mpp *multipleProposalProof) GetHeaders() []*interceptedBlocks.InterceptedHeader {
-	return mpp.slashableHeaders.headers
+func (mpp *multipleProposalProof) GetHeaders() HeaderInfoList {
+	return mpp.slashableHeaders.Data
 }

--- a/process/slash/multipleHeaderSigningProof.go
+++ b/process/slash/multipleHeaderSigningProof.go
@@ -1,9 +1,5 @@
 package slash
 
-import (
-	"github.com/ElrondNetwork/elrond-go/process/block/interceptedBlocks"
-)
-
 type multipleSigningProof struct {
 	slashableHeaders map[string]slashingHeaders
 	pubKeys          [][]byte
@@ -39,7 +35,7 @@ func (msp *multipleSigningProof) GetLevel(pubKey []byte) ThreatLevel {
 }
 
 // GetHeaders - returns the slashing proofs headers for a given validator, if exists, nil otherwise
-func (msp *multipleSigningProof) GetHeaders(pubKey []byte) []*interceptedBlocks.InterceptedHeader {
+func (msp *multipleSigningProof) GetHeaders(pubKey []byte) HeaderInfoList {
 	if _, exists := msp.slashableHeaders[string(pubKey)]; exists {
 		return msp.slashableHeaders[string(pubKey)].headers
 	}
@@ -56,14 +52,9 @@ func convertData(data map[string]SlashingResult) (map[string]slashingHeaders, []
 	pubKeys := make([][]byte, 0, len(data))
 
 	for pubKey, slashableData := range data {
-		headers, err := convertInterceptedDataToInterceptedHeaders(slashableData.Data)
-		if err != nil {
-			return nil, nil, err
-		}
-
 		slashableHeaders[pubKey] = slashingHeaders{
 			slashingLevel: slashableData.SlashingLevel,
-			headers:       headers,
+			headers:       slashableData.Data,
 		}
 
 		pubKeys = append(pubKeys, []byte(pubKey))

--- a/process/slash/multipleHeaderSigningProof_test.go
+++ b/process/slash/multipleHeaderSigningProof_test.go
@@ -1,0 +1,75 @@
+package slash_test
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/process/slash"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMultipleSigningProof(t *testing.T) {
+	tests := []struct {
+		args        func() map[string]slash.SlashingResult
+		expectedErr error
+	}{
+		{
+			args: func() map[string]slash.SlashingResult {
+				return nil
+			},
+			expectedErr: process.ErrNilSlashResult,
+		},
+		{
+			args: func() map[string]slash.SlashingResult {
+				return make(map[string]slash.SlashingResult)
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, currTest := range tests {
+		_, err := slash.NewMultipleSigningProof(currTest.args())
+		require.Equal(t, currTest.expectedErr, err)
+	}
+}
+
+func TestMultipleSigningProof_GetHeaders_GetLevel_GetType(t *testing.T) {
+	h1 := &slash.HeaderInfo{
+		Header: &testscommon.HeaderHandlerStub{TimestampField: 1},
+		Hash:   []byte("h1"),
+	}
+	h2 := &slash.HeaderInfo{
+		Header: &testscommon.HeaderHandlerStub{TimestampField: 2},
+		Hash:   []byte("h2"),
+	}
+
+	slashRes1 := slash.SlashingResult{
+		SlashingLevel: slash.Medium,
+		Headers:       slash.HeaderInfoList{h1},
+	}
+	slashRes2 := slash.SlashingResult{
+		SlashingLevel: slash.High,
+		Headers:       slash.HeaderInfoList{h2},
+	}
+	slashRes := map[string]slash.SlashingResult{
+		"pubKey1": slashRes1,
+		"pubKey2": slashRes2,
+	}
+
+	proof, err := slash.NewMultipleSigningProof(slashRes)
+	require.Nil(t, err)
+
+	require.Equal(t, slash.MultipleSigning, proof.GetType())
+	require.Equal(t, slash.Medium, proof.GetLevel([]byte("pubKey1")))
+	require.Equal(t, slash.High, proof.GetLevel([]byte("pubKey2")))
+	require.Equal(t, slash.Low, proof.GetLevel([]byte("pubKey3")))
+
+	require.Len(t, proof.GetHeaders([]byte("pubKey1")), 1)
+	require.Len(t, proof.GetHeaders([]byte("pubKey2")), 1)
+	require.Len(t, proof.GetHeaders([]byte("pubKey3")), 0)
+
+	require.Contains(t, proof.GetHeaders([]byte("pubKey1")), h1)
+	require.Contains(t, proof.GetHeaders([]byte("pubKey2")), h2)
+	require.Nil(t, proof.GetHeaders([]byte("pubKey3")))
+}

--- a/process/slash/notifier/proofTxDataExtractor.go
+++ b/process/slash/notifier/proofTxDataExtractor.go
@@ -27,8 +27,8 @@ func txDataFromMultipleHeaderProposalProof(proof slash.MultipleProposalProofHand
 	}
 
 	return &proofTxData{
-		round:     headers[0].HeaderHandler().GetRound(),
-		shardID:   headers[0].HeaderHandler().GetShardID(),
+		round:     headers[0].Header.GetRound(),
+		shardID:   headers[0].Header.GetShardID(),
 		bytes:     proofBytes,
 		slashType: proof.GetType(),
 	}, nil
@@ -54,8 +54,8 @@ func txDataFromMultipleHeaderSigningProof(proof slash.MultipleSigningProofHandle
 	}
 
 	return &proofTxData{
-		round:     headers[0].HeaderHandler().GetRound(),
-		shardID:   headers[0].HeaderHandler().GetShardID(),
+		round:     headers[0].Header.GetRound(),
+		shardID:   headers[0].Header.GetShardID(),
 		bytes:     proofBytes,
 		slashType: proof.GetType(),
 	}, nil

--- a/process/slash/notifier/slashingNotifier_test.go
+++ b/process/slash/notifier/slashingNotifier_test.go
@@ -166,7 +166,7 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_NilHeader_ExpectError(t
 	sn, _ := notifier.NewSlashingNotifier(args)
 	tx, err := sn.CreateShardSlashingTransaction(&slashMocks.MultipleHeaderSigningProofStub{
 		GetHeadersCalled: func(pubKey []byte) slash.HeaderInfoList {
-			return slash.HeaderInfoList{}
+			return slash.HeaderInfoList{nil}
 		},
 		GetPubKeysCalled: func() [][]byte {
 			return [][]byte{[]byte("pubKey")}
@@ -222,7 +222,7 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_MultipleProposalProof(t
 
 	sn, _ := notifier.NewSlashingNotifier(args)
 
-	h1 := slash.HeaderInfo{
+	h1 := &slash.HeaderInfo{
 		Header: &block.HeaderV2{
 			Header: &block.Header{
 				Round: 4,
@@ -230,7 +230,7 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_MultipleProposalProof(t
 		},
 		Hash: []byte("h1"),
 	}
-	h2 := slash.HeaderInfo{
+	h2 := &slash.HeaderInfo{
 		Header: &block.HeaderV2{
 			Header: &block.Header{
 				Round: 4,
@@ -272,7 +272,7 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_MultipleSignProof(t *te
 
 	pk1 := []byte("pubKey1")
 
-	h1 := slash.HeaderInfo{
+	h1 := &slash.HeaderInfo{
 		Header: &block.HeaderV2{
 			Header: &block.Header{
 				Round: 4,
@@ -280,7 +280,7 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_MultipleSignProof(t *te
 		},
 		Hash: []byte("h1"),
 	}
-	h2 := slash.HeaderInfo{
+	h2 := &slash.HeaderInfo{
 		Header: &block.HeaderV2{
 			Header: &block.Header{
 				Round: 4,

--- a/process/slash/notifier/slashingNotifier_test.go
+++ b/process/slash/notifier/slashingNotifier_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	crypto "github.com/ElrondNetwork/elrond-go-crypto"
+	"github.com/ElrondNetwork/elrond-go/consensus/mock"
 	mockGenesis "github.com/ElrondNetwork/elrond-go/genesis/mock"
-	"github.com/ElrondNetwork/elrond-go/integrationTests/mock"
+	mockIntegration "github.com/ElrondNetwork/elrond-go/integrationTests/mock"
 	"github.com/ElrondNetwork/elrond-go/process"
-	"github.com/ElrondNetwork/elrond-go/process/block/interceptedBlocks"
 	"github.com/ElrondNetwork/elrond-go/process/slash"
 	"github.com/ElrondNetwork/elrond-go/process/slash/notifier"
 	"github.com/ElrondNetwork/elrond-go/state"
@@ -165,8 +165,8 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_NilHeader_ExpectError(t
 	args := generateSlashingNotifierArgs()
 	sn, _ := notifier.NewSlashingNotifier(args)
 	tx, err := sn.CreateShardSlashingTransaction(&slashMocks.MultipleHeaderSigningProofStub{
-		GetHeadersCalled: func(pubKey []byte) []*interceptedBlocks.InterceptedHeader {
-			return []*interceptedBlocks.InterceptedHeader{nil}
+		GetHeadersCalled: func(pubKey []byte) slash.HeaderInfoList {
+			return slash.HeaderInfoList{}
 		},
 		GetPubKeysCalled: func() [][]byte {
 			return [][]byte{[]byte("pubKey")}
@@ -222,25 +222,25 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_MultipleProposalProof(t
 
 	sn, _ := notifier.NewSlashingNotifier(args)
 
-	h1 := slashMocks.CreateInterceptedHeaderData(
-		&block.HeaderV2{
+	h1 := slash.HeaderInfo{
+		Header: &block.HeaderV2{
 			Header: &block.Header{
-				Round:        4,
-				PrevRandSeed: []byte("seed1"),
+				Round: 4,
 			},
 		},
-	)
-	h2 := slashMocks.CreateInterceptedHeaderData(
-		&block.HeaderV2{
+		Hash: []byte("h1"),
+	}
+	h2 := slash.HeaderInfo{
+		Header: &block.HeaderV2{
 			Header: &block.Header{
-				Round:        4,
-				PrevRandSeed: []byte("seed2"),
+				Round: 4,
 			},
 		},
-	)
+		Hash: []byte("h2"),
+	}
 	proof := &slashMocks.MultipleHeaderProposalProofStub{
-		GetHeadersCalled: func() []*interceptedBlocks.InterceptedHeader {
-			return []*interceptedBlocks.InterceptedHeader{h1, h2}
+		GetHeadersCalled: func() slash.HeaderInfoList {
+			return slash.HeaderInfoList{h1, h2}
 		},
 	}
 
@@ -272,28 +272,28 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_MultipleSignProof(t *te
 
 	pk1 := []byte("pubKey1")
 
-	h1 := slashMocks.CreateInterceptedHeaderData(
-		&block.HeaderV2{
+	h1 := slash.HeaderInfo{
+		Header: &block.HeaderV2{
 			Header: &block.Header{
-				Round:        4,
-				PrevRandSeed: []byte("seed1"),
+				Round: 4,
 			},
 		},
-	)
-	h2 := slashMocks.CreateInterceptedHeaderData(
-		&block.HeaderV2{
+		Hash: []byte("h1"),
+	}
+	h2 := slash.HeaderInfo{
+		Header: &block.HeaderV2{
 			Header: &block.Header{
-				Round:        4,
-				PrevRandSeed: []byte("seed2"),
+				Round: 4,
 			},
 		},
-	)
+		Hash: []byte("h2"),
+	}
 	proof := &slashMocks.MultipleHeaderSigningProofStub{
 		GetLevelCalled: func([]byte) slash.ThreatLevel {
 			return slash.High
 		},
-		GetHeadersCalled: func([]byte) []*interceptedBlocks.InterceptedHeader {
-			return []*interceptedBlocks.InterceptedHeader{h1, h2}
+		GetHeadersCalled: func([]byte) slash.HeaderInfoList {
+			return slash.HeaderInfoList{h1, h2}
 		},
 		GetPubKeysCalled: func() [][]byte {
 			return [][]byte{pk1}
@@ -331,7 +331,7 @@ func generateSlashingNotifierArgs() *notifier.SlashingNotifierArgs {
 		PrivateKey:      &mock.PrivateKeyMock{},
 		PublicKey:       &mock.PublicKeyMock{},
 		PubKeyConverter: &testscommon.PubkeyConverterMock{},
-		Signer:          &mock.SignerMock{},
+		Signer:          &mockIntegration.SignerMock{},
 		AccountAdapter:  accountsAdapter,
 		Hasher:          &hashingMocks.HasherMock{},
 		Marshaller:      &testscommon.MarshalizerMock{},

--- a/process/slash/notifier/slashingNotifier_test.go
+++ b/process/slash/notifier/slashingNotifier_test.go
@@ -115,10 +115,8 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_InvalidPubKey_ExpectErr
 
 	sn, _ := notifier.NewSlashingNotifier(args)
 	proofStub := &slashMocks.MultipleHeaderProposalProofStub{
-		GetHeadersCalled: func() []*interceptedBlocks.InterceptedHeader {
-			return []*interceptedBlocks.InterceptedHeader{
-				slashMocks.CreateInterceptedHeaderData(&block.HeaderV2{Header: &block.Header{Round: 1}}),
-			}
+		GetHeadersCalled: func() slash.HeaderInfoList {
+			return slash.HeaderInfoList{&slash.HeaderInfo{Header: &block.HeaderV2{}}}
 		},
 	}
 
@@ -137,10 +135,8 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_InvalidAccount_ExpectEr
 	}
 	sn, _ := notifier.NewSlashingNotifier(args)
 	proofStub := &slashMocks.MultipleHeaderProposalProofStub{
-		GetHeadersCalled: func() []*interceptedBlocks.InterceptedHeader {
-			return []*interceptedBlocks.InterceptedHeader{
-				slashMocks.CreateInterceptedHeaderData(&block.HeaderV2{Header: &block.Header{Round: 1}}),
-			}
+		GetHeadersCalled: func() slash.HeaderInfoList {
+			return slash.HeaderInfoList{&slash.HeaderInfo{Header: &block.HeaderV2{}}}
 		},
 	}
 
@@ -160,10 +156,8 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_InvalidMarshaller_Expec
 
 	sn, _ := notifier.NewSlashingNotifier(args)
 	proofStub := &slashMocks.MultipleHeaderProposalProofStub{
-		GetHeadersCalled: func() []*interceptedBlocks.InterceptedHeader {
-			return []*interceptedBlocks.InterceptedHeader{
-				slashMocks.CreateInterceptedHeaderData(&block.HeaderV2{Header: &block.Header{Round: 1}}),
-			}
+		GetHeadersCalled: func() slash.HeaderInfoList {
+			return slash.HeaderInfoList{&slash.HeaderInfo{Header: &block.HeaderV2{}}}
 		},
 	}
 
@@ -177,10 +171,8 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_InvalidSlashType_Expect
 
 	sn, _ := notifier.NewSlashingNotifier(args)
 	proofStub := &slashMocks.MultipleHeaderProposalProofStub{
-		GetHeadersCalled: func() []*interceptedBlocks.InterceptedHeader {
-			return []*interceptedBlocks.InterceptedHeader{
-				slashMocks.CreateInterceptedHeaderData(&block.HeaderV2{Header: &block.Header{Round: 1}}),
-			}
+		GetHeadersCalled: func() slash.HeaderInfoList {
+			return slash.HeaderInfoList{&slash.HeaderInfo{Header: &block.HeaderV2{}}}
 		},
 		GetTypeCalled: func() slash.SlashingType {
 			return "invalid"
@@ -219,10 +211,8 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_InvalidProofSignature_E
 
 	sn, _ := notifier.NewSlashingNotifier(args)
 	proofStub := &slashMocks.MultipleHeaderProposalProofStub{
-		GetHeadersCalled: func() []*interceptedBlocks.InterceptedHeader {
-			return []*interceptedBlocks.InterceptedHeader{
-				slashMocks.CreateInterceptedHeaderData(&block.HeaderV2{Header: &block.Header{Round: 1}}),
-			}
+		GetHeadersCalled: func() slash.HeaderInfoList {
+			return slash.HeaderInfoList{&slash.HeaderInfo{Header: &block.HeaderV2{}}}
 		},
 	}
 
@@ -248,10 +238,8 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_InvalidTxSignature_Expe
 
 	sn, _ := notifier.NewSlashingNotifier(args)
 	proofStub := &slashMocks.MultipleHeaderProposalProofStub{
-		GetHeadersCalled: func() []*interceptedBlocks.InterceptedHeader {
-			return []*interceptedBlocks.InterceptedHeader{
-				slashMocks.CreateInterceptedHeaderData(&block.HeaderV2{Header: &block.Header{Round: 1}}),
-			}
+		GetHeadersCalled: func() slash.HeaderInfoList {
+			return slash.HeaderInfoList{&slash.HeaderInfo{Header: &block.HeaderV2{}}}
 		},
 	}
 
@@ -272,27 +260,24 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_MultipleProposalProof(t
 
 	round := uint64(100000)
 	shardID := uint32(2)
-	h1 := slashMocks.CreateInterceptedHeaderData(
-		&block.HeaderV2{
-			Header: &block.Header{
-				Round:        round,
-				ShardID:      shardID,
-				PrevRandSeed: []byte("seed1"),
-			},
+	h1 := &block.HeaderV2{
+		Header: &block.Header{
+			Round:        round,
+			ShardID:      shardID,
+			PrevRandSeed: []byte("seed1"),
 		},
-	)
-	h2 := slashMocks.CreateInterceptedHeaderData(
-		&block.HeaderV2{
-			Header: &block.Header{
-				Round:        round,
-				ShardID:      shardID,
-				PrevRandSeed: []byte("seed2"),
-			},
+	}
+	h2 := &block.HeaderV2{
+		Header: &block.Header{
+			Round:        round,
+			ShardID:      shardID,
+			PrevRandSeed: []byte("seed2"),
 		},
-	)
+	}
+
 	proof := &slashMocks.MultipleHeaderProposalProofStub{
 		GetHeadersCalled: func() slash.HeaderInfoList {
-			return slash.HeaderInfoList{h1, h2}
+			return slash.HeaderInfoList{&slash.HeaderInfo{Header: h1}, &slash.HeaderInfo{Header: h2}}
 		},
 	}
 
@@ -327,30 +312,27 @@ func TestSlashingNotifier_CreateShardSlashingTransaction_MultipleSignProof(t *te
 	shardID := uint32(2)
 	pk1 := []byte("pubKey1")
 
-	h1 := slashMocks.CreateInterceptedHeaderData(
-		&block.HeaderV2{
-			Header: &block.Header{
-				Round:        round,
-				ShardID:      shardID,
-				PrevRandSeed: []byte("seed1"),
-			},
+	h1 := &block.HeaderV2{
+		Header: &block.Header{
+			Round:        round,
+			ShardID:      shardID,
+			PrevRandSeed: []byte("seed1"),
 		},
-	)
-	h2 := slashMocks.CreateInterceptedHeaderData(
-		&block.HeaderV2{
-			Header: &block.Header{
-				Round:        round,
-				ShardID:      shardID,
-				PrevRandSeed: []byte("seed2"),
-			},
+	}
+	h2 := &block.HeaderV2{
+		Header: &block.Header{
+			Round:        round,
+			ShardID:      shardID,
+			PrevRandSeed: []byte("seed2"),
 		},
-	)
+	}
+
 	proof := &slashMocks.MultipleHeaderSigningProofStub{
 		GetLevelCalled: func([]byte) slash.ThreatLevel {
 			return slash.High
 		},
 		GetHeadersCalled: func([]byte) slash.HeaderInfoList {
-			return slash.HeaderInfoList{h1, h2}
+			return slash.HeaderInfoList{&slash.HeaderInfo{Header: h1}, &slash.HeaderInfo{Header: h2}}
 		},
 		GetPubKeysCalled: func() [][]byte {
 			return [][]byte{pk1}

--- a/process/slash/proofConverter.go
+++ b/process/slash/proofConverter.go
@@ -1,11 +1,9 @@
 package slash
 
 import (
-	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	coreSlash "github.com/ElrondNetwork/elrond-go-core/data/slash"
 	"github.com/ElrondNetwork/elrond-go/process"
-	"github.com/ElrondNetwork/elrond-go/process/block/interceptedBlocks"
 )
 
 // ToProtoMultipleHeaderProposal converts a MultipleProposalProofHandler to its specific proto structure
@@ -43,16 +41,16 @@ func ToProtoMultipleHeaderSign(proof MultipleSigningProofHandler) (*coreSlash.Mu
 	}, nil
 }
 
-func getHeadersFromInterceptedHeaders(interceptedHeaders []*interceptedBlocks.InterceptedHeader) (coreSlash.Headers, error) {
+func getHeadersFromInterceptedHeaders(interceptedHeaders HeaderInfoList) (coreSlash.Headers, error) {
 	headers := make([]data.HeaderHandler, 0, len(interceptedHeaders))
 	ret := coreSlash.Headers{}
 
 	for _, interceptedHeader := range interceptedHeaders {
-		if check.IfNil(interceptedHeader) || check.IfNil(interceptedHeader.HeaderHandler()) {
+		if interceptedHeader.Header == nil {
 			return ret, process.ErrNilHeaderHandler
 		}
 
-		headers = append(headers, interceptedHeader.HeaderHandler())
+		headers = append(headers, interceptedHeader.Header)
 	}
 
 	err := ret.SetHeaders(headers)

--- a/process/slash/proofConverter.go
+++ b/process/slash/proofConverter.go
@@ -41,16 +41,16 @@ func ToProtoMultipleHeaderSign(proof MultipleSigningProofHandler) (*coreSlash.Mu
 	}, nil
 }
 
-func getHeadersFromInterceptedHeaders(interceptedHeaders HeaderInfoList) (coreSlash.Headers, error) {
-	headers := make([]data.HeaderHandler, 0, len(interceptedHeaders))
+func getHeadersFromInterceptedHeaders(headerInfoList HeaderInfoList) (coreSlash.Headers, error) {
+	headers := make([]data.HeaderHandler, 0, len(headerInfoList))
 	ret := coreSlash.Headers{}
 
-	for _, interceptedHeader := range interceptedHeaders {
-		if interceptedHeader.Header == nil {
+	for _, headerInfo := range headerInfoList {
+		if headerInfo == nil || headerInfo.Header == nil {
 			return ret, process.ErrNilHeaderHandler
 		}
 
-		headers = append(headers, interceptedHeader.Header)
+		headers = append(headers, headerInfo.Header)
 	}
 
 	err := ret.SetHeaders(headers)

--- a/process/slash/proofConverter_test.go
+++ b/process/slash/proofConverter_test.go
@@ -14,7 +14,7 @@ import (
 func TestToProtoMultipleHeaderProposal_NilHeaders_ExpectError(t *testing.T) {
 	proof := &slashMocks.MultipleHeaderProposalProofStub{
 		GetHeadersCalled: func() slash.HeaderInfoList {
-			return slash.HeaderInfoList{}
+			return slash.HeaderInfoList{nil}
 		},
 	}
 	res, err := slash.ToProtoMultipleHeaderProposal(proof)
@@ -27,8 +27,8 @@ func TestToProtoMultipleHeaderProposal(t *testing.T) {
 	h1 := &block.HeaderV2{Header: &block.Header{Nonce: 1, Round: 1}}
 	h2 := &block.HeaderV2{Header: &block.Header{Nonce: 2, Round: 2}}
 
-	h1Info := slash.HeaderInfo{Header: h1, Hash: []byte("h1")}
-	h2Info := slash.HeaderInfo{Header: h2, Hash: []byte("h2")}
+	h1Info := &slash.HeaderInfo{Header: h1, Hash: []byte("h1")}
+	h2Info := &slash.HeaderInfo{Header: h2, Hash: []byte("h2")}
 
 	proof := &slashMocks.MultipleHeaderProposalProofStub{
 		GetHeadersCalled: func() slash.HeaderInfoList {
@@ -54,7 +54,7 @@ func TestToProtoMultipleHeaderSign_NilHeaders_ExpectError(t *testing.T) {
 			return [][]byte{[]byte("address")}
 		},
 		GetHeadersCalled: func([]byte) slash.HeaderInfoList {
-			return slash.HeaderInfoList{}
+			return slash.HeaderInfoList{nil}
 		},
 	}
 	res, err := slash.ToProtoMultipleHeaderSign(proof)
@@ -67,8 +67,8 @@ func TestToProtoMultipleHeaderSign(t *testing.T) {
 	h1 := &block.HeaderV2{Header: &block.Header{Nonce: 1, Round: 1}}
 	h2 := &block.HeaderV2{Header: &block.Header{Nonce: 2, Round: 2}}
 
-	h1Info := slash.HeaderInfo{Header: h1, Hash: []byte("h1")}
-	h2Info := slash.HeaderInfo{Header: h2, Hash: []byte("h2")}
+	h1Info := &slash.HeaderInfo{Header: h1, Hash: []byte("h1")}
+	h2Info := &slash.HeaderInfo{Header: h2, Hash: []byte("h2")}
 
 	pk1 := []byte("pubKey1")
 	pk2 := []byte("pubKey2")

--- a/process/slash/proofConverter_test.go
+++ b/process/slash/proofConverter_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	coreSlash "github.com/ElrondNetwork/elrond-go-core/data/slash"
 	"github.com/ElrondNetwork/elrond-go/process"
-	"github.com/ElrondNetwork/elrond-go/process/block/interceptedBlocks"
 	"github.com/ElrondNetwork/elrond-go/process/slash"
 	"github.com/ElrondNetwork/elrond-go/testscommon/slashMocks"
 	"github.com/stretchr/testify/require"
@@ -14,8 +13,8 @@ import (
 
 func TestToProtoMultipleHeaderProposal_NilHeaders_ExpectError(t *testing.T) {
 	proof := &slashMocks.MultipleHeaderProposalProofStub{
-		GetHeadersCalled: func() []*interceptedBlocks.InterceptedHeader {
-			return []*interceptedBlocks.InterceptedHeader{nil}
+		GetHeadersCalled: func() slash.HeaderInfoList {
+			return slash.HeaderInfoList{}
 		},
 	}
 	res, err := slash.ToProtoMultipleHeaderProposal(proof)
@@ -28,12 +27,12 @@ func TestToProtoMultipleHeaderProposal(t *testing.T) {
 	h1 := &block.HeaderV2{Header: &block.Header{Nonce: 1, Round: 1}}
 	h2 := &block.HeaderV2{Header: &block.Header{Nonce: 2, Round: 2}}
 
-	interceptedHeader1 := slashMocks.CreateInterceptedHeaderData(h1)
-	interceptedHeader2 := slashMocks.CreateInterceptedHeaderData(h2)
+	h1Info := slash.HeaderInfo{Header: h1, Hash: []byte("h1")}
+	h2Info := slash.HeaderInfo{Header: h2, Hash: []byte("h2")}
 
 	proof := &slashMocks.MultipleHeaderProposalProofStub{
-		GetHeadersCalled: func() []*interceptedBlocks.InterceptedHeader {
-			return []*interceptedBlocks.InterceptedHeader{interceptedHeader1, interceptedHeader2}
+		GetHeadersCalled: func() slash.HeaderInfoList {
+			return slash.HeaderInfoList{h1Info, h2Info}
 		},
 		GetLevelCalled: func() slash.ThreatLevel {
 			return slash.High
@@ -54,8 +53,8 @@ func TestToProtoMultipleHeaderSign_NilHeaders_ExpectError(t *testing.T) {
 		GetPubKeysCalled: func() [][]byte {
 			return [][]byte{[]byte("address")}
 		},
-		GetHeadersCalled: func([]byte) []*interceptedBlocks.InterceptedHeader {
-			return []*interceptedBlocks.InterceptedHeader{nil}
+		GetHeadersCalled: func([]byte) slash.HeaderInfoList {
+			return slash.HeaderInfoList{}
 		},
 	}
 	res, err := slash.ToProtoMultipleHeaderSign(proof)
@@ -68,8 +67,8 @@ func TestToProtoMultipleHeaderSign(t *testing.T) {
 	h1 := &block.HeaderV2{Header: &block.Header{Nonce: 1, Round: 1}}
 	h2 := &block.HeaderV2{Header: &block.Header{Nonce: 2, Round: 2}}
 
-	interceptedHeader1 := slashMocks.CreateInterceptedHeaderData(h1)
-	interceptedHeader2 := slashMocks.CreateInterceptedHeaderData(h2)
+	h1Info := slash.HeaderInfo{Header: h1, Hash: []byte("h1")}
+	h2Info := slash.HeaderInfo{Header: h2, Hash: []byte("h2")}
 
 	pk1 := []byte("pubKey1")
 	pk2 := []byte("pubKey2")
@@ -78,12 +77,12 @@ func TestToProtoMultipleHeaderSign(t *testing.T) {
 		GetPubKeysCalled: func() [][]byte {
 			return [][]byte{pk1, pk2}
 		},
-		GetHeadersCalled: func(pubKey []byte) []*interceptedBlocks.InterceptedHeader {
+		GetHeadersCalled: func(pubKey []byte) slash.HeaderInfoList {
 			switch string(pubKey) {
 			case string(pk1):
-				return []*interceptedBlocks.InterceptedHeader{interceptedHeader1}
+				return slash.HeaderInfoList{h1Info}
 			case string(pk2):
-				return []*interceptedBlocks.InterceptedHeader{interceptedHeader1, interceptedHeader2}
+				return slash.HeaderInfoList{h1Info, h2Info}
 			default:
 				return nil
 			}

--- a/testscommon/slashMocks/headersCacheSub.go
+++ b/testscommon/slashMocks/headersCacheSub.go
@@ -1,16 +1,18 @@
 package slashMocks
 
-import "github.com/ElrondNetwork/elrond-go-core/data"
+import (
+	"github.com/ElrondNetwork/elrond-go/process/slash"
+)
 
 // HeadersCacheStub -
 type HeadersCacheStub struct {
-	AddCalled func(round uint64, hash []byte, header data.HeaderHandler) error
+	AddCalled func(round uint64, header *slash.HeaderInfo) error
 }
 
 // Add -
-func (hcs *HeadersCacheStub) Add(round uint64, hash []byte, header data.HeaderHandler) error {
+func (hcs *HeadersCacheStub) Add(round uint64, header *slash.HeaderInfo) error {
 	if hcs.AddCalled != nil {
-		return hcs.AddCalled(round, hash, header)
+		return hcs.AddCalled(round, header)
 	}
 	return nil
 }

--- a/testscommon/slashMocks/multipleHeaderProposalsProofStub.go
+++ b/testscommon/slashMocks/multipleHeaderProposalsProofStub.go
@@ -1,7 +1,6 @@
 package slashMocks
 
 import (
-	"github.com/ElrondNetwork/elrond-go/process/block/interceptedBlocks"
 	"github.com/ElrondNetwork/elrond-go/process/slash"
 )
 
@@ -9,7 +8,7 @@ import (
 type MultipleHeaderProposalProofStub struct {
 	GetTypeCalled    func() slash.SlashingType
 	GetLevelCalled   func() slash.ThreatLevel
-	GetHeadersCalled func() []*interceptedBlocks.InterceptedHeader
+	GetHeadersCalled func() slash.HeaderInfoList
 }
 
 // GetType -
@@ -29,7 +28,7 @@ func (mps *MultipleHeaderProposalProofStub) GetLevel() slash.ThreatLevel {
 }
 
 // GetHeaders -
-func (mps *MultipleHeaderProposalProofStub) GetHeaders() []*interceptedBlocks.InterceptedHeader {
+func (mps *MultipleHeaderProposalProofStub) GetHeaders() slash.HeaderInfoList {
 	if mps.GetHeadersCalled != nil {
 		return mps.GetHeadersCalled()
 	}

--- a/testscommon/slashMocks/multipleHeaderSigningProofStub.go
+++ b/testscommon/slashMocks/multipleHeaderSigningProofStub.go
@@ -1,7 +1,6 @@
 package slashMocks
 
 import (
-	"github.com/ElrondNetwork/elrond-go/process/block/interceptedBlocks"
 	"github.com/ElrondNetwork/elrond-go/process/slash"
 )
 
@@ -9,7 +8,7 @@ import (
 type MultipleHeaderSigningProofStub struct {
 	GetTypeCalled    func() slash.SlashingType
 	GetPubKeysCalled func() [][]byte
-	GetHeadersCalled func(pubKey []byte) []*interceptedBlocks.InterceptedHeader
+	GetHeadersCalled func(pubKey []byte) slash.HeaderInfoList
 	GetLevelCalled   func(pubKey []byte) slash.ThreatLevel
 }
 
@@ -38,7 +37,7 @@ func (mps *MultipleHeaderSigningProofStub) GetLevel(pubKey []byte) slash.ThreatL
 }
 
 // GetHeaders -
-func (mps *MultipleHeaderSigningProofStub) GetHeaders(pubKey []byte) []*interceptedBlocks.InterceptedHeader {
+func (mps *MultipleHeaderSigningProofStub) GetHeaders(pubKey []byte) slash.HeaderInfoList {
 	if mps.GetHeadersCalled != nil {
 		return mps.GetHeadersCalled(pubKey)
 	}

--- a/testscommon/slashMocks/roundDetectorCacheStub.go
+++ b/testscommon/slashMocks/roundDetectorCacheStub.go
@@ -1,25 +1,27 @@
 package slashMocks
 
-import "github.com/ElrondNetwork/elrond-go/process"
+import (
+	"github.com/ElrondNetwork/elrond-go/process/slash"
+)
 
 // RoundDetectorCacheStub -
 type RoundDetectorCacheStub struct {
-	AddCalled            func(round uint64, pubKey []byte, data process.InterceptedData) error
-	GetDataCalled        func(round uint64, pubKey []byte) []process.InterceptedData
+	AddCalled            func(round uint64, pubKey []byte, header slash.HeaderInfo) error
+	GetDataCalled        func(round uint64, pubKey []byte) slash.HeaderInfoList
 	GetPubKeysCalled     func(round uint64) [][]byte
 	IsInterfaceNilCalled func() bool
 }
 
 // Add -
-func (rdc *RoundDetectorCacheStub) Add(round uint64, pubKey []byte, data process.InterceptedData) error {
+func (rdc *RoundDetectorCacheStub) Add(round uint64, pubKey []byte, headerInfo slash.HeaderInfo) error {
 	if rdc.AddCalled != nil {
-		return rdc.AddCalled(round, pubKey, data)
+		return rdc.AddCalled(round, pubKey, headerInfo)
 	}
 	return nil
 }
 
 // GetData -
-func (rdc *RoundDetectorCacheStub) GetData(round uint64, pubKey []byte) []process.InterceptedData {
+func (rdc *RoundDetectorCacheStub) GetData(round uint64, pubKey []byte) slash.HeaderInfoList {
 	if rdc.GetDataCalled != nil {
 		return rdc.GetDataCalled(round, pubKey)
 	}

--- a/testscommon/slashMocks/roundDetectorCacheStub.go
+++ b/testscommon/slashMocks/roundDetectorCacheStub.go
@@ -20,8 +20,8 @@ func (rdc *RoundDetectorCacheStub) Add(round uint64, pubKey []byte, headerInfo *
 	return nil
 }
 
-// GetData -
-func (rdc *RoundDetectorCacheStub) GetData(round uint64, pubKey []byte) slash.HeaderInfoList {
+// GetHeaders -
+func (rdc *RoundDetectorCacheStub) GetHeaders(round uint64, pubKey []byte) slash.HeaderInfoList {
 	if rdc.GetDataCalled != nil {
 		return rdc.GetDataCalled(round, pubKey)
 	}

--- a/testscommon/slashMocks/roundDetectorCacheStub.go
+++ b/testscommon/slashMocks/roundDetectorCacheStub.go
@@ -6,14 +6,14 @@ import (
 
 // RoundDetectorCacheStub -
 type RoundDetectorCacheStub struct {
-	AddCalled            func(round uint64, pubKey []byte, header slash.HeaderInfo) error
+	AddCalled            func(round uint64, pubKey []byte, header *slash.HeaderInfo) error
 	GetDataCalled        func(round uint64, pubKey []byte) slash.HeaderInfoList
 	GetPubKeysCalled     func(round uint64) [][]byte
 	IsInterfaceNilCalled func() bool
 }
 
 // Add -
-func (rdc *RoundDetectorCacheStub) Add(round uint64, pubKey []byte, headerInfo slash.HeaderInfo) error {
+func (rdc *RoundDetectorCacheStub) Add(round uint64, pubKey []byte, headerInfo *slash.HeaderInfo) error {
 	if rdc.AddCalled != nil {
 		return rdc.AddCalled(round, pubKey, headerInfo)
 	}


### PR DESCRIPTION
- Created a new struct `called HeaderInfo` which holds a `HeaderHandler` and its associated `hash`.
- Refactored `process/slash` to use this new struct instead of  `InterceptedHeader`
- Added tests for proofs