### PR TITLE
Backwards compatibility fixes 2022.01.27

### DIFF
--- a/factory/apiResolverFactory.go
+++ b/factory/apiResolverFactory.go
@@ -271,6 +271,7 @@ func createScQueryElement(
 		CompiledSCPool:     smartContractsCache,
 		WorkingDir:         args.workingDir,
 		EpochNotifier:      args.coreComponents.EpochNotifier(),
+		EnableEpochs:       args.epochConfig.EnableEpochs,
 		NilCompiledSCStore: true,
 	}
 

--- a/factory/blockProcessorCreator.go
+++ b/factory/blockProcessorCreator.go
@@ -988,6 +988,7 @@ func (pcf *processComponentsFactory) createVMFactoryShard(
 		EpochNotifier:      pcf.coreData.EpochNotifier(),
 		NilCompiledSCStore: false,
 		ConfigSCStorage:    configSCStorage,
+		EnableEpochs:       pcf.epochConfig.EnableEpochs,
 	}
 
 	argsNewVMFactory := shard.ArgVMContainerFactory{
@@ -1026,6 +1027,7 @@ func (pcf *processComponentsFactory) createVMFactoryMeta(
 		NFTStorageHandler:  nftStorageHandler,
 		EpochNotifier:      pcf.coreData.EpochNotifier(),
 		NilCompiledSCStore: false,
+		EnableEpochs:       pcf.epochConfig.EnableEpochs,
 	}
 
 	argsNewVMContainer := metachain.ArgsNewVMContainerFactory{

--- a/genesis/process/genesisBlockCreator.go
+++ b/genesis/process/genesisBlockCreator.go
@@ -220,7 +220,7 @@ func mustDoGenesisProcess(arg ArgsGenesisBlockCreator) bool {
 }
 
 func (gbc *genesisBlockCreator) createEmptyGenesisBlocks() (map[uint32]data.HeaderHandler, error) {
-	err := gbc.computeDNSAddresses()
+	err := gbc.computeDNSAddresses(createGenesisConfig())
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +267,7 @@ func (gbc *genesisBlockCreator) CreateGenesisBlocks() (map[uint32]data.HeaderHan
 			return nil, err
 		}
 
-		err = gbc.computeDNSAddresses()
+		err = gbc.computeDNSAddresses(gbc.arg.EpochConfig.EnableEpochs)
 		if err != nil {
 			return nil, err
 		}
@@ -402,7 +402,7 @@ func (gbc *genesisBlockCreator) createHeaders(
 }
 
 // in case of hardfork initial smart contracts deployment is not called as they are all imported from previous state
-func (gbc *genesisBlockCreator) computeDNSAddresses() error {
+func (gbc *genesisBlockCreator) computeDNSAddresses(enableEpochs config.EnableEpochs) error {
 	var dnsSC genesis.InitialSmartContractHandler
 	for _, sc := range gbc.arg.SmartContractParser.InitialSmartContracts() {
 		if sc.GetType() == genesis.DNSType {
@@ -435,6 +435,7 @@ func (gbc *genesisBlockCreator) computeDNSAddresses() error {
 		CompiledSCPool:     gbc.arg.Data.Datapool().SmartContracts(),
 		EpochNotifier:      epochNotifier,
 		NilCompiledSCStore: true,
+		EnableEpochs:       enableEpochs,
 	}
 	blockChainHook, err := hooks.NewBlockChainHookImpl(argsHook)
 	if err != nil {

--- a/genesis/process/genesisBlockCreator_test.go
+++ b/genesis/process/genesisBlockCreator_test.go
@@ -35,7 +35,7 @@ import (
 
 var nodePrice = big.NewInt(5000)
 
-//TODO improve code coverage of this package
+// TODO improve code coverage of this package
 func createMockArgument(
 	t *testing.T,
 	genesisFilename string,
@@ -250,7 +250,7 @@ func TestGenesisBlockCreator_CreateGenesisBlockAfterHardForkShouldCreateSCResult
 	)
 	hardForkGbc, err := NewGenesisBlockCreator(newArgs)
 	assert.Nil(t, err)
-	err = hardForkGbc.computeDNSAddresses()
+	err = hardForkGbc.computeDNSAddresses(gbc.arg.EpochConfig.EnableEpochs)
 	assert.Nil(t, err)
 
 	mapAfterHardForkAddresses, err := newArgs.SmartContractParser.GetDeployedSCAddresses(genesis.DNSType)

--- a/genesis/process/metaGenesisBlockCreator.go
+++ b/genesis/process/metaGenesisBlockCreator.go
@@ -284,6 +284,7 @@ func createProcessorsForMetaGenesisBlock(arg ArgsGenesisBlockCreator, enableEpoc
 		CompiledSCPool:     arg.Data.Datapool().SmartContracts(),
 		EpochNotifier:      epochNotifier,
 		NilCompiledSCStore: true,
+		EnableEpochs:       enableEpochs,
 	}
 
 	pubKeyVerifier, err := disabled.NewMessageSignVerifier(arg.BlockSignKeyGen)

--- a/genesis/process/shardGenesisBlockCreator.go
+++ b/genesis/process/shardGenesisBlockCreator.go
@@ -97,6 +97,7 @@ func createGenesisConfig() config.EnableEpochs {
 		MultiESDTTransferFixOnCallBackOnEnableEpoch:       unreachableEpoch,
 		OptimizeGasUsedInCrossMiniBlocksEnableEpoch:       unreachableEpoch,
 		CorrectFirstQueuedEpoch:                           unreachableEpoch,
+		CorrectJailedNotUnstakedEmptyQueueEpoch:           unreachableEpoch,
 		FixOOGReturnCodeEnableEpoch:                       unreachableEpoch,
 		RemoveNonUpdatedStorageEnableEpoch:                unreachableEpoch,
 		DeleteDelegatorAfterClaimRewardsEnableEpoch:       unreachableEpoch,
@@ -109,6 +110,7 @@ func createGenesisConfig() config.EnableEpochs {
 		CleanUpInformativeSCRsEnableEpoch:                 unreachableEpoch,
 		StorageAPICostOptimizationEnableEpoch:             unreachableEpoch,
 		TransformToMultiShardCreateEnableEpoch:            unreachableEpoch,
+		ESDTRegisterAndSetAllRolesEnableEpoch:             unreachableEpoch,
 	}
 }
 
@@ -346,10 +348,10 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, enableEpo
 		Accounts:                     arg.Accounts,
 		ShardCoordinator:             arg.ShardCoordinator,
 		EpochNotifier:                epochNotifier,
-		ESDTMultiTransferEnableEpoch: unreachableEpoch,
-		ESDTTransferRoleEnableEpoch:  unreachableEpoch,
-		GlobalMintBurnDisableEpoch:   unreachableEpoch,
-		ESDTTransferMetaEnableEpoch:  unreachableEpoch,
+		ESDTMultiTransferEnableEpoch: enableEpochs.ESDTMultiTransferEnableEpoch,
+		ESDTTransferRoleEnableEpoch:  enableEpochs.ESDTTransferRoleEnableEpoch,
+		GlobalMintBurnDisableEpoch:   enableEpochs.GlobalMintBurnDisableEpoch,
+		ESDTTransferMetaEnableEpoch:  enableEpochs.BuiltInFunctionOnMetaEnableEpoch,
 	}
 	builtInFuncs, nftStorageHandler, err := builtInFunctions.CreateBuiltInFuncContainerAndNFTStorageHandler(argsBuiltIn)
 	if err != nil {
@@ -370,6 +372,7 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, enableEpo
 		CompiledSCPool:     arg.Data.Datapool().SmartContracts(),
 		EpochNotifier:      epochNotifier,
 		NilCompiledSCStore: true,
+		EnableEpochs:       enableEpochs,
 	}
 	esdtTransferParser, err := parsers.NewESDTTransferParser(arg.Core.InternalMarshalizer())
 	if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -57,11 +57,9 @@ github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/agnivade/levenshtein v1.0.3/go.mod h1:4SFRZbbXWLF4MU1T9Qg0pGgH3Pjs+t6ie5efyrwRJXs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
@@ -966,7 +964,6 @@ github.com/shurcooL/vfsgen v0.0.0-20180121065927-ffb13db8def0/go.mod h1:TrYk7fJV
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -1330,7 +1327,6 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -2,6 +2,7 @@ package block
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -284,6 +285,11 @@ func (sp *shardProcessor) ProcessBlock(
 
 	if !sp.verifyStateRoot(header.GetRootHash()) {
 		err = process.ErrRootStateDoesNotMatch
+		return err
+	}
+
+	if header.Nonce == 512480 {
+		err = errors.New("forced error on header with nonce 512480")
 		return err
 	}
 

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -2,7 +2,6 @@ package block
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -285,11 +284,6 @@ func (sp *shardProcessor) ProcessBlock(
 
 	if !sp.verifyStateRoot(header.GetRootHash()) {
 		err = process.ErrRootStateDoesNotMatch
-		return err
-	}
-
-	if header.Nonce == 512480 {
-		err = errors.New("forced error on header with nonce 512480")
 		return err
 	}
 

--- a/process/mock/accountWrapperMock.go
+++ b/process/mock/accountWrapperMock.go
@@ -158,7 +158,7 @@ func (awm *AccountWrapMock) AccountDataHandler() vmcommon.AccountDataHandler {
 	return awm.trackableDataTrie
 }
 
-//IncreaseNonce -
+// IncreaseNonce -
 func (awm *AccountWrapMock) IncreaseNonce(val uint64) {
 	awm.nonce = awm.nonce + val
 }

--- a/process/smartContract/hooks/blockChainHook_test.go
+++ b/process/smartContract/hooks/blockChainHook_test.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"testing"
 
+	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
+	"github.com/ElrondNetwork/elrond-go-core/data/esdt"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/mock"
@@ -17,6 +20,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 	dataRetrieverMock "github.com/ElrondNetwork/elrond-go/testscommon/dataRetriever"
 	stateMock "github.com/ElrondNetwork/elrond-go/testscommon/state"
+	"github.com/ElrondNetwork/elrond-go/testscommon/trie"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	vmcommonBuiltInFunctions "github.com/ElrondNetwork/elrond-vm-common/builtInFunctions"
 	"github.com/pkg/errors"
@@ -534,4 +538,201 @@ func TestBlockChainHookImpl_ProcessBuiltInFunction(t *testing.T) {
 	output, err := bh.ProcessBuiltInFunction(input)
 	require.NoError(t, err)
 	require.Equal(t, vmcommon.Ok, output.ReturnCode)
+}
+
+func TestBlockChainHookImpl_GetESDTToken(t *testing.T) {
+	t.Parallel()
+
+	address := []byte("address")
+	token := []byte("tkn")
+	nonce := uint64(0)
+	emptyESDTData := &esdt.ESDigitalToken{Value: big.NewInt(0)}
+	expectedErr := errors.New("expected error")
+	completeEsdtTokenKey := []byte(core.ElrondProtectedKeyPrefix + core.ESDTKeyIdentifier + string(token))
+	testESDTData := &esdt.ESDigitalToken{
+		Type:       uint32(core.Fungible),
+		Value:      big.NewInt(1),
+		Properties: []byte("properties"),
+		TokenMetaData: &esdt.MetaData{
+			Nonce:      1,
+			Name:       []byte("name"),
+			Creator:    []byte("creator"),
+			Royalties:  2,
+			Hash:       []byte("hash"),
+			URIs:       [][]byte{[]byte("uri1"), []byte("uri2")},
+			Attributes: []byte("attributes"),
+		},
+		Reserved: []byte("reserved"),
+	}
+
+	t.Run("account not found returns an empty esdt data", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockVMAccountsArguments()
+		args.Accounts = &stateMock.AccountsStub{
+			GetExistingAccountCalled: func(_ []byte) (vmcommon.AccountHandler, error) {
+				return nil, state.ErrAccNotFound
+			},
+		}
+
+		bh, _ := hooks.NewBlockChainHookImpl(args)
+		esdtData, err := bh.GetESDTToken(address, token, nonce)
+		assert.Nil(t, err)
+		require.NotNil(t, esdtData)
+		assert.Equal(t, emptyESDTData, esdtData)
+	})
+	t.Run("accountsDB errors returns error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockVMAccountsArguments()
+		args.Accounts = &stateMock.AccountsStub{
+			GetExistingAccountCalled: func(_ []byte) (vmcommon.AccountHandler, error) {
+				return nil, expectedErr
+			},
+		}
+
+		bh, _ := hooks.NewBlockChainHookImpl(args)
+		esdtData, err := bh.GetESDTToken(address, token, nonce)
+		assert.Nil(t, esdtData)
+		assert.Equal(t, expectedErr, err)
+	})
+	t.Run("backwards compatibility - retrieve value errors, should return error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockVMAccountsArguments()
+		args.Accounts = &stateMock.AccountsStub{
+			GetExistingAccountCalled: func(addres []byte) (vmcommon.AccountHandler, error) {
+				addressHandler := mock.NewAccountWrapMock(address)
+				addressHandler.SetDataTrie(nil)
+
+				return addressHandler, nil
+			},
+		}
+
+		bh, _ := hooks.NewBlockChainHookImpl(args)
+		bh.SetFlagOptimizeNFTStore(false)
+
+		esdtData, err := bh.GetESDTToken(address, token, nonce)
+		assert.Nil(t, esdtData)
+		assert.Equal(t, state.ErrNilTrie, err)
+	})
+	t.Run("backwards compatibility - empty byte slice should return empty esdt token", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockVMAccountsArguments()
+		args.Accounts = &stateMock.AccountsStub{
+			GetExistingAccountCalled: func(addres []byte) (vmcommon.AccountHandler, error) {
+				addressHandler := mock.NewAccountWrapMock(address)
+				addressHandler.SetDataTrie(&trie.TrieStub{
+					GetCalled: func(key []byte) ([]byte, error) {
+						return make([]byte, 0), nil
+					},
+				})
+
+				return addressHandler, nil
+			},
+		}
+
+		bh, _ := hooks.NewBlockChainHookImpl(args)
+		bh.SetFlagOptimizeNFTStore(false)
+
+		esdtData, err := bh.GetESDTToken(address, token, nonce)
+		assert.Equal(t, emptyESDTData, esdtData)
+		assert.Nil(t, err)
+	})
+	t.Run("backwards compatibility - should load the esdt data in case of an NFT", func(t *testing.T) {
+		t.Parallel()
+
+		nftNonce := uint64(44)
+		args := createMockVMAccountsArguments()
+		args.Accounts = &stateMock.AccountsStub{
+			GetExistingAccountCalled: func(addres []byte) (vmcommon.AccountHandler, error) {
+				addressHandler := mock.NewAccountWrapMock(address)
+				buffToken, _ := args.Marshalizer.Marshal(testESDTData)
+				key := append(completeEsdtTokenKey, big.NewInt(0).SetUint64(nftNonce).Bytes()...)
+				_ = addressHandler.DataTrieTracker().SaveKeyValue(key, buffToken)
+
+				return addressHandler, nil
+			},
+		}
+
+		bh, _ := hooks.NewBlockChainHookImpl(args)
+		bh.SetFlagOptimizeNFTStore(false)
+
+		esdtData, err := bh.GetESDTToken(address, token, nftNonce)
+		assert.Equal(t, testESDTData, esdtData)
+		assert.Nil(t, err)
+	})
+	t.Run("backwards compatibility - should load the esdt data", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockVMAccountsArguments()
+		args.Accounts = &stateMock.AccountsStub{
+			GetExistingAccountCalled: func(addres []byte) (vmcommon.AccountHandler, error) {
+				addressHandler := mock.NewAccountWrapMock(address)
+				buffToken, _ := args.Marshalizer.Marshal(testESDTData)
+				_ = addressHandler.DataTrieTracker().SaveKeyValue(completeEsdtTokenKey, buffToken)
+
+				return addressHandler, nil
+			},
+		}
+
+		bh, _ := hooks.NewBlockChainHookImpl(args)
+		bh.SetFlagOptimizeNFTStore(false)
+
+		esdtData, err := bh.GetESDTToken(address, token, nonce)
+		assert.Equal(t, testESDTData, esdtData)
+		assert.Nil(t, err)
+	})
+	t.Run("new optimized implementation - NFTStorageHandler errors", func(t *testing.T) {
+		t.Parallel()
+
+		nftNonce := uint64(44)
+		args := createMockVMAccountsArguments()
+		args.Accounts = &stateMock.AccountsStub{
+			GetExistingAccountCalled: func(addres []byte) (vmcommon.AccountHandler, error) {
+				return mock.NewAccountWrapMock(address), nil
+			},
+		}
+		args.NFTStorageHandler = &testscommon.SimpleNFTStorageHandlerStub{
+			GetESDTNFTTokenOnDestinationCalled: func(accnt vmcommon.UserAccountHandler, esdtTokenKey []byte, nonce uint64) (*esdt.ESDigitalToken, bool, error) {
+				assert.Equal(t, completeEsdtTokenKey, esdtTokenKey)
+				assert.Equal(t, nftNonce, nonce)
+
+				return nil, false, expectedErr
+			},
+		}
+
+		bh, _ := hooks.NewBlockChainHookImpl(args)
+
+		esdtData, err := bh.GetESDTToken(address, token, nftNonce)
+		assert.Nil(t, esdtData)
+		assert.Equal(t, expectedErr, err)
+	})
+	t.Run("new optimized implementation - should return the esdt by calling NFTStorageHandler", func(t *testing.T) {
+		t.Parallel()
+
+		nftNonce := uint64(44)
+		args := createMockVMAccountsArguments()
+		args.Accounts = &stateMock.AccountsStub{
+			GetExistingAccountCalled: func(addres []byte) (vmcommon.AccountHandler, error) {
+				return mock.NewAccountWrapMock(address), nil
+			},
+		}
+		args.NFTStorageHandler = &testscommon.SimpleNFTStorageHandlerStub{
+			GetESDTNFTTokenOnDestinationCalled: func(accnt vmcommon.UserAccountHandler, esdtTokenKey []byte, nonce uint64) (*esdt.ESDigitalToken, bool, error) {
+				assert.Equal(t, completeEsdtTokenKey, esdtTokenKey)
+				assert.Equal(t, nftNonce, nonce)
+				copyToken := *testESDTData
+
+				return &copyToken, false, nil
+			},
+		}
+
+		bh, _ := hooks.NewBlockChainHookImpl(args)
+
+		esdtData, err := bh.GetESDTToken(address, token, nftNonce)
+		assert.Equal(t, testESDTData, esdtData)
+		assert.Nil(t, err)
+	})
 }

--- a/process/smartContract/hooks/export_test.go
+++ b/process/smartContract/hooks/export_test.go
@@ -1,0 +1,6 @@
+package hooks
+
+// SetFlagOptimizeNFTStore -
+func (bh *BlockChainHookImpl) SetFlagOptimizeNFTStore(value bool) {
+	bh.flagOptimizeNFTStore.SetValue(value)
+}


### PR DESCRIPTION
- backwards compatibility fix by using old method of retrieving the ESDT token from the trie. The legacy function is tight to the `optimize nft metadata store` flag
- fixed the forgotten epoch configs flags on the blockchain hook implementation