### PR TITLE
epochStart: fix pending miniblocks computation at start in epoch

### DIFF
--- a/consensus/broadcast/delayedBroadcast_test.go
+++ b/consensus/broadcast/delayedBroadcast_test.go
@@ -233,7 +233,7 @@ func TestDelayedBlockBroadcaster_HeaderReceivedForRegisteredDelayedDataShouldBro
 	dbb.HeaderReceived(metaBlock, []byte("meta hash"))
 	sleepTime := common.ExtraDelayForBroadcastBlockInfo +
 		common.ExtraDelayBetweenBroadcastMbsAndTxs +
-		10*time.Millisecond
+		100*time.Millisecond
 	time.Sleep(sleepTime)
 	assert.True(t, mbBroadcastCalled.IsSet())
 	assert.True(t, txBroadcastCalled.IsSet())

--- a/epochStart/bootstrap/shardStorageHandler.go
+++ b/epochStart/bootstrap/shardStorageHandler.go
@@ -180,24 +180,28 @@ func (ssh *shardStorageHandler) getProcessedAndPendingMiniBlocks(
 	meta *block.MetaBlock,
 	headers map[string]data.HeaderHandler,
 ) ([]bootstrapStorage.MiniBlocksInMeta, []bootstrapStorage.PendingMiniBlocksInfo, error) {
-	shardData, err := getEpochStartShardData(meta, ssh.shardCoordinator.SelfId())
+	epochStartShardData, err := getEpochStartShardData(meta, ssh.shardCoordinator.SelfId())
 	if err != nil {
 		return nil, nil, err
 	}
 
-	neededMeta, ok := headers[string(shardData.FirstPendingMetaBlock)].(*block.MetaBlock)
+	header, ok := headers[string(epochStartShardData.FirstPendingMetaBlock)]
 	if !ok {
 		return nil, nil, epochStart.ErrMissingHeader
 	}
+	neededMeta, ok := header.(*block.MetaBlock)
+	if !ok {
+		return nil, nil, epochStart.ErrWrongTypeAssertion
+	}
 	if check.IfNil(neededMeta) {
-		return nil, nil, epochStart.ErrMissingHeader
+		return nil, nil, epochStart.ErrNilMetaBlock
 	}
 
 	pendingMBsMap := make(map[string]struct{})
 	pendingMBsPerShardMap := make(map[uint32][][]byte)
-	for _, mbHeader := range shardData.PendingMiniBlockHeaders {
-		senderShId := mbHeader.SenderShardID
-		pendingMBsPerShardMap[senderShId] = append(pendingMBsPerShardMap[senderShId], mbHeader.Hash)
+	for _, mbHeader := range epochStartShardData.PendingMiniBlockHeaders {
+		receiverShardID := mbHeader.ReceiverShardID
+		pendingMBsPerShardMap[receiverShardID] = append(pendingMBsPerShardMap[receiverShardID], mbHeader.Hash)
 		pendingMBsMap[string(mbHeader.Hash)] = struct{}{}
 	}
 
@@ -214,7 +218,7 @@ func (ssh *shardStorageHandler) getProcessedAndPendingMiniBlocks(
 	processedMiniBlocks := make([]bootstrapStorage.MiniBlocksInMeta, 0)
 	if len(processedMbHashes) > 0 {
 		processedMiniBlocks = append(processedMiniBlocks, bootstrapStorage.MiniBlocksInMeta{
-			MetaHash:         shardData.FirstPendingMetaBlock,
+			MetaHash:         epochStartShardData.FirstPendingMetaBlock,
 			MiniBlocksHashes: processedMbHashes,
 		})
 	}
@@ -322,10 +326,6 @@ func (ssh *shardStorageHandler) saveTriggerRegistry(components *ComponentsNeeded
 func getAllMiniBlocksWithDst(metaBlock *block.MetaBlock, destId uint32) map[string]block.MiniBlockHeader {
 	hashDst := make(map[string]block.MiniBlockHeader)
 	for i := 0; i < len(metaBlock.ShardInfo); i++ {
-		if metaBlock.ShardInfo[i].ShardID == destId {
-			continue
-		}
-
 		for _, val := range metaBlock.ShardInfo[i].ShardMiniBlockHeaders {
 			isCrossShardDestMe := val.ReceiverShardID == destId && val.SenderShardID != destId
 			if !isCrossShardDestMe {

--- a/epochStart/bootstrap/shardStorageHandler_test.go
+++ b/epochStart/bootstrap/shardStorageHandler_test.go
@@ -4,16 +4,23 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
+	"github.com/ElrondNetwork/elrond-go-core/data/typeConverters"
+	"github.com/ElrondNetwork/elrond-go-core/hashing"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/epochStart"
 	"github.com/ElrondNetwork/elrond-go/epochStart/mock"
+	"github.com/ElrondNetwork/elrond-go/process/block/bootstrapStorage"
 	"github.com/ElrondNetwork/elrond-go/sharding"
+	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/nodeTypeProviderMock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewShardStorageHandler_ShouldWork(t *testing.T) {
@@ -165,3 +172,263 @@ func TestGetAllMiniBlocksWithDst(t *testing.T) {
 	assert.Equal(t, shardMbHeaders[string(hash1)], shardMiniBlockHeader)
 	assert.NotNil(t, shardMbHeaders[string(hash2)])
 }
+
+func TestShardStorageHandler_getProcessedAndPendingMiniBlocksErrorGettingEpochStartShardData(t *testing.T) {
+	t.Parallel()
+
+	args := createDefaultShardStorageArgs()
+	shardStorage, _ := NewShardStorageHandler(args.generalConfig, args.prefsConfig, args.shardCoordinator, args.pathManagerHandler, args.marshalizer, args.hasher, 1, args.uint64Converter, args.nodeTypeProvider)
+	meta := &block.MetaBlock{
+		Nonce:      100,
+		EpochStart: block.EpochStart{},
+	}
+	headers := map[string]data.HeaderHandler{}
+
+	miniBlocksInMeta, pendingMiniBlocksInfoList, err := shardStorage.getProcessedAndPendingMiniBlocks(meta, headers)
+	require.Nil(t, miniBlocksInMeta)
+	require.Nil(t, pendingMiniBlocksInfoList)
+	require.Equal(t, epochStart.ErrEpochStartDataForShardNotFound, err)
+}
+
+func TestShardStorageHandler_getProcessedAndPendingMiniBlocksMissingHeader(t *testing.T) {
+	t.Parallel()
+
+	lastFinishedMetaBlock := "last finished meta block"
+	args := createDefaultShardStorageArgs()
+	shardStorage, _ := NewShardStorageHandler(args.generalConfig, args.prefsConfig, args.shardCoordinator, args.pathManagerHandler, args.marshalizer, args.hasher, 1, args.uint64Converter, args.nodeTypeProvider)
+	meta := &block.MetaBlock{
+		Nonce: 100,
+		EpochStart: block.EpochStart{
+			LastFinalizedHeaders: createDefaultEpochStartShardData([]byte(lastFinishedMetaBlock), []byte("headerHash")),
+		},
+	}
+	headers := map[string]data.HeaderHandler{}
+
+	miniBlocksInMeta, pendingMiniBlocksInfoList, err := shardStorage.getProcessedAndPendingMiniBlocks(meta, headers)
+	require.Nil(t, miniBlocksInMeta)
+	require.Nil(t, pendingMiniBlocksInfoList)
+	require.Equal(t, epochStart.ErrMissingHeader, err)
+}
+
+func TestShardStorageHandler_getProcessedAndPendingMiniBlocksWrongHeader(t *testing.T) {
+	t.Parallel()
+
+	lastFinishedMetaBlockHash := "last finished meta block"
+	firstPendingMeta := "first pending meta"
+	args := createDefaultShardStorageArgs()
+	shardStorage, _ := NewShardStorageHandler(args.generalConfig, args.prefsConfig, args.shardCoordinator, args.pathManagerHandler, args.marshalizer, args.hasher, 1, args.uint64Converter, args.nodeTypeProvider)
+	lastFinishedHeaders := createDefaultEpochStartShardData([]byte(lastFinishedMetaBlockHash), []byte("headerHash"))
+	lastFinishedHeaders[0].FirstPendingMetaBlock = []byte(firstPendingMeta)
+	meta := &block.MetaBlock{
+		Nonce: 100,
+		EpochStart: block.EpochStart{
+			LastFinalizedHeaders: lastFinishedHeaders,
+		},
+	}
+	headers := map[string]data.HeaderHandler{
+		lastFinishedMetaBlockHash: &block.MetaBlock{},
+		firstPendingMeta:          &block.Header{},
+	}
+
+	miniBlocksInMeta, pendingMiniBlocksInfoList, err := shardStorage.getProcessedAndPendingMiniBlocks(meta, headers)
+	require.Nil(t, miniBlocksInMeta)
+	require.Nil(t, pendingMiniBlocksInfoList)
+	require.Equal(t, epochStart.ErrWrongTypeAssertion, err)
+}
+
+func TestShardStorageHandler_getProcessedAndPendingMiniBlocksNilMetaBlock(t *testing.T) {
+	t.Parallel()
+
+	lastFinishedMetaBlockHash := "last finished meta block"
+	firstPendingMeta := "first pending meta"
+	args := createDefaultShardStorageArgs()
+	shardStorage, _ := NewShardStorageHandler(args.generalConfig, args.prefsConfig, args.shardCoordinator, args.pathManagerHandler, args.marshalizer, args.hasher, 1, args.uint64Converter, args.nodeTypeProvider)
+	lastFinishedHeaders := createDefaultEpochStartShardData([]byte(lastFinishedMetaBlockHash), []byte("headerHash"))
+	lastFinishedHeaders[0].FirstPendingMetaBlock = []byte(firstPendingMeta)
+	meta := &block.MetaBlock{
+		Nonce: 100,
+		EpochStart: block.EpochStart{
+			LastFinalizedHeaders: lastFinishedHeaders,
+		},
+	}
+
+	var nilMetaBlock *block.MetaBlock
+	headers := map[string]data.HeaderHandler{
+		lastFinishedMetaBlockHash: &block.MetaBlock{},
+		firstPendingMeta:          nilMetaBlock,
+	}
+
+	miniBlocksInMeta, pendingMiniBlocksInfoList, err := shardStorage.getProcessedAndPendingMiniBlocks(meta, headers)
+	require.Nil(t, miniBlocksInMeta)
+	require.Nil(t, pendingMiniBlocksInfoList)
+	require.Equal(t, epochStart.ErrNilMetaBlock, err)
+}
+
+func TestShardStorageHandler_getProcessedAndPendingMiniBlocksNoProcessedNoPendingMbs(t *testing.T) {
+	t.Parallel()
+
+	lastFinishedMetaBlockHash := "last finished meta block"
+	firstPendingMeta := "first pending meta"
+	args := createDefaultShardStorageArgs()
+	shardStorage, _ := NewShardStorageHandler(args.generalConfig, args.prefsConfig, args.shardCoordinator, args.pathManagerHandler, args.marshalizer, args.hasher, 1, args.uint64Converter, args.nodeTypeProvider)
+	lastFinishedHeaders := createDefaultEpochStartShardData([]byte(lastFinishedMetaBlockHash), []byte("headerHash"))
+	lastFinishedHeaders[0].FirstPendingMetaBlock = []byte(firstPendingMeta)
+	lastFinishedHeaders[0].PendingMiniBlockHeaders = nil
+	meta := &block.MetaBlock{
+		Nonce: 100,
+		EpochStart: block.EpochStart{
+			LastFinalizedHeaders: lastFinishedHeaders,
+		},
+	}
+
+	neededMeta := &block.MetaBlock{Nonce: 98}
+
+	headers := map[string]data.HeaderHandler{
+		lastFinishedMetaBlockHash: &block.MetaBlock{},
+		firstPendingMeta:          neededMeta,
+	}
+
+	miniBlocksInMeta, pendingMiniBlocksInfoList, err := shardStorage.getProcessedAndPendingMiniBlocks(meta, headers)
+	require.Nil(t, err)
+	require.Len(t, pendingMiniBlocksInfoList, 0)
+	require.Len(t, miniBlocksInMeta, 0)
+}
+
+func TestShardStorageHandler_getProcessedAndPendingMiniBlocksWithProcessedAndPendingMbs(t *testing.T) {
+	t.Parallel()
+
+	args := createDefaultShardStorageArgs()
+	shardStorage, _ := NewShardStorageHandler(args.generalConfig, args.prefsConfig, args.shardCoordinator, args.pathManagerHandler, args.marshalizer, args.hasher, 1, args.uint64Converter, args.nodeTypeProvider)
+	scenario := createPendingAndProcessedMiniBlocksScenario()
+	processedMiniBlocks, pendingMiniBlocks, err := shardStorage.getProcessedAndPendingMiniBlocks(scenario.metaBlock, scenario.headers)
+
+	require.Nil(t, err)
+	require.Equal(t, scenario.expectedPendingMbs, pendingMiniBlocks)
+	require.Equal(t, scenario.expectedProcessedMbs, processedMiniBlocks)
+}
+
+type shardStorageArgs struct {
+	generalConfig      config.Config
+	prefsConfig        config.PreferencesConfig
+	shardCoordinator   sharding.Coordinator
+	pathManagerHandler storage.PathManagerHandler
+	marshalizer        marshal.Marshalizer
+	hasher             hashing.Hasher
+	currentEpoch       uint32
+	uint64Converter    typeConverters.Uint64ByteSliceConverter
+	nodeTypeProvider   core.NodeTypeProviderHandler
+}
+
+func createDefaultShardStorageArgs() shardStorageArgs {
+	return shardStorageArgs{
+		generalConfig:      testscommon.GetGeneralConfig(),
+		prefsConfig:        config.PreferencesConfig{},
+		shardCoordinator:   &mock.ShardCoordinatorStub{},
+		pathManagerHandler: &testscommon.PathManagerStub{},
+		marshalizer:        &mock.MarshalizerMock{},
+		hasher:             &testscommon.HasherMock{},
+		currentEpoch:       0,
+		uint64Converter:    &mock.Uint64ByteSliceConverterMock{},
+		nodeTypeProvider:   &nodeTypeProviderMock.NodeTypeProviderStub{},
+	}
+}
+
+func createDefaultEpochStartShardData(lastFinishedMetaBlockHash []byte, shardHeaderHash []byte) []block.EpochStartShardData {
+	return []block.EpochStartShardData{
+		{
+			HeaderHash:            shardHeaderHash,
+			ShardID:               0,
+			LastFinishedMetaBlock: lastFinishedMetaBlockHash,
+			PendingMiniBlockHeaders: []block.MiniBlockHeader{
+				{SenderShardID: 1, ReceiverShardID: 0},
+			},
+		},
+	}
+}
+
+type scenarioData struct {
+	shardHeader                       *block.Header
+	headers                           map[string]data.HeaderHandler
+	metaBlock                         *block.MetaBlock
+	expectedPendingMbs                []bootstrapStorage.PendingMiniBlocksInfo
+	expectedProcessedMbs              []bootstrapStorage.MiniBlocksInMeta
+}
+
+func createPendingAndProcessedMiniBlocksScenario() scenarioData {
+	lastFinishedMetaBlockHash := "lastMetaBlockHash"
+	firstPendingMetaHash := "firstPendingMetaHash"
+	prevShardHeaderHash := "prevShardHeaderHash"
+	shardHeaderHash := "shardHeaderHash"
+
+	crossMbHeaders := []block.MiniBlockHeader{
+		{Hash: []byte("mb_1_0_0"), SenderShardID: 1, ReceiverShardID: 0},
+		{Hash: []byte("mb_2_0_1"), SenderShardID: 2, ReceiverShardID: 0},
+		{Hash: []byte("mb_meta_0_2"), SenderShardID: core.MetachainShardId, ReceiverShardID: 0},
+		{Hash: []byte("mb_2_0_3"), SenderShardID: 2, ReceiverShardID: 0},
+		{Hash: []byte("mb_1_0_4"), SenderShardID: 1, ReceiverShardID: 0},
+	}
+
+	intraMbHeaders := []block.MiniBlockHeader{
+		{Hash: []byte("mb_0_0_0"), SenderShardID: 0, ReceiverShardID: 0},
+		{Hash: []byte("mb_0_0_1"), SenderShardID: 0, ReceiverShardID: 0},
+		{Hash: []byte("mb_0_0_2"), SenderShardID: 0, ReceiverShardID: 0},
+	}
+
+	processedMbsHeaders := []block.MiniBlockHeader{crossMbHeaders[0]}
+	processedMbsHeaders = append(processedMbsHeaders, intraMbHeaders...)
+	pendingMbsHeaders := crossMbHeaders[1:]
+
+	shardHeader := &block.Header{
+		ShardID:          0,
+		Nonce:            96,
+		PrevHash:         []byte(prevShardHeaderHash),
+		MiniBlockHeaders: processedMbsHeaders,
+	}
+
+	expectedPendingMiniBlocks := []bootstrapStorage.PendingMiniBlocksInfo{
+		{ShardID: 0, MiniBlocksHashes: [][]byte{crossMbHeaders[1].Hash, crossMbHeaders[2].Hash, crossMbHeaders[3].Hash, crossMbHeaders[4].Hash}},
+	}
+	expectedProcessedMiniBlocks := []bootstrapStorage.MiniBlocksInMeta{
+		{MetaHash: []byte(firstPendingMetaHash), MiniBlocksHashes: [][]byte{crossMbHeaders[0].Hash}},
+	}
+
+	headers := map[string]data.HeaderHandler{
+		lastFinishedMetaBlockHash: &block.MetaBlock{
+			Nonce:    94,
+			PrevHash: []byte("before last finished meta"),
+		},
+		firstPendingMetaHash: &block.MetaBlock{
+			Nonce:    95,
+			PrevHash: []byte(lastFinishedMetaBlockHash),
+			ShardInfo: []block.ShardData{
+				{ShardID: 0, HeaderHash: []byte(prevShardHeaderHash), ShardMiniBlockHeaders: processedMbsHeaders},
+				{ShardID: 1, HeaderHash: []byte("header hash "), ShardMiniBlockHeaders: []block.MiniBlockHeader{crossMbHeaders[4]}},
+				{ShardID: 2, HeaderHash: []byte("header hash 2 "), ShardMiniBlockHeaders: []block.MiniBlockHeader{crossMbHeaders[1], crossMbHeaders[3]}},
+				{ShardID: core.MetachainShardId, HeaderHash: []byte("header hash 3"), ShardMiniBlockHeaders: []block.MiniBlockHeader{crossMbHeaders[2]}},
+			},
+		},
+		shardHeaderHash: shardHeader,
+		prevShardHeaderHash: &block.Header{
+			Nonce:    95,
+			PrevHash: []byte("prevPrevShardHeaderHash"),
+		},
+	}
+
+	meta := &block.MetaBlock{
+		Nonce: 100,
+		EpochStart: block.EpochStart{
+			LastFinalizedHeaders: []block.EpochStartShardData{
+				{ShardID: 0, Nonce: 96, FirstPendingMetaBlock: []byte(firstPendingMetaHash), LastFinishedMetaBlock: []byte(lastFinishedMetaBlockHash), PendingMiniBlockHeaders: pendingMbsHeaders},
+			},
+		},
+	}
+
+	return scenarioData{
+		shardHeader:                       shardHeader,
+		headers:                           headers,
+		metaBlock:                         meta,
+		expectedPendingMbs:                expectedPendingMiniBlocks,
+		expectedProcessedMbs:              expectedProcessedMiniBlocks,
+	}
+}
+


### PR DESCRIPTION
fixes the computation of pending miniblocks and processed miniblocks at start in epoch

Some details:
At start in epoch, the pending/processed miniblocks are computed out of the start of epoch metablock and used for bootstrapping and setting the tracker with the correct information.
In cases where there are partially processed Metablocks referenced in the start of epoch metablock for a shard, the miniblocks That were already processed are not set as processed.

One other fix, also for the pending miniblocks at bootstrap is that the shardID for the pending miniblocks was wrongly set to the sender shard instead of the receiver shard, although this does not have an effect, as the shard ID is not used afterwards.