### PR TITLE
Fixed trie iterators to work with the new AccountsAPI implementation 

### DIFF
--- a/factory/apiResolverFactory.go
+++ b/factory/apiResolverFactory.go
@@ -151,7 +151,6 @@ func CreateApiResolver(args *ApiResolverArgs) (facade.ApiResolver, error) {
 		ShardID:            args.BootstrapComponents.ShardCoordinator().SelfId(),
 		Accounts:           accountsWrapper,
 		PublicKeyConverter: args.CoreComponents.AddressPubKeyConverter(),
-		BlockChain:         args.DataComponents.Blockchain(),
 		QueryService:       scQueryService,
 	}
 	totalStakedValueHandler, err := trieIteratorsFactory.CreateTotalStakedValueHandler(argsProcessors)

--- a/integrationTests/testProcessorNodeWithTestWebServer.go
+++ b/integrationTests/testProcessorNodeWithTestWebServer.go
@@ -173,7 +173,6 @@ func createFacadeComponents(tpn *TestProcessorNode) (nodeFacade.ApiResolver, nod
 		ShardID:            tpn.ShardCoordinator.SelfId(),
 		Accounts:           accountsWrapper,
 		QueryService:       tpn.SCQueryService,
-		BlockChain:         tpn.BlockChain,
 		PublicKeyConverter: TestAddressPubkeyConverter,
 	}
 	totalStakedValueHandler, err := factory.CreateTotalStakedValueHandler(args)

