### PR TITLE
snapshot last rootHash after restart

### DIFF
--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -1086,7 +1086,6 @@ func (adb *AccountsDB) SnapshotState(rootHash []byte) {
 		log.Warn("could not set lastSnapshotStarted", "err", err, "rootHash", rootHash)
 	}
 
-	log.Trace("accountsDB.SnapshotState", "root hash", rootHash)
 	trieStorageManager.EnterPruningBufferingMode()
 
 	stats := newSnapshotStatistics(1)

--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -146,7 +146,13 @@ func NewAccountsDB(
 func startSnapshotAfterRestart(adb AccountsAdapter, tsm common.StorageManager) {
 	rootHash, err := tsm.Get([]byte(lastSnapshotStarted))
 	if err != nil {
-		log.Error("startSnapshotAfterRestart root hash", "error", err)
+		log.Warn("startSnapshotAfterRestart root hash", "error", err)
+
+		err = tsm.Put([]byte(common.ActiveDBKey), []byte(common.ActiveDBVal))
+		if err != nil {
+			log.Warn("error while putting active DB value into main storer", "error", err)
+		}
+
 		return
 	}
 	log.Debug("snapshot hash after restart", "hash", rootHash)

--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -1083,7 +1083,7 @@ func (adb *AccountsDB) SnapshotState(rootHash []byte) {
 	adb.lastSnapshot.epoch = epoch
 	err = trieStorageManager.Put([]byte(lastSnapshotStarted), rootHash)
 	if err != nil {
-		log.Warn("could not set lastSnapshotStarted", "err", err)
+		log.Warn("could not set lastSnapshotStarted", "err", err, "rootHash", rootHash)
 	}
 
 	log.Trace("accountsDB.SnapshotState", "root hash", rootHash)

--- a/state/accountsDB_test.go
+++ b/state/accountsDB_test.go
@@ -1988,6 +1988,7 @@ func TestAccountsDB_SnapshotStateCleansCheckpointHashesHolder(t *testing.T) {
 		},
 	}
 	adb, tr, trieStorage := getDefaultStateComponents(checkpointHashesHolder)
+	_ = trieStorage.Put([]byte(common.ActiveDBKey), []byte(common.ActiveDBVal))
 
 	accountsAddresses := generateAccounts(t, 3, adb)
 	newHashes := modifyDataTries(t, accountsAddresses, adb)
@@ -2367,8 +2368,11 @@ func TestAccountsDB_NewAccountsDbStartsSnapshotAfterRestart(t *testing.T) {
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
 			return &testscommon.StorageManagerStub{
-				GetCalled: func(_ []byte) ([]byte, error) {
-					return nil, fmt.Errorf("key not found")
+				GetCalled: func(key []byte) ([]byte, error) {
+					if bytes.Equal(key, []byte(common.ActiveDBKey)) {
+						return nil, fmt.Errorf("key not found")
+					}
+					return []byte("rootHash"), nil
 				},
 				ShouldTakeSnapshotCalled: func() bool {
 					return true

--- a/state/peerAccountsDB.go
+++ b/state/peerAccountsDB.go
@@ -56,6 +56,7 @@ func NewPeerAccountsDB(
 				identifier: "load code",
 			},
 			storagePruningManager: storagePruningManager,
+			lastSnapshot:          &snapshotInfo{},
 		},
 	}
 
@@ -103,6 +104,15 @@ func (adb *PeerAccountsDB) SnapshotState(rootHash []byte) {
 	if !trieStorageManager.ShouldTakeSnapshot() {
 		log.Debug("skipping snapshot for rootHash", "hash", rootHash)
 		return
+	}
+
+	log.Debug("starting snapshot", "rootHash", rootHash, "epoch", epoch)
+
+	adb.lastSnapshot.rootHash = rootHash
+	adb.lastSnapshot.epoch = epoch
+	err = trieStorageManager.Put([]byte(lastSnapshotStarted), rootHash)
+	if err != nil {
+		log.Warn("could not set lastSnapshotStarted", "err", err, "rootHash", rootHash)
 	}
 
 	stats := newSnapshotStatistics(0)

--- a/state/peerAccountsDB_test.go
+++ b/state/peerAccountsDB_test.go
@@ -1,6 +1,7 @@
 package state_test
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"sync"
@@ -237,8 +238,11 @@ func TestPeerAccountsDB_NewAccountsDbStartsSnapshotAfterRestart(t *testing.T) {
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
 			return &testscommon.StorageManagerStub{
-				GetCalled: func(_ []byte) ([]byte, error) {
-					return nil, fmt.Errorf("key not found")
+				GetCalled: func(key []byte) ([]byte, error) {
+					if bytes.Equal(key, []byte(common.ActiveDBKey)) {
+						return nil, fmt.Errorf("key not found")
+					}
+					return []byte("rootHash"), nil
 				},
 				ShouldTakeSnapshotCalled: func() bool {
 					return true


### PR DESCRIPTION
When starting a node, if a snapshot is necessary, start the snapshoting process from the last snapshotRootHash that was not completed.