### PR TITLE
Backwards compatibility fix on tx interceptor for gaslimit value

### DIFF
--- a/factory/coreComponents.go
+++ b/factory/coreComponents.go
@@ -85,6 +85,7 @@ type coreComponents struct {
 	watchdog                      core.WatchdogTimer
 	nodesSetupHandler             sharding.GenesisNodesSetupHandler
 	economicsData                 process.EconomicsDataHandler
+	apiEconomicsData              process.EconomicsDataHandler
 	ratingsData                   process.RatingsInfoHandler
 	rater                         sharding.PeerAccountListAndRatingHandler
 	nodesShuffler                 sharding.NodesShuffler
@@ -256,6 +257,11 @@ func (ccf *coreComponentsFactory) Create() (*coreComponents, error) {
 		return nil, err
 	}
 
+	apiEconomicsData, err := economics.NewAPIEconomicsData(economicsData)
+	if err != nil {
+		return nil, err
+	}
+
 	log.Trace("creating ratings data")
 	ratingDataArgs := rating.RatingsDataArg{
 		Config:                   ccf.ratingsConfig,
@@ -333,6 +339,7 @@ func (ccf *coreComponentsFactory) Create() (*coreComponents, error) {
 		watchdog:                      watchdogTimer,
 		nodesSetupHandler:             genesisNodesConfig,
 		economicsData:                 economicsData,
+		apiEconomicsData:              apiEconomicsData,
 		ratingsData:                   ratingsData,
 		rater:                         rater,
 		nodesShuffler:                 nodesShuffler,

--- a/factory/coreComponentsHandler.go
+++ b/factory/coreComponentsHandler.go
@@ -406,6 +406,18 @@ func (mcc *managedCoreComponents) EconomicsData() process.EconomicsDataHandler {
 	return mcc.coreComponents.economicsData
 }
 
+// APIEconomicsData returns the configured economics data to be used on the REST API sub-system
+func (mcc *managedCoreComponents) APIEconomicsData() process.EconomicsDataHandler {
+	mcc.mutCoreComponents.RLock()
+	defer mcc.mutCoreComponents.RUnlock()
+
+	if mcc.coreComponents == nil {
+		return nil
+	}
+
+	return mcc.coreComponents.apiEconomicsData
+}
+
 // RatingsData returns the configured ratings data
 func (mcc *managedCoreComponents) RatingsData() process.RatingsInfoHandler {
 	mcc.mutCoreComponents.RLock()

--- a/factory/interface.go
+++ b/factory/interface.go
@@ -110,6 +110,7 @@ type CoreComponentsHolder interface {
 	SyncTimer() ntp.SyncTimer
 	RoundHandler() consensus.RoundHandler
 	EconomicsData() process.EconomicsDataHandler
+	APIEconomicsData() process.EconomicsDataHandler
 	RatingsData() process.RatingsInfoHandler
 	Rater() sharding.PeerAccountListAndRatingHandler
 	GenesisNodesSetup() sharding.GenesisNodesSetupHandler

--- a/factory/mock/coreComponentsMock.go
+++ b/factory/mock/coreComponentsMock.go
@@ -42,6 +42,7 @@ type CoreComponentsMock struct {
 	mutIntMarshalizer           sync.RWMutex
 	RoundHandlerField           consensus.RoundHandler
 	EconomicsHandler            process.EconomicsDataHandler
+	APIEconomicsHandler         process.EconomicsDataHandler
 	RatingsConfig               process.RatingsInfoHandler
 	RatingHandler               sharding.PeerAccountListAndRatingHandler
 	NodesConfig                 sharding.GenesisNodesSetupHandler
@@ -182,6 +183,11 @@ func (ccm *CoreComponentsMock) RoundHandler() consensus.RoundHandler {
 // EconomicsData -
 func (ccm *CoreComponentsMock) EconomicsData() process.EconomicsDataHandler {
 	return ccm.EconomicsHandler
+}
+
+// APIEconomicsData -
+func (ccm *CoreComponentsMock) APIEconomicsData() process.EconomicsDataHandler {
+	return ccm.APIEconomicsHandler
 }
 
 // RatingsData -

--- a/integrationTests/mock/coreComponentsStub.go
+++ b/integrationTests/mock/coreComponentsStub.go
@@ -38,6 +38,7 @@ type CoreComponentsStub struct {
 	SyncTimerField                     ntp.SyncTimer
 	RoundHandlerField                  consensus.RoundHandler
 	EconomicsDataField                 process.EconomicsDataHandler
+	APIEconomicsHandler                process.EconomicsDataHandler
 	RatingsDataField                   process.RatingsInfoHandler
 	RaterField                         sharding.PeerAccountListAndRatingHandler
 	GenesisNodesSetupField             sharding.GenesisNodesSetupHandler
@@ -104,6 +105,11 @@ func (ccs *CoreComponentsStub) RoundHandler() consensus.RoundHandler {
 // EconomicsData -
 func (ccs *CoreComponentsStub) EconomicsData() process.EconomicsDataHandler {
 	return ccs.EconomicsDataField
+}
+
+// APIEconomicsData -
+func (ccs *CoreComponentsStub) APIEconomicsData() process.EconomicsDataHandler {
+	return ccs.APIEconomicsHandler
 }
 
 // RatingsData -

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -2148,6 +2148,7 @@ func (tpn *TestProcessorNode) initNode() {
 	coreComponents.TxVersionCheckField = versioning.NewTxVersionChecker(tpn.MinTransactionVersion)
 	coreComponents.Uint64ByteSliceConverterField = TestUint64Converter
 	coreComponents.EconomicsDataField = tpn.EconomicsData
+	coreComponents.APIEconomicsHandler = tpn.EconomicsData
 	coreComponents.SyncTimerField = &mock.SyncTimerMock{}
 	coreComponents.EpochNotifierField = tpn.EpochNotifier
 	coreComponents.ArwenChangeLockerInternal = tpn.ArwenChangeLocker

--- a/integrationTests/vm/testInitializer.go
+++ b/integrationTests/vm/testInitializer.go
@@ -1,3 +1,4 @@
+//go:build cgo
 // +build cgo
 
 package vm
@@ -80,7 +81,7 @@ var log = logger.GetOrCreate("integrationtests")
 
 const maxTrieLevelInMemory = uint(5)
 
-// ArgEnableEpoch will specify the enable epoch values for certain flags
+// ArgEnableEpoch will specify enable epoch values for certain flags
 type ArgEnableEpoch struct {
 	PenalizedTooMuchGasEnableEpoch      uint32
 	BuiltinEnableEpoch                  uint32
@@ -351,7 +352,7 @@ func CreateAccount(accnts state.AccountsAdapter, pubKey []byte, nonce uint64, ba
 }
 
 func createEconomicsData(penalizedTooMuchGasEnableEpoch uint32) (process.EconomicsDataHandler, error) {
-	maxGasLimitPerBlock := strconv.FormatUint(math.MaxUint64-1, 10)
+	maxGasLimitPerBlock := strconv.FormatUint(math.MaxUint64, 10)
 	minGasPrice := strconv.FormatUint(1, 10)
 	minGasLimit := strconv.FormatUint(1, 10)
 	testProtocolSustainabilityAddress := "erd1932eft30w753xyvme8d49qejgkjc09n5e49w4mwdjtm0neld797su0dlxp"
@@ -758,6 +759,7 @@ func createDefaultVMConfig() *config.VirtualMachineConfig {
 	}
 }
 
+// ResultsCreateTxProcessor is the struct that will hold all needed processor instances
 type ResultsCreateTxProcessor struct {
 	TxProc             process.TransactionProcessor
 	SCProc             *smartContract.TestScProcessor

--- a/integrationTests/vm/testInitializer.go
+++ b/integrationTests/vm/testInitializer.go
@@ -1,6 +1,3 @@
-//go:build cgo
-// +build cgo
-
 package vm
 
 import (

--- a/integrationTests/vm/txsFee/moveBalance_test.go
+++ b/integrationTests/vm/txsFee/moveBalance_test.go
@@ -208,7 +208,7 @@ func TestMoveBalanceMoreGasThanGasLimitPerMiniBlockForSafeCrossShard(t *testing.
 	tx := vm.CreateTransaction(0, big.NewInt(500), sndAddr, rcvAddr, gasPrice, gasLimit, []byte("aaaa"))
 
 	_, err = testContext.TxProcessor.ProcessTransaction(tx)
-	require.Equal(t, process.ErrMoreGasThanGasLimitPerMiniBlockForSafeCrossShard, err)
+	require.Equal(t, process.ErrMoreGasThanGasLimitPerBlock, err)
 	require.Nil(t, testContext.GetLatestError())
 
 	_, err = testContext.Accounts.Commit()

--- a/node/mock/factory/coreComponentsStub.go
+++ b/node/mock/factory/coreComponentsStub.go
@@ -38,6 +38,7 @@ type CoreComponentsMock struct {
 	NtpTimer                    ntp.SyncTimer
 	RoundHandlerField           consensus.RoundHandler
 	EconomicsHandler            process.EconomicsDataHandler
+	APIEconomicsHandler         process.EconomicsDataHandler
 	RatingsConfig               process.RatingsInfoHandler
 	RatingHandler               sharding.PeerAccountListAndRatingHandler
 	NodesConfig                 sharding.GenesisNodesSetupHandler
@@ -104,6 +105,11 @@ func (ccm *CoreComponentsMock) RoundHandler() consensus.RoundHandler {
 // EconomicsData -
 func (ccm *CoreComponentsMock) EconomicsData() process.EconomicsDataHandler {
 	return ccm.EconomicsHandler
+}
+
+// APIEconomicsData -
+func (ccm *CoreComponentsMock) APIEconomicsData() process.EconomicsDataHandler {
+	return ccm.APIEconomicsHandler
 }
 
 // RatingsData -

--- a/node/node.go
+++ b/node/node.go
@@ -828,7 +828,7 @@ func (n *Node) commonTransactionValidation(
 		txSingleSigner,
 		n.coreComponents.AddressPubKeyConverter(),
 		n.processComponents.ShardCoordinator(),
-		n.coreComponents.EconomicsData(),
+		n.coreComponents.APIEconomicsData(),
 		whiteListerVerifiedTxs,
 		argumentParser,
 		[]byte(n.coreComponents.ChainID()),

--- a/node/nodeBlocks_test.go
+++ b/node/nodeBlocks_test.go
@@ -550,6 +550,7 @@ func getDefaultCoreComponents() *factory.CoreComponentsMock {
 		NtpTimer:              &testscommon.SyncTimerStub{},
 		RoundHandlerField:     &testscommon.RoundHandlerMock{},
 		EconomicsHandler:      &economicsmocks.EconomicsHandlerMock{},
+		APIEconomicsHandler:   &economicsmocks.EconomicsHandlerMock{},
 		RatingsConfig:         &testscommon.RatingsInfoMock{},
 		RatingHandler:         &testscommon.RaterMock{},
 		NodesConfig:           &testscommon.NodesSetupStub{},

--- a/process/economics/apiEconomicsData.go
+++ b/process/economics/apiEconomicsData.go
@@ -1,0 +1,36 @@
+package economics
+
+import (
+	"github.com/ElrondNetwork/elrond-go-core/data"
+	"github.com/ElrondNetwork/elrond-go/process"
+)
+
+type apiEconomicsData struct {
+	*economicsData
+}
+
+// NewAPIEconomicsData will create a wrapped object over the provided economics data
+func NewAPIEconomicsData(data *economicsData) (*apiEconomicsData, error) {
+	if data == nil {
+		return nil, process.ErrNilEconomicsData
+	}
+
+	return &apiEconomicsData{
+		economicsData: data,
+	}, nil
+}
+
+// CheckValidityTxValues checks if the provided transaction is economically correct. It overloads the original method
+// as the check in this instance for the gas limit should be done on the MaxGasLimitPerMiniBlockForSafeCrossShard value
+func (ed *apiEconomicsData) CheckValidityTxValues(tx data.TransactionWithFeeHandler) error {
+	if tx.GetGasLimit() > ed.MaxGasLimitPerMiniBlockForSafeCrossShard() {
+		return process.ErrMoreGasThanGasLimitPerMiniBlockForSafeCrossShard
+	}
+
+	return ed.economicsData.CheckValidityTxValues(tx)
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (ed *apiEconomicsData) IsInterfaceNil() bool {
+	return ed == nil
+}

--- a/process/economics/apiEconomicsData_test.go
+++ b/process/economics/apiEconomicsData_test.go
@@ -17,12 +17,16 @@ func TestNewAPIEconomicsData(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil economics data", func(t *testing.T) {
+		t.Parallel()
+
 		apiEconomicsData, err := economics.NewAPIEconomicsData(nil)
 
 		assert.True(t, check.IfNil(apiEconomicsData))
 		assert.Equal(t, process.ErrNilEconomicsData, err)
 	})
 	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
 		args := createArgsForEconomicsData(1)
 		economicsData, _ := economics.NewEconomicsData(args)
 		apiEconomicsData, err := economics.NewAPIEconomicsData(economicsData)
@@ -47,6 +51,8 @@ func TestApiEconomicsData_CheckValidityTxValues(t *testing.T) {
 	apiEconomicsData, _ := economics.NewAPIEconomicsData(economicsData)
 
 	t.Run("maximum gas limit as defined should work", func(t *testing.T) {
+		t.Parallel()
+
 		tx := &transaction.Transaction{
 			GasPrice: minGasPrice + 1,
 			GasLimit: maxGasLimitPerBlock,
@@ -56,6 +62,8 @@ func TestApiEconomicsData_CheckValidityTxValues(t *testing.T) {
 		require.Nil(t, err)
 	})
 	t.Run("maximum gas limit + 1 as defined should error", func(t *testing.T) {
+		t.Parallel()
+
 		tx := &transaction.Transaction{
 			GasPrice: minGasPrice + 1,
 			GasLimit: maxGasLimitPerBlock + 1,
@@ -65,6 +73,8 @@ func TestApiEconomicsData_CheckValidityTxValues(t *testing.T) {
 		require.Equal(t, process.ErrMoreGasThanGasLimitPerMiniBlockForSafeCrossShard, err)
 	})
 	t.Run("maximum gas limit - 1 as defined should work", func(t *testing.T) {
+		t.Parallel()
+
 		tx := &transaction.Transaction{
 			GasPrice: minGasPrice + 1,
 			GasLimit: maxGasLimitPerBlock - 1,

--- a/process/economics/apiEconomicsData_test.go
+++ b/process/economics/apiEconomicsData_test.go
@@ -1,0 +1,76 @@
+package economics_test
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
+	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/process/economics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAPIEconomicsData(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil economics data", func(t *testing.T) {
+		apiEconomicsData, err := economics.NewAPIEconomicsData(nil)
+
+		assert.True(t, check.IfNil(apiEconomicsData))
+		assert.Equal(t, process.ErrNilEconomicsData, err)
+	})
+	t.Run("should work", func(t *testing.T) {
+		args := createArgsForEconomicsData(1)
+		economicsData, _ := economics.NewEconomicsData(args)
+		apiEconomicsData, err := economics.NewAPIEconomicsData(economicsData)
+
+		assert.False(t, check.IfNil(apiEconomicsData))
+		assert.Nil(t, err)
+	})
+}
+
+func TestApiEconomicsData_CheckValidityTxValues(t *testing.T) {
+	t.Parallel()
+
+	args := createArgsForEconomicsData(1)
+	minGasPrice := uint64(500)
+	minGasLimit := uint64(12)
+	maxGasLimitPerBlock := uint64(42)
+	args.Economics.FeeSettings.GasLimitSettings[0].MaxGasLimitPerMiniBlock = fmt.Sprintf("%d", maxGasLimitPerBlock)
+	args.Economics.FeeSettings.GasLimitSettings[0].MaxGasLimitPerMetaMiniBlock = fmt.Sprintf("%d", maxGasLimitPerBlock*10)
+	args.Economics.FeeSettings.MinGasPrice = fmt.Sprintf("%d", minGasPrice)
+	args.Economics.FeeSettings.GasLimitSettings[0].MinGasLimit = fmt.Sprintf("%d", minGasLimit)
+	economicsData, _ := economics.NewEconomicsData(args)
+	apiEconomicsData, _ := economics.NewAPIEconomicsData(economicsData)
+
+	t.Run("maximum gas limit as defined should work", func(t *testing.T) {
+		tx := &transaction.Transaction{
+			GasPrice: minGasPrice + 1,
+			GasLimit: maxGasLimitPerBlock,
+			Value:    big.NewInt(0),
+		}
+		err := apiEconomicsData.CheckValidityTxValues(tx)
+		require.Nil(t, err)
+	})
+	t.Run("maximum gas limit + 1 as defined should error", func(t *testing.T) {
+		tx := &transaction.Transaction{
+			GasPrice: minGasPrice + 1,
+			GasLimit: maxGasLimitPerBlock + 1,
+			Value:    big.NewInt(0),
+		}
+		err := apiEconomicsData.CheckValidityTxValues(tx)
+		require.Equal(t, process.ErrMoreGasThanGasLimitPerMiniBlockForSafeCrossShard, err)
+	})
+	t.Run("maximum gas limit - 1 as defined should work", func(t *testing.T) {
+		tx := &transaction.Transaction{
+			GasPrice: minGasPrice + 1,
+			GasLimit: maxGasLimitPerBlock - 1,
+			Value:    big.NewInt(0),
+		}
+		err := apiEconomicsData.CheckValidityTxValues(tx)
+		require.Nil(t, err)
+	})
+}

--- a/process/economics/economicsData.go
+++ b/process/economics/economicsData.go
@@ -69,7 +69,7 @@ type ArgsNewEconomicsData struct {
 	GasPriceModifierEnableEpoch    uint32
 }
 
-// NewEconomicsData will create and object with information about economics parameters
+// NewEconomicsData will create an object with information about economics parameters
 func NewEconomicsData(args ArgsNewEconomicsData) (*economicsData, error) {
 	if check.IfNil(args.BuiltInFunctionsCostHandler) {
 		return nil, process.ErrNilBuiltInFunctionsCostHandler
@@ -461,8 +461,9 @@ func (ed *economicsData) CheckValidityTxValues(tx data.TransactionWithFeeHandler
 		}
 	}
 
-	if tx.GetGasLimit() > ed.MaxGasLimitPerMiniBlockForSafeCrossShard() {
-		return process.ErrMoreGasThanGasLimitPerMiniBlockForSafeCrossShard
+	//The following check should be kept as it is in order to avoid backwards compatibility issues
+	if tx.GetGasLimit() >= ed.maxGasLimitPerBlock {
+		return process.ErrMoreGasThanGasLimitPerBlock
 	}
 
 	// The following is required to mitigate a "big value" attack

--- a/process/economics/economicsData_test.go
+++ b/process/economics/economicsData_test.go
@@ -619,6 +619,7 @@ func TestEconomicsData_TxWithLowerGasLimitShouldErr(t *testing.T) {
 	assert.Equal(t, process.ErrInsufficientGasLimitInTx, err)
 }
 
+// This test should not be modified due to backwards compatibility reasons
 func TestEconomicsData_TxWithHigherGasLimitShouldErr(t *testing.T) {
 	t.Parallel()
 
@@ -626,7 +627,7 @@ func TestEconomicsData_TxWithHigherGasLimitShouldErr(t *testing.T) {
 	minGasPrice := uint64(500)
 	minGasLimit := uint64(12)
 	maxGasLimitPerBlock := minGasLimit
-	args.Economics.FeeSettings.GasLimitSettings[0].MaxGasLimitPerMiniBlock = fmt.Sprintf("%d", maxGasLimitPerBlock)
+	args.Economics.FeeSettings.GasLimitSettings[0].MaxGasLimitPerBlock = fmt.Sprintf("%d", maxGasLimitPerBlock)
 	args.Economics.FeeSettings.GasLimitSettings[0].MaxGasLimitPerMetaMiniBlock = fmt.Sprintf("%d", maxGasLimitPerBlock*10)
 	args.Economics.FeeSettings.MinGasPrice = fmt.Sprintf("%d", minGasPrice)
 	args.Economics.FeeSettings.GasLimitSettings[0].MinGasLimit = fmt.Sprintf("%d", minGasLimit)
@@ -640,7 +641,7 @@ func TestEconomicsData_TxWithHigherGasLimitShouldErr(t *testing.T) {
 
 	err := economicsData.CheckValidityTxValues(tx)
 
-	assert.Equal(t, process.ErrMoreGasThanGasLimitPerMiniBlockForSafeCrossShard, err)
+	assert.Equal(t, process.ErrMoreGasThanGasLimitPerBlock, err)
 }
 
 func TestEconomicsData_TxWithWithMinGasPriceAndLimitShouldWork(t *testing.T) {
@@ -672,7 +673,7 @@ func TestEconomicsData_TxWithWithMoreGasLimitThanMaximumPerMiniBlockForSafeCross
 	minGasPrice := uint64(500)
 	minGasLimit := uint64(12)
 	maxGasLimitPerBlock := uint64(42)
-	args.Economics.FeeSettings.GasLimitSettings[0].MaxGasLimitPerMiniBlock = fmt.Sprintf("%d", maxGasLimitPerBlock)
+	args.Economics.FeeSettings.GasLimitSettings[0].MaxGasLimitPerBlock = fmt.Sprintf("%d", maxGasLimitPerBlock)
 	args.Economics.FeeSettings.GasLimitSettings[0].MaxGasLimitPerMetaMiniBlock = fmt.Sprintf("%d", maxGasLimitPerBlock*10)
 	args.Economics.FeeSettings.MinGasPrice = fmt.Sprintf("%d", minGasPrice)
 	args.Economics.FeeSettings.GasLimitSettings[0].MinGasLimit = fmt.Sprintf("%d", minGasLimit)
@@ -686,7 +687,7 @@ func TestEconomicsData_TxWithWithMoreGasLimitThanMaximumPerMiniBlockForSafeCross
 			Value:    big.NewInt(0),
 		}
 		err := economicsData.CheckValidityTxValues(tx)
-		require.Nil(t, err)
+		require.Equal(t, process.ErrMoreGasThanGasLimitPerBlock, err)
 	})
 	t.Run("maximum gas limit + 1 as defined should error", func(t *testing.T) {
 		tx := &transaction.Transaction{
@@ -695,7 +696,7 @@ func TestEconomicsData_TxWithWithMoreGasLimitThanMaximumPerMiniBlockForSafeCross
 			Value:    big.NewInt(0),
 		}
 		err := economicsData.CheckValidityTxValues(tx)
-		require.Equal(t, process.ErrMoreGasThanGasLimitPerMiniBlockForSafeCrossShard, err)
+		require.Equal(t, process.ErrMoreGasThanGasLimitPerBlock, err)
 	})
 	t.Run("maximum gas limit - 1 as defined should work", func(t *testing.T) {
 		tx := &transaction.Transaction{

--- a/process/errors.go
+++ b/process/errors.go
@@ -470,9 +470,6 @@ var ErrOverflow = errors.New("type overflow occured")
 // ErrNilTxValidator signals that a nil tx validator has been provided
 var ErrNilTxValidator = errors.New("nil transaction validator")
 
-// ErrNilHdrValidator signals that a nil header validator has been provided
-var ErrNilHdrValidator = errors.New("nil header validator")
-
 // ErrNilPendingMiniBlocksHandler signals that a nil pending miniblocks handler has been provided
 var ErrNilPendingMiniBlocksHandler = errors.New("nil pending miniblocks handler")
 
@@ -937,6 +934,9 @@ var ErrMoreGasConsumedThanProvided = errors.New("more gas used than provided")
 
 // ErrInvalidGasModifier signals that provided gas modifier is invalid
 var ErrInvalidGasModifier = errors.New("invalid gas modifier")
+
+// ErrMoreGasThanGasLimitPerBlock signals that more gas was provided than gas limit per block
+var ErrMoreGasThanGasLimitPerBlock = errors.New("more gas was provided than gas limit per block")
 
 // ErrMoreGasThanGasLimitPerMiniBlockForSafeCrossShard signals that more gas was provided than gas limit per mini block for safe cross shard
 var ErrMoreGasThanGasLimitPerMiniBlockForSafeCrossShard = errors.New("more gas was provided than gas limit per mini block for safe cross shard")


### PR DESCRIPTION
- removed backwards compatibility issue on transactions at interceptor level
- added protection on the API for transactions with higher gas limit than the transaction processor can cope