### PR TITLE
Fix genesis header changes

### DIFF
--- a/factory/processComponents.go
+++ b/factory/processComponents.go
@@ -845,7 +845,9 @@ func getGenesisBlockForShard(miniBlocks []*dataBlock.MiniBlock, shardId uint32) 
 
 func (pcf *processComponentsFactory) indexGenesisBlocks(genesisBlocks map[uint32]data.HeaderHandler, initialIndexingData map[uint32]*genesis.IndexingData) error {
 	currentShardId := pcf.bootstrapComponents.ShardCoordinator().SelfId()
-	genesisBlockHeader := genesisBlocks[currentShardId]
+	originalGenesisBlockHeader := genesisBlocks[currentShardId]
+	genesisBlockHeader := originalGenesisBlockHeader.Clone()
+
 	genesisBlockHash, err := core.CalculateHash(pcf.coreData.InternalMarshalizer(), pcf.coreData.Hasher(), genesisBlockHeader)
 	if err != nil {
 		return err


### PR DESCRIPTION
Use a clone of the genesis header when changing it for indexing genesis data. Otherwise, an observer would have lost sync with the network