### PR TITLE
Fix number of epochs to keep in case of full archive

### DIFF
--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -522,14 +522,12 @@ func processConfigFullArchiveMode(log logger.Logger, configs *config.Configs) er
 	configs.GeneralConfig.StoragePruning.ValidatorCleanOldEpochsData = false
 	configs.GeneralConfig.StoragePruning.ObserverCleanOldEpochsData = false
 	configs.GeneralConfig.StoragePruning.Enabled = true
-	configs.GeneralConfig.StoragePruning.NumEpochsToKeep = math.MaxUint64
 
 	log.Warn("the node is in full archive mode! Will auto-set some config values",
 		"GeneralSettings.StartInEpochEnabled", generalConfigs.GeneralSettings.StartInEpochEnabled,
 		"StoragePruning.ValidatorCleanOldEpochsData", generalConfigs.StoragePruning.ValidatorCleanOldEpochsData,
 		"StoragePruning.ObserverCleanOldEpochsData", generalConfigs.StoragePruning.ObserverCleanOldEpochsData,
 		"StoragePruning.Enabled", generalConfigs.StoragePruning.Enabled,
-		"StoragePruning.NumEpochsToKeep", configs.GeneralConfig.StoragePruning.NumEpochsToKeep,
 	)
 
 	return nil


### PR DESCRIPTION
Previously, if the node was started as a full archive, the number of epochs to keep config value would have been overridden to Max uint64, which is not useful anymore, as now we have full history pruning storer. This solves the situation when a full archive node opens all the databases from the current epoch to genesis when starting the node.

Testing procedure:
1. start a testnet with some nodes (not all of them) being full archive (setting the `--full-archive` flag when starting or setting ` FullArchive = true` inside prefs.toml 
2. after a few epochs (let's say 10 epochs) restart a full archive node
3. check it's log and search for `initPersistersInEpoch` - epochs older than current epoch - 4 should not be observed in those log lines
4. repeat for more full archive nodes