### PR TITLE
Improve code coverage scheduled transactions

### DIFF
--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -1555,6 +1555,8 @@ func TestBaseProcessor_ProcessScheduledBlockShouldFail(t *testing.T) {
 	t.Parallel()
 
 	t.Run("execute all scheduled txs fail", func(t *testing.T) {
+		t.Parallel()
+
 		arguments := CreateMockArguments(createComponentHolderMocks())
 
 		localErr := errors.New("execute all err")
@@ -1574,6 +1576,8 @@ func TestBaseProcessor_ProcessScheduledBlockShouldFail(t *testing.T) {
 		assert.Equal(t, localErr, err)
 	})
 	t.Run("get root hash fail", func(t *testing.T) {
+		t.Parallel()
+
 		arguments := CreateMockArguments(createComponentHolderMocks())
 
 		localErr := errors.New("root hash err")
@@ -1731,6 +1735,8 @@ func TestBaseProcessor_gasAndFeesDelta(t *testing.T) {
 	}
 
 	t.Run("final accumulatedFees lower then initial accumulatedFees", func(t *testing.T) {
+		t.Parallel()
+
 		initialGasAndFees := scheduled.GasAndFees{
 			AccumulatedFees: big.NewInt(100),
 		}
@@ -1743,6 +1749,8 @@ func TestBaseProcessor_gasAndFeesDelta(t *testing.T) {
 		assert.Equal(t, zeroGasAndFees, gasAndFees)
 	})
 	t.Run("final devFees lower then initial devFees", func(t *testing.T) {
+		t.Parallel()
+
 		initialGasAndFees := scheduled.GasAndFees{
 			AccumulatedFees: big.NewInt(10),
 			DeveloperFees:   big.NewInt(100),
@@ -1757,6 +1765,8 @@ func TestBaseProcessor_gasAndFeesDelta(t *testing.T) {
 		assert.Equal(t, zeroGasAndFees, gasAndFees)
 	})
 	t.Run("final gasProvided lower then initial gasProvided", func(t *testing.T) {
+		t.Parallel()
+
 		initialGasAndFees := scheduled.GasAndFees{
 			AccumulatedFees: big.NewInt(11),
 			DeveloperFees:   big.NewInt(12),
@@ -1773,6 +1783,8 @@ func TestBaseProcessor_gasAndFeesDelta(t *testing.T) {
 		assert.Equal(t, zeroGasAndFees, gasAndFees)
 	})
 	t.Run("final gasPenalized lower then initial gasPenalized", func(t *testing.T) {
+		t.Parallel()
+
 		initialGasAndFees := scheduled.GasAndFees{
 			AccumulatedFees: big.NewInt(11),
 			DeveloperFees:   big.NewInt(12),
@@ -1791,6 +1803,8 @@ func TestBaseProcessor_gasAndFeesDelta(t *testing.T) {
 		assert.Equal(t, zeroGasAndFees, gasAndFees)
 	})
 	t.Run("final gasRefunded lower then initial gasRefunded", func(t *testing.T) {
+		t.Parallel()
+
 		initialGasAndFees := scheduled.GasAndFees{
 			AccumulatedFees: big.NewInt(11),
 			DeveloperFees:   big.NewInt(12),
@@ -1811,6 +1825,8 @@ func TestBaseProcessor_gasAndFeesDelta(t *testing.T) {
 		assert.Equal(t, zeroGasAndFees, gasAndFees)
 	})
 	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
 		expectedGasAndFees := scheduled.GasAndFees{
 			AccumulatedFees: big.NewInt(0).Sub(finalGasAndFees.AccumulatedFees, initialGasAndFees.AccumulatedFees),
 			DeveloperFees:   big.NewInt(0).Sub(finalGasAndFees.DeveloperFees, initialGasAndFees.DeveloperFees),

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/rewardTx"
+	"github.com/ElrondNetwork/elrond-go-core/data/scheduled"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/elrond-go-core/data/typeConverters/uint64ByteSlice"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
@@ -1548,4 +1549,271 @@ func TestBaseProcessor_updateState(t *testing.T) {
 
 	assert.Equal(t, []byte("rootHash"), pruneRootHash)
 	assert.Equal(t, []byte("rootHash"), cancelPruneRootHash)
+}
+
+func TestBaseProcessor_ProcessScheduledBlockShouldFail(t *testing.T) {
+	t.Parallel()
+
+	t.Run("execute all scheduled txs fail", func(t *testing.T) {
+		arguments := CreateMockArguments(createComponentHolderMocks())
+
+		localErr := errors.New("execute all err")
+		scheduledTxsExec := &testscommon.ScheduledTxsExecutionStub{
+			ExecuteAllCalled: func(func() time.Duration) error {
+				return localErr
+			},
+		}
+
+		arguments.ScheduledTxsExecutionHandler = scheduledTxsExec
+		bp, _ := blproc.NewShardProcessor(arguments)
+
+		err := bp.ProcessScheduledBlock(
+			&block.MetaBlock{}, &block.Body{}, haveTime,
+		)
+
+		assert.Equal(t, localErr, err)
+	})
+	t.Run("get root hash fail", func(t *testing.T) {
+		arguments := CreateMockArguments(createComponentHolderMocks())
+
+		localErr := errors.New("root hash err")
+		accounts := &stateMock.AccountsStub{
+			RootHashCalled: func() ([]byte, error) {
+				return nil, localErr
+			},
+		}
+		arguments.AccountsDB[state.UserAccountsState] = accounts
+
+		bp, _ := blproc.NewShardProcessor(arguments)
+
+		err := bp.ProcessScheduledBlock(
+			&block.MetaBlock{}, &block.Body{}, haveTime,
+		)
+
+		assert.Equal(t, localErr, err)
+	})
+}
+
+func TestBaseProcessor_ProcessScheduledBlockShouldWork(t *testing.T) {
+	t.Parallel()
+	rootHash := []byte("root hash to be tested")
+	accounts := &stateMock.AccountsStub{
+		RootHashCalled: func() ([]byte, error) {
+			return rootHash, nil
+		},
+	}
+
+	initialGasAndFees := scheduled.GasAndFees{
+		AccumulatedFees: big.NewInt(10),
+		DeveloperFees:   big.NewInt(10),
+		GasProvided:     10,
+		GasPenalized:    10,
+		GasRefunded:     10,
+	}
+
+	finalGasAndFees := scheduled.GasAndFees{
+		AccumulatedFees: big.NewInt(100),
+		DeveloperFees:   big.NewInt(100),
+		GasProvided:     100,
+		GasPenalized:    100,
+		GasRefunded:     100,
+	}
+
+	feeHandler := createFeeHandlerMockForProcessScheduledBlock(initialGasAndFees, finalGasAndFees)
+	gasHandler := createGasHandlerMockForProcessScheduledBlock(initialGasAndFees, finalGasAndFees)
+
+	expectedGasAndFees := blproc.GasAndFeesDelta(initialGasAndFees, finalGasAndFees)
+
+	wasCalledSetScheduledRootHash := false
+	wasCalledSetScheduledGasAndFees := false
+	scheduledTxsExec := &testscommon.ScheduledTxsExecutionStub{
+		ExecuteAllCalled: func(func() time.Duration) error {
+			return nil
+		},
+		SetScheduledRootHashCalled: func(hash []byte) {
+			wasCalledSetScheduledRootHash = true
+			require.Equal(t, rootHash, hash)
+		},
+		SetScheduledGasAndFeesCalled: func(gasAndFees scheduled.GasAndFees) {
+			wasCalledSetScheduledGasAndFees = true
+			require.Equal(t, expectedGasAndFees, gasAndFees)
+		},
+	}
+
+	arguments := CreateMockArguments(createComponentHolderMocks())
+	arguments.AccountsDB[state.UserAccountsState] = accounts
+	arguments.ScheduledTxsExecutionHandler = scheduledTxsExec
+	arguments.FeeHandler = feeHandler
+	arguments.GasHandler = gasHandler
+	bp, _ := blproc.NewShardProcessor(arguments)
+
+	err := bp.ProcessScheduledBlock(
+		&block.MetaBlock{}, &block.Body{}, haveTime,
+	)
+	require.Nil(t, err)
+
+	assert.True(t, wasCalledSetScheduledGasAndFees)
+	assert.True(t, wasCalledSetScheduledRootHash)
+}
+
+func createFeeHandlerMockForProcessScheduledBlock(initial, final scheduled.GasAndFees) process.TransactionFeeHandler {
+	runCount := 0
+	return &mock.FeeAccumulatorStub{
+		GetAccumulatedFeesCalled: func() *big.Int {
+			if runCount%4 >= 2 {
+				return final.AccumulatedFees
+			}
+			runCount++
+			return initial.AccumulatedFees
+		},
+		GetDeveloperFeesCalled: func() *big.Int {
+			if runCount%4 >= 2 {
+				return final.DeveloperFees
+			}
+			runCount++
+			return initial.DeveloperFees
+		},
+	}
+}
+
+func createGasHandlerMockForProcessScheduledBlock(initial, final scheduled.GasAndFees) process.GasHandler {
+	runCount := 0
+	return &mock.GasHandlerMock{
+		TotalGasProvidedCalled: func() uint64 {
+			if runCount%6 >= 3 {
+				return final.GasProvided
+			}
+			runCount++
+			return initial.GasProvided
+		},
+		TotalGasPenalizedCalled: func() uint64 {
+			if runCount%6 >= 3 {
+				return final.GasPenalized
+			}
+			runCount++
+			return initial.GasPenalized
+		},
+		TotalGasRefundedCalled: func() uint64 {
+			if runCount%6 >= 3 {
+				return final.GasRefunded
+			}
+			runCount++
+			return initial.GasRefunded
+		},
+	}
+}
+
+func TestBaseProcessor_gasAndFeesDelta(t *testing.T) {
+	zeroGasAndFees := process.GetZeroGasAndFees()
+
+	initialGasAndFees := scheduled.GasAndFees{
+		AccumulatedFees: big.NewInt(10),
+		DeveloperFees:   big.NewInt(10),
+		GasProvided:     10,
+		GasPenalized:    10,
+		GasRefunded:     10,
+	}
+
+	finalGasAndFees := scheduled.GasAndFees{
+		AccumulatedFees: big.NewInt(100),
+		DeveloperFees:   big.NewInt(100),
+		GasProvided:     100,
+		GasPenalized:    100,
+		GasRefunded:     100,
+	}
+
+	t.Run("final accumulatedFees lower then initial accumulatedFees", func(t *testing.T) {
+		initialGasAndFees := scheduled.GasAndFees{
+			AccumulatedFees: big.NewInt(100),
+		}
+
+		finalGasAndFees := scheduled.GasAndFees{
+			AccumulatedFees: big.NewInt(10),
+		}
+
+		gasAndFees := blproc.GasAndFeesDelta(initialGasAndFees, finalGasAndFees)
+		assert.Equal(t, zeroGasAndFees, gasAndFees)
+	})
+	t.Run("final devFees lower then initial devFees", func(t *testing.T) {
+		initialGasAndFees := scheduled.GasAndFees{
+			AccumulatedFees: big.NewInt(10),
+			DeveloperFees:   big.NewInt(100),
+		}
+
+		finalGasAndFees := scheduled.GasAndFees{
+			AccumulatedFees: big.NewInt(100),
+			DeveloperFees:   big.NewInt(10),
+		}
+
+		gasAndFees := blproc.GasAndFeesDelta(initialGasAndFees, finalGasAndFees)
+		assert.Equal(t, zeroGasAndFees, gasAndFees)
+	})
+	t.Run("final gasProvided lower then initial gasProvided", func(t *testing.T) {
+		initialGasAndFees := scheduled.GasAndFees{
+			AccumulatedFees: big.NewInt(10),
+			DeveloperFees:   big.NewInt(10),
+			GasProvided:     100,
+		}
+
+		finalGasAndFees := scheduled.GasAndFees{
+			AccumulatedFees: big.NewInt(100),
+			DeveloperFees:   big.NewInt(100),
+			GasProvided:     10,
+		}
+
+		gasAndFees := blproc.GasAndFeesDelta(initialGasAndFees, finalGasAndFees)
+		assert.Equal(t, zeroGasAndFees, gasAndFees)
+	})
+	t.Run("final gasPenalized lower then initial gasPenalized", func(t *testing.T) {
+		initialGasAndFees := scheduled.GasAndFees{
+			AccumulatedFees: big.NewInt(10),
+			DeveloperFees:   big.NewInt(10),
+			GasProvided:     10,
+			GasPenalized:    100,
+		}
+
+		finalGasAndFees := scheduled.GasAndFees{
+			AccumulatedFees: big.NewInt(100),
+			DeveloperFees:   big.NewInt(100),
+			GasProvided:     100,
+			GasPenalized:    10,
+		}
+
+		gasAndFees := blproc.GasAndFeesDelta(initialGasAndFees, finalGasAndFees)
+		assert.Equal(t, zeroGasAndFees, gasAndFees)
+	})
+	t.Run("final gasRefunded lower then initial gasRefunded", func(t *testing.T) {
+		initialGasAndFees := scheduled.GasAndFees{
+			AccumulatedFees: big.NewInt(10),
+			DeveloperFees:   big.NewInt(10),
+			GasProvided:     10,
+			GasPenalized:    10,
+			GasRefunded:     100,
+		}
+
+		finalGasAndFees := scheduled.GasAndFees{
+			AccumulatedFees: big.NewInt(100),
+			DeveloperFees:   big.NewInt(100),
+			GasProvided:     100,
+			GasPenalized:    100,
+			GasRefunded:     10,
+		}
+
+		gasAndFees := blproc.GasAndFeesDelta(initialGasAndFees, finalGasAndFees)
+		assert.Equal(t, zeroGasAndFees, gasAndFees)
+	})
+	t.Run("should work", func(t *testing.T) {
+		expectedGasAndFees := scheduled.GasAndFees{
+			AccumulatedFees: big.NewInt(0).Sub(finalGasAndFees.AccumulatedFees, initialGasAndFees.AccumulatedFees),
+			DeveloperFees:   big.NewInt(0).Sub(finalGasAndFees.DeveloperFees, initialGasAndFees.DeveloperFees),
+			GasProvided:     finalGasAndFees.GasProvided - initialGasAndFees.GasProvided,
+			GasPenalized:    finalGasAndFees.GasPenalized - initialGasAndFees.GasPenalized,
+			GasRefunded:     finalGasAndFees.GasRefunded - initialGasAndFees.GasRefunded,
+		}
+
+		gasAndFees := blproc.GasAndFeesDelta(initialGasAndFees, finalGasAndFees)
+
+		assert.Equal(t, expectedGasAndFees, gasAndFees)
+	})
+
 }

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -1656,6 +1656,7 @@ func TestBaseProcessor_ProcessScheduledBlockShouldWork(t *testing.T) {
 	assert.True(t, wasCalledSetScheduledRootHash)
 }
 
+// get initial fees on first getGasAndFees call and final fees on second call
 func createFeeHandlerMockForProcessScheduledBlock(initial, final scheduled.GasAndFees) process.TransactionFeeHandler {
 	runCount := 0
 	return &mock.FeeAccumulatorStub{
@@ -1676,6 +1677,7 @@ func createFeeHandlerMockForProcessScheduledBlock(initial, final scheduled.GasAn
 	}
 }
 
+// get initial gas consumed on first getGasAndFees call and final gas consumed on second call
 func createGasHandlerMockForProcessScheduledBlock(initial, final scheduled.GasAndFees) process.GasHandler {
 	runCount := 0
 	return &mock.GasHandlerMock{

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -1604,25 +1604,31 @@ func TestBaseProcessor_ProcessScheduledBlockShouldWork(t *testing.T) {
 	}
 
 	initialGasAndFees := scheduled.GasAndFees{
-		AccumulatedFees: big.NewInt(10),
-		DeveloperFees:   big.NewInt(10),
-		GasProvided:     10,
-		GasPenalized:    10,
-		GasRefunded:     10,
+		AccumulatedFees: big.NewInt(11),
+		DeveloperFees:   big.NewInt(12),
+		GasProvided:     13,
+		GasPenalized:    14,
+		GasRefunded:     15,
 	}
 
 	finalGasAndFees := scheduled.GasAndFees{
-		AccumulatedFees: big.NewInt(100),
-		DeveloperFees:   big.NewInt(100),
-		GasProvided:     100,
-		GasPenalized:    100,
-		GasRefunded:     100,
+		AccumulatedFees: big.NewInt(101),
+		DeveloperFees:   big.NewInt(103),
+		GasProvided:     105,
+		GasPenalized:    107,
+		GasRefunded:     109,
 	}
 
 	feeHandler := createFeeHandlerMockForProcessScheduledBlock(initialGasAndFees, finalGasAndFees)
 	gasHandler := createGasHandlerMockForProcessScheduledBlock(initialGasAndFees, finalGasAndFees)
 
-	expectedGasAndFees := blproc.GasAndFeesDelta(initialGasAndFees, finalGasAndFees)
+	expectedGasAndFees := scheduled.GasAndFees{
+		AccumulatedFees: big.NewInt(90),
+		DeveloperFees:   big.NewInt(91),
+		GasProvided:     92,
+		GasPenalized:    93,
+		GasRefunded:     94,
+	}
 
 	wasCalledSetScheduledRootHash := false
 	wasCalledSetScheduledGasAndFees := false
@@ -1709,19 +1715,19 @@ func TestBaseProcessor_gasAndFeesDelta(t *testing.T) {
 	zeroGasAndFees := process.GetZeroGasAndFees()
 
 	initialGasAndFees := scheduled.GasAndFees{
-		AccumulatedFees: big.NewInt(10),
-		DeveloperFees:   big.NewInt(10),
-		GasProvided:     10,
-		GasPenalized:    10,
-		GasRefunded:     10,
+		AccumulatedFees: big.NewInt(11),
+		DeveloperFees:   big.NewInt(12),
+		GasProvided:     13,
+		GasPenalized:    14,
+		GasRefunded:     15,
 	}
 
 	finalGasAndFees := scheduled.GasAndFees{
-		AccumulatedFees: big.NewInt(100),
-		DeveloperFees:   big.NewInt(100),
-		GasProvided:     100,
-		GasPenalized:    100,
-		GasRefunded:     100,
+		AccumulatedFees: big.NewInt(101),
+		DeveloperFees:   big.NewInt(103),
+		GasProvided:     105,
+		GasPenalized:    107,
+		GasRefunded:     109,
 	}
 
 	t.Run("final accumulatedFees lower then initial accumulatedFees", func(t *testing.T) {
@@ -1752,14 +1758,14 @@ func TestBaseProcessor_gasAndFeesDelta(t *testing.T) {
 	})
 	t.Run("final gasProvided lower then initial gasProvided", func(t *testing.T) {
 		initialGasAndFees := scheduled.GasAndFees{
-			AccumulatedFees: big.NewInt(10),
-			DeveloperFees:   big.NewInt(10),
+			AccumulatedFees: big.NewInt(11),
+			DeveloperFees:   big.NewInt(12),
 			GasProvided:     100,
 		}
 
 		finalGasAndFees := scheduled.GasAndFees{
-			AccumulatedFees: big.NewInt(100),
-			DeveloperFees:   big.NewInt(100),
+			AccumulatedFees: big.NewInt(101),
+			DeveloperFees:   big.NewInt(102),
 			GasProvided:     10,
 		}
 
@@ -1768,16 +1774,16 @@ func TestBaseProcessor_gasAndFeesDelta(t *testing.T) {
 	})
 	t.Run("final gasPenalized lower then initial gasPenalized", func(t *testing.T) {
 		initialGasAndFees := scheduled.GasAndFees{
-			AccumulatedFees: big.NewInt(10),
-			DeveloperFees:   big.NewInt(10),
-			GasProvided:     10,
+			AccumulatedFees: big.NewInt(11),
+			DeveloperFees:   big.NewInt(12),
+			GasProvided:     13,
 			GasPenalized:    100,
 		}
 
 		finalGasAndFees := scheduled.GasAndFees{
-			AccumulatedFees: big.NewInt(100),
-			DeveloperFees:   big.NewInt(100),
-			GasProvided:     100,
+			AccumulatedFees: big.NewInt(101),
+			DeveloperFees:   big.NewInt(102),
+			GasProvided:     103,
 			GasPenalized:    10,
 		}
 
@@ -1786,18 +1792,18 @@ func TestBaseProcessor_gasAndFeesDelta(t *testing.T) {
 	})
 	t.Run("final gasRefunded lower then initial gasRefunded", func(t *testing.T) {
 		initialGasAndFees := scheduled.GasAndFees{
-			AccumulatedFees: big.NewInt(10),
-			DeveloperFees:   big.NewInt(10),
-			GasProvided:     10,
-			GasPenalized:    10,
+			AccumulatedFees: big.NewInt(11),
+			DeveloperFees:   big.NewInt(12),
+			GasProvided:     13,
+			GasPenalized:    14,
 			GasRefunded:     100,
 		}
 
 		finalGasAndFees := scheduled.GasAndFees{
-			AccumulatedFees: big.NewInt(100),
-			DeveloperFees:   big.NewInt(100),
-			GasProvided:     100,
-			GasPenalized:    100,
+			AccumulatedFees: big.NewInt(101),
+			DeveloperFees:   big.NewInt(102),
+			GasProvided:     103,
+			GasPenalized:    104,
 			GasRefunded:     10,
 		}
 

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
+	"github.com/ElrondNetwork/elrond-go-core/data/scheduled"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
@@ -136,7 +137,7 @@ func NewShardProcessorEmptyWith3shards(
 			Version:                        "softwareVersion",
 			HistoryRepository:              &dblookupext.HistoryRepositoryStub{},
 			EpochNotifier:                  &epochNotifier.EpochNotifierStub{},
-			RoundNotifier:      &mock.RoundNotifierStub{},
+			RoundNotifier:                  &mock.RoundNotifierStub{},
 			GasHandler:                     &mock.GasHandlerMock{},
 			ScheduledTxsExecutionHandler:   &testscommon.ScheduledTxsExecutionStub{},
 			ScheduledMiniBlocksEnableEpoch: 2,
@@ -414,4 +415,8 @@ func (bp *baseProcessor) UpdateState(
 	statePruningQueue core.Queue,
 ) {
 	bp.updateStateStorage(finalHeader, rootHash, prevRootHash, accounts, statePruningQueue)
+}
+
+func GasAndFeesDelta(initialGasAndFees, finalGasAndFees scheduled.GasAndFees) scheduled.GasAndFees {
+	return gasAndFeesDelta(initialGasAndFees, finalGasAndFees)
 }

--- a/process/block/pendingMb/pendingMiniBlocks_test.go
+++ b/process/block/pendingMb/pendingMiniBlocks_test.go
@@ -73,7 +73,7 @@ func TestPendingMiniBlockHeaders_AddProcessedHeaderShouldWork(t *testing.T) {
 		},
 	}
 
-	t.Run("same send and receiver shard, empty pendingMb", func(t *testing.T) {
+	t.Run("same sender and receiver shard, empty pendingMb", func(t *testing.T) {
 		header := createMockHeader(shardMiniBlockHeaders, miniBlockHeaders)
 		err := pmb.AddProcessedHeader(header)
 		assert.Nil(t, err)
@@ -112,7 +112,7 @@ func TestPendingMiniBlockHeaders_AddProcessedHeaderShouldWork(t *testing.T) {
 		pendingMb := pmb.GetPendingMiniBlocks(core.MetachainShardId)
 		assert.Equal(t, 0, len(pendingMb))
 	})
-	t.Run("same send and receiver shard, empty pendingMb", func(t *testing.T) {
+	t.Run("different sender and receiver shard, non empty pendingMb", func(t *testing.T) {
 		receivedShardId := uint32(1)
 		miniBlockHeaders := []block.MiniBlockHeader{
 			{
@@ -129,6 +129,36 @@ func TestPendingMiniBlockHeaders_AddProcessedHeaderShouldWork(t *testing.T) {
 			},
 		}
 		header := createMockHeader(shardMiniBlockHeaders, miniBlockHeaders)
+		err := pmb.AddProcessedHeader(header)
+		assert.Nil(t, err)
+
+		pendingMb := pmb.GetPendingMiniBlocks(receivedShardId)
+		assert.Equal(t, 2, len(pendingMb))
+	})
+	t.Run("different sender and receiver shard, delete already added, non empty pendingMb", func(t *testing.T) {
+		receivedShardId := uint32(1)
+		miniBlockHeaders := []block.MiniBlockHeader{
+			{
+				Hash:            []byte("mb header hash"),
+				SenderShardID:   0,
+				ReceiverShardID: receivedShardId,
+			},
+		}
+		shardMiniBlockHeaders := []block.MiniBlockHeader{
+			{
+				Hash:            []byte("shard mb header hash"),
+				SenderShardID:   0,
+				ReceiverShardID: receivedShardId,
+			},
+		}
+		header := createMockHeader(shardMiniBlockHeaders, miniBlockHeaders)
+
+		mbHashes := make([][]byte, 0)
+		mbHashes = append(mbHashes, []byte("mbHash1"))
+		mbHashes = append(mbHashes, []byte("mbHash2"))
+
+		pmb.SetPendingMiniBlocks(receivedShardId, mbHashes)
+
 		err := pmb.AddProcessedHeader(header)
 		assert.Nil(t, err)
 

--- a/process/block/pendingMb/pendingMiniBlocks_test.go
+++ b/process/block/pendingMb/pendingMiniBlocks_test.go
@@ -3,6 +3,8 @@ package pendingMb_test
 import (
 	"testing"
 
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/block/pendingMb"
@@ -14,11 +16,11 @@ func TestNewPendingMiniBlocks_ShouldWork(t *testing.T) {
 
 	pmb, err := pendingMb.NewPendingMiniBlocks()
 
-	assert.NotNil(t, pmb)
+	assert.False(t, check.IfNil(pmb))
 	assert.Nil(t, err)
 }
 
-func TestPendingMiniBlockHeaders_AddCommittedHeaderNilHeaderShouldErr(t *testing.T) {
+func TestPendingMiniBlockHeaders_AddProcessedHeaderNilHeaderShouldErr(t *testing.T) {
 	t.Parallel()
 
 	pmb, _ := pendingMb.NewPendingMiniBlocks()
@@ -35,6 +37,104 @@ func TestPendingMiniBlockHeaders_AddProcessedHeaderWrongHeaderShouldErr(t *testi
 	err := pmb.AddProcessedHeader(header)
 
 	assert.Equal(t, process.ErrWrongTypeAssertion, err)
+}
+
+func createMockHeader(
+	shardMiniBlockHeaders []block.MiniBlockHeader,
+	miniBlockHeaders []block.MiniBlockHeader,
+) *block.MetaBlock {
+	return &block.MetaBlock{
+		Nonce: 1,
+		ShardInfo: []block.ShardData{
+			{
+				ShardMiniBlockHeaders: shardMiniBlockHeaders,
+			},
+		},
+		MiniBlockHeaders: miniBlockHeaders,
+	}
+}
+
+func TestPendingMiniBlockHeaders_AddProcessedHeaderShouldWork(t *testing.T) {
+	t.Parallel()
+
+	pmb, _ := pendingMb.NewPendingMiniBlocks()
+	shardMiniBlockHeaders := []block.MiniBlockHeader{
+		{
+			Hash:            []byte("mb header hash"),
+			SenderShardID:   0,
+			ReceiverShardID: 0,
+		},
+	}
+	miniBlockHeaders := []block.MiniBlockHeader{
+		{
+			Hash:            []byte("mb header hash"),
+			SenderShardID:   0,
+			ReceiverShardID: 0,
+		},
+	}
+
+	t.Run("same send and receiver shard, empty pendingMb", func(t *testing.T) {
+		header := createMockHeader(shardMiniBlockHeaders, miniBlockHeaders)
+		err := pmb.AddProcessedHeader(header)
+		assert.Nil(t, err)
+
+		pendingMb := pmb.GetPendingMiniBlocks(0)
+		assert.Equal(t, 0, len(pendingMb))
+	})
+	t.Run("metachain receiver shard, empty pendingMb", func(t *testing.T) {
+		receivedShardId := core.MetachainShardId
+		miniBlockHeaders := []block.MiniBlockHeader{
+			{
+				Hash:            []byte("mb header hash"),
+				SenderShardID:   0,
+				ReceiverShardID: receivedShardId,
+			},
+		}
+		header := createMockHeader(shardMiniBlockHeaders, miniBlockHeaders)
+		err := pmb.AddProcessedHeader(header)
+		assert.Nil(t, err)
+
+		pendingMb := pmb.GetPendingMiniBlocks(receivedShardId)
+		assert.Equal(t, 0, len(pendingMb))
+	})
+	t.Run("metachain sender shard, empty pendingMb", func(t *testing.T) {
+		miniBlockHeaders := []block.MiniBlockHeader{
+			{
+				Hash:            []byte("mb header hash"),
+				SenderShardID:   core.MetachainShardId,
+				ReceiverShardID: core.AllShardId,
+			},
+		}
+		header := createMockHeader(shardMiniBlockHeaders, miniBlockHeaders)
+		err := pmb.AddProcessedHeader(header)
+		assert.Nil(t, err)
+
+		pendingMb := pmb.GetPendingMiniBlocks(core.MetachainShardId)
+		assert.Equal(t, 0, len(pendingMb))
+	})
+	t.Run("same send and receiver shard, empty pendingMb", func(t *testing.T) {
+		receivedShardId := uint32(1)
+		miniBlockHeaders := []block.MiniBlockHeader{
+			{
+				Hash:            []byte("mb header hash"),
+				SenderShardID:   0,
+				ReceiverShardID: receivedShardId,
+			},
+		}
+		shardMiniBlockHeaders := []block.MiniBlockHeader{
+			{
+				Hash:            []byte("shard mb header hash"),
+				SenderShardID:   0,
+				ReceiverShardID: receivedShardId,
+			},
+		}
+		header := createMockHeader(shardMiniBlockHeaders, miniBlockHeaders)
+		err := pmb.AddProcessedHeader(header)
+		assert.Nil(t, err)
+
+		pendingMb := pmb.GetPendingMiniBlocks(receivedShardId)
+		assert.Equal(t, 2, len(pendingMb))
+	})
 }
 
 func TestPendingMiniBlockHeaders_RevertHeaderNilHeaderShouldErr(t *testing.T) {
@@ -54,4 +154,22 @@ func TestPendingMiniBlockHeaders_RevertHeaderWrongHeaderTypeShouldErr(t *testing
 	err := pmb.RevertHeader(header)
 
 	assert.Equal(t, process.ErrWrongTypeAssertion, err)
+}
+
+func TestPendingMiniBlockHeaders_SetPendingMiniBlocks(t *testing.T) {
+	t.Parallel()
+
+	pmb, _ := pendingMb.NewPendingMiniBlocks()
+
+	mbHashes := make([][]byte, 0)
+	mbHashes = append(mbHashes, []byte("mbHash1"))
+	mbHashes = append(mbHashes, []byte("mbHash2"))
+
+	pmb.SetPendingMiniBlocks(1, mbHashes)
+
+	pendingMb := pmb.GetPendingMiniBlocks(1)
+	assert.Equal(t, 2, len(pendingMb))
+
+	pendingMb = pmb.GetPendingMiniBlocks(0)
+	assert.Equal(t, 0, len(pendingMb))
 }

--- a/process/block/preprocess/scheduledTxsExecution_test.go
+++ b/process/block/preprocess/scheduledTxsExecution_test.go
@@ -793,7 +793,7 @@ func TestScheduledTxsExecution_getMarshalledScheduledRootHashSCRsGasAndFeesShoul
 	assert.Error(t, err)
 }
 
-func TestScheduledTxsExecution_getMarshalledScheduledRootHashSCRsGasAndFees(t *testing.T) {
+func TestScheduledTxsExecution_getMarshalledScheduledRootHashSCRsGasAndFeesShouldWork(t *testing.T) {
 	t.Parallel()
 
 	scheduledRootHash := []byte("root hash")

--- a/process/block/preprocess/scheduledTxsExecution_test.go
+++ b/process/block/preprocess/scheduledTxsExecution_test.go
@@ -813,7 +813,7 @@ func TestScheduledTxsExecution_getMarshalledScheduledRootHashSCRsGasAndFees(t *t
 		Scrs: map[int32]scheduled.SmartContractResults{
 			0: {
 				TxHandlers: []*smartContractResult.SmartContractResult{
-					&smartContractResult.SmartContractResult{
+					{
 						Nonce: 1,
 					},
 				},

--- a/process/block/preprocess/scheduledTxsExecution_test.go
+++ b/process/block/preprocess/scheduledTxsExecution_test.go
@@ -731,7 +731,7 @@ func TestScheduledTxsExecution_getScheduledRootHashSCRsGasAndFeesForHeaderShould
 	t.Parallel()
 
 	headerHash := []byte("root hash")
-	gasAndFees := &scheduled.GasAndFees{
+	expectedGasAndFees := &scheduled.GasAndFees{
 		AccumulatedFees: big.NewInt(100),
 	}
 
@@ -742,7 +742,7 @@ func TestScheduledTxsExecution_getScheduledRootHashSCRsGasAndFeesForHeaderShould
 				TxHandlers: []*smartContractResult.SmartContractResult{},
 			},
 		},
-		GasAndFees: gasAndFees,
+		GasAndFees: expectedGasAndFees,
 	}
 	marshalledSCRsSavedData, _ := json.Marshal(scheduledSCRs)
 
@@ -758,10 +758,10 @@ func TestScheduledTxsExecution_getScheduledRootHashSCRsGasAndFeesForHeaderShould
 		&mock.ShardCoordinatorStub{},
 	)
 
-	scheduledRootHash, txHandlersMap, gasAndFees2, _ := scheduledTxsExec.getScheduledRootHashSCRsGasAndFeesForHeader(headerHash)
+	scheduledRootHash, txHandlersMap, gasAndFees, _ := scheduledTxsExec.getScheduledRootHashSCRsGasAndFeesForHeader(headerHash)
 
 	assert.Equal(t, headerHash, scheduledRootHash)
-	assert.Equal(t, gasAndFees, gasAndFees2)
+	assert.Equal(t, expectedGasAndFees, gasAndFees)
 	assert.NotNil(t, txHandlersMap)
 }
 
@@ -873,11 +873,7 @@ func TestScheduledTxsExecution_RollBackToBlockShouldWork(t *testing.T) {
 			},
 		},
 		GasAndFees: &scheduled.GasAndFees{
-			AccumulatedFees: &big.Int{},
-			DeveloperFees:   &big.Int{},
-			GasProvided:     0,
-			GasPenalized:    0,
-			GasRefunded:     0,
+			AccumulatedFees: big.NewInt(100),
 		}}
 	marshalledSCRsSavedData, _ := json.Marshal(scheduledSCRs)
 

--- a/process/block/preprocess/scheduledTxsExecution_test.go
+++ b/process/block/preprocess/scheduledTxsExecution_test.go
@@ -422,16 +422,22 @@ func TestScheduledTxsExecution_computeScheduledSCRsShouldWork(t *testing.T) {
 	}
 
 	t.Run("nil maps, empty scheduled scrs", func(t *testing.T) {
+		t.Parallel()
+
 		scheduledTxsExec.computeScheduledSCRs(nil, nil)
 
 		assert.Equal(t, 0, len(scheduledTxsExec.mapScheduledSCRs))
 	})
 	t.Run("nil map after txs execition, empty scheduled scrs", func(t *testing.T) {
+		t.Parallel()
+
 		scheduledTxsExec.computeScheduledSCRs(mapAllIntermediateTxsBeforeScheduledExecution, nil)
 
 		assert.Equal(t, 0, len(scheduledTxsExec.mapScheduledSCRs))
 	})
 	t.Run("nil map after txs execition, empty scheduled scrs", func(t *testing.T) {
+		t.Parallel()
+
 		mapAllIntermediateTxsAfterScheduledExecution := map[block.Type]map[string]data.TransactionHandler{
 			0: {
 				"txHash1": &transaction.Transaction{Nonce: 1},
@@ -446,6 +452,8 @@ func TestScheduledTxsExecution_computeScheduledSCRsShouldWork(t *testing.T) {
 		assert.Equal(t, 0, len(scheduledTxsExec.mapScheduledSCRs))
 	})
 	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
 		scheduledTxsExec.computeScheduledSCRs(
 			mapAllIntermediateTxsBeforeScheduledExecution,
 			mapAllIntermediateTxsAfterScheduledExecution,
@@ -471,6 +479,8 @@ func TestScheduledTxsExecution_getAllIntermediateTxsAfterScheduledExecution(t *t
 	}
 
 	t.Run("not already existing txs, different shard", func(t *testing.T) {
+		t.Parallel()
+
 		scheduledTxsExec, _ := NewScheduledTxsExecution(
 			&testscommon.TxProcessorMock{},
 			&mock.TransactionCoordinatorMock{},
@@ -492,6 +502,8 @@ func TestScheduledTxsExecution_getAllIntermediateTxsAfterScheduledExecution(t *t
 		assert.Equal(t, 2, len(scrsInfo))
 	})
 	t.Run("not already existing txs, same shard", func(t *testing.T) {
+		t.Parallel()
+
 		scheduledTxsExec, _ := NewScheduledTxsExecution(
 			&testscommon.TxProcessorMock{},
 			&mock.TransactionCoordinatorMock{},
@@ -513,6 +525,8 @@ func TestScheduledTxsExecution_getAllIntermediateTxsAfterScheduledExecution(t *t
 		assert.Equal(t, 0, len(scrsInfo))
 	})
 	t.Run("not existing block type, different shard", func(t *testing.T) {
+		t.Parallel()
+
 		scheduledTxsExec, _ := NewScheduledTxsExecution(
 			&testscommon.TxProcessorMock{},
 			&mock.TransactionCoordinatorMock{},
@@ -534,6 +548,8 @@ func TestScheduledTxsExecution_getAllIntermediateTxsAfterScheduledExecution(t *t
 		assert.Equal(t, 2, len(scrsInfo))
 	})
 	t.Run("already existing txs, different shard", func(t *testing.T) {
+		t.Parallel()
+
 		scheduledTxsExec, _ := NewScheduledTxsExecution(
 			&testscommon.TxProcessorMock{},
 			&mock.TransactionCoordinatorMock{},
@@ -688,6 +704,8 @@ func TestScheduledTxsExecution_getScheduledRootHashSCRsGasAndFeesForHeaderShould
 	rootHash := []byte("root hash")
 
 	t.Run("failed to get SCRs saved data from storage", func(t *testing.T) {
+		t.Parallel()
+
 		expectedErr := errors.New("storer err")
 		scheduledTxsExec, _ := NewScheduledTxsExecution(
 			&testscommon.TxProcessorMock{},
@@ -701,10 +719,15 @@ func TestScheduledTxsExecution_getScheduledRootHashSCRsGasAndFeesForHeaderShould
 			&mock.ShardCoordinatorStub{},
 		)
 
-		_, _, _, err := scheduledTxsExec.getScheduledRootHashSCRsGasAndFeesForHeader(rootHash)
+		scheduledRootHash, txHandlersMap, gasAndFees, err := scheduledTxsExec.getScheduledRootHashSCRsGasAndFeesForHeader(rootHash)
+		assert.Nil(t, scheduledRootHash)
+		assert.Nil(t, gasAndFees)
+		assert.Nil(t, txHandlersMap)
 		assert.Equal(t, expectedErr, err)
 	})
 	t.Run("failed to unmarshal data", func(t *testing.T) {
+		t.Parallel()
+
 		expectedErr := errors.New("marshaller err")
 		scheduledTxsExec, _ := NewScheduledTxsExecution(
 			&testscommon.TxProcessorMock{},
@@ -722,7 +745,10 @@ func TestScheduledTxsExecution_getScheduledRootHashSCRsGasAndFeesForHeaderShould
 			&mock.ShardCoordinatorStub{},
 		)
 
-		_, _, _, err := scheduledTxsExec.getScheduledRootHashSCRsGasAndFeesForHeader(rootHash)
+		scheduledRootHash, txHandlersMap, gasAndFees, err := scheduledTxsExec.getScheduledRootHashSCRsGasAndFeesForHeader(rootHash)
+		assert.Nil(t, scheduledRootHash)
+		assert.Nil(t, gasAndFees)
+		assert.Nil(t, txHandlersMap)
 		assert.Equal(t, expectedErr, err)
 	})
 }


### PR DESCRIPTION
Improve unit tests coverage in process/block:
- scheduled related stuff: in baseProcess and preprocess/ScheduledTxsExecution
- pendingMiniBlocks