### PR TITLE
fix tokensParser + more unit tests

### DIFF
--- a/common/tokensParser.go
+++ b/common/tokensParser.go
@@ -5,8 +5,19 @@ import (
 	"strings"
 )
 
-// esdtTickerNumRandChars represents the number of hex-encoded random characters sequence of a ticker
-const esdtTickerNumRandChars = 6
+const (
+	// esdtTickerNumRandChars represents the number of hex-encoded random characters sequence of a ticker
+	esdtTickerNumRandChars = 6
+
+	// separatorChar represents the character that separated the token ticker by the random sequence
+	separatorChar = "-"
+
+	// minLengthForTickerName represents the minimum number of characters a token's ticker can have
+	minLengthForTickerName = 3
+
+	// maxLengthForTickerName represents the maximum number of characters a token's ticker can have
+	maxLengthForTickerName = 10
+)
 
 // TODO: move this to core
 
@@ -15,17 +26,33 @@ func ExtractTokenIDAndNonceFromTokenStorageKey(tokenKey []byte) ([]byte, uint64)
 	// ALC-1q2w3e for fungible
 	// ALC-2w3e4rX for non fungible
 	token := string(tokenKey)
-	splitToken := strings.Split(token, "-")
-	if len(splitToken) < 2 {
+
+	// filtering by the index of first occurrence is faster than splitting
+	indexOfFirstHyphen := strings.Index(token, separatorChar)
+	if indexOfFirstHyphen < 0 {
 		return tokenKey, 0
 	}
 
-	if len(splitToken[1]) < esdtTickerNumRandChars+1 {
+	tokenTicker := token[:indexOfFirstHyphen]
+	randomSequencePlusNonce := token[indexOfFirstHyphen+1:]
+
+	tokenTickerLen := len(tokenTicker)
+
+	areTickerAndRandomSequenceInvalid := tokenTickerLen == 0 ||
+		tokenTickerLen < minLengthForTickerName ||
+		tokenTickerLen > maxLengthForTickerName ||
+		len(randomSequencePlusNonce) == 0
+
+	if areTickerAndRandomSequenceInvalid {
+		return tokenKey, 0
+	}
+
+	if len(randomSequencePlusNonce) < esdtTickerNumRandChars+1 {
 		return tokenKey, 0
 	}
 
 	// ALC-1q2w3eX - X is the nonce
-	nonceStr := splitToken[1][esdtTickerNumRandChars:]
+	nonceStr := randomSequencePlusNonce[esdtTickerNumRandChars:]
 	nonceBigInt := big.NewInt(0).SetBytes([]byte(nonceStr))
 
 	numCharsSinceNonce := len(token) - len(nonceStr)

--- a/common/tokensParser_test.go
+++ b/common/tokensParser_test.go
@@ -13,10 +13,7 @@ func TestExtractTokenIDAndNonceFromTokenStorageKey(t *testing.T) {
 	t.Run("regular esdt, should work", func(t *testing.T) {
 		t.Parallel()
 
-		id := "ALC-1q2w3e"
-		tokenName, nonce := ExtractTokenIDAndNonceFromTokenStorageKey([]byte(id))
-		require.Equal(t, uint64(0), nonce)
-		require.Equal(t, []byte(id), tokenName)
+		checkTickerAndNonceExtraction(t, "ALC-1q2w3e", "ALC-1q2w3e", 0)
 	})
 
 	t.Run("non fungible, should work", func(t *testing.T) {
@@ -25,17 +22,42 @@ func TestExtractTokenIDAndNonceFromTokenStorageKey(t *testing.T) {
 		nonceBI := big.NewInt(37)
 		id := "ALC-1q2w3e"
 		tokenKey := id + string(nonceBI.Bytes())
-		tokenName, nonce := ExtractTokenIDAndNonceFromTokenStorageKey([]byte(tokenKey))
-		require.Equal(t, nonceBI.Uint64(), nonce)
-		require.Equal(t, []byte(id), tokenName)
+
+		checkTickerAndNonceExtraction(t, tokenKey, id, nonceBI.Uint64())
 	})
 
-	t.Run("invalid key, should return provided key", func(t *testing.T) {
+	t.Run("malformed keys, should be treated correctly", func(t *testing.T) {
 		t.Parallel()
 
-		id := "INVALID_KEY"
-		tokenName, nonce := ExtractTokenIDAndNonceFromTokenStorageKey([]byte(id))
-		require.Equal(t, uint64(0), nonce)
-		require.Equal(t, []byte(id), tokenName)
+		checkTickerAndNonceExtraction(t, "INVALID_KEY", "INVALID_KEY", 0)
+
+		checkTickerAndNonceExtraction(t, "--------", "--------", 0)
+
+		checkTickerAndNonceExtraction(t, "a--------", "a--------", 0)
+
+		checkTickerAndNonceExtraction(t, "abcdef", "abcdef", 0)
+
+		checkTickerAndNonceExtraction(t, "a-b-c-d-e-f", "a-b-c-d-e-f", 0)
+
+		checkTickerAndNonceExtraction(t, "abc-def", "abc-def", 0)
+
+		checkTickerAndNonceExtraction(t, "abcdef-", "abcdef-", 0)
+
+		checkTickerAndNonceExtraction(t, "abcdefabcdefabcdef-", "abcdefabcdefabcdef-", 0)
+
+		checkTickerAndNonceExtraction(t, "ab-cdefabcdefabcdef", "ab-cdefabcdefabcdef", 0)
 	})
+
+	t.Run("test for edge case when the nonce is the hyphen ascii char", func(t *testing.T) {
+		t.Parallel()
+
+		// "-" represents nonce 45 and should not be treated as a separator
+		checkTickerAndNonceExtraction(t, "EGLDMEXF-8aa8b6-", "EGLDMEXF-8aa8b6", 45)
+	})
+}
+
+func checkTickerAndNonceExtraction(t *testing.T, input string, expectedTicker string, expectedNonce uint64) {
+	tokenName, nonce := ExtractTokenIDAndNonceFromTokenStorageKey([]byte(input))
+	require.Equal(t, expectedNonce, nonce)
+	require.Equal(t, []byte(expectedTicker), tokenName)
 }


### PR DESCRIPTION
fix for "ExtractTokenIDAndNonceFromTokenStorageKey" when the nonce could have been represented as a hyphen when the key is converted to string. also, added more guards in regards to the ticker's min/max length + optimize by using `Index` instead of `Split`