--- a/node/trieIterators/commonStakingProcessor.go
+++ b/node/trieIterators/commonStakingProcessor.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go/epochStart"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/state"
@@ -19,7 +18,6 @@ type stakingValidatorInfo struct {
 
 type commonStakingProcessor struct {
 	queryService process.SCQueryService
-	blockChain   data.ChainHandler
 	accounts     *AccountsWrapper
 }
 
@@ -53,16 +51,6 @@ func (csp *commonStakingProcessor) getValidatorInfoFromSC(validatorAddress []byt
 }
 
 func (csp *commonStakingProcessor) getAccount(scAddress []byte) (state.UserAccountHandler, error) {
-	rootHash := csp.blockChain.GetCurrentBlockRootHash()
-	if len(rootHash) == 0 {
-		return nil, ErrNodeNotInitialized
-	}
-
-	err := csp.accounts.RecreateTrie(rootHash)
-	if err != nil {
-		return nil, err
-	}
-
 	accountHandler, err := csp.accounts.GetExistingAccount(scAddress)
 	if err != nil {
 		return nil, err

--- a/node/trieIterators/delegatedListProcessor.go
+++ b/node/trieIterators/delegatedListProcessor.go
@@ -30,7 +30,6 @@ func NewDelegatedListProcessor(arg ArgTrieIteratorProcessor) (*delegatedListProc
 	return &delegatedListProcessor{
 		commonStakingProcessor: &commonStakingProcessor{
 			queryService: arg.QueryService,
-			blockChain:   arg.BlockChain,
 			accounts:     arg.Accounts,
 		},
 		publicKeyConverter: arg.PublicKeyConverter,
@@ -88,7 +87,7 @@ func (dlp *delegatedListProcessor) getDelegatorsInfo(delegationSC []byte, delega
 	for _, delegatorAddress := range delegatorsList {
 		value, err = dlp.getActiveFund(delegationSC, delegatorAddress)
 		if err != nil {
-			//delegatorAddress byte slice might not represent a real delegator address
+			// delegatorAddress byte slice might not represent a real delegator address
 			continue
 		}
 

--- a/node/trieIterators/directStakedListProcessor.go
+++ b/node/trieIterators/directStakedListProcessor.go
@@ -26,7 +26,6 @@ func NewDirectStakedListProcessor(arg ArgTrieIteratorProcessor) (*directStakedLi
 	return &directStakedListProcessor{
 		commonStakingProcessor: &commonStakingProcessor{
 			queryService: arg.QueryService,
-			blockChain:   arg.BlockChain,
 			accounts:     arg.Accounts,
 		},
 		publicKeyConverter: arg.PublicKeyConverter,

--- a/node/trieIterators/factory/delegatedListHandlerFactory_test.go
+++ b/node/trieIterators/factory/delegatedListHandlerFactory_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go/node/mock"
 	"github.com/ElrondNetwork/elrond-go/node/trieIterators"
-	"github.com/ElrondNetwork/elrond-go/testscommon"
 	stateMock "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,7 +35,6 @@ func TestCreateDelegatedListHandlerHandler_DelegatedListProcessor(t *testing.T) 
 			AccountsAdapter: &stateMock.AccountsStub{},
 		},
 		PublicKeyConverter: &mock.PubkeyConverterMock{},
-		BlockChain:         &testscommon.ChainHandlerStub{},
 		QueryService:       &mock.SCQueryServiceStub{},
 	}
 

--- a/node/trieIterators/factory/directStakedListHandlerFactory_test.go
+++ b/node/trieIterators/factory/directStakedListHandlerFactory_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go/node/mock"
 	"github.com/ElrondNetwork/elrond-go/node/trieIterators"
-	"github.com/ElrondNetwork/elrond-go/testscommon"
 	stateMock "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,7 +35,6 @@ func TestCreateDirectStakedListHandlerHandler_DirectStakedListProcessor(t *testi
 			AccountsAdapter: &stateMock.AccountsStub{},
 		},
 		PublicKeyConverter: &mock.PubkeyConverterMock{},
-		BlockChain:         &testscommon.ChainHandlerStub{},
 		QueryService:       &mock.SCQueryServiceStub{},
 	}
 

--- a/node/trieIterators/factory/stakeValuesHandlerFactory_test.go
+++ b/node/trieIterators/factory/stakeValuesHandlerFactory_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go/node/mock"
 	"github.com/ElrondNetwork/elrond-go/node/trieIterators"
-	"github.com/ElrondNetwork/elrond-go/testscommon"
 	stateMock "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,7 +35,6 @@ func TestCreateTotalStakedValueHandler_TotalStakedValueProcessor(t *testing.T) {
 			AccountsAdapter: &stateMock.AccountsStub{},
 		},
 		PublicKeyConverter: &mock.PubkeyConverterMock{},
-		BlockChain:         &testscommon.ChainHandlerStub{},
 		QueryService:       &mock.SCQueryServiceStub{},
 	}
 

--- a/node/trieIterators/stakeValuesProcessor.go
+++ b/node/trieIterators/stakeValuesProcessor.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
-	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/api"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/state"
@@ -29,7 +28,6 @@ type stakedValuesProcessor struct {
 type ArgTrieIteratorProcessor struct {
 	ShardID            uint32
 	Accounts           *AccountsWrapper
-	BlockChain         data.ChainHandler
 	QueryService       process.SCQueryService
 	PublicKeyConverter core.PubkeyConverter
 }
@@ -44,7 +42,6 @@ func NewTotalStakedValueProcessor(arg ArgTrieIteratorProcessor) (*stakedValuesPr
 	return &stakedValuesProcessor{
 		commonStakingProcessor: &commonStakingProcessor{
 			queryService: arg.QueryService,
-			blockChain:   arg.BlockChain,
 			accounts:     arg.Accounts,
 		},
 		publicKeyConverter: arg.PublicKeyConverter,
@@ -54,9 +51,6 @@ func NewTotalStakedValueProcessor(arg ArgTrieIteratorProcessor) (*stakedValuesPr
 func checkArguments(arg ArgTrieIteratorProcessor) error {
 	if arg.Accounts == nil || check.IfNil(arg.Accounts) {
 		return ErrNilAccountsAdapter
-	}
-	if check.IfNil(arg.BlockChain) {
-		return ErrNilBlockChain
 	}
 	if check.IfNil(arg.QueryService) {
 		return ErrNilQueryService
@@ -98,7 +92,7 @@ func (svp *stakedValuesProcessor) computeBaseStakedAndTopUp() (*big.Int, *big.In
 		return nil, nil, err
 	}
 
-	//TODO investigate if a call to GetAllLeavesKeysOnChannel (without values) might increase performance
+	// TODO investigate if a call to GetAllLeavesKeysOnChannel (without values) might increase performance
 	chLeaves, err := validatorAccount.DataTrie().GetAllLeavesOnChannel(rootHash)
 	if err != nil {
 		return nil, nil, err

--- a/node/trieIterators/stakeValuesProcessor_test.go
+++ b/node/trieIterators/stakeValuesProcessor_test.go
@@ -120,7 +120,7 @@ func TestTotalStakedValueProcessor_GetTotalStakedValue_CannotGetAccount(t *testi
 	require.Equal(t, expectedErr, err)
 }
 
-func TestTotalStakedValueProcessor_GetTotalStakedValue_CannotRecreateTree(t *testing.T) {
+func TestTotalStakedValueProcessor_GetTotalStakedValueAccountsAdapterErrors(t *testing.T) {
 	t.Parallel()
 
 	expectedErr := errors.New("expected error")


### PR DESCRIPTION
- fixed trie iterators to work as designed with new accountsAPI implementation

Testing scenario:

1. start a testnet from `master` branch (or other branch started from `master` branch).
2. test the /network/economics route. It will return an error like operation in account not permitted
3. retest with this branch, the endpoint should work