### PR TITLE
Double transactions detector & tx cache fixes

### DIFF
--- a/factory/blockProcessorCreator.go
+++ b/factory/blockProcessorCreator.go
@@ -324,6 +324,15 @@ func (pcf *processComponentsFactory) newShardBlockProcessor(
 		return nil, nil, err
 	}
 
+	argsDetector := coordinator.ArgsPrintDoubleTransactionsDetector{
+		Marshaller:    pcf.coreData.InternalMarshalizer(),
+		Hasher:        pcf.coreData.Hasher(),
+		EpochNotifier: pcf.epochNotifier,
+
+		AddFailedRelayedTxToInvalidMBsDisableEpoch: pcf.epochConfig.EnableEpochs.AddFailedRelayedTxToInvalidMBsDisableEpoch,
+	}
+	doubleTransactionsDetector, err := coordinator.NewPrintDoubleTransactionsDetector(argsDetector)
+
 	argsTransactionCoordinator := coordinator.ArgTransactionCoordinator{
 		Hasher:                            pcf.coreData.Hasher(),
 		Marshalizer:                       pcf.coreData.InternalMarshalizer(),
@@ -344,6 +353,7 @@ func (pcf *processComponentsFactory) newShardBlockProcessor(
 		EpochNotifier:                     pcf.epochNotifier,
 		ScheduledTxsExecutionHandler:      scheduledTxsExecutionHandler,
 		ScheduledMiniBlocksEnableEpoch:    enableEpochs.ScheduledMiniBlocksEnableEpoch,
+		DoubleTransactionsDetector:        doubleTransactionsDetector,
 	}
 	txCoordinator, err := coordinator.NewTransactionCoordinator(argsTransactionCoordinator)
 	if err != nil {
@@ -595,6 +605,15 @@ func (pcf *processComponentsFactory) newMetaBlockProcessor(
 		return nil, nil, err
 	}
 
+	argsDetector := coordinator.ArgsPrintDoubleTransactionsDetector{
+		Marshaller:    pcf.coreData.InternalMarshalizer(),
+		Hasher:        pcf.coreData.Hasher(),
+		EpochNotifier: pcf.epochNotifier,
+
+		AddFailedRelayedTxToInvalidMBsDisableEpoch: pcf.epochConfig.EnableEpochs.AddFailedRelayedTxToInvalidMBsDisableEpoch,
+	}
+	doubleTransactionsDetector, err := coordinator.NewPrintDoubleTransactionsDetector(argsDetector)
+
 	argsTransactionCoordinator := coordinator.ArgTransactionCoordinator{
 		Hasher:                            pcf.coreData.Hasher(),
 		Marshalizer:                       pcf.coreData.InternalMarshalizer(),
@@ -615,6 +634,7 @@ func (pcf *processComponentsFactory) newMetaBlockProcessor(
 		EpochNotifier:                     pcf.epochNotifier,
 		ScheduledTxsExecutionHandler:      scheduledTxsExecutionHandler,
 		ScheduledMiniBlocksEnableEpoch:    enableEpochs.ScheduledMiniBlocksEnableEpoch,
+		DoubleTransactionsDetector:        doubleTransactionsDetector,
 	}
 	txCoordinator, err := coordinator.NewTransactionCoordinator(argsTransactionCoordinator)
 	if err != nil {

--- a/genesis/process/metaGenesisBlockCreator.go
+++ b/genesis/process/metaGenesisBlockCreator.go
@@ -463,6 +463,15 @@ func createProcessorsForMetaGenesisBlock(arg ArgsGenesisBlockCreator, enableEpoc
 		return nil, err
 	}
 
+	argsDetector := coordinator.ArgsPrintDoubleTransactionsDetector{
+		Marshaller:    arg.Core.InternalMarshalizer(),
+		Hasher:        arg.Core.Hasher(),
+		EpochNotifier: epochNotifier,
+
+		AddFailedRelayedTxToInvalidMBsDisableEpoch: enableEpochs.AddFailedRelayedTxToInvalidMBsDisableEpoch,
+	}
+	doubleTransactionsDetector, err := coordinator.NewPrintDoubleTransactionsDetector(argsDetector)
+
 	argsTransactionCoordinator := coordinator.ArgTransactionCoordinator{
 		Hasher:                            arg.Core.Hasher(),
 		Marshalizer:                       arg.Core.InternalMarshalizer(),
@@ -483,6 +492,7 @@ func createProcessorsForMetaGenesisBlock(arg ArgsGenesisBlockCreator, enableEpoc
 		EpochNotifier:                     epochNotifier,
 		ScheduledTxsExecutionHandler:      disabledScheduledTxsExecutionHandler,
 		ScheduledMiniBlocksEnableEpoch:    enableEpochs.ScheduledMiniBlocksEnableEpoch,
+		DoubleTransactionsDetector:        doubleTransactionsDetector,
 	}
 	txCoordinator, err := coordinator.NewTransactionCoordinator(argsTransactionCoordinator)
 	if err != nil {

--- a/integrationTests/multiShard/relayedTx/common.go
+++ b/integrationTests/multiShard/relayedTx/common.go
@@ -16,7 +16,7 @@ import (
 // CreateGeneralSetupForRelayTxTest will create the general setup for relayed transactions
 func CreateGeneralSetupForRelayTxTest() ([]*integrationTests.TestProcessorNode, []int, []*integrationTests.TestWalletAccount, *integrationTests.TestWalletAccount) {
 	numOfShards := 2
-	nodesPerShard := 1
+	nodesPerShard := 2
 	numMetachainNodes := 1
 
 	nodes := integrationTests.CreateNodes(

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -1574,6 +1574,7 @@ func (tpn *TestProcessorNode) initInnerProcessors(gasMap map[string]map[string]u
 		EpochNotifier:                     tpn.EpochNotifier,
 		ScheduledTxsExecutionHandler:      scheduledTxsExecutionHandler,
 		ScheduledMiniBlocksEnableEpoch:    tpn.ScheduledMiniBlocksEnableEpoch,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tpn.TxCoordinator, _ = coordinator.NewTransactionCoordinator(argsTransactionCoordinator)
 	scheduledTxsExecutionHandler.SetTransactionCoordinator(tpn.TxCoordinator)
@@ -1809,6 +1810,7 @@ func (tpn *TestProcessorNode) initMetaInnerProcessors() {
 		EpochNotifier:                     tpn.EpochNotifier,
 		ScheduledTxsExecutionHandler:      scheduledTxsExecutionHandler,
 		ScheduledMiniBlocksEnableEpoch:    tpn.ScheduledMiniBlocksEnableEpoch,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tpn.TxCoordinator, _ = coordinator.NewTransactionCoordinator(argsTransactionCoordinator)
 	scheduledTxsExecutionHandler.SetTransactionCoordinator(tpn.TxCoordinator)

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -417,6 +417,7 @@ func createMockTransactionCoordinatorArguments(
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 
 	return argsTransactionCoordinator

--- a/process/coordinator/printDoubleTransactionsDetector.go
+++ b/process/coordinator/printDoubleTransactionsDetector.go
@@ -1,0 +1,127 @@
+package coordinator
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/atomic"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/data/block"
+	"github.com/ElrondNetwork/elrond-go-core/hashing"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-go/process"
+)
+
+const printReportHeader = "double transactions found (this is not critical, thus)\nshowing the whole block body:\n"
+const nilBlockBodyMessage = "nil block body in printDoubleTransactionsDetector.ProcessBlockBody"
+const noDoubledTransactionsFoundMessage = "no double transactions found"
+const doubledTransactionsFoundButFlagActive = "double transactions found but this is expected until the AddFailedRelayedTxToInvalidMBsDisableEpoch is deactivated"
+
+// ArgsPrintDoubleTransactionsDetector is the argument DTO structure used in the NewPrintDoubleTransactionsDetector function
+type ArgsPrintDoubleTransactionsDetector struct {
+	Marshaller    marshal.Marshalizer
+	Hasher        hashing.Hasher
+	EpochNotifier process.EpochNotifier
+
+	AddFailedRelayedTxToInvalidMBsDisableEpoch uint32
+}
+
+type printDoubleTransactionsDetector struct {
+	marshaller marshal.Marshalizer
+	hasher     hashing.Hasher
+	logger     logger.Logger
+
+	addFailedRelayedTxToInvalidMBsDisableEpoch uint32
+	flagAddFailedRelayedTxToInvalidMBs         atomic.Flag
+}
+
+// NewPrintDoubleTransactionsDetector creates a new instance of printDoubleTransactionsDetector
+func NewPrintDoubleTransactionsDetector(args ArgsPrintDoubleTransactionsDetector) (*printDoubleTransactionsDetector, error) {
+	err := checkArgsPrintDoubleTransactionsDetector(args)
+	if err != nil {
+		return nil, err
+	}
+
+	detector := &printDoubleTransactionsDetector{
+		marshaller: args.Marshaller,
+		hasher:     args.Hasher,
+		addFailedRelayedTxToInvalidMBsDisableEpoch: args.AddFailedRelayedTxToInvalidMBsDisableEpoch,
+		logger: log,
+	}
+
+	args.EpochNotifier.RegisterNotifyHandler(detector)
+
+	return detector, nil
+}
+
+func checkArgsPrintDoubleTransactionsDetector(args ArgsPrintDoubleTransactionsDetector) error {
+	if check.IfNil(args.Marshaller) {
+		return process.ErrNilMarshalizer
+	}
+	if check.IfNil(args.Hasher) {
+		return process.ErrNilHasher
+	}
+	if check.IfNil(args.EpochNotifier) {
+		return process.ErrNilEpochNotifier
+	}
+
+	return nil
+}
+
+// ProcessBlockBody processes the block body provided in search of doubled transactions. If there are doubled transactions,
+// this method will log as error the event providing as much information as possible
+func (detector *printDoubleTransactionsDetector) ProcessBlockBody(body *block.Body) {
+	if body == nil {
+		detector.logger.Error(nilBlockBodyMessage)
+		return
+	}
+
+	transactions := make(map[string]int)
+	doubleTransactionsExist := false
+	printReport := strings.Builder{}
+
+	for _, miniBlock := range body.MiniBlocks {
+		mbHash, _ := core.CalculateHash(detector.marshaller, detector.hasher, miniBlock)
+		log.Debug("checking for double transactions: miniblock",
+			"sender shard", miniBlock.SenderShardID,
+			"receiver shard", miniBlock.ReceiverShardID,
+			"type", miniBlock.Type,
+			"num txs", len(miniBlock.TxHashes),
+			"hash", mbHash)
+		printReport.WriteString(fmt.Sprintf(" miniblock hash %s, type %s, %d -> %d\n",
+			hex.EncodeToString(mbHash), miniBlock.Type.String(), miniBlock.SenderShardID, miniBlock.ReceiverShardID))
+
+		for _, txHash := range miniBlock.TxHashes {
+			transactions[string(txHash)]++
+			printReport.WriteString(fmt.Sprintf("  tx hash %s\n", hex.EncodeToString(txHash)))
+
+			doubleTransactionsExist = doubleTransactionsExist || transactions[string(txHash)] > 1
+		}
+	}
+
+	if !doubleTransactionsExist {
+		detector.logger.Debug(noDoubledTransactionsFoundMessage)
+		return
+	}
+	if detector.flagAddFailedRelayedTxToInvalidMBs.IsSet() {
+		detector.logger.Debug(doubledTransactionsFoundButFlagActive)
+		return
+	}
+
+	detector.logger.Error(printReportHeader + printReport.String())
+}
+
+// EpochConfirmed is called whenever a new epoch is confirmed
+func (detector *printDoubleTransactionsDetector) EpochConfirmed(epoch uint32, _ uint64) {
+	detector.flagAddFailedRelayedTxToInvalidMBs.SetValue(epoch < detector.addFailedRelayedTxToInvalidMBsDisableEpoch)
+	log.Debug("printDoubleTransactionsDetector: add failed relayed tx to invalid miniblocks",
+		"enabled", detector.flagAddFailedRelayedTxToInvalidMBs.IsSet())
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (detector *printDoubleTransactionsDetector) IsInterfaceNil() bool {
+	return detector == nil
+}

--- a/process/coordinator/printDoubleTransactionsDetector_test.go
+++ b/process/coordinator/printDoubleTransactionsDetector_test.go
@@ -1,0 +1,231 @@
+package coordinator
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/data/block"
+	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/ElrondNetwork/elrond-go/vm/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+func createMockArgsPrintDoubleTransactionsDetector() ArgsPrintDoubleTransactionsDetector {
+	return ArgsPrintDoubleTransactionsDetector{
+		Marshaller:    &testscommon.MarshalizerMock{},
+		Hasher:        &testscommon.HasherStub{},
+		EpochNotifier: &mock.EpochNotifierStub{},
+	}
+}
+
+func TestNewPrintDoubleTransactionsDetector(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil marshaller should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsPrintDoubleTransactionsDetector()
+		args.Marshaller = nil
+
+		detector, err := NewPrintDoubleTransactionsDetector(args)
+		assert.True(t, check.IfNil(detector))
+		assert.Equal(t, process.ErrNilMarshalizer, err)
+	})
+	t.Run("nil hasher should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsPrintDoubleTransactionsDetector()
+		args.Hasher = nil
+
+		detector, err := NewPrintDoubleTransactionsDetector(args)
+		assert.True(t, check.IfNil(detector))
+		assert.Equal(t, process.ErrNilHasher, err)
+	})
+	t.Run("nil epoch notifier should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsPrintDoubleTransactionsDetector()
+		args.EpochNotifier = nil
+
+		detector, err := NewPrintDoubleTransactionsDetector(args)
+		assert.True(t, check.IfNil(detector))
+		assert.Equal(t, process.ErrNilEpochNotifier, err)
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgsPrintDoubleTransactionsDetector()
+
+		detector, err := NewPrintDoubleTransactionsDetector(args)
+		assert.False(t, check.IfNil(detector))
+		assert.Nil(t, err)
+	})
+}
+
+func TestPrintDoubleTransactionsDetector_ProcessBlockBody(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil block body", func(t *testing.T) {
+		t.Parallel()
+
+		errorCalled := false
+		args := createMockArgsPrintDoubleTransactionsDetector()
+		detector, _ := NewPrintDoubleTransactionsDetector(args)
+		detector.logger = &testscommon.LoggerStub{
+			ErrorCalled: func(message string, args ...interface{}) {
+				errorCalled = message == nilBlockBodyMessage
+			},
+		}
+
+		detector.ProcessBlockBody(nil)
+		assert.True(t, errorCalled)
+	})
+	t.Run("empty block body", func(t *testing.T) {
+		t.Parallel()
+
+		errorCalled := false
+		args := createMockArgsPrintDoubleTransactionsDetector()
+		detector, _ := NewPrintDoubleTransactionsDetector(args)
+		detector.logger = &testscommon.LoggerStub{
+			ErrorCalled: func(message string, args ...interface{}) {
+				assert.Fail(t, "should have not called error")
+			},
+			DebugCalled: func(message string, args ...interface{}) {
+				errorCalled = message == noDoubledTransactionsFoundMessage
+			},
+		}
+
+		detector.ProcessBlockBody(&block.Body{})
+		assert.True(t, errorCalled)
+	})
+	t.Run("no doubled transactions", func(t *testing.T) {
+		t.Parallel()
+
+		errorCalled := false
+		args := createMockArgsPrintDoubleTransactionsDetector()
+		detector, _ := NewPrintDoubleTransactionsDetector(args)
+		detector.logger = &testscommon.LoggerStub{
+			ErrorCalled: func(message string, args ...interface{}) {
+				assert.Fail(t, "should have not called error")
+			},
+			DebugCalled: func(message string, args ...interface{}) {
+				errorCalled = message == noDoubledTransactionsFoundMessage
+			},
+		}
+
+		body := &block.Body{
+			MiniBlocks: []*block.MiniBlock{
+				{
+					TxHashes: [][]byte{[]byte("tx hash1"), []byte("tx hash2")},
+				},
+				{
+					TxHashes: [][]byte{[]byte("tx hash3"), []byte("tx hash4")},
+				},
+			},
+		}
+		detector.ProcessBlockBody(body)
+		assert.True(t, errorCalled)
+	})
+	t.Run("doubled transactions in different miniblocks but feature not active", func(t *testing.T) {
+		t.Parallel()
+
+		errorCalled := false
+		args := createMockArgsPrintDoubleTransactionsDetector()
+		args.AddFailedRelayedTxToInvalidMBsDisableEpoch = 100000
+		detector, _ := NewPrintDoubleTransactionsDetector(args)
+		detector.logger = &testscommon.LoggerStub{
+			ErrorCalled: func(message string, args ...interface{}) {
+				assert.Fail(t, "should have not called error")
+			},
+			DebugCalled: func(message string, args ...interface{}) {
+				errorCalled = message == doubledTransactionsFoundButFlagActive
+			},
+		}
+
+		body := &block.Body{
+			MiniBlocks: []*block.MiniBlock{
+				{
+					TxHashes: [][]byte{[]byte("tx hash1"), []byte("tx hash2")},
+				},
+				{
+					TxHashes: [][]byte{[]byte("tx hash1"), []byte("tx hash4")},
+				},
+			},
+		}
+		detector.ProcessBlockBody(body)
+		assert.True(t, errorCalled)
+	})
+	t.Run("doubled transactions in different miniblocks", func(t *testing.T) {
+		t.Parallel()
+
+		errorCalled := false
+		expectedMessage := printReportHeader + ` miniblock hash , type TxBlock, 0 -> 0
+  tx hash 7478206861736831
+  tx hash 7478206861736832
+ miniblock hash , type TxBlock, 0 -> 0
+  tx hash 7478206861736831
+  tx hash 7478206861736834
+`
+		args := createMockArgsPrintDoubleTransactionsDetector()
+		detector, _ := NewPrintDoubleTransactionsDetector(args)
+		detector.logger = &testscommon.LoggerStub{
+			ErrorCalled: func(message string, args ...interface{}) {
+				assert.Equal(t, expectedMessage, message)
+				errorCalled = message == expectedMessage
+			},
+			DebugCalled: func(message string, args ...interface{}) {
+				assert.Fail(t, "should have not called debug")
+			},
+		}
+
+		body := &block.Body{
+			MiniBlocks: []*block.MiniBlock{
+				{
+					TxHashes: [][]byte{[]byte("tx hash1"), []byte("tx hash2")},
+				},
+				{
+					TxHashes: [][]byte{[]byte("tx hash1"), []byte("tx hash4")},
+				},
+			},
+		}
+		detector.ProcessBlockBody(body)
+		assert.True(t, errorCalled)
+	})
+	t.Run("doubled transactions in same miniblock", func(t *testing.T) {
+		t.Parallel()
+
+		errorCalled := false
+		expectedMessage := printReportHeader + ` miniblock hash , type TxBlock, 0 -> 0
+  tx hash 7478206861736831
+  tx hash 7478206861736831
+ miniblock hash , type TxBlock, 0 -> 0
+  tx hash 7478206861736832
+  tx hash 7478206861736834
+`
+		args := createMockArgsPrintDoubleTransactionsDetector()
+		detector, _ := NewPrintDoubleTransactionsDetector(args)
+		detector.logger = &testscommon.LoggerStub{
+			ErrorCalled: func(message string, args ...interface{}) {
+				assert.Equal(t, expectedMessage, message)
+				errorCalled = message == expectedMessage
+			},
+			DebugCalled: func(message string, args ...interface{}) {
+				assert.Fail(t, "should have not called debug")
+			},
+		}
+
+		body := &block.Body{
+			MiniBlocks: []*block.MiniBlock{
+				{
+					TxHashes: [][]byte{[]byte("tx hash1"), []byte("tx hash1")},
+				},
+				{
+					TxHashes: [][]byte{[]byte("tx hash2"), []byte("tx hash4")},
+				},
+			},
+		}
+		detector.ProcessBlockBody(body)
+		assert.True(t, errorCalled)
+	})
+}

--- a/process/coordinator/process.go
+++ b/process/coordinator/process.go
@@ -3,7 +3,6 @@ package coordinator
 import (
 	"bytes"
 	"fmt"
-
 	"math/big"
 	"sort"
 	"sync"
@@ -54,6 +53,7 @@ type ArgTransactionCoordinator struct {
 	EpochNotifier                     process.EpochNotifier
 	ScheduledTxsExecutionHandler      process.ScheduledTxsExecutionHandler
 	ScheduledMiniBlocksEnableEpoch    uint32
+	DoubleTransactionsDetector        process.DoubleTransactionDetector
 }
 
 type transactionCoordinator struct {
@@ -87,6 +87,7 @@ type transactionCoordinator struct {
 	scheduledTxsExecutionHandler      process.ScheduledTxsExecutionHandler
 	scheduledMiniBlocksEnableEpoch    uint32
 	flagScheduledMiniBlocks           atomic.Flag
+	doubleTransactionsDetector        process.DoubleTransactionDetector
 }
 
 // NewTransactionCoordinator creates a transaction coordinator to run and coordinate preprocessors and processors
@@ -111,6 +112,7 @@ func NewTransactionCoordinator(args ArgTransactionCoordinator) (*transactionCoor
 		transactionsLogProcessor:          args.TransactionsLogProcessor,
 		scheduledTxsExecutionHandler:      args.ScheduledTxsExecutionHandler,
 		scheduledMiniBlocksEnableEpoch:    args.ScheduledMiniBlocksEnableEpoch,
+		doubleTransactionsDetector:        args.DoubleTransactionsDetector,
 	}
 	log.Debug("coordinator/process: enable epoch for block gas and fees re-check", "epoch", tc.blockGasAndFeesReCheckEnableEpoch)
 
@@ -445,13 +447,7 @@ func (tc *transactionCoordinator) ProcessBlockTransaction(
 		return timeRemaining() >= 0
 	}
 
-	for _, miniBlock := range body.MiniBlocks {
-		log.Trace("ProcessBlockTransaction: miniblock",
-			"sender shard", miniBlock.SenderShardID,
-			"receiver shard", miniBlock.ReceiverShardID,
-			"type", miniBlock.Type,
-			"num txs", len(miniBlock.TxHashes))
-	}
+	tc.doubleTransactionsDetector.ProcessBlockBody(body)
 
 	startTime := time.Now()
 	mbIndex, err := tc.processMiniBlocksToMe(header, body, haveTime)
@@ -672,11 +668,11 @@ func (tc *transactionCoordinator) CreateMbsAndProcessCrossShardTransactionsDstMe
 			continue
 		}
 
-		//TODO: Should be removed this condition, just to allow processing of any kind of mbs as scheduled in destination shard?
-		//If this will be removed avoid to process mini blocks of type SmartContractResults or implement scheduled support there
+		// TODO: Should be removed this condition, just to allow processing of any kind of mbs as scheduled in destination shard?
+		// If this will be removed avoid to process mini blocks of type SmartContractResults or implement scheduled support there
 		if scheduledMode && !miniBlock.IsScheduledMiniBlock() {
 			shouldSkipShard[miniBlockInfo.SenderShardID] = true
-			//TODO: Change this to log.Trace
+			// TODO: Change this to log.Trace
 			log.Debug("transactionCoordinator.CreateMbsAndProcessCrossShardTransactionsDstMe: mini block was not scheduled in sender shard",
 				"scheduled mode", scheduledMode,
 				"sender shard", miniBlockInfo.SenderShardID,
@@ -1582,6 +1578,9 @@ func checkTransactionCoordinatorNilParameters(arguments ArgTransactionCoordinato
 	}
 	if check.IfNil(arguments.ScheduledTxsExecutionHandler) {
 		return process.ErrNilScheduledTxsExecutionHandler
+	}
+	if check.IfNil(arguments.DoubleTransactionsDetector) {
+		return process.ErrNilDoubleTransactionsDetector
 	}
 
 	return nil

--- a/process/coordinator/process_test.go
+++ b/process/coordinator/process_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/batch"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
@@ -237,6 +238,7 @@ func createMockTransactionCoordinatorArguments() ArgTransactionCoordinator {
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 
 	return argsTransactionCoordinator
@@ -440,6 +442,17 @@ func TestNewTransactionCoordinator_NilScheduledTxsExecutionHandler(t *testing.T)
 	assert.Equal(t, process.ErrNilScheduledTxsExecutionHandler, err)
 }
 
+func TestNewTransactionCoordinator_NilDoubleTransactionsDetector(t *testing.T) {
+	t.Parallel()
+
+	argsTransactionCoordinator := createMockTransactionCoordinatorArguments()
+	argsTransactionCoordinator.DoubleTransactionsDetector = nil
+	tc, err := NewTransactionCoordinator(argsTransactionCoordinator)
+
+	assert.True(t, check.IfNil(tc))
+	assert.Equal(t, process.ErrNilDoubleTransactionsDetector, err)
+}
+
 func TestNewTransactionCoordinator_OK(t *testing.T) {
 	t.Parallel()
 
@@ -447,8 +460,7 @@ func TestNewTransactionCoordinator_OK(t *testing.T) {
 	tc, err := NewTransactionCoordinator(argsTransactionCoordinator)
 
 	assert.Nil(t, err)
-	assert.NotNil(t, tc)
-	assert.False(t, tc.IsInterfaceNil())
+	assert.False(t, check.IfNil(tc))
 }
 
 func TestTransactionCoordinator_GetAllCurrentLogs(t *testing.T) {
@@ -2554,6 +2566,7 @@ func TestTransactionCoordinator_VerifyCreatedMiniBlocksShouldReturnWhenEpochIsNo
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
 	assert.Nil(t, err)
@@ -2601,6 +2614,7 @@ func TestTransactionCoordinator_VerifyCreatedMiniBlocksShouldErrMaxGasLimitPerMi
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
@@ -2670,6 +2684,7 @@ func TestTransactionCoordinator_VerifyCreatedMiniBlocksShouldErrMaxAccumulatedFe
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
@@ -2745,6 +2760,7 @@ func TestTransactionCoordinator_VerifyCreatedMiniBlocksShouldErrMaxDeveloperFees
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
@@ -2820,6 +2836,7 @@ func TestTransactionCoordinator_VerifyCreatedMiniBlocksShouldWork(t *testing.T) 
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
@@ -2878,6 +2895,7 @@ func TestTransactionCoordinator_GetAllTransactionsShouldWork(t *testing.T) {
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
 	assert.Nil(t, err)
@@ -2960,6 +2978,7 @@ func TestTransactionCoordinator_VerifyGasLimitShouldErrMaxGasLimitPerMiniBlockIn
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
 	assert.Nil(t, err)
@@ -3052,6 +3071,7 @@ func TestTransactionCoordinator_VerifyGasLimitShouldWork(t *testing.T) {
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
 	assert.Nil(t, err)
@@ -3130,6 +3150,7 @@ func TestTransactionCoordinator_CheckGasProvidedByMiniBlockInReceiverShardShould
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
 	assert.Nil(t, err)
@@ -3179,6 +3200,7 @@ func TestTransactionCoordinator_CheckGasProvidedByMiniBlockInReceiverShardShould
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
 	assert.Nil(t, err)
@@ -3235,6 +3257,7 @@ func TestTransactionCoordinator_CheckGasProvidedByMiniBlockInReceiverShardShould
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
 	assert.Nil(t, err)
@@ -3298,6 +3321,7 @@ func TestTransactionCoordinator_CheckGasProvidedByMiniBlockInReceiverShardShould
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
 	assert.Nil(t, err)
@@ -3364,6 +3388,7 @@ func TestTransactionCoordinator_CheckGasProvidedByMiniBlockInReceiverShardShould
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
@@ -3417,6 +3442,7 @@ func TestTransactionCoordinator_VerifyFeesShouldErrMissingTransaction(t *testing
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
@@ -3474,6 +3500,7 @@ func TestTransactionCoordinator_VerifyFeesShouldErrMaxAccumulatedFeesExceeded(t 
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
@@ -3541,6 +3568,7 @@ func TestTransactionCoordinator_VerifyFeesShouldErrMaxDeveloperFeesExceeded(t *t
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
 	assert.Nil(t, err)
@@ -3614,6 +3642,7 @@ func TestTransactionCoordinator_VerifyFeesShouldErrMaxAccumulatedFeesExceededWhe
 			},
 		},
 		ScheduledMiniBlocksEnableEpoch: 2,
+		DoubleTransactionsDetector:     &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
 	assert.Nil(t, err)
@@ -3692,6 +3721,7 @@ func TestTransactionCoordinator_VerifyFeesShouldErrMaxDeveloperFeesExceededWhenS
 			},
 		},
 		ScheduledMiniBlocksEnableEpoch: 2,
+		DoubleTransactionsDetector:     &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
 	assert.Nil(t, err)
@@ -3770,6 +3800,7 @@ func TestTransactionCoordinator_VerifyFeesShouldWork(t *testing.T) {
 			},
 		},
 		ScheduledMiniBlocksEnableEpoch: 2,
+		DoubleTransactionsDetector:     &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
 	assert.Nil(t, err)
@@ -3840,6 +3871,7 @@ func TestTransactionCoordinator_GetMaxAccumulatedAndDeveloperFeesShouldErr(t *te
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
 	assert.Nil(t, err)
@@ -3891,6 +3923,7 @@ func TestTransactionCoordinator_GetMaxAccumulatedAndDeveloperFeesShouldWork(t *t
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 	tc, err := NewTransactionCoordinator(txCoordinatorArgs)
 	assert.Nil(t, err)
@@ -3956,6 +3989,7 @@ func TestTransactionCoordinator_RevertIfNeededShouldWork(t *testing.T) {
 		EpochNotifier:                     &epochNotifier.EpochNotifierStub{},
 		ScheduledTxsExecutionHandler:      &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch:    2,
+		DoubleTransactionsDetector:        &testscommon.PanicDoubleTransactionsDetector{},
 	}
 
 	txHashes := make([][]byte, 0)
@@ -3992,4 +4026,4 @@ func TestTransactionCoordinator_RevertIfNeededShouldWork(t *testing.T) {
 	assert.Equal(t, len(txHashes), numTxsFeesReverted)
 }
 
-//TODO: Add unit tests for AddIntermediateTransactions and GetAllIntermediateTxs methods
+// TODO: Add unit tests for AddIntermediateTransactions and GetAllIntermediateTxs methods

--- a/process/errors.go
+++ b/process/errors.go
@@ -1057,3 +1057,6 @@ var ErrScheduledRootHashDoesNotMatch = errors.New("scheduled root hash does not 
 
 // ErrNilAdditionalData signals that additional data is nil
 var ErrNilAdditionalData = errors.New("nil additional data")
+
+// ErrNilDoubleTransactionsDetector signals that a nil double transactions detector has been provided
+var ErrNilDoubleTransactionsDetector = errors.New("nil double transactions detector")

--- a/process/interceptors/baseDataInterceptor.go
+++ b/process/interceptors/baseDataInterceptor.go
@@ -70,7 +70,7 @@ func (bdi *baseDataInterceptor) processInterceptedData(data process.InterceptedD
 			"type", data.Type(),
 			"pid", p2p.MessageOriginatorPid(msg),
 			"seq no", p2p.MessageOriginatorSeq(msg),
-			"data", data.String(),
+			"intercepted data", data.String(),
 			"error", err.Error(),
 		)
 		bdi.processDebugInterceptedData(data, err)
@@ -85,7 +85,7 @@ func (bdi *baseDataInterceptor) processInterceptedData(data process.InterceptedD
 			"type", data.Type(),
 			"pid", p2p.MessageOriginatorPid(msg),
 			"seq no", p2p.MessageOriginatorSeq(msg),
-			"data", data.String(),
+			"intercepted data", data.String(),
 			"error", err.Error(),
 		)
 		bdi.processDebugInterceptedData(data, err)
@@ -98,7 +98,7 @@ func (bdi *baseDataInterceptor) processInterceptedData(data process.InterceptedD
 		"type", data.Type(),
 		"pid", p2p.MessageOriginatorPid(msg),
 		"seq no", p2p.MessageOriginatorSeq(msg),
-		"data", data.String(),
+		"intercepted data", data.String(),
 	)
 	bdi.processDebugInterceptedData(data, err)
 }

--- a/process/interface.go
+++ b/process/interface.go
@@ -1148,3 +1148,9 @@ type ScheduledTxsExecutionHandler interface {
 	IsScheduledTx(txHash []byte) bool
 	IsInterfaceNil() bool
 }
+
+// DoubleTransactionDetector is able to detect if a transaction hash is present more than once in a block body
+type DoubleTransactionDetector interface {
+	ProcessBlockBody(body *block.Body)
+	IsInterfaceNil() bool
+}

--- a/process/transaction/interceptedTransaction.go
+++ b/process/transaction/interceptedTransaction.go
@@ -2,6 +2,7 @@ package transaction
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 
@@ -396,11 +397,12 @@ func (inTx *InterceptedTransaction) Type() string {
 
 // String returns the transaction's most important fields as string
 func (inTx *InterceptedTransaction) String() string {
-	return fmt.Sprintf("sender=%s, nonce=%d, value=%s, recv=%s",
+	return fmt.Sprintf("sender=%s, nonce=%d, value=%s, recv=%s, data=%s",
 		logger.DisplayByteSlice(inTx.tx.SndAddr),
 		inTx.tx.Nonce,
 		inTx.tx.Value.String(),
 		logger.DisplayByteSlice(inTx.tx.RcvAddr),
+		hex.EncodeToString(inTx.tx.Data),
 	)
 }
 

--- a/process/transaction/interceptedTransaction_test.go
+++ b/process/transaction/interceptedTransaction_test.go
@@ -157,7 +157,7 @@ func createInterceptedTxFromPlainTxWithArgParser(tx *dataTransaction.Transaction
 	)
 }
 
-//------- NewInterceptedTransaction
+// ------- NewInterceptedTransaction
 
 func TestNewInterceptedTransaction_NilBufferShouldErr(t *testing.T) {
 	t.Parallel()
@@ -565,7 +565,7 @@ func TestNewInterceptedTransaction_ShouldWork(t *testing.T) {
 	assert.Equal(t, tx, txi.Transaction())
 }
 
-//------- CheckValidity
+// ------- CheckValidity
 
 func TestInterceptedTransaction_CheckValidityNilSignatureShouldErr(t *testing.T) {
 	t.Parallel()
@@ -1297,7 +1297,7 @@ func TestInterceptedTransaction_CheckValiditySecondTimeDoesNotVerifySig(t *testi
 	require.Nil(t, err)
 	require.True(t, sigVerified)
 
-	//second check should find txi in whitelist and should not verify sig
+	// second check should find txi in whitelist and should not verify sig
 	sigVerified = false
 	err = txi.CheckValidity()
 	require.Nil(t, err)
@@ -1450,7 +1450,7 @@ func TestInterceptedTransaction_CheckValidityOfRelayedTxV2(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-//------- IsInterfaceNil
+// ------- IsInterfaceNil
 func TestInterceptedTransaction_IsInterfaceNil(t *testing.T) {
 	t.Parallel()
 
@@ -1591,12 +1591,14 @@ func TestInterceptedTransaction_String(t *testing.T) {
 	value := big.NewInt(150)
 	sndAddr := []byte("snd")
 	rcvAdrr := []byte("rcv")
+	dataField := []byte("data")
 
 	tx := &dataTransaction.Transaction{
 		Nonce:   nonce,
 		RcvAddr: rcvAdrr,
 		SndAddr: sndAddr,
 		Value:   value,
+		Data:    dataField,
 	}
 
 	marshalizer := &mock.MarshalizerMock{}
@@ -1623,8 +1625,8 @@ func TestInterceptedTransaction_String(t *testing.T) {
 	)
 
 	expectedFormat := fmt.Sprintf(
-		"sender=%s, nonce=%d, value=%s, recv=%s",
-		logger.DisplayByteSlice(sndAddr), nonce, value.String(), logger.DisplayByteSlice(rcvAdrr),
+		"sender=%s, nonce=%d, value=%s, recv=%s, data=%s",
+		logger.DisplayByteSlice(sndAddr), nonce, value.String(), logger.DisplayByteSlice(rcvAdrr), hex.EncodeToString(dataField),
 	)
 
 	assert.Equal(t, expectedFormat, txin.String())

--- a/process/unsigned/interceptedUnsignedTransaction.go
+++ b/process/unsigned/interceptedUnsignedTransaction.go
@@ -1,6 +1,7 @@
 package unsigned
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/big"
 
@@ -156,11 +157,12 @@ func (inUTx *InterceptedUnsignedTransaction) Type() string {
 
 // String returns the unsigned transaction's most important fields as string
 func (inUTx *InterceptedUnsignedTransaction) String() string {
-	return fmt.Sprintf("sender=%s, nonce=%d, value=%s, recv=%s",
+	return fmt.Sprintf("sender=%s, nonce=%d, value=%s, recv=%s, data=%s",
 		logger.DisplayByteSlice(inUTx.uTx.SndAddr),
 		inUTx.uTx.Nonce,
 		inUTx.uTx.Value.String(),
 		logger.DisplayByteSlice(inUTx.uTx.RcvAddr),
+		hex.EncodeToString(inUTx.uTx.Data),
 	)
 }
 

--- a/process/unsigned/interceptedUnsignedTransaction_test.go
+++ b/process/unsigned/interceptedUnsignedTransaction_test.go
@@ -2,6 +2,7 @@ package unsigned_test
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -53,7 +54,7 @@ func createMockPubkeyConverter() *mock.PubkeyConverterMock {
 	return mock.NewPubkeyConverterMock(32)
 }
 
-//------- NewInterceptedUnsignedTransaction
+// ------- NewInterceptedUnsignedTransaction
 
 func TestNewInterceptedUnsignedTransaction_NilBufferShouldErr(t *testing.T) {
 	t.Parallel()
@@ -168,7 +169,7 @@ func TestNewInterceptedUnsignedTransaction_ShouldWork(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-//------- CheckValidity
+// ------- CheckValidity
 
 func TestInterceptedUnsignedTransaction_CheckValidityNilTxHashShouldErr(t *testing.T) {
 	t.Parallel()
@@ -296,7 +297,7 @@ func TestInterceptedUnsignedTransaction_CheckValidityShouldWork(t *testing.T) {
 	assert.Equal(t, tx, txi.Transaction())
 }
 
-//------- getters
+// ------- getters
 
 func TestInterceptedUnsignedTransaction_OkValsGettersShouldWork(t *testing.T) {
 	t.Parallel()
@@ -326,7 +327,7 @@ func TestInterceptedUnsignedTransaction_OkValsGettersShouldWork(t *testing.T) {
 	assert.Equal(t, senderAddress, txi.SenderAddress())
 }
 
-//------- IsInterfaceNil
+// ------- IsInterfaceNil
 
 func TestInterceptedTransaction_IsInterfaceNil(t *testing.T) {
 	t.Parallel()
@@ -370,8 +371,8 @@ func TestInterceptedUnsignedTransaction_String(t *testing.T) {
 	txi, _ := createInterceptedScrFromPlainScr(tx)
 
 	expectedFormat := fmt.Sprintf(
-		"sender=%s, nonce=%d, value=%s, recv=%s",
-		logger.DisplayByteSlice(senderAddress), nonce, value, logger.DisplayByteSlice(recvAddress),
+		"sender=%s, nonce=%d, value=%s, recv=%s, data=%s",
+		logger.DisplayByteSlice(senderAddress), nonce, value, logger.DisplayByteSlice(recvAddress), hex.EncodeToString(tx.Data),
 	)
 
 	assert.Equal(t, expectedFormat, txi.String())

--- a/storage/txcache/txListForSender.go
+++ b/storage/txcache/txListForSender.go
@@ -136,10 +136,20 @@ func (listForSender *txListForSender) findInsertionPlace(incomingTx *WrappedTran
 			return nil, storage.ErrItemAlreadyInCache
 		}
 
-		if currentTxNonce == incomingNonce && currentTxGasPrice > incomingGasPrice {
-			// The incoming transaction will be placed right after the existing one, which has same nonce but higher price.
-			// If the nonces are the same, but the incoming gas price is higher or equal, the search loop continues.
-			return element, nil
+		if currentTxNonce == incomingNonce {
+			if currentTxGasPrice > incomingGasPrice {
+				// The incoming transaction will be placed right after the existing one, which has same nonce but higher price.
+				// If the nonces are the same, but the incoming gas price is higher or equal, the search loop continues.
+				return element, nil
+			}
+			if currentTxGasPrice == incomingGasPrice {
+				// The incoming transaction will be placed right after the existing one, which has same nonce and the same price.
+				// (but different hash, because of some other fields like receiver, value or data)
+				// This will order out the transactions having the same nonce and gas price
+				if bytes.Compare(currentTx.TxHash, incomingTx.TxHash) < 0 {
+					return element, nil
+				}
+			}
 		}
 
 		if currentTxNonce < incomingNonce {

--- a/storage/txcache/txListForSender_test.go
+++ b/storage/txcache/txListForSender_test.go
@@ -47,7 +47,7 @@ func TestListForSender_AddTx_SortsCorrectlyWhenSameNonceSamePrice(t *testing.T) 
 	list.AddTx(createTxWithParams([]byte("g"), ".", 3, 128, 42, 99), txGasHandler, txFeeHelper)
 
 	// In case of same-nonce, same-price transactions, the newer one has priority
-	require.Equal(t, []string{"a", "f", "e", "c", "b", "g", "d"}, list.getTxHashesAsStrings())
+	require.Equal(t, []string{"a", "f", "e", "b", "c", "g", "d"}, list.getTxHashesAsStrings())
 }
 
 func TestListForSender_AddTx_IgnoresDuplicates(t *testing.T) {
@@ -206,7 +206,7 @@ func TestListForSender_SelectBatchToWithLimitedGasBandwidth(t *testing.T) {
 	txGasHandler, txFeeHelper := dummyParams()
 
 	for index := 0; index < 40; index++ {
-		wtx := createTx([]byte{byte(index)},".", uint64(index))
+		wtx := createTx([]byte{byte(index)}, ".", uint64(index))
 		tx, _ := wtx.Tx.(*transaction.Transaction)
 		tx.GasLimit = 1000000
 		list.AddTx(wtx, txGasHandler, txFeeHelper)
@@ -221,7 +221,7 @@ func TestListForSender_SelectBatchToWithLimitedGasBandwidth(t *testing.T) {
 	require.Nil(t, destination[1])
 
 	// Second batch
-	journal = list.selectBatchTo(false, destination[1:], 50,20000000)
+	journal = list.selectBatchTo(false, destination[1:], 50, 20000000)
 	require.Equal(t, 20, journal.copied)
 	require.NotNil(t, destination[20])
 	require.Nil(t, destination[21])
@@ -418,7 +418,7 @@ func dummyParamsWithGasPriceAndGasLimit(minGasPrice uint64, minGasLimit uint64) 
 	return txGasHandler, txFeeHelper
 }
 
-func dummyParamsWithGasPrice(minGasPrice uint64)(TxGasHandler, feeHelper) {
+func dummyParamsWithGasPrice(minGasPrice uint64) (TxGasHandler, feeHelper) {
 	return dummyParamsWithGasPriceAndGasLimit(minGasPrice, 50000)
 }
 

--- a/testscommon/loggerStub.go
+++ b/testscommon/loggerStub.go
@@ -1,0 +1,86 @@
+package testscommon
+
+import logger "github.com/ElrondNetwork/elrond-go-logger"
+
+// LoggerStub -
+type LoggerStub struct {
+	TraceCalled      func(message string, args ...interface{})
+	DebugCalled      func(message string, args ...interface{})
+	InfoCalled       func(message string, args ...interface{})
+	WarnCalled       func(message string, args ...interface{})
+	ErrorCalled      func(message string, args ...interface{})
+	LogIfErrorCalled func(err error, args ...interface{})
+	LogCalled        func(line *logger.LogLine)
+	SetLevelCalled   func(logLevel logger.LogLevel)
+	GetLevelCalled   func() logger.LogLevel
+}
+
+// Trace -
+func (stub *LoggerStub) Trace(message string, args ...interface{}) {
+	if stub.TraceCalled != nil {
+		stub.TraceCalled(message, args...)
+	}
+}
+
+// Debug -
+func (stub *LoggerStub) Debug(message string, args ...interface{}) {
+	if stub.DebugCalled != nil {
+		stub.DebugCalled(message, args...)
+	}
+}
+
+// Info -
+func (stub *LoggerStub) Info(message string, args ...interface{}) {
+	if stub.InfoCalled != nil {
+		stub.InfoCalled(message, args...)
+	}
+}
+
+// Warn -
+func (stub *LoggerStub) Warn(message string, args ...interface{}) {
+	if stub.WarnCalled != nil {
+		stub.WarnCalled(message, args...)
+	}
+}
+
+// Error -
+func (stub *LoggerStub) Error(message string, args ...interface{}) {
+	if stub.ErrorCalled != nil {
+		stub.ErrorCalled(message, args...)
+	}
+}
+
+// LogIfError -
+func (stub *LoggerStub) LogIfError(err error, args ...interface{}) {
+	if stub.LogIfErrorCalled != nil {
+		stub.LogIfErrorCalled(err, args...)
+	}
+}
+
+// Log -
+func (stub *LoggerStub) Log(line *logger.LogLine) {
+	if stub.LogCalled != nil {
+		stub.LogCalled(line)
+	}
+}
+
+// SetLevel -
+func (stub *LoggerStub) SetLevel(logLevel logger.LogLevel) {
+	if stub.SetLevelCalled != nil {
+		stub.SetLevelCalled(logLevel)
+	}
+}
+
+// GetLevel -
+func (stub *LoggerStub) GetLevel() logger.LogLevel {
+	if stub.GetLevelCalled != nil {
+		return stub.GetLevelCalled()
+	}
+
+	return logger.LogTrace
+}
+
+// IsInterfaceNil -
+func (stub *LoggerStub) IsInterfaceNil() bool {
+	return stub == nil
+}

--- a/testscommon/panicDoubleTransactionsDetector.go
+++ b/testscommon/panicDoubleTransactionsDetector.go
@@ -1,0 +1,56 @@
+package testscommon
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/ElrondNetwork/elrond-go-core/data/block"
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+)
+
+const noDoubledTransactionsFoundMessage = "no double transactions found"
+const printReportHeader = "double transactions found (this is not critical, thus)\nshowing the whole block body:\n"
+
+var log = logger.GetOrCreate("testcommon")
+
+// PanicDoubleTransactionsDetector -
+type PanicDoubleTransactionsDetector struct {
+}
+
+// ProcessBlockBody -
+func (detector *PanicDoubleTransactionsDetector) ProcessBlockBody(body *block.Body) {
+	transactions := make(map[string]int)
+	doubleTransactionsExist := false
+	printReport := strings.Builder{}
+
+	for _, miniBlock := range body.MiniBlocks {
+		log.Debug("checking for double transactions: miniblock",
+			"sender shard", miniBlock.SenderShardID,
+			"receiver shard", miniBlock.ReceiverShardID,
+			"type", miniBlock.Type,
+			"num txs", len(miniBlock.TxHashes))
+		printReport.WriteString(fmt.Sprintf(" miniblock type %s, %d -> %d\n",
+			miniBlock.Type.String(), miniBlock.SenderShardID, miniBlock.ReceiverShardID))
+
+		for _, txHash := range miniBlock.TxHashes {
+			transactions[string(txHash)]++
+			printReport.WriteString(fmt.Sprintf("  tx hash %s\n", hex.EncodeToString(txHash)))
+
+			doubleTransactionsExist = doubleTransactionsExist || transactions[string(txHash)] > 1
+		}
+	}
+
+	if !doubleTransactionsExist {
+		log.Debug(noDoubledTransactionsFoundMessage)
+		return
+	}
+
+	log.Error(printReportHeader + printReport.String())
+	panic("PanicDoubleTransactionsDetector.ProcessBlockBody - test failed")
+}
+
+// IsInterfaceNil -
+func (detector *PanicDoubleTransactionsDetector) IsInterfaceNil() bool {
+	return detector == nil
+}


### PR DESCRIPTION
- minor fix in tx cache transaction selection & adding a critical section
- fixed some prints in the intercepted data implementations
- added double transactions detector