### PR TITLE
No process error on shuffle out

### DIFF
--- a/common/context.go
+++ b/common/context.go
@@ -2,8 +2,12 @@ package common
 
 import "context"
 
-// WasContextClosed will return true if the provided context has been closed
-func WasContextClosed(ctx context.Context) bool {
+// IsContextDone will return true if the provided context signals it is done
+func IsContextDone(ctx context.Context) bool {
+	if ctx == nil {
+		return true
+	}
+
 	select {
 	case <-ctx.Done():
 		return true

--- a/common/context.go
+++ b/common/context.go
@@ -1,0 +1,13 @@
+package common
+
+import "context"
+
+// WasContextClosed will return true if the provided context has been closed
+func WasContextClosed(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
+}

--- a/common/context_test.go
+++ b/common/context_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// nolint
 func TestIsContextDone(t *testing.T) {
 	t.Parallel()
 

--- a/common/context_test.go
+++ b/common/context_test.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWasContextClosed(t *testing.T) {
+	t.Parallel()
+
+	numTests := 10
+	ctx, cancel := context.WithCancel(context.Background())
+	for i := 0; i < numTests; i++ {
+		assert.False(t, WasContextClosed(ctx))
+	}
+	cancel()
+	for i := 0; i < numTests; i++ {
+		assert.True(t, WasContextClosed(ctx))
+	}
+}

--- a/common/context_test.go
+++ b/common/context_test.go
@@ -7,34 +7,39 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWasContextClosed(t *testing.T) {
+func TestIsContextDone(t *testing.T) {
 	t.Parallel()
 
-	numTests := 10
-	ctx, cancel := context.WithCancel(context.Background())
-	for i := 0; i < numTests; i++ {
-		assert.False(t, WasContextClosed(ctx))
-	}
-	cancel()
-	for i := 0; i < numTests; i++ {
-		assert.True(t, WasContextClosed(ctx))
-	}
+	t.Run("valid context tests", func(t *testing.T) {
+		numTests := 10
+		ctx, cancel := context.WithCancel(context.Background())
+		for i := 0; i < numTests; i++ {
+			assert.False(t, IsContextDone(ctx))
+		}
+		cancel()
+		for i := 0; i < numTests; i++ {
+			assert.True(t, IsContextDone(ctx))
+		}
+	})
+	t.Run("nil context", func(t *testing.T) {
+		assert.True(t, IsContextDone(nil))
+	})
 }
 
-func BenchmarkWasContextClosed_WhenClosed(b *testing.B) {
+func BenchmarkIsContextDone_WhenDone(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
 	for i := 0; i < b.N; i++ {
-		_ = WasContextClosed(ctx)
+		_ = IsContextDone(ctx)
 	}
 }
 
-func BenchmarkWasContextClosed_WhenNotClosed(b *testing.B) {
+func BenchmarkIsContextDone_WhenNotDone(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	for i := 0; i < b.N; i++ {
-		_ = WasContextClosed(ctx)
+		_ = IsContextDone(ctx)
 	}
 }

--- a/common/context_test.go
+++ b/common/context_test.go
@@ -20,3 +20,21 @@ func TestWasContextClosed(t *testing.T) {
 		assert.True(t, WasContextClosed(ctx))
 	}
 }
+
+func BenchmarkWasContextClosed_WhenClosed(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	for i := 0; i < b.N; i++ {
+		_ = WasContextClosed(ctx)
+	}
+}
+
+func BenchmarkWasContextClosed_WhenNotClosed(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for i := 0; i < b.N; i++ {
+		_ = WasContextClosed(ctx)
+	}
+}

--- a/consensus/chronology/chronology.go
+++ b/consensus/chronology/chronology.go
@@ -126,12 +126,12 @@ func (chr *chronology) startRounds(ctx context.Context) {
 		case <-time.After(time.Millisecond):
 		}
 
-		chr.startRound()
+		chr.startRound(ctx)
 	}
 }
 
 // startRound calls the current subround, given by the finished tasks in this round
-func (chr *chronology) startRound() {
+func (chr *chronology) startRound(ctx context.Context) {
 	if chr.subroundId == srBeforeStartRound {
 		chr.updateRound()
 	}
@@ -149,7 +149,7 @@ func (chr *chronology) startRound() {
 	log.Debug(display.Headline(msg, chr.syncTimer.FormattedCurrentTime(), "."))
 	logger.SetCorrelationSubround(sr.Name())
 
-	if !sr.DoWork(chr.roundHandler) {
+	if !sr.DoWork(ctx, chr.roundHandler) {
 		chr.subroundId = srBeforeStartRound
 		return
 	}

--- a/consensus/chronology/export_test.go
+++ b/consensus/chronology/export_test.go
@@ -1,11 +1,13 @@
 package chronology
 
 import (
+	"context"
+
 	"github.com/ElrondNetwork/elrond-go/consensus"
 )
 
 func (chr *chronology) StartRound() {
-	chr.startRound()
+	chr.startRound(context.Background())
 }
 
 func (chr *chronology) SubroundId() int {

--- a/consensus/interface.go
+++ b/consensus/interface.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"context"
 	"time"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
@@ -27,7 +28,7 @@ type RoundHandler interface {
 // SubroundHandler defines the actions which should be handled by a subround implementation
 type SubroundHandler interface {
 	// DoWork implements of the subround's job
-	DoWork(roundHandler RoundHandler) bool
+	DoWork(ctx context.Context, roundHandler RoundHandler) bool
 	// Previous returns the ID of the previous subround
 	Previous() int
 	// Next returns the ID of the next subround

--- a/consensus/mock/subroundHandlerMock.go
+++ b/consensus/mock/subroundHandlerMock.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"context"
+
 	"github.com/ElrondNetwork/elrond-go/consensus"
 )
 
@@ -19,7 +21,7 @@ type SubroundHandlerMock struct {
 }
 
 // DoWork -
-func (srm *SubroundHandlerMock) DoWork(roundHandler consensus.RoundHandler) bool {
+func (srm *SubroundHandlerMock) DoWork(_ context.Context, roundHandler consensus.RoundHandler) bool {
 	return srm.DoWorkCalled(roundHandler)
 }
 

--- a/consensus/spos/bls/export_test.go
+++ b/consensus/spos/bls/export_test.go
@@ -1,6 +1,7 @@
 package bls
 
 import (
+	"context"
 	"time"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
@@ -130,7 +131,7 @@ type SubroundStartRound *subroundStartRound
 
 // DoStartRoundJob method does the job of the subround StartRound
 func (sr *subroundStartRound) DoStartRoundJob() bool {
-	return sr.doStartRoundJob()
+	return sr.doStartRoundJob(context.Background())
 }
 
 // DoStartRoundConsensusCheck method checks if the consensus is achieved in the subround StartRound
@@ -160,7 +161,7 @@ func (sr *subroundBlock) BlockChain() data.ChainHandler {
 
 // DoBlockJob method does the job of the subround Block
 func (sr *subroundBlock) DoBlockJob() bool {
-	return sr.doBlockJob()
+	return sr.doBlockJob(context.Background())
 }
 
 // ProcessReceivedBlock method processes the received proposed block in the subround Block
@@ -220,7 +221,7 @@ type SubroundSignature *subroundSignature
 
 // DoSignatureJob method does the job of the subround Signature
 func (sr *subroundSignature) DoSignatureJob() bool {
-	return sr.doSignatureJob()
+	return sr.doSignatureJob(context.Background())
 }
 
 // ReceivedSignature method is called when a signature is received through the signature channel
@@ -245,7 +246,7 @@ type SubroundEndRound *subroundEndRound
 
 // DoEndRoundJob method does the job of the subround EndRound
 func (sr *subroundEndRound) DoEndRoundJob() bool {
-	return sr.doEndRoundJob()
+	return sr.doEndRoundJob(context.Background())
 }
 
 // DoEndRoundConsensusCheck method checks if the consensus is achieved

--- a/consensus/spos/bls/subroundBlock.go
+++ b/consensus/spos/bls/subroundBlock.go
@@ -109,8 +109,8 @@ func (sr *subroundBlock) doBlockJob(ctx context.Context) bool {
 }
 
 func printLogMessage(ctx context.Context, baseMessage string, err error) {
-	if common.WasContextClosed(ctx) {
-		log.Debug(baseMessage + "context is closing")
+	if common.IsContextDone(ctx) {
+		log.Debug(baseMessage + " context is closing")
 		return
 	}
 

--- a/consensus/spos/bls/subroundEndRound.go
+++ b/consensus/spos/bls/subroundEndRound.go
@@ -2,6 +2,7 @@ package bls
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -151,7 +152,7 @@ func (sr *subroundEndRound) receivedHeader(headerHandler data.HeaderHandler) {
 }
 
 // doEndRoundJob method does the job of the subround EndRound
-func (sr *subroundEndRound) doEndRoundJob() bool {
+func (sr *subroundEndRound) doEndRoundJob(_ context.Context) bool {
 	if !sr.IsSelfLeaderInCurrentRound() {
 		if sr.IsNodeInConsensusGroup(sr.SelfPubKey()) {
 			err := sr.prepareBroadcastBlockDataForValidator()

--- a/consensus/spos/bls/subroundSignature.go
+++ b/consensus/spos/bls/subroundSignature.go
@@ -1,6 +1,7 @@
 package bls
 
 import (
+	"context"
 	"encoding/hex"
 	"time"
 
@@ -60,7 +61,7 @@ func checkNewSubroundSignatureParams(
 }
 
 // doSignatureJob method does the job of the subround Signature
-func (sr *subroundSignature) doSignatureJob() bool {
+func (sr *subroundSignature) doSignatureJob(_ context.Context) bool {
 	if !sr.IsNodeInConsensusGroup(sr.SelfPubKey()) {
 		return true
 	}
@@ -77,7 +78,7 @@ func (sr *subroundSignature) doSignatureJob() bool {
 	isSelfLeader := sr.IsSelfLeaderInCurrentRound()
 
 	if !isSelfLeader {
-		//TODO: Analyze it is possible to send message only to leader with O(1) instead of O(n)
+		// TODO: Analyze it is possible to send message only to leader with O(1) instead of O(n)
 		cnsMsg := consensus.NewConsensusMessage(
 			sr.GetData(),
 			signatureShare,

--- a/consensus/spos/bls/subroundStartRound.go
+++ b/consensus/spos/bls/subroundStartRound.go
@@ -1,6 +1,7 @@
 package bls
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"sync"
@@ -87,7 +88,7 @@ func (sr *subroundStartRound) SetOutportHandler(outportHandler outport.OutportHa
 }
 
 // doStartRoundJob method does the job of the subround StartRound
-func (sr *subroundStartRound) doStartRoundJob() bool {
+func (sr *subroundStartRound) doStartRoundJob(_ context.Context) bool {
 	sr.ResetConsensusState()
 	sr.RoundIndex = sr.RoundHandler().Index()
 	sr.RoundTimeStamp = sr.RoundHandler().TimeStamp()

--- a/consensus/spos/subround_test.go
+++ b/consensus/spos/subround_test.go
@@ -1,6 +1,7 @@
 package spos_test
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -546,7 +547,7 @@ func TestSubround_NewSubroundShouldWork(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	sr.Job = func() bool {
+	sr.Job = func(_ context.Context) bool {
 		return true
 	}
 	sr.Check = func() bool {
@@ -589,7 +590,7 @@ func TestSubround_DoWorkShouldReturnFalseWhenJobFunctionIsNotSet(t *testing.T) {
 		return time.Until(maxTime)
 	}
 
-	r := sr.DoWork(roundHandlerMock)
+	r := sr.DoWork(context.Background(), roundHandlerMock)
 
 	assert.False(t, r)
 }
@@ -616,7 +617,7 @@ func TestSubround_DoWorkShouldReturnFalseWhenCheckFunctionIsNotSet(t *testing.T)
 		currentPid,
 		&statusHandler.AppStatusHandlerStub{},
 	)
-	sr.Job = func() bool {
+	sr.Job = func(_ context.Context) bool {
 		return true
 	}
 	sr.Check = nil
@@ -627,7 +628,7 @@ func TestSubround_DoWorkShouldReturnFalseWhenCheckFunctionIsNotSet(t *testing.T)
 		return time.Until(maxTime)
 	}
 
-	r := sr.DoWork(roundHandlerMock)
+	r := sr.DoWork(context.Background(), roundHandlerMock)
 	assert.False(t, r)
 }
 
@@ -663,7 +664,7 @@ func testDoWork(t *testing.T, checkDone bool, shouldWork bool) {
 		currentPid,
 		&statusHandler.AppStatusHandlerStub{},
 	)
-	sr.Job = func() bool {
+	sr.Job = func(_ context.Context) bool {
 		return true
 	}
 	sr.Check = func() bool {
@@ -676,7 +677,7 @@ func testDoWork(t *testing.T, checkDone bool, shouldWork bool) {
 		return time.Until(maxTime)
 	}
 
-	r := sr.DoWork(roundHandlerMock)
+	r := sr.DoWork(context.Background(), roundHandlerMock)
 	assert.Equal(t, shouldWork, r)
 }
 
@@ -708,7 +709,7 @@ func TestSubround_DoWorkShouldReturnTrueWhenJobIsDoneAndConsensusIsDoneAfterAWhi
 	checkSuccess := false
 	mut.Unlock()
 
-	sr.Job = func() bool {
+	sr.Job = func(_ context.Context) bool {
 		return true
 	}
 	sr.Check = func() bool {
@@ -733,7 +734,7 @@ func TestSubround_DoWorkShouldReturnTrueWhenJobIsDoneAndConsensusIsDoneAfterAWhi
 		ch <- true
 	}()
 
-	r := sr.DoWork(roundHandlerMock)
+	r := sr.DoWork(context.Background(), roundHandlerMock)
 
 	assert.True(t, r)
 }
@@ -760,7 +761,7 @@ func TestSubround_Previous(t *testing.T) {
 		currentPid,
 		&statusHandler.AppStatusHandlerStub{},
 	)
-	sr.Job = func() bool {
+	sr.Job = func(_ context.Context) bool {
 		return true
 	}
 	sr.Check = func() bool {
@@ -792,7 +793,7 @@ func TestSubround_Current(t *testing.T) {
 		currentPid,
 		&statusHandler.AppStatusHandlerStub{},
 	)
-	sr.Job = func() bool {
+	sr.Job = func(_ context.Context) bool {
 		return true
 	}
 	sr.Check = func() bool {
@@ -824,7 +825,7 @@ func TestSubround_Next(t *testing.T) {
 		currentPid,
 		&statusHandler.AppStatusHandlerStub{},
 	)
-	sr.Job = func() bool {
+	sr.Job = func(_ context.Context) bool {
 		return true
 	}
 	sr.Check = func() bool {
@@ -856,7 +857,7 @@ func TestSubround_StartTime(t *testing.T) {
 		currentPid,
 		&statusHandler.AppStatusHandlerStub{},
 	)
-	sr.Job = func() bool {
+	sr.Job = func(_ context.Context) bool {
 		return true
 	}
 	sr.Check = func() bool {
@@ -888,7 +889,7 @@ func TestSubround_EndTime(t *testing.T) {
 		currentPid,
 		&statusHandler.AppStatusHandlerStub{},
 	)
-	sr.Job = func() bool {
+	sr.Job = func(_ context.Context) bool {
 		return true
 	}
 	sr.Check = func() bool {
@@ -920,7 +921,7 @@ func TestSubround_Name(t *testing.T) {
 		currentPid,
 		&statusHandler.AppStatusHandlerStub{},
 	)
-	sr.Job = func() bool {
+	sr.Job = func(_ context.Context) bool {
 		return true
 	}
 	sr.Check = func() bool {

--- a/process/mock/syncStarterStub.go
+++ b/process/mock/syncStarterStub.go
@@ -1,11 +1,13 @@
 package mock
 
+import "context"
+
 // SyncStarterStub -
 type SyncStarterStub struct {
 	SyncBlockCalled func() error
 }
 
 // SyncBlock -
-func (sss *SyncStarterStub) SyncBlock() error {
+func (sss *SyncStarterStub) SyncBlock(_ context.Context) error {
 	return sss.SyncBlockCalled()
 }

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -500,7 +500,7 @@ func (boot *baseBootstrap) syncBlocks(ctx context.Context) {
 			continue
 		}
 
-		err := boot.syncStarter.SyncBlock()
+		err := boot.syncStarter.SyncBlock(ctx)
 		if err != nil {
 			if common.IsContextDone(ctx) {
 				log.Debug("SyncBlock finished, bootstrap's go routine is stopping...")

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -502,7 +502,7 @@ func (boot *baseBootstrap) syncBlocks(ctx context.Context) {
 
 		err := boot.syncStarter.SyncBlock()
 		if err != nil {
-			if common.WasContextClosed(ctx) {
+			if common.IsContextDone(ctx) {
 				log.Debug("SyncBlock finished, bootstrap's go routine is stopping...")
 				return
 			}

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -502,6 +502,11 @@ func (boot *baseBootstrap) syncBlocks(ctx context.Context) {
 
 		err := boot.syncStarter.SyncBlock()
 		if err != nil {
+			if common.WasContextClosed(ctx) {
+				log.Debug("SyncBlock finished, bootstrap's go routine is stopping...")
+				return
+			}
+
 			log.Debug("SyncBlock", "error", err.Error())
 		}
 	}

--- a/process/sync/interface.go
+++ b/process/sync/interface.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"context"
+
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go/storage"
 )
@@ -20,7 +22,7 @@ type blockBootstrapper interface {
 
 // syncStarter defines the behavior of component that can start sync-ing blocks
 type syncStarter interface {
-	SyncBlock() error
+	SyncBlock(ctx context.Context) error
 }
 
 // forkDetector is the interface needed by base fork detector to deal with shards and meta nodes

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -177,9 +177,7 @@ func (boot *MetaBootstrap) SyncBlock() error {
 	isErrGetNodeFromDB := err != nil && strings.Contains(err.Error(), common.GetNodeFromDBErrorString)
 	if isErrGetNodeFromDB {
 		errSync := boot.syncAccountsDBs()
-		if errSync != nil {
-			log.Debug("SyncBlock syncTrie", "error", errSync)
-		}
+		err = errSync
 	}
 
 	return err

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -172,15 +172,15 @@ func (boot *MetaBootstrap) setLastEpochStartRound() {
 // If either header and body are received the ProcessBlock and CommitBlock method will be called successively.
 // These methods will execute the block and its transactions. Finally if everything works, the block will be committed
 // in the blockchain, and all this mechanism will be reiterated for the next block.
-func (boot *MetaBootstrap) SyncBlock() error {
+func (boot *MetaBootstrap) SyncBlock(ctx context.Context) error {
 	err := boot.syncBlock()
 	isErrGetNodeFromDB := err != nil && strings.Contains(err.Error(), common.GetNodeFromDBErrorString)
 	if isErrGetNodeFromDB {
 		errSync := boot.syncAccountsDBs()
-		if errSync != nil {
+		shouldOutputLog := errSync != nil && !common.IsContextDone(ctx)
+		if shouldOutputLog {
 			log.Debug("SyncBlock syncTrie", "error", errSync)
 		}
-		err = errSync
 	}
 
 	return err

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -177,6 +177,9 @@ func (boot *MetaBootstrap) SyncBlock() error {
 	isErrGetNodeFromDB := err != nil && strings.Contains(err.Error(), common.GetNodeFromDBErrorString)
 	if isErrGetNodeFromDB {
 		errSync := boot.syncAccountsDBs()
+		if errSync != nil {
+			log.Debug("SyncBlock syncTrie", "error", errSync)
+		}
 		err = errSync
 	}
 

--- a/process/sync/metablock_test.go
+++ b/process/sync/metablock_test.go
@@ -1625,7 +1625,7 @@ func TestMetaBootstrap_SyncBlockErrGetNodeDBShouldSyncAccounts(t *testing.T) {
 	bs, _ := sync.NewMetaBootstrap(args)
 	err := bs.SyncBlock()
 
-	assert.Equal(t, errGetNodeFromDB, err)
+	assert.Nil(t, err)
 	assert.True(t, accountsSyncCalled)
 	assert.True(t, validatorSyncCalled)
 }

--- a/process/sync/metablock_test.go
+++ b/process/sync/metablock_test.go
@@ -2,6 +2,7 @@ package sync_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"reflect"
 	goSync "sync"
@@ -431,7 +432,7 @@ func TestMetaBootstrap_SyncBlockShouldCallRollBack(t *testing.T) {
 	args.BlockProcessor = createMetaBlockProcessor(args.ChainHandler)
 
 	bs, _ := sync.NewMetaBootstrap(args)
-	r := bs.SyncBlock()
+	r := bs.SyncBlock(context.Background())
 
 	assert.Equal(t, process.ErrNilHeadersNonceHashStorage, r)
 }
@@ -468,7 +469,7 @@ func TestMetaBootstrap_ShouldReturnTimeIsOutWhenMissingHeader(t *testing.T) {
 	args.BlockProcessor = createMetaBlockProcessor(args.ChainHandler)
 
 	bs, _ := sync.NewMetaBootstrap(args)
-	r := bs.SyncBlock()
+	r := bs.SyncBlock(context.Background())
 
 	assert.Equal(t, process.ErrTimeIsOut, r)
 }
@@ -654,7 +655,7 @@ func TestMetaBootstrap_ShouldReturnNilErr(t *testing.T) {
 	)
 
 	bs, _ := sync.NewMetaBootstrap(args)
-	r := bs.SyncBlock()
+	r := bs.SyncBlock(context.Background())
 
 	assert.Nil(t, r)
 }
@@ -722,7 +723,7 @@ func TestMetaBootstrap_SyncBlockShouldReturnErrorWhenProcessBlockFailed(t *testi
 	)
 
 	bs, _ := sync.NewMetaBootstrap(args)
-	err := bs.SyncBlock()
+	err := bs.SyncBlock(context.Background())
 
 	assert.Equal(t, process.ErrBlockHashDoesNotMatch, err)
 }
@@ -1623,9 +1624,9 @@ func TestMetaBootstrap_SyncBlockErrGetNodeDBShouldSyncAccounts(t *testing.T) {
 	}}
 
 	bs, _ := sync.NewMetaBootstrap(args)
-	err := bs.SyncBlock()
+	err := bs.SyncBlock(context.Background())
 
-	assert.Nil(t, err)
+	assert.Equal(t, errGetNodeFromDB, err)
 	assert.True(t, accountsSyncCalled)
 	assert.True(t, validatorSyncCalled)
 }

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -141,9 +141,7 @@ func (boot *ShardBootstrap) SyncBlock() error {
 	isErrGetNodeFromDB := err != nil && strings.Contains(err.Error(), common.GetNodeFromDBErrorString)
 	if isErrGetNodeFromDB {
 		errSync := boot.syncUserAccountsState()
-		if errSync != nil {
-			log.Debug("SyncBlock syncTrie", "error", errSync)
-		}
+		err = errSync
 	}
 
 	return err

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -141,6 +141,9 @@ func (boot *ShardBootstrap) SyncBlock() error {
 	isErrGetNodeFromDB := err != nil && strings.Contains(err.Error(), common.GetNodeFromDBErrorString)
 	if isErrGetNodeFromDB {
 		errSync := boot.syncUserAccountsState()
+		if errSync != nil {
+			log.Debug("SyncBlock syncTrie", "error", errSync)
+		}
 		err = errSync
 	}
 

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -136,15 +136,15 @@ func (boot *ShardBootstrap) StartSyncingBlocks() {
 // If either header and body are received the ProcessBlock and CommitBlock method will be called successively.
 // These methods will execute the block and its transactions. Finally if everything works, the block will be committed
 // in the blockchain, and all this mechanism will be reiterated for the next block.
-func (boot *ShardBootstrap) SyncBlock() error {
+func (boot *ShardBootstrap) SyncBlock(ctx context.Context) error {
 	err := boot.syncBlock()
 	isErrGetNodeFromDB := err != nil && strings.Contains(err.Error(), common.GetNodeFromDBErrorString)
 	if isErrGetNodeFromDB {
 		errSync := boot.syncUserAccountsState()
-		if errSync != nil {
+		shouldOutputLog := errSync != nil && !common.IsContextDone(ctx)
+		if shouldOutputLog {
 			log.Debug("SyncBlock syncTrie", "error", errSync)
 		}
-		err = errSync
 	}
 
 	return err

--- a/process/sync/shardblock_test.go
+++ b/process/sync/shardblock_test.go
@@ -2062,7 +2062,7 @@ func TestShardBootstrap_SyncBlockGetNodeDBErrorShouldSync(t *testing.T) {
 	bs, _ := sync.NewShardBootstrap(args)
 
 	err := bs.SyncBlock()
-	assert.Equal(t, errGetNodeFromDB, err)
+	assert.Nil(t, err)
 	assert.True(t, syncCalled)
 }
 

--- a/process/sync/shardblock_test.go
+++ b/process/sync/shardblock_test.go
@@ -2,6 +2,7 @@ package sync_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -501,7 +502,7 @@ func TestBootstrap_SyncBlockShouldCallForkChoice(t *testing.T) {
 	args.BlockProcessor = createBlockProcessor(args.ChainHandler)
 
 	bs, _ := sync.NewShardBootstrap(args)
-	r := bs.SyncBlock()
+	r := bs.SyncBlock(context.Background())
 
 	assert.Equal(t, process.ErrNilHeadersStorage, r)
 }
@@ -539,7 +540,7 @@ func TestBootstrap_ShouldReturnTimeIsOutWhenMissingHeader(t *testing.T) {
 	args.BlockProcessor = createBlockProcessor(args.ChainHandler)
 
 	bs, _ := sync.NewShardBootstrap(args)
-	r := bs.SyncBlock()
+	r := bs.SyncBlock(context.Background())
 
 	assert.Equal(t, process.ErrTimeIsOut, r)
 }
@@ -596,7 +597,7 @@ func TestBootstrap_ShouldReturnTimeIsOutWhenMissingBody(t *testing.T) {
 
 	bs, _ := sync.NewShardBootstrap(args)
 	bs.RequestHeaderWithNonce(2)
-	r := bs.SyncBlock()
+	r := bs.SyncBlock(context.Background())
 
 	assert.Equal(t, process.ErrTimeIsOut, r)
 }
@@ -805,7 +806,7 @@ func TestBootstrap_ShouldReturnNilErr(t *testing.T) {
 	)
 
 	bs, _ := sync.NewShardBootstrap(args)
-	r := bs.SyncBlock()
+	r := bs.SyncBlock(context.Background())
 
 	assert.Nil(t, r)
 }
@@ -888,7 +889,7 @@ func TestBootstrap_SyncBlockShouldReturnErrorWhenProcessBlockFailed(t *testing.T
 
 	bs, _ := sync.NewShardBootstrap(args)
 
-	err := bs.SyncBlock()
+	err := bs.SyncBlock(context.Background())
 	assert.Equal(t, process.ErrBlockHashDoesNotMatch, err)
 }
 
@@ -2061,8 +2062,8 @@ func TestShardBootstrap_SyncBlockGetNodeDBErrorShouldSync(t *testing.T) {
 
 	bs, _ := sync.NewShardBootstrap(args)
 
-	err := bs.SyncBlock()
-	assert.Nil(t, err)
+	err := bs.SyncBlock(context.Background())
+	assert.Equal(t, errGetNodeFromDB, err)
 	assert.True(t, syncCalled)
 }
 


### PR DESCRIPTION
- suppressed original processing errors when the node is shuffling between shards