### PR TITLE
HeartbeatV2-integration tests

### DIFF
--- a/dataRetriever/errors.go
+++ b/dataRetriever/errors.go
@@ -238,3 +238,6 @@ var InvalidChunkIndex = errors.New("invalid chunk index")
 
 // ErrInvalidNumOfPeerAuthentication signals that an invalid number of peer authentication was provided
 var ErrInvalidNumOfPeerAuthentication = errors.New("invalid num of peer authentication")
+
+// ErrNilPeerShardMapper signals that a nil peer shard mapper has been provided
+var ErrNilPeerShardMapper = errors.New("nil peer shard mapper")

--- a/dataRetriever/factory/resolverscontainer/args.go
+++ b/dataRetriever/factory/resolverscontainer/args.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/p2p"
+	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 )
 
@@ -30,4 +31,5 @@ type FactoryArgs struct {
 	IsFullHistoryNode                    bool
 	NodesCoordinator                     dataRetriever.NodesCoordinator
 	MaxNumOfPeerAuthenticationInResponse int
+	PeerShardMapper                      process.PeerShardMapper
 }

--- a/dataRetriever/factory/resolverscontainer/baseResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/baseResolversContainerFactory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/resolvers"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/resolvers/topicResolverSender"
+	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/factory"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 )
@@ -43,6 +44,7 @@ type baseResolversContainerFactory struct {
 	numFullHistoryPeers                  int
 	nodesCoordinator                     dataRetriever.NodesCoordinator
 	maxNumOfPeerAuthenticationInResponse int
+	peerShardMapper                      process.PeerShardMapper
 }
 
 func (brcf *baseResolversContainerFactory) checkParams() error {
@@ -100,6 +102,9 @@ func (brcf *baseResolversContainerFactory) checkParams() error {
 	if brcf.maxNumOfPeerAuthenticationInResponse < minNumOfPeerAuthentication {
 		return fmt.Errorf("%w for maxNumOfPeerAuthenticationInResponse, expected %d, received %d",
 			dataRetriever.ErrInvalidValue, minNumOfPeerAuthentication, brcf.maxNumOfPeerAuthenticationInResponse)
+	}
+	if check.IfNil(brcf.peerShardMapper) {
+		return dataRetriever.ErrNilPeerShardMapper
 	}
 
 	return nil
@@ -281,6 +286,7 @@ func (brcf *baseResolversContainerFactory) generatePeerAuthenticationResolver() 
 		PeerAuthenticationPool:               brcf.dataPools.PeerAuthentications(),
 		NodesCoordinator:                     brcf.nodesCoordinator,
 		MaxNumOfPeerAuthenticationInResponse: brcf.maxNumOfPeerAuthenticationInResponse,
+		PeerShardMapper:                      brcf.peerShardMapper,
 	}
 	peerAuthResolver, err := resolvers.NewPeerAuthenticationResolver(arg)
 	if err != nil {

--- a/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory.go
@@ -57,6 +57,7 @@ func NewMetaResolversContainerFactory(
 		numFullHistoryPeers:                  int(args.ResolverConfig.NumFullHistoryPeers),
 		nodesCoordinator:                     args.NodesCoordinator,
 		maxNumOfPeerAuthenticationInResponse: args.MaxNumOfPeerAuthenticationInResponse,
+		peerShardMapper:                      args.PeerShardMapper,
 	}
 
 	err = base.checkParams()

--- a/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory_test.go
+++ b/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory_test.go
@@ -317,5 +317,6 @@ func getArgumentsMeta() resolverscontainer.FactoryArgs {
 		},
 		NodesCoordinator:                     &mock.NodesCoordinatorStub{},
 		MaxNumOfPeerAuthenticationInResponse: 5,
+		PeerShardMapper:                      &p2pmocks.NetworkShardingCollectorStub{},
 	}
 }

--- a/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory.go
@@ -55,6 +55,7 @@ func NewShardResolversContainerFactory(
 		numFullHistoryPeers:                  int(args.ResolverConfig.NumFullHistoryPeers),
 		nodesCoordinator:                     args.NodesCoordinator,
 		maxNumOfPeerAuthenticationInResponse: args.MaxNumOfPeerAuthenticationInResponse,
+		peerShardMapper:                      args.PeerShardMapper,
 	}
 
 	err = base.checkParams()

--- a/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory_test.go
+++ b/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory_test.go
@@ -408,5 +408,6 @@ func getArgumentsShard() resolverscontainer.FactoryArgs {
 		},
 		NodesCoordinator:                     &mock.NodesCoordinatorStub{},
 		MaxNumOfPeerAuthenticationInResponse: 5,
+		PeerShardMapper:                      &p2pmocks.NetworkShardingCollectorStub{},
 	}
 }

--- a/dataRetriever/requestHandlers/requestHandler.go
+++ b/dataRetriever/requestHandlers/requestHandler.go
@@ -726,7 +726,7 @@ func (rrh *resolverRequestHandler) RequestPeerAuthenticationsChunk(destShardID u
 		"epoch", rrh.epoch,
 	)
 
-	resolver, err := rrh.resolversFinder.CrossShardResolver(factory.PeerAuthenticationTopic, destShardID)
+	resolver, err := rrh.resolversFinder.MetaChainResolver(factory.PeerAuthenticationTopic)
 	if err != nil {
 		log.Error("RequestPeerAuthenticationsChunk.CrossShardResolver",
 			"error", err.Error(),
@@ -763,7 +763,7 @@ func (rrh *resolverRequestHandler) RequestPeerAuthenticationsByHashes(destShardI
 		"shard", destShardID,
 	)
 
-	resolver, err := rrh.resolversFinder.CrossShardResolver(factory.PeerAuthenticationTopic, destShardID)
+	resolver, err := rrh.resolversFinder.MetaChainResolver(factory.PeerAuthenticationTopic)
 	if err != nil {
 		log.Error("RequestPeerAuthenticationsChunk.CrossShardResolver",
 			"error", err.Error(),

--- a/dataRetriever/requestHandlers/requestHandler_test.go
+++ b/dataRetriever/requestHandlers/requestHandler_test.go
@@ -1171,8 +1171,7 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsChunk(t *testing.T) {
 		}
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
-				CrossShardResolverCalled: func(baseTopic string, crossShard uint32) (dataRetriever.Resolver, error) {
-					assert.Equal(t, providedShardId, crossShard)
+				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
 					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
 					return paResolver, errExpected
 				},
@@ -1199,8 +1198,7 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsChunk(t *testing.T) {
 		}
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
-				CrossShardResolverCalled: func(baseTopic string, crossShard uint32) (dataRetriever.Resolver, error) {
-					assert.Equal(t, providedShardId, crossShard)
+				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
 					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
 					return mbResolver, nil
 				},
@@ -1228,8 +1226,7 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsChunk(t *testing.T) {
 		}
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
-				CrossShardResolverCalled: func(baseTopic string, crossShard uint32) (dataRetriever.Resolver, error) {
-					assert.Equal(t, providedShardId, crossShard)
+				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
 					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
 					return paResolver, nil
 				},
@@ -1264,8 +1261,7 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsChunk(t *testing.T) {
 		}
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
-				CrossShardResolverCalled: func(baseTopic string, crossShard uint32) (dataRetriever.Resolver, error) {
-					assert.Equal(t, providedShardId, crossShard)
+				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
 					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
 					return paResolver, nil
 				},
@@ -1299,8 +1295,7 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsByHashes(t *testing.T)
 		}
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
-				CrossShardResolverCalled: func(baseTopic string, crossShard uint32) (dataRetriever.Resolver, error) {
-					assert.Equal(t, providedShardId, crossShard)
+				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
 					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
 					return paResolver, errExpected
 				},
@@ -1327,10 +1322,9 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsByHashes(t *testing.T)
 		}
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
-				CrossShardResolverCalled: func(baseTopic string, crossShard uint32) (dataRetriever.Resolver, error) {
-					assert.Equal(t, providedShardId, crossShard)
+				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
 					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
-					return mbResolver, nil
+					return mbResolver, errExpected
 				},
 			},
 			&mock.RequestedItemsHandlerStub{},
@@ -1356,8 +1350,7 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsByHashes(t *testing.T)
 		}
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
-				CrossShardResolverCalled: func(baseTopic string, crossShard uint32) (dataRetriever.Resolver, error) {
-					assert.Equal(t, providedShardId, crossShard)
+				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
 					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
 					return paResolver, nil
 				},
@@ -1392,8 +1385,7 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsByHashes(t *testing.T)
 		}
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
-				CrossShardResolverCalled: func(baseTopic string, crossShard uint32) (dataRetriever.Resolver, error) {
-					assert.Equal(t, providedShardId, crossShard)
+				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
 					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
 					return paResolver, nil
 				},

--- a/dataRetriever/resolvers/peerAuthenticationResolver.go
+++ b/dataRetriever/resolvers/peerAuthenticationResolver.go
@@ -12,6 +12,7 @@ import (
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/p2p"
+	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/storage"
 )
 
@@ -23,6 +24,7 @@ type ArgPeerAuthenticationResolver struct {
 	ArgBaseResolver
 	PeerAuthenticationPool               storage.Cacher
 	NodesCoordinator                     dataRetriever.NodesCoordinator
+	PeerShardMapper                      process.PeerShardMapper
 	MaxNumOfPeerAuthenticationInResponse int
 }
 
@@ -32,6 +34,7 @@ type peerAuthenticationResolver struct {
 	messageProcessor
 	peerAuthenticationPool               storage.Cacher
 	nodesCoordinator                     dataRetriever.NodesCoordinator
+	peerShardMapper                      process.PeerShardMapper
 	maxNumOfPeerAuthenticationInResponse int
 }
 
@@ -54,6 +57,7 @@ func NewPeerAuthenticationResolver(arg ArgPeerAuthenticationResolver) (*peerAuth
 		},
 		peerAuthenticationPool:               arg.PeerAuthenticationPool,
 		nodesCoordinator:                     arg.NodesCoordinator,
+		peerShardMapper:                      arg.PeerShardMapper,
 		maxNumOfPeerAuthenticationInResponse: arg.MaxNumOfPeerAuthenticationInResponse,
 	}, nil
 }
@@ -68,6 +72,9 @@ func checkArgPeerAuthenticationResolver(arg ArgPeerAuthenticationResolver) error
 	}
 	if check.IfNil(arg.NodesCoordinator) {
 		return dataRetriever.ErrNilNodesCoordinator
+	}
+	if check.IfNil(arg.PeerShardMapper) {
+		return dataRetriever.ErrNilPeerShardMapper
 	}
 	if arg.MaxNumOfPeerAuthenticationInResponse < minNumOfPeerAuthentication {
 		return dataRetriever.ErrInvalidNumOfPeerAuthentication
@@ -91,12 +98,22 @@ func (res *peerAuthenticationResolver) RequestDataFromChunk(chunkIndex uint32, e
 	chunkBuffer := make([]byte, bytesInUint32)
 	binary.BigEndian.PutUint32(chunkBuffer, chunkIndex)
 
+	b := &batch.Batch{
+		Data: make([][]byte, 1),
+	}
+	b.Data[0] = chunkBuffer
+
+	dataBuff, err := res.marshalizer.Marshal(b)
+	if err != nil {
+		return err
+	}
+
 	return res.SendOnRequestTopic(
 		&dataRetriever.RequestData{
 			Type:       dataRetriever.ChunkType,
 			ChunkIndex: chunkIndex,
 			Epoch:      epoch,
-			Value:      chunkBuffer,
+			Value:      dataBuff,
 		},
 		[][]byte{chunkBuffer},
 	)
@@ -291,7 +308,12 @@ func (res *peerAuthenticationResolver) fetchPeerAuthenticationSlicesForPublicKey
 
 // fetchPeerAuthenticationAsByteSlice returns the value from authentication pool if exists
 func (res *peerAuthenticationResolver) fetchPeerAuthenticationAsByteSlice(pk []byte) ([]byte, error) {
-	value, ok := res.peerAuthenticationPool.Peek(pk)
+	pid, ok := res.peerShardMapper.GetPeerID(pk)
+	if !ok {
+		return nil, dataRetriever.ErrPeerAuthNotFound
+	}
+
+	value, ok := res.peerAuthenticationPool.Peek(pid.Bytes())
 	if ok {
 		return res.marshalizer.Marshal(value)
 	}

--- a/dataRetriever/resolvers/peerAuthenticationResolver.go
+++ b/dataRetriever/resolvers/peerAuthenticationResolver.go
@@ -96,6 +96,7 @@ func (res *peerAuthenticationResolver) RequestDataFromChunk(chunkIndex uint32, e
 			Type:       dataRetriever.ChunkType,
 			ChunkIndex: chunkIndex,
 			Epoch:      epoch,
+			Value:      chunkBuffer,
 		},
 		[][]byte{chunkBuffer},
 	)
@@ -235,20 +236,15 @@ func (res *peerAuthenticationResolver) sendPeerAuthsForHashes(dataBuff [][]byte,
 	return res.sendData(dataBuff, hashesBuff, 0, 0, pid)
 }
 
-// sendLargeDataBuff splits dataBuff into chunks and sends a message for each
+// sendLargeDataBuff splits dataBuff into chunks and sends a message for first chunk
 func (res *peerAuthenticationResolver) sendLargeDataBuff(dataBuff [][]byte, reference []byte, chunkSize int, pid core.PeerID) error {
 	maxChunks := res.getMaxChunks(dataBuff)
-	for chunkIndex := 0; chunkIndex < maxChunks; chunkIndex++ {
-		chunk, err := res.extractChunk(dataBuff, chunkIndex, chunkSize, maxChunks)
-		if err != nil {
-			return err
-		}
-		err = res.sendData(chunk, reference, 0, 0, pid)
-		if err != nil {
-			return err
-		}
+	chunk, err := res.extractChunk(dataBuff, 0, chunkSize, maxChunks)
+	if err != nil {
+		return err
 	}
-	return nil
+
+	return res.sendData(chunk, reference, 0, maxChunks, pid)
 }
 
 // getMaxChunks returns the max num of chunks from a buffer

--- a/dataRetriever/resolvers/peerAuthenticationResolver.go
+++ b/dataRetriever/resolvers/peerAuthenticationResolver.go
@@ -253,7 +253,7 @@ func (res *peerAuthenticationResolver) sendPeerAuthsForHashes(dataBuff [][]byte,
 	return res.sendData(dataBuff, hashesBuff, 0, 0, pid)
 }
 
-// sendLargeDataBuff splits dataBuff into chunks and sends a message for first chunk
+// sendLargeDataBuff splits dataBuff into chunks and sends a message for the first chunk
 func (res *peerAuthenticationResolver) sendLargeDataBuff(dataBuff [][]byte, reference []byte, chunkSize int, pid core.PeerID) error {
 	maxChunks := res.getMaxChunks(dataBuff)
 	chunk, err := res.extractChunk(dataBuff, 0, chunkSize, maxChunks)

--- a/dataRetriever/resolvers/peerAuthenticationResolver.go
+++ b/dataRetriever/resolvers/peerAuthenticationResolver.go
@@ -308,7 +308,7 @@ func (res *peerAuthenticationResolver) fetchPeerAuthenticationSlicesForPublicKey
 
 // fetchPeerAuthenticationAsByteSlice returns the value from authentication pool if exists
 func (res *peerAuthenticationResolver) fetchPeerAuthenticationAsByteSlice(pk []byte) ([]byte, error) {
-	pid, ok := res.peerShardMapper.GetPeerID(pk)
+	pid, ok := res.peerShardMapper.GetLastKnownPeerID(pk)
 	if !ok {
 		return nil, dataRetriever.ErrPeerAuthNotFound
 	}

--- a/dataRetriever/resolvers/peerAuthenticationResolver_test.go
+++ b/dataRetriever/resolvers/peerAuthenticationResolver_test.go
@@ -509,14 +509,8 @@ func TestPeerAuthenticationResolver_ProcessReceivedMessage(t *testing.T) {
 				b := &batch.Batch{}
 				err := arg.Marshalizer.Unmarshal(b, buff)
 				assert.Nil(t, err)
-				if messagesSent == 0 {
-					// first message is full
-					assert.Equal(t, arg.MaxNumOfPeerAuthenticationInResponse, len(b.Data))
-				}
-				if messagesSent == 1 {
-					// second message is len(providedKeys)%MaxNumOfPeerAuthenticationInResponse
-					assert.Equal(t, len(providedKeys)%arg.MaxNumOfPeerAuthenticationInResponse, len(b.Data))
-				}
+				assert.Equal(t, arg.MaxNumOfPeerAuthenticationInResponse, len(b.Data))
+
 				messagesSent++
 				return nil
 			},
@@ -531,7 +525,7 @@ func TestPeerAuthenticationResolver_ProcessReceivedMessage(t *testing.T) {
 		assert.Nil(t, err)
 		err = res.ProcessReceivedMessage(createRequestMsgWithChunkIndex(dataRetriever.HashArrayType, providedHashes, epoch, chunkIndex), fromConnectedPeer)
 		assert.Nil(t, err)
-		assert.Equal(t, 2, messagesSent)
+		assert.Equal(t, 1, messagesSent) // only one message sent
 	})
 }
 

--- a/dataRetriever/resolvers/peerAuthenticationResolver_test.go
+++ b/dataRetriever/resolvers/peerAuthenticationResolver_test.go
@@ -49,7 +49,7 @@ func createMockArgPeerAuthenticationResolver() resolvers.ArgPeerAuthenticationRe
 		},
 		MaxNumOfPeerAuthenticationInResponse: 5,
 		PeerShardMapper: &processMock.PeerShardMapperStub{
-			GetPeerIDCalled: func(pk []byte) (*core.PeerID, bool) {
+			GetLastKnownPeerIDCalled: func(pk []byte) (*core.PeerID, bool) {
 				pid := core.PeerID("pid")
 				return &pid, true
 			},
@@ -468,7 +468,7 @@ func TestPeerAuthenticationResolver_ProcessReceivedMessage(t *testing.T) {
 			},
 		}
 		arg.PeerShardMapper = &processMock.PeerShardMapperStub{
-			GetPeerIDCalled: func(pk []byte) (*core.PeerID, bool) {
+			GetLastKnownPeerIDCalled: func(pk []byte) (*core.PeerID, bool) {
 				pid := core.PeerID(pk)
 				return &pid, true
 			},
@@ -539,7 +539,7 @@ func TestPeerAuthenticationResolver_ProcessReceivedMessage(t *testing.T) {
 			},
 		}
 		arg.PeerShardMapper = &processMock.PeerShardMapperStub{
-			GetPeerIDCalled: func(pk []byte) (*core.PeerID, bool) {
+			GetLastKnownPeerIDCalled: func(pk []byte) (*core.PeerID, bool) {
 				pid := core.PeerID(pk)
 				return &pid, true
 			},

--- a/dataRetriever/resolvers/peerAuthenticationResolver_test.go
+++ b/dataRetriever/resolvers/peerAuthenticationResolver_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/mock"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/resolvers"
 	"github.com/ElrondNetwork/elrond-go/p2p"
+	processMock "github.com/ElrondNetwork/elrond-go/process/mock"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,6 +48,12 @@ func createMockArgPeerAuthenticationResolver() resolvers.ArgPeerAuthenticationRe
 			},
 		},
 		MaxNumOfPeerAuthenticationInResponse: 5,
+		PeerShardMapper: &processMock.PeerShardMapperStub{
+			GetPeerIDCalled: func(pk []byte) (*core.PeerID, bool) {
+				pid := core.PeerID("pid")
+				return &pid, true
+			},
+		},
 	}
 }
 
@@ -128,6 +135,15 @@ func TestNewPeerAuthenticationResolver(t *testing.T) {
 		arg.MaxNumOfPeerAuthenticationInResponse = 1
 		res, err := resolvers.NewPeerAuthenticationResolver(arg)
 		assert.Equal(t, dataRetriever.ErrInvalidNumOfPeerAuthentication, err)
+		assert.Nil(t, res)
+	})
+	t.Run("nil PeerShardMapper should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgPeerAuthenticationResolver()
+		arg.PeerShardMapper = nil
+		res, err := resolvers.NewPeerAuthenticationResolver(arg)
+		assert.Equal(t, dataRetriever.ErrNilPeerShardMapper, err)
 		assert.Nil(t, res)
 	})
 	t.Run("should work", func(t *testing.T) {
@@ -451,6 +467,13 @@ func TestPeerAuthenticationResolver_ProcessReceivedMessage(t *testing.T) {
 				return nil
 			},
 		}
+		arg.PeerShardMapper = &processMock.PeerShardMapperStub{
+			GetPeerIDCalled: func(pk []byte) (*core.PeerID, bool) {
+				pid := core.PeerID(pk)
+				return &pid, true
+			},
+		}
+
 		res, err := resolvers.NewPeerAuthenticationResolver(arg)
 		assert.Nil(t, err)
 		assert.False(t, res.IsInterfaceNil())
@@ -515,6 +538,13 @@ func TestPeerAuthenticationResolver_ProcessReceivedMessage(t *testing.T) {
 				return nil
 			},
 		}
+		arg.PeerShardMapper = &processMock.PeerShardMapperStub{
+			GetPeerIDCalled: func(pk []byte) (*core.PeerID, bool) {
+				pid := core.PeerID(pk)
+				return &pid, true
+			},
+		}
+
 		res, err := resolvers.NewPeerAuthenticationResolver(arg)
 		assert.Nil(t, err)
 		assert.False(t, res.IsInterfaceNil())

--- a/epochStart/bootstrap/disabled/disabledPeerShardMapper.go
+++ b/epochStart/bootstrap/disabled/disabledPeerShardMapper.go
@@ -1,0 +1,30 @@
+package disabled
+
+import "github.com/ElrondNetwork/elrond-go-core/core"
+
+// peerShardMapper -
+type peerShardMapper struct {
+}
+
+// NewPeerShardMapper -
+func NewPeerShardMapper() *peerShardMapper {
+	return &peerShardMapper{}
+}
+
+func (p *peerShardMapper) GetPeerID(_ []byte) (*core.PeerID, bool) {
+	return nil, false
+}
+
+// UpdatePeerIDPublicKeyPair -
+func (p *peerShardMapper) UpdatePeerIDPublicKeyPair(_ core.PeerID, _ []byte) {
+}
+
+// GetPeerInfo -
+func (p *peerShardMapper) GetPeerInfo(_ core.PeerID) core.P2PPeerInfo {
+	return core.P2PPeerInfo{}
+}
+
+// IsInterfaceNil -
+func (p *peerShardMapper) IsInterfaceNil() bool {
+	return p == nil
+}

--- a/epochStart/bootstrap/disabled/disabledPeerShardMapper.go
+++ b/epochStart/bootstrap/disabled/disabledPeerShardMapper.go
@@ -2,29 +2,30 @@ package disabled
 
 import "github.com/ElrondNetwork/elrond-go-core/core"
 
-// peerShardMapper -
+// peerShardMapper represents the disabled structure of peerShardMapper
 type peerShardMapper struct {
 }
 
-// NewPeerShardMapper -
+// NewPeerShardMapper returns default instance
 func NewPeerShardMapper() *peerShardMapper {
 	return &peerShardMapper{}
 }
 
-func (p *peerShardMapper) GetPeerID(_ []byte) (*core.PeerID, bool) {
+// GetLastKnownPeerID returns nothing
+func (p *peerShardMapper) GetLastKnownPeerID(_ []byte) (*core.PeerID, bool) {
 	return nil, false
 }
 
-// UpdatePeerIDPublicKeyPair -
+// UpdatePeerIDPublicKeyPair does nothing
 func (p *peerShardMapper) UpdatePeerIDPublicKeyPair(_ core.PeerID, _ []byte) {
 }
 
-// GetPeerInfo -
+// GetPeerInfo returns default instance
 func (p *peerShardMapper) GetPeerInfo(_ core.PeerID) core.P2PPeerInfo {
 	return core.P2PPeerInfo{}
 }
 
-// IsInterfaceNil -
+// IsInterfaceNil returns true if there is no value under the interface
 func (p *peerShardMapper) IsInterfaceNil() bool {
 	return p == nil
 }

--- a/epochStart/bootstrap/factory/epochStartInterceptorsContainerFactory.go
+++ b/epochStart/bootstrap/factory/epochStartInterceptorsContainerFactory.go
@@ -72,6 +72,8 @@ func NewEpochStartInterceptorsContainer(args ArgsEpochStartInterceptorContainer)
 	sizeCheckDelta := 0
 	validityAttester := disabled.NewValidityAttester()
 	epochStartTrigger := disabled.NewEpochStartTrigger()
+	// TODO: move the peerShardMapper creation before boostrapComponents
+	peerShardMapper := disabled.NewPeerShardMapper()
 
 	containerFactoryArgs := interceptorscontainer.CommonInterceptorsContainerFactoryArgs{
 		CoreComponents:               args.CoreComponents,
@@ -100,6 +102,7 @@ func NewEpochStartInterceptorsContainer(args ArgsEpochStartInterceptorContainer)
 		PeerSignatureHandler:         cryptoComponents.PeerSignatureHandler(),
 		SignaturesHandler:            args.SignaturesHandler,
 		HeartbeatExpiryTimespanInSec: args.Config.HeartbeatV2.HeartbeatExpiryTimespanInSec,
+		PeerShardMapper:              peerShardMapper,
 	}
 
 	interceptorsContainerFactory, err := interceptorscontainer.NewMetaInterceptorsContainerFactory(containerFactoryArgs)

--- a/factory/processComponents.go
+++ b/factory/processComponents.go
@@ -243,6 +243,9 @@ func (pcf *processComponentsFactory) Create() (*processComponents, error) {
 
 	// TODO: maybe move PeerShardMapper to network components
 	peerShardMapper, err := pcf.prepareNetworkShardingCollector()
+	if err != nil {
+		return nil, err
+	}
 
 	resolversContainerFactory, err := pcf.newResolverContainerFactory(currentEpochProvider, peerShardMapper)
 	if err != nil {
@@ -427,9 +430,6 @@ func (pcf *processComponentsFactory) Create() (*processComponents, error) {
 		return nil, err
 	}
 
-	if err != nil {
-		return nil, err
-	}
 	interceptorContainerFactory, blackListHandler, err := pcf.newInterceptorContainerFactory(
 		headerSigVerifier,
 		pcf.bootstrapComponents.HeaderIntegrityVerifier(),

--- a/heartbeat/sender/heartbeatSender.go
+++ b/heartbeat/sender/heartbeatSender.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/data/batch"
 	"github.com/ElrondNetwork/elrond-go/heartbeat"
 )
 
@@ -109,7 +110,16 @@ func (sender *heartbeatSender) execute() error {
 		return err
 	}
 
-	sender.messenger.Broadcast(sender.topic, msgBytes)
+	b := batch.Batch{
+		Data: make([][]byte, 1),
+	}
+	b.Data[0] = msgBytes
+	data, err := sender.marshaller.Marshal(b)
+	if err != nil {
+		return err
+	}
+
+	sender.messenger.Broadcast(sender.topic, data)
 
 	return nil
 }

--- a/heartbeat/sender/peerAuthenticationSender.go
+++ b/heartbeat/sender/peerAuthenticationSender.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/data/batch"
 	crypto "github.com/ElrondNetwork/elrond-go-crypto"
 	"github.com/ElrondNetwork/elrond-go/heartbeat"
 )
@@ -112,7 +113,16 @@ func (sender *peerAuthenticationSender) execute() error {
 		return err
 	}
 
-	sender.messenger.Broadcast(sender.topic, msgBytes)
+	b := batch.Batch{
+		Data: make([][]byte, 1),
+	}
+	b.Data[0] = msgBytes
+	data, err := sender.marshaller.Marshal(b)
+	if err != nil {
+		return err
+	}
+
+	sender.messenger.Broadcast(sender.topic, data)
 
 	return nil
 }

--- a/heartbeat/sender/peerAuthenticationSender_test.go
+++ b/heartbeat/sender/peerAuthenticationSender_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/data/batch"
 	"github.com/ElrondNetwork/elrond-go-crypto"
 	"github.com/ElrondNetwork/elrond-go-crypto/signing"
 	"github.com/ElrondNetwork/elrond-go-crypto/signing/ed25519"
@@ -331,8 +332,11 @@ func TestPeerAuthenticationSender_execute(t *testing.T) {
 		log.Info("args", "pid", argsBase.messenger.ID().Pretty(), "bls sk", skBytes, "bls pk", pkBytes)
 
 		// verify the received bytes if they can be converted in a valid peer authentication message
+		recoveredBatch := batch.Batch{}
+		err = argsBase.marshaller.Unmarshal(&recoveredBatch, buffResulted)
+		assert.Nil(t, err)
 		recoveredMessage := &heartbeat.PeerAuthentication{}
-		err = argsBase.marshaller.Unmarshal(recoveredMessage, buffResulted)
+		err = argsBase.marshaller.Unmarshal(recoveredMessage, recoveredBatch.Data[0])
 		assert.Nil(t, err)
 		assert.Equal(t, pkBytes, recoveredMessage.Pubkey)
 		assert.Equal(t, argsBase.messenger.ID().Pretty(), core.PeerID(recoveredMessage.Pid).Pretty())

--- a/integrationTests/interface.go
+++ b/integrationTests/interface.go
@@ -45,7 +45,7 @@ type NodesCoordinatorFactory interface {
 
 // NetworkShardingUpdater defines the updating methods used by the network sharding component
 type NetworkShardingUpdater interface {
-	GetPeerID(pk []byte) (*core.PeerID, bool)
+	GetLastKnownPeerID(pk []byte) (*core.PeerID, bool)
 	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo
 	UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte)
 	UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID uint32)

--- a/integrationTests/interface.go
+++ b/integrationTests/interface.go
@@ -45,7 +45,9 @@ type NodesCoordinatorFactory interface {
 
 // NetworkShardingUpdater defines the updating methods used by the network sharding component
 type NetworkShardingUpdater interface {
+	GetPeerID(pk []byte) (*core.PeerID, bool)
 	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo
+	UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte)
 	UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID uint32)
 	UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
 	IsInterfaceNil() bool

--- a/integrationTests/mock/networkShardingCollectorMock.go
+++ b/integrationTests/mock/networkShardingCollectorMock.go
@@ -7,8 +7,9 @@ import (
 )
 
 type networkShardingCollectorMock struct {
-	mutPeerIdPkMap sync.RWMutex
-	peerIdPkMap    map[core.PeerID][]byte
+	mutMaps     sync.RWMutex
+	peerIdPkMap map[core.PeerID][]byte
+	pkPeerIdMap map[string]core.PeerID
 
 	mutFallbackPkShardMap sync.RWMutex
 	fallbackPkShardMap    map[string]uint32
@@ -24,17 +25,27 @@ type networkShardingCollectorMock struct {
 func NewNetworkShardingCollectorMock() *networkShardingCollectorMock {
 	return &networkShardingCollectorMock{
 		peerIdPkMap:         make(map[core.PeerID][]byte),
+		pkPeerIdMap:         make(map[string]core.PeerID),
 		peerIdSubType:       make(map[core.PeerID]uint32),
 		fallbackPkShardMap:  make(map[string]uint32),
 		fallbackPidShardMap: make(map[string]uint32),
 	}
 }
 
-// UpdatePeerIdPublicKey -
-func (nscm *networkShardingCollectorMock) UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID uint32) {
-	nscm.mutPeerIdPkMap.Lock()
+// UpdatePeerIDPublicKeyPair -
+func (nscm *networkShardingCollectorMock) UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte) {
+	nscm.mutMaps.Lock()
 	nscm.peerIdPkMap[pid] = pk
-	nscm.mutPeerIdPkMap.Unlock()
+	nscm.pkPeerIdMap[string(pk)] = pid
+	nscm.mutMaps.Unlock()
+}
+
+// UpdatePeerIDInfo -
+func (nscm *networkShardingCollectorMock) UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID uint32) {
+	nscm.mutMaps.Lock()
+	nscm.peerIdPkMap[pid] = pk
+	nscm.pkPeerIdMap[string(pk)] = pid
+	nscm.mutMaps.Unlock()
 
 	if shardID == core.AllShardId {
 		return
@@ -64,7 +75,18 @@ func (nscm *networkShardingCollectorMock) GetPeerInfo(pid core.PeerID) core.P2PP
 	return core.P2PPeerInfo{
 		PeerType:    core.ObserverPeer,
 		PeerSubType: core.P2PPeerSubType(nscm.peerIdSubType[pid]),
+		PkBytes:     nscm.peerIdPkMap[pid],
 	}
+}
+
+// GetPeerID -
+func (nscm *networkShardingCollectorMock) GetPeerID(pk []byte) (*core.PeerID, bool) {
+	nscm.mutMaps.RLock()
+	defer nscm.mutMaps.RUnlock()
+
+	pid, ok := nscm.pkPeerIdMap[string(pk)]
+
+	return &pid, ok
 }
 
 // IsInterfaceNil -

--- a/integrationTests/mock/networkShardingCollectorMock.go
+++ b/integrationTests/mock/networkShardingCollectorMock.go
@@ -79,8 +79,8 @@ func (nscm *networkShardingCollectorMock) GetPeerInfo(pid core.PeerID) core.P2PP
 	}
 }
 
-// GetPeerID -
-func (nscm *networkShardingCollectorMock) GetPeerID(pk []byte) (*core.PeerID, bool) {
+// GetLastKnownPeerID -
+func (nscm *networkShardingCollectorMock) GetLastKnownPeerID(pk []byte) (*core.PeerID, bool) {
 	nscm.mutMaps.RLock()
 	defer nscm.mutMaps.RUnlock()
 

--- a/integrationTests/mock/peerShardMapperStub.go
+++ b/integrationTests/mock/peerShardMapperStub.go
@@ -4,6 +4,24 @@ import "github.com/ElrondNetwork/elrond-go-core/core"
 
 // PeerShardMapperStub -
 type PeerShardMapperStub struct {
+	GetPeerIDCalled                 func(pk []byte) (*core.PeerID, bool)
+	UpdatePeerIDPublicKeyPairCalled func(pid core.PeerID, pk []byte)
+}
+
+// UpdatePeerIDPublicKeyPair -
+func (psms *PeerShardMapperStub) UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte) {
+	if psms.UpdatePeerIDPublicKeyPairCalled != nil {
+		psms.UpdatePeerIDPublicKeyPairCalled(pid, pk)
+	}
+}
+
+// GetPeerID -
+func (psms *PeerShardMapperStub) GetPeerID(pk []byte) (*core.PeerID, bool) {
+	if psms.GetPeerIDCalled != nil {
+		return psms.GetPeerIDCalled(pk)
+	}
+
+	return nil, false
 }
 
 // GetPeerInfo -

--- a/integrationTests/mock/peerShardMapperStub.go
+++ b/integrationTests/mock/peerShardMapperStub.go
@@ -4,7 +4,7 @@ import "github.com/ElrondNetwork/elrond-go-core/core"
 
 // PeerShardMapperStub -
 type PeerShardMapperStub struct {
-	GetPeerIDCalled                 func(pk []byte) (*core.PeerID, bool)
+	GetLastKnownPeerIDCalled        func(pk []byte) (*core.PeerID, bool)
 	UpdatePeerIDPublicKeyPairCalled func(pid core.PeerID, pk []byte)
 }
 
@@ -15,10 +15,10 @@ func (psms *PeerShardMapperStub) UpdatePeerIDPublicKeyPair(pid core.PeerID, pk [
 	}
 }
 
-// GetPeerID -
-func (psms *PeerShardMapperStub) GetPeerID(pk []byte) (*core.PeerID, bool) {
-	if psms.GetPeerIDCalled != nil {
-		return psms.GetPeerIDCalled(pk)
+// GetLastKnownPeerID -
+func (psms *PeerShardMapperStub) GetLastKnownPeerID(pk []byte) (*core.PeerID, bool) {
+	if psms.GetLastKnownPeerIDCalled != nil {
+		return psms.GetLastKnownPeerIDCalled(pk)
 	}
 
 	return nil, false

--- a/integrationTests/node/heartbeatV2/heartbeatV2_test.go
+++ b/integrationTests/node/heartbeatV2/heartbeatV2_test.go
@@ -1,0 +1,342 @@
+package heartbeatV2
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/partitioning"
+	"github.com/ElrondNetwork/elrond-go-core/core/random"
+	crypto "github.com/ElrondNetwork/elrond-go-crypto"
+	"github.com/ElrondNetwork/elrond-go-crypto/signing"
+	"github.com/ElrondNetwork/elrond-go-crypto/signing/mcl"
+	"github.com/ElrondNetwork/elrond-go-crypto/signing/mcl/singlesig"
+	"github.com/ElrondNetwork/elrond-go/common"
+	"github.com/ElrondNetwork/elrond-go/config"
+	dataRetrieverInterface "github.com/ElrondNetwork/elrond-go/dataRetriever"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever/factory/containers"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever/factory/resolverscontainer"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever/requestHandlers"
+	"github.com/ElrondNetwork/elrond-go/factory"
+	"github.com/ElrondNetwork/elrond-go/heartbeat/mock"
+	heartbeatProcessor "github.com/ElrondNetwork/elrond-go/heartbeat/processor"
+	"github.com/ElrondNetwork/elrond-go/heartbeat/sender"
+	"github.com/ElrondNetwork/elrond-go/integrationTests"
+	testsMock "github.com/ElrondNetwork/elrond-go/integrationTests/mock"
+	"github.com/ElrondNetwork/elrond-go/p2p"
+	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/process/interceptors"
+	interceptorFactory "github.com/ElrondNetwork/elrond-go/process/interceptors/factory"
+	interceptorsProcessor "github.com/ElrondNetwork/elrond-go/process/interceptors/processor"
+	processMock "github.com/ElrondNetwork/elrond-go/process/mock"
+	"github.com/ElrondNetwork/elrond-go/sharding"
+	"github.com/ElrondNetwork/elrond-go/state"
+	"github.com/ElrondNetwork/elrond-go/storage"
+	"github.com/ElrondNetwork/elrond-go/storage/timecache"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/ElrondNetwork/elrond-go/testscommon/dataRetriever"
+	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
+	trieFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	defaultNodeName           = "node"
+	timeBetweenPeerAuths      = 10 * time.Second
+	timeBetweenHeartbeats     = 2 * time.Second
+	timeBetweenSendsWhenError = time.Second
+	thresholdBetweenSends     = 0.2
+)
+
+func TestHeartbeatV2_AllPeersSendMessages(t *testing.T) {
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	interactingNodes := 3
+	nodes, pks, senders, dataPools, processors := createAndStartNodes(interactingNodes)
+	assert.Equal(t, interactingNodes, len(nodes))
+	assert.Equal(t, interactingNodes, len(pks))
+	assert.Equal(t, interactingNodes, len(senders))
+	assert.Equal(t, interactingNodes, len(dataPools))
+	assert.Equal(t, interactingNodes, len(processors))
+
+	// Wait for messages to broadcast
+	time.Sleep(5 * time.Second)
+
+	for i := 0; i < interactingNodes; i++ {
+		paCache := dataPools[i].PeerAuthentications()
+		hbCache := dataPools[i].Heartbeats()
+
+		assert.Equal(t, interactingNodes, len(paCache.Keys()))
+		assert.Equal(t, interactingNodes, len(hbCache.Keys()))
+
+		// Check this node received messages from all peers
+		for _, node := range nodes {
+			assert.True(t, paCache.Has(node.ID().Bytes()))
+			assert.True(t, hbCache.Has(node.ID().Bytes()))
+		}
+	}
+}
+
+func createAndStartNodes(interactingNodes int) ([]p2p.Messenger,
+	[]crypto.PublicKey,
+	[]factory.HeartbeatV2Sender,
+	[]dataRetrieverInterface.PoolsHolder,
+	[]factory.PeerAuthenticationRequestsProcessor,
+) {
+	keyGen := signing.NewKeyGenerator(mcl.NewSuiteBLS12())
+	sigHandler := createMockPeerSignatureHandler(keyGen)
+
+	nodes := make([]p2p.Messenger, interactingNodes)
+	pks := make([]crypto.PublicKey, interactingNodes)
+	senders := make([]factory.HeartbeatV2Sender, interactingNodes)
+	dataPools := make([]dataRetrieverInterface.PoolsHolder, interactingNodes)
+
+	// Create and connect messengers
+	for i := 0; i < interactingNodes; i++ {
+		nodes[i] = integrationTests.CreateMessengerWithNoDiscovery()
+		connectNodeToPeers(nodes[i], nodes[:i])
+	}
+
+	// Create data interceptors, senders
+	// new for loop is needed as peers must be connected before sender creation
+	for i := 0; i < interactingNodes; i++ {
+		dataPools[i] = dataRetriever.NewPoolsHolderMock()
+		createPeerAuthMultiDataInterceptor(nodes[i], dataPools[i].PeerAuthentications(), sigHandler)
+		createHeartbeatMultiDataInterceptor(nodes[i], dataPools[i].Heartbeats(), sigHandler)
+
+		nodeName := fmt.Sprintf("%s%d", defaultNodeName, i)
+		sk, pk := keyGen.GeneratePair()
+		pks[i] = pk
+
+		s := createSender(nodeName, nodes[i], sigHandler, sk)
+		senders[i] = s
+
+	}
+
+	/*pksArray := make([][]byte, 0)
+	for i := 0; i < interactingNodes; i++ {
+		pk, _ := pks[i].ToByteArray()
+		pksArray = append(pksArray, pk)
+	}
+	for i := 0; i < interactingNodes; i++ {
+		// processors[i] = createRequestProcessor(pksArray, nodes[i], dataPools[i])
+	}*/
+	processors := make([]factory.PeerAuthenticationRequestsProcessor, interactingNodes)
+
+	return nodes, pks, senders, dataPools, processors
+}
+
+func connectNodeToPeers(node p2p.Messenger, peers []p2p.Messenger) {
+	for _, peer := range peers {
+		_ = peer.ConnectToPeer(integrationTests.GetConnectableAddress(node))
+	}
+}
+
+func createSender(nodeName string, messenger p2p.Messenger, peerSigHandler crypto.PeerSignatureHandler, sk crypto.PrivateKey) factory.HeartbeatV2Sender {
+	argsSender := sender.ArgSender{
+		Messenger:                          messenger,
+		Marshaller:                         testscommon.MarshalizerMock{},
+		PeerAuthenticationTopic:            common.PeerAuthenticationTopic,
+		HeartbeatTopic:                     common.HeartbeatV2Topic,
+		PeerAuthenticationTimeBetweenSends: timeBetweenPeerAuths,
+		PeerAuthenticationTimeBetweenSendsWhenError: timeBetweenSendsWhenError,
+		PeerAuthenticationThresholdBetweenSends:     thresholdBetweenSends,
+		HeartbeatTimeBetweenSends:                   timeBetweenHeartbeats,
+		HeartbeatTimeBetweenSendsWhenError:          timeBetweenSendsWhenError,
+		HeartbeatThresholdBetweenSends:              thresholdBetweenSends,
+		VersionNumber:                               "v01",
+		NodeDisplayName:                             nodeName,
+		Identity:                                    nodeName + "_identity",
+		PeerSubType:                                 core.RegularPeer,
+		CurrentBlockProvider:                        &testscommon.ChainHandlerStub{},
+		PeerSignatureHandler:                        peerSigHandler,
+		PrivateKey:                                  sk,
+		RedundancyHandler:                           &mock.RedundancyHandlerStub{},
+	}
+
+	msgsSender, _ := sender.NewSender(argsSender)
+	return msgsSender
+}
+
+func createRequestProcessor(pks [][]byte, messenger p2p.Messenger,
+	dataPools dataRetrieverInterface.PoolsHolder,
+) factory.PeerAuthenticationRequestsProcessor {
+
+	dataPacker, _ := partitioning.NewSimpleDataPacker(&testscommon.MarshalizerMock{})
+	shardCoordinator := &sharding.OneShardCoordinator{}
+	trieStorageManager, _ := integrationTests.CreateTrieStorageManager(testscommon.CreateMemUnit())
+	trieContainer := state.NewDataTriesHolder()
+
+	_, stateTrie := integrationTests.CreateAccountsDB(integrationTests.UserAccount, trieStorageManager)
+	trieContainer.Put([]byte(trieFactory.UserAccountTrie), stateTrie)
+
+	_, peerTrie := integrationTests.CreateAccountsDB(integrationTests.ValidatorAccount, trieStorageManager)
+	trieContainer.Put([]byte(trieFactory.PeerAccountTrie), peerTrie)
+
+	trieStorageManagers := make(map[string]common.StorageManager)
+	trieStorageManagers[trieFactory.UserAccountTrie] = trieStorageManager
+	trieStorageManagers[trieFactory.PeerAccountTrie] = trieStorageManager
+
+	resolverContainerFactory := resolverscontainer.FactoryArgs{
+		ShardCoordinator:            shardCoordinator,
+		Messenger:                   messenger,
+		Store:                       integrationTests.CreateStore(2),
+		Marshalizer:                 &testscommon.MarshalizerMock{},
+		DataPools:                   dataPools,
+		Uint64ByteSliceConverter:    integrationTests.TestUint64Converter,
+		DataPacker:                  dataPacker,
+		TriesContainer:              trieContainer,
+		SizeCheckDelta:              100,
+		InputAntifloodHandler:       &testsMock.NilAntifloodHandler{},
+		OutputAntifloodHandler:      &testsMock.NilAntifloodHandler{},
+		NumConcurrentResolvingJobs:  10,
+		CurrentNetworkEpochProvider: &testsMock.CurrentNetworkEpochProviderStub{},
+		PreferredPeersHolder:        &p2pmocks.PeersHolderStub{},
+		ResolverConfig: config.ResolverConfig{
+			NumCrossShardPeers:  2,
+			NumIntraShardPeers:  1,
+			NumFullHistoryPeers: 3,
+		},
+		NodesCoordinator: &processMock.NodesCoordinatorMock{
+			GetAllEligibleValidatorsPublicKeysCalled: func() (map[uint32][][]byte, error) {
+				pksMap := make(map[uint32][][]byte, 1)
+				pksMap[0] = pks
+				return pksMap, nil
+			},
+		},
+		MaxNumOfPeerAuthenticationInResponse: 10,
+	}
+	resolversContainerFactory, _ := resolverscontainer.NewShardResolversContainerFactory(resolverContainerFactory)
+
+	resolversContainer, _ := resolversContainerFactory.Create()
+	resolverFinder, _ := containers.NewResolversFinder(resolversContainer, shardCoordinator)
+	whitelistHandler := &testscommon.WhiteListHandlerStub{
+		IsWhiteListedCalled: func(interceptedData process.InterceptedData) bool {
+			return true
+		},
+	}
+	requestedItemsHandler := timecache.NewTimeCache(5 * time.Second)
+	requestHandler, _ := requestHandlers.NewResolverRequestHandler(
+		resolverFinder,
+		requestedItemsHandler,
+		whitelistHandler,
+		100,
+		shardCoordinator.SelfId(),
+		time.Second,
+	)
+
+	argsProcessor := heartbeatProcessor.ArgPeerAuthenticationRequestsProcessor{
+		RequestHandler: requestHandler,
+		NodesCoordinator: &processMock.NodesCoordinatorMock{
+			GetAllEligibleValidatorsPublicKeysCalled: func() (map[uint32][][]byte, error) {
+				pksMap := make(map[uint32][][]byte, 1)
+				pksMap[0] = pks
+				return pksMap, nil
+			},
+		},
+		PeerAuthenticationPool:  dataPools.PeerAuthentications(),
+		ShardId:                 0,
+		Epoch:                   0,
+		MessagesInChunk:         10,
+		MinPeersThreshold:       1.0,
+		DelayBetweenRequests:    2 * time.Second,
+		MaxTimeout:              10 * time.Second,
+		MaxMissingKeysInRequest: 5,
+		Randomizer:              &random.ConcurrentSafeIntRandomizer{},
+	}
+
+	requestProcessor, _ := heartbeatProcessor.NewPeerAuthenticationRequestsProcessor(argsProcessor)
+	return requestProcessor
+}
+
+func createPeerAuthMultiDataInterceptor(messenger p2p.Messenger, peerAuthCacher storage.Cacher, sigHandler crypto.PeerSignatureHandler) {
+	argProcessor := interceptorsProcessor.ArgPeerAuthenticationInterceptorProcessor{
+		PeerAuthenticationCacher: peerAuthCacher,
+	}
+	paProcessor, _ := interceptorsProcessor.NewPeerAuthenticationInterceptorProcessor(argProcessor)
+
+	args := createMockInterceptedDataFactoryArgs(sigHandler, messenger.ID())
+	paFactory, _ := interceptorFactory.NewInterceptedPeerAuthenticationDataFactory(args)
+
+	createMockMultiDataInterceptor(common.PeerAuthenticationTopic, messenger, paFactory, paProcessor)
+}
+
+func createHeartbeatMultiDataInterceptor(messenger p2p.Messenger, heartbeatCacher storage.Cacher, sigHandler crypto.PeerSignatureHandler) {
+	argProcessor := interceptorsProcessor.ArgHeartbeatInterceptorProcessor{
+		HeartbeatCacher: heartbeatCacher,
+	}
+	hbProcessor, _ := interceptorsProcessor.NewHeartbeatInterceptorProcessor(argProcessor)
+
+	args := createMockInterceptedDataFactoryArgs(sigHandler, messenger.ID())
+	hbFactory, _ := interceptorFactory.NewInterceptedHeartbeatDataFactory(args)
+
+	createMockMultiDataInterceptor(common.HeartbeatV2Topic, messenger, hbFactory, hbProcessor)
+}
+
+func createMockInterceptedDataFactoryArgs(sigHandler crypto.PeerSignatureHandler, pid core.PeerID) interceptorFactory.ArgInterceptedDataFactory {
+	return interceptorFactory.ArgInterceptedDataFactory{
+		CoreComponents: &processMock.CoreComponentsMock{
+			IntMarsh: &testscommon.MarshalizerMock{},
+		},
+		NodesCoordinator: &processMock.NodesCoordinatorMock{
+			GetValidatorWithPublicKeyCalled: func(publicKey []byte) (validator sharding.Validator, shardId uint32, err error) {
+				return nil, 0, nil
+			},
+		},
+		PeerSignatureHandler:         sigHandler,
+		SignaturesHandler:            &processMock.SignaturesHandlerStub{},
+		HeartbeatExpiryTimespanInSec: 10,
+		PeerID:                       pid,
+	}
+}
+
+func createMockMultiDataInterceptor(topic string, messenger p2p.Messenger, dataFactory process.InterceptedDataFactory, processor process.InterceptorProcessor) {
+	mdInterceptor, _ := interceptors.NewMultiDataInterceptor(
+		interceptors.ArgMultiDataInterceptor{
+			Topic:            topic,
+			Marshalizer:      testscommon.MarshalizerMock{},
+			DataFactory:      dataFactory,
+			Processor:        processor,
+			Throttler:        createMockThrottler(),
+			AntifloodHandler: &testsMock.P2PAntifloodHandlerStub{},
+			WhiteListRequest: &testscommon.WhiteListHandlerStub{
+				IsWhiteListedCalled: func(interceptedData process.InterceptedData) bool {
+					return true
+				},
+			},
+			PreferredPeersHolder: &p2pmocks.PeersHolderStub{},
+			CurrentPeerId:        messenger.ID(),
+		},
+	)
+
+	_ = messenger.CreateTopic(topic, true)
+	_ = messenger.RegisterMessageProcessor(topic, common.DefaultInterceptorsIdentifier, mdInterceptor)
+}
+
+func createMockPeerSignatureHandler(keyGen crypto.KeyGenerator) crypto.PeerSignatureHandler {
+	singleSigner := singlesig.NewBlsSigner()
+
+	return &mock.PeerSignatureHandlerStub{
+		VerifyPeerSignatureCalled: func(pk []byte, pid core.PeerID, signature []byte) error {
+			senderPubKey, err := keyGen.PublicKeyFromByteArray(pk)
+			if err != nil {
+				return err
+			}
+			return singleSigner.Verify(senderPubKey, pid.Bytes(), signature)
+		},
+		GetPeerSignatureCalled: func(privateKey crypto.PrivateKey, pid []byte) ([]byte, error) {
+			return singleSigner.Sign(privateKey, pid)
+		},
+	}
+}
+
+func createMockThrottler() *processMock.InterceptorThrottlerStub {
+	return &processMock.InterceptorThrottlerStub{
+		CanProcessCalled: func() bool {
+			return true
+		},
+	}
+}

--- a/integrationTests/node/heartbeatV2/heartbeatV2_test.go
+++ b/integrationTests/node/heartbeatV2/heartbeatV2_test.go
@@ -1,46 +1,12 @@
 package heartbeatV2
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/ElrondNetwork/elrond-go-core/core"
-	"github.com/ElrondNetwork/elrond-go-core/core/random"
-	crypto "github.com/ElrondNetwork/elrond-go-crypto"
-	"github.com/ElrondNetwork/elrond-go-crypto/signing"
-	"github.com/ElrondNetwork/elrond-go-crypto/signing/mcl"
-	"github.com/ElrondNetwork/elrond-go-crypto/signing/mcl/singlesig"
-	"github.com/ElrondNetwork/elrond-go/common"
-	dataRetrieverInterface "github.com/ElrondNetwork/elrond-go/dataRetriever"
-	"github.com/ElrondNetwork/elrond-go/dataRetriever/resolvers"
-	"github.com/ElrondNetwork/elrond-go/dataRetriever/resolvers/topicResolverSender"
-	"github.com/ElrondNetwork/elrond-go/factory"
 	"github.com/ElrondNetwork/elrond-go/heartbeat"
-	"github.com/ElrondNetwork/elrond-go/heartbeat/mock"
-	"github.com/ElrondNetwork/elrond-go/heartbeat/sender"
 	"github.com/ElrondNetwork/elrond-go/integrationTests"
-	testsMock "github.com/ElrondNetwork/elrond-go/integrationTests/mock"
-	"github.com/ElrondNetwork/elrond-go/p2p"
-	"github.com/ElrondNetwork/elrond-go/process"
-	"github.com/ElrondNetwork/elrond-go/process/interceptors"
-	interceptorFactory "github.com/ElrondNetwork/elrond-go/process/interceptors/factory"
-	interceptorsProcessor "github.com/ElrondNetwork/elrond-go/process/interceptors/processor"
-	processMock "github.com/ElrondNetwork/elrond-go/process/mock"
-	"github.com/ElrondNetwork/elrond-go/sharding"
-	"github.com/ElrondNetwork/elrond-go/storage"
-	"github.com/ElrondNetwork/elrond-go/testscommon"
-	"github.com/ElrondNetwork/elrond-go/testscommon/dataRetriever"
-	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	"github.com/stretchr/testify/assert"
-)
-
-const (
-	defaultNodeName           = "node"
-	timeBetweenPeerAuths      = 10 * time.Second
-	timeBetweenHeartbeats     = 2 * time.Second
-	timeBetweenSendsWhenError = time.Second
-	thresholdBetweenSends     = 0.2
 )
 
 func TestHeartbeatV2_AllPeersSendMessages(t *testing.T) {
@@ -48,23 +14,25 @@ func TestHeartbeatV2_AllPeersSendMessages(t *testing.T) {
 		t.Skip("this is not a short test")
 	}
 
-	keyGen := signing.NewKeyGenerator(mcl.NewSuiteBLS12())
-	sigHandler := createMockPeerSignatureHandler(keyGen)
-
 	interactingNodes := 3
-	nodes, senders, dataPools := createAndStartNodes(interactingNodes, keyGen, sigHandler)
+	nodes := make([]*integrationTests.TestHeartbeatNode, interactingNodes)
+	for i := 0; i < interactingNodes; i++ {
+		nodes[i] = integrationTests.NewTestHeartbeatNode(3, 0, interactingNodes)
+	}
 	assert.Equal(t, interactingNodes, len(nodes))
-	assert.Equal(t, interactingNodes, len(senders))
-	assert.Equal(t, interactingNodes, len(dataPools))
+
+	connectNodes(nodes, interactingNodes)
 
 	// Wait for messages to broadcast
 	time.Sleep(time.Second * 5)
 
-	// Check sent messages
-	maxMessageAgeAllowed := time.Second * 7
-	checkMessages(t, nodes, dataPools, maxMessageAgeAllowed)
+	for i := 0; i < len(nodes); i++ {
+		nodes[i].Close()
+	}
 
-	closeComponents(t, nodes, senders, dataPools, nil)
+	// Check sent messages
+	maxMessageAgeAllowed := time.Second * 5
+	checkMessages(t, nodes, maxMessageAgeAllowed)
 }
 
 func TestHeartbeatV2_PeerJoiningLate(t *testing.T) {
@@ -72,151 +40,67 @@ func TestHeartbeatV2_PeerJoiningLate(t *testing.T) {
 		t.Skip("this is not a short test")
 	}
 
-	keyGen := signing.NewKeyGenerator(mcl.NewSuiteBLS12())
-	sigHandler := createMockPeerSignatureHandler(keyGen)
-	shardCoordinator := &sharding.OneShardCoordinator{}
-
 	interactingNodes := 3
-	nodes, senders, dataPools := createAndStartNodes(interactingNodes, keyGen, sigHandler)
+	nodes := make([]*integrationTests.TestHeartbeatNode, interactingNodes)
+	for i := 0; i < interactingNodes; i++ {
+		nodes[i] = integrationTests.NewTestHeartbeatNode(3, 0, interactingNodes)
+	}
 	assert.Equal(t, interactingNodes, len(nodes))
-	assert.Equal(t, interactingNodes, len(senders))
-	assert.Equal(t, interactingNodes, len(dataPools))
+
+	connectNodes(nodes, interactingNodes)
 
 	// Wait for messages to broadcast
-	time.Sleep(time.Second * 3)
+	time.Sleep(time.Second * 5)
 
 	// Check sent messages
 	maxMessageAgeAllowed := time.Second * 5
-	checkMessages(t, nodes, dataPools, maxMessageAgeAllowed)
+	checkMessages(t, nodes, maxMessageAgeAllowed)
 
 	// Add new delayed node which requests messages
-	delayedNode, delayedNodeDataPool := createDelayedNode(nodes, sigHandler)
+	delayedNode := integrationTests.NewTestHeartbeatNode(3, 0, interactingNodes+1)
 	nodes = append(nodes, delayedNode)
-	dataPools = append(dataPools, delayedNodeDataPool)
+	connectNodes(nodes, len(nodes))
+	// Wait for messages to broadcast and requests to finish
+	time.Sleep(time.Second * 5)
 
-	pksArray := make([][]byte, 0)
-	for _, node := range nodes {
-		pksArray = append(pksArray, node.ID().Bytes())
+	for i := 0; i < len(nodes); i++ {
+		nodes[i].Close()
 	}
-
-	// Create resolvers and request chunk from delayed node
-	paResolvers := createPeerAuthResolvers(pksArray, nodes, dataPools, shardCoordinator)
-	newNodeIndex := len(nodes) - 1
-	_ = paResolvers[newNodeIndex].RequestDataFromChunk(0, 0)
-
-	// Wait for messages to broadcast
-	time.Sleep(time.Second * 3)
-
-	delayedNodeCache := delayedNodeDataPool.PeerAuthentications()
-	assert.Equal(t, len(nodes)-1, delayedNodeCache.Len())
-
-	// Only search for messages from initially created nodes.
-	// Last one does not send peerAuthentication yet
-	for i := 0; i < len(nodes)-1; i++ {
-		assert.True(t, delayedNodeCache.Has(nodes[i].ID().Bytes()))
-	}
-
-	// Create sender for last node
-	nodeName := fmt.Sprintf("%s%d", defaultNodeName, newNodeIndex)
-	sk, _ := keyGen.GeneratePair()
-	s := createSender(nodeName, delayedNode, sigHandler, sk)
-	senders = append(senders, s)
-
-	// Wait to make sure all peers send messages again
-	time.Sleep(time.Second * 3)
 
 	// Check sent messages again - now should have from all peers
 	maxMessageAgeAllowed = time.Second * 5 // should not have messages from first Send
-	checkMessages(t, nodes, dataPools, maxMessageAgeAllowed)
-
-	// Add new delayed node which requests messages by hash array
-	delayedNode, delayedNodeDataPool = createDelayedNode(nodes, sigHandler)
-	nodes = append(nodes, delayedNode)
-	dataPools = append(dataPools, delayedNodeDataPool)
-	delayedNodeResolver := createPeerAuthResolver(pksArray, delayedNodeDataPool.PeerAuthentications(), delayedNode, shardCoordinator)
-	_ = delayedNodeResolver.RequestDataFromHashArray(pksArray, 0)
-
-	// Wait for messages to broadcast
-	time.Sleep(time.Second * 3)
-
-	// Check that the node received peer auths from all of them
-	assert.Equal(t, len(nodes)-1, delayedNodeDataPool.PeerAuthentications().Len())
-	for _, node := range nodes {
-		assert.True(t, delayedNodeDataPool.PeerAuthentications().Has(node.ID().Bytes()))
-	}
-
-	closeComponents(t, nodes, senders, dataPools, paResolvers)
+	checkMessages(t, nodes, maxMessageAgeAllowed)
 }
 
-func TestHeartbeatV2_NetworkShouldSendMessages(t *testing.T) {
-	if testing.Short() {
-		t.Skip("this is not a short test")
+func connectNodes(nodes []*integrationTests.TestHeartbeatNode, interactingNodes int) {
+	for i := 0; i < interactingNodes-1; i++ {
+		for j := i + 1; j < interactingNodes; j++ {
+			src := nodes[i]
+			dst := nodes[j]
+			_ = src.ConnectTo(dst)
+		}
 	}
-
-	keyGen := signing.NewKeyGenerator(mcl.NewSuiteBLS12())
-	sigHandler := createMockPeerSignatureHandler(keyGen)
-
-	nodes, _ := integrationTests.CreateFixedNetworkOf8Peers()
-	interactingNodes := len(nodes)
-
-	// Create components
-	dataPools := make([]dataRetrieverInterface.PoolsHolder, interactingNodes)
-	senders := make([]factory.HeartbeatV2Sender, interactingNodes)
-	for i := 0; i < interactingNodes; i++ {
-		dataPools[i] = dataRetriever.NewPoolsHolderMock()
-		createPeerAuthMultiDataInterceptor(nodes[i], dataPools[i].PeerAuthentications(), sigHandler)
-		createHeartbeatMultiDataInterceptor(nodes[i], dataPools[i].Heartbeats(), sigHandler)
-
-		nodeName := fmt.Sprintf("%s%d", defaultNodeName, i)
-		sk, _ := keyGen.GeneratePair()
-
-		s := createSender(nodeName, nodes[i], sigHandler, sk)
-		senders[i] = s
-	}
-
-	// Wait for all peers to send peer auth messages twice
-	time.Sleep(time.Second * 15)
-
-	checkMessages(t, nodes, dataPools, time.Second*7)
-
-	closeComponents(t, nodes, senders, dataPools, nil)
 }
 
-func createDelayedNode(nodes []p2p.Messenger, sigHandler crypto.PeerSignatureHandler) (p2p.Messenger, dataRetrieverInterface.PoolsHolder) {
-	node := integrationTests.CreateMessengerWithNoDiscovery()
-	connectNodeToPeers(node, nodes)
-
-	// Wait for last peer to join
-	time.Sleep(time.Second * 2)
-
-	dataPool := dataRetriever.NewPoolsHolderMock()
-
-	// Create multi data interceptors for the delayed node in order to receive messages
-	createPeerAuthMultiDataInterceptor(node, dataPool.PeerAuthentications(), sigHandler)
-	createHeartbeatMultiDataInterceptor(node, dataPool.Heartbeats(), sigHandler)
-
-	return node, dataPool
-}
-
-func checkMessages(t *testing.T, nodes []p2p.Messenger, dataPools []dataRetrieverInterface.PoolsHolder, maxMessageAgeAllowed time.Duration) {
+func checkMessages(t *testing.T, nodes []*integrationTests.TestHeartbeatNode, maxMessageAgeAllowed time.Duration) {
 	numOfNodes := len(nodes)
 	for i := 0; i < numOfNodes; i++ {
-		paCache := dataPools[i].PeerAuthentications()
-		hbCache := dataPools[i].Heartbeats()
+		paCache := nodes[i].DataPool.PeerAuthentications()
+		hbCache := nodes[i].DataPool.Heartbeats()
 
 		assert.Equal(t, numOfNodes, paCache.Len())
 		assert.Equal(t, numOfNodes, hbCache.Len())
 
 		// Check this node received messages from all peers
 		for _, node := range nodes {
-			assert.True(t, paCache.Has(node.ID().Bytes()))
-			assert.True(t, hbCache.Has(node.ID().Bytes()))
+			assert.True(t, paCache.Has(node.Messenger.ID().Bytes()))
+			assert.True(t, hbCache.Has(node.Messenger.ID().Bytes()))
 
 			// Also check message age
-			value, _ := paCache.Get(node.ID().Bytes())
+			value, _ := paCache.Get(node.Messenger.ID().Bytes())
 			msg := value.(heartbeat.PeerAuthentication)
 
-			marshaller := testscommon.MarshalizerMock{}
+			marshaller := integrationTests.TestMarshaller
 			payload := &heartbeat.Payload{}
 			err := marshaller.Unmarshal(payload, msg.Payload)
 			assert.Nil(t, err)
@@ -224,250 +108,6 @@ func checkMessages(t *testing.T, nodes []p2p.Messenger, dataPools []dataRetrieve
 			currentTimestamp := time.Now().Unix()
 			messageAge := time.Duration(currentTimestamp - payload.Timestamp)
 			assert.True(t, messageAge < maxMessageAgeAllowed)
-		}
-	}
-}
-
-func createAndStartNodes(interactingNodes int, keyGen crypto.KeyGenerator, sigHandler crypto.PeerSignatureHandler) (
-	[]p2p.Messenger,
-	[]factory.HeartbeatV2Sender,
-	[]dataRetrieverInterface.PoolsHolder,
-) {
-	nodes := make([]p2p.Messenger, interactingNodes)
-	senders := make([]factory.HeartbeatV2Sender, interactingNodes)
-	dataPools := make([]dataRetrieverInterface.PoolsHolder, interactingNodes)
-
-	// Create and connect messengers
-	for i := 0; i < interactingNodes; i++ {
-		nodes[i] = integrationTests.CreateMessengerWithNoDiscovery()
-		connectNodeToPeers(nodes[i], nodes[:i])
-	}
-
-	// Create data interceptors, senders
-	// new for loop is needed as peers must be connected before sender creation
-	for i := 0; i < interactingNodes; i++ {
-		dataPools[i] = dataRetriever.NewPoolsHolderMock()
-		createPeerAuthMultiDataInterceptor(nodes[i], dataPools[i].PeerAuthentications(), sigHandler)
-		createHeartbeatMultiDataInterceptor(nodes[i], dataPools[i].Heartbeats(), sigHandler)
-
-		nodeName := fmt.Sprintf("%s%d", defaultNodeName, i)
-		sk, _ := keyGen.GeneratePair()
-
-		s := createSender(nodeName, nodes[i], sigHandler, sk)
-		senders[i] = s
-	}
-
-	return nodes, senders, dataPools
-}
-
-func connectNodeToPeers(node p2p.Messenger, peers []p2p.Messenger) {
-	for _, peer := range peers {
-		_ = peer.ConnectToPeer(integrationTests.GetConnectableAddress(node))
-	}
-}
-
-func createSender(nodeName string, messenger p2p.Messenger, peerSigHandler crypto.PeerSignatureHandler, sk crypto.PrivateKey) factory.HeartbeatV2Sender {
-	argsSender := sender.ArgSender{
-		Messenger:                          messenger,
-		Marshaller:                         testscommon.MarshalizerMock{},
-		PeerAuthenticationTopic:            common.PeerAuthenticationTopic,
-		HeartbeatTopic:                     common.HeartbeatV2Topic,
-		PeerAuthenticationTimeBetweenSends: timeBetweenPeerAuths,
-		PeerAuthenticationTimeBetweenSendsWhenError: timeBetweenSendsWhenError,
-		PeerAuthenticationThresholdBetweenSends:     thresholdBetweenSends,
-		HeartbeatTimeBetweenSends:                   timeBetweenHeartbeats,
-		HeartbeatTimeBetweenSendsWhenError:          timeBetweenSendsWhenError,
-		HeartbeatThresholdBetweenSends:              thresholdBetweenSends,
-		VersionNumber:                               "v01",
-		NodeDisplayName:                             nodeName,
-		Identity:                                    nodeName + "_identity",
-		PeerSubType:                                 core.RegularPeer,
-		CurrentBlockProvider:                        &testscommon.ChainHandlerStub{},
-		PeerSignatureHandler:                        peerSigHandler,
-		PrivateKey:                                  sk,
-		RedundancyHandler:                           &mock.RedundancyHandlerStub{},
-	}
-
-	msgsSender, _ := sender.NewSender(argsSender)
-	return msgsSender
-}
-
-func createPeerAuthResolvers(pks [][]byte, nodes []p2p.Messenger, dataPools []dataRetrieverInterface.PoolsHolder, shardCoordinator sharding.Coordinator) []dataRetrieverInterface.PeerAuthenticationResolver {
-	paResolvers := make([]dataRetrieverInterface.PeerAuthenticationResolver, len(nodes))
-	for idx, node := range nodes {
-		paResolvers[idx] = createPeerAuthResolver(pks, dataPools[idx].PeerAuthentications(), node, shardCoordinator)
-	}
-
-	return paResolvers
-}
-
-func createPeerAuthResolver(pks [][]byte, peerAuthPool storage.Cacher, messenger p2p.Messenger, shardCoordinator sharding.Coordinator) dataRetrieverInterface.PeerAuthenticationResolver {
-	intraShardTopic := common.ConsensusTopic +
-		shardCoordinator.CommunicationIdentifier(shardCoordinator.SelfId())
-
-	peerListCreator, _ := topicResolverSender.NewDiffPeerListCreator(messenger, common.PeerAuthenticationTopic, intraShardTopic, "")
-
-	argsTopicResolverSender := topicResolverSender.ArgTopicResolverSender{
-		Messenger:                   messenger,
-		TopicName:                   common.PeerAuthenticationTopic,
-		PeerListCreator:             peerListCreator,
-		Marshalizer:                 &testscommon.MarshalizerMock{},
-		Randomizer:                  &random.ConcurrentSafeIntRandomizer{},
-		TargetShardId:               shardCoordinator.SelfId(),
-		OutputAntiflooder:           &testsMock.NilAntifloodHandler{},
-		NumCrossShardPeers:          len(pks),
-		NumIntraShardPeers:          1,
-		NumFullHistoryPeers:         3,
-		CurrentNetworkEpochProvider: &testsMock.CurrentNetworkEpochProviderStub{},
-		PreferredPeersHolder:        &p2pmocks.PeersHolderStub{},
-		SelfShardIdProvider:         shardCoordinator,
-	}
-	resolverSender, _ := topicResolverSender.NewTopicResolverSender(argsTopicResolverSender)
-
-	argsPAResolver := resolvers.ArgPeerAuthenticationResolver{
-		ArgBaseResolver: resolvers.ArgBaseResolver{
-			SenderResolver:   resolverSender,
-			Marshalizer:      &testscommon.MarshalizerMock{},
-			AntifloodHandler: &testsMock.NilAntifloodHandler{},
-			Throttler:        createMockThrottler(),
-		},
-		PeerAuthenticationPool:               peerAuthPool,
-		NodesCoordinator:                     createMockNodesCoordinator(pks),
-		MaxNumOfPeerAuthenticationInResponse: 10,
-	}
-	peerAuthResolver, _ := resolvers.NewPeerAuthenticationResolver(argsPAResolver)
-
-	_ = messenger.CreateTopic(peerAuthResolver.RequestTopic(), true)
-	_ = messenger.RegisterMessageProcessor(peerAuthResolver.RequestTopic(), common.DefaultResolversIdentifier, peerAuthResolver)
-
-	return peerAuthResolver
-}
-
-func createPeerAuthMultiDataInterceptor(messenger p2p.Messenger, peerAuthCacher storage.Cacher, sigHandler crypto.PeerSignatureHandler) {
-	argProcessor := interceptorsProcessor.ArgPeerAuthenticationInterceptorProcessor{
-		PeerAuthenticationCacher: peerAuthCacher,
-	}
-	paProcessor, _ := interceptorsProcessor.NewPeerAuthenticationInterceptorProcessor(argProcessor)
-
-	args := createMockInterceptedDataFactoryArgs(sigHandler, messenger.ID())
-	paFactory, _ := interceptorFactory.NewInterceptedPeerAuthenticationDataFactory(args)
-
-	createMockMultiDataInterceptor(common.PeerAuthenticationTopic, messenger, paFactory, paProcessor)
-}
-
-func createHeartbeatMultiDataInterceptor(messenger p2p.Messenger, heartbeatCacher storage.Cacher, sigHandler crypto.PeerSignatureHandler) {
-	argProcessor := interceptorsProcessor.ArgHeartbeatInterceptorProcessor{
-		HeartbeatCacher: heartbeatCacher,
-	}
-	hbProcessor, _ := interceptorsProcessor.NewHeartbeatInterceptorProcessor(argProcessor)
-
-	args := createMockInterceptedDataFactoryArgs(sigHandler, messenger.ID())
-	hbFactory, _ := interceptorFactory.NewInterceptedHeartbeatDataFactory(args)
-
-	createMockMultiDataInterceptor(common.HeartbeatV2Topic, messenger, hbFactory, hbProcessor)
-}
-
-func createMockInterceptedDataFactoryArgs(sigHandler crypto.PeerSignatureHandler, pid core.PeerID) interceptorFactory.ArgInterceptedDataFactory {
-	return interceptorFactory.ArgInterceptedDataFactory{
-		CoreComponents: &processMock.CoreComponentsMock{
-			IntMarsh: &testscommon.MarshalizerMock{},
-		},
-		NodesCoordinator: &processMock.NodesCoordinatorMock{
-			GetValidatorWithPublicKeyCalled: func(publicKey []byte) (validator sharding.Validator, shardId uint32, err error) {
-				return nil, 0, nil
-			},
-		},
-		PeerSignatureHandler:         sigHandler,
-		SignaturesHandler:            &processMock.SignaturesHandlerStub{},
-		HeartbeatExpiryTimespanInSec: 10,
-		PeerID:                       pid,
-	}
-}
-
-func createMockMultiDataInterceptor(topic string, messenger p2p.Messenger, dataFactory process.InterceptedDataFactory, processor process.InterceptorProcessor) {
-	mdInterceptor, _ := interceptors.NewMultiDataInterceptor(
-		interceptors.ArgMultiDataInterceptor{
-			Topic:            topic,
-			Marshalizer:      testscommon.MarshalizerMock{},
-			DataFactory:      dataFactory,
-			Processor:        processor,
-			Throttler:        createMockThrottler(),
-			AntifloodHandler: &testsMock.P2PAntifloodHandlerStub{},
-			WhiteListRequest: &testscommon.WhiteListHandlerStub{
-				IsWhiteListedCalled: func(interceptedData process.InterceptedData) bool {
-					return true
-				},
-			},
-			PreferredPeersHolder: &p2pmocks.PeersHolderStub{},
-			CurrentPeerId:        messenger.ID(),
-		},
-	)
-
-	_ = messenger.CreateTopic(topic, true)
-	_ = messenger.RegisterMessageProcessor(topic, common.DefaultInterceptorsIdentifier, mdInterceptor)
-}
-
-func createMockPeerSignatureHandler(keyGen crypto.KeyGenerator) crypto.PeerSignatureHandler {
-	singleSigner := singlesig.NewBlsSigner()
-
-	return &mock.PeerSignatureHandlerStub{
-		VerifyPeerSignatureCalled: func(pk []byte, pid core.PeerID, signature []byte) error {
-			senderPubKey, err := keyGen.PublicKeyFromByteArray(pk)
-			if err != nil {
-				return err
-			}
-			return singleSigner.Verify(senderPubKey, pid.Bytes(), signature)
-		},
-		GetPeerSignatureCalled: func(privateKey crypto.PrivateKey, pid []byte) ([]byte, error) {
-			return singleSigner.Sign(privateKey, pid)
-		},
-	}
-}
-
-func createMockNodesCoordinator(pks [][]byte) dataRetrieverInterface.NodesCoordinator {
-	return &processMock.NodesCoordinatorMock{
-		GetAllEligibleValidatorsPublicKeysCalled: func() (map[uint32][][]byte, error) {
-			pksMap := make(map[uint32][][]byte, 1)
-			pksMap[0] = pks
-			return pksMap, nil
-		},
-	}
-}
-
-func createMockThrottler() *processMock.InterceptorThrottlerStub {
-	return &processMock.InterceptorThrottlerStub{
-		CanProcessCalled: func() bool {
-			return true
-		},
-	}
-}
-
-func closeComponents(t *testing.T,
-	nodes []p2p.Messenger,
-	senders []factory.HeartbeatV2Sender,
-	dataPools []dataRetrieverInterface.PoolsHolder,
-	resolvers []dataRetrieverInterface.PeerAuthenticationResolver) {
-	interactingNodes := len(nodes)
-	for i := 0; i < interactingNodes; i++ {
-		var err error
-		if senders != nil && len(senders) > i {
-			err = senders[i].Close()
-			assert.Nil(t, err)
-		}
-
-		if dataPools != nil && len(dataPools) > i {
-			err = dataPools[i].Close()
-			assert.Nil(t, err)
-		}
-
-		if resolvers != nil && len(resolvers) > i {
-			err = resolvers[i].Close()
-			assert.Nil(t, err)
-		}
-
-		if nodes != nil && len(nodes) > i {
-			err = nodes[i].Close()
-			assert.Nil(t, err)
 		}
 	}
 }

--- a/integrationTests/testHeartbeatNode.go
+++ b/integrationTests/testHeartbeatNode.go
@@ -1,0 +1,383 @@
+package integrationTests
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/core/partitioning"
+	"github.com/ElrondNetwork/elrond-go-core/core/random"
+	crypto "github.com/ElrondNetwork/elrond-go-crypto"
+	"github.com/ElrondNetwork/elrond-go-crypto/signing"
+	"github.com/ElrondNetwork/elrond-go-crypto/signing/mcl"
+	"github.com/ElrondNetwork/elrond-go-crypto/signing/mcl/singlesig"
+	"github.com/ElrondNetwork/elrond-go/common"
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever/factory/containers"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever/factory/resolverscontainer"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever/requestHandlers"
+	"github.com/ElrondNetwork/elrond-go/factory"
+	"github.com/ElrondNetwork/elrond-go/heartbeat/processor"
+	"github.com/ElrondNetwork/elrond-go/heartbeat/sender"
+	"github.com/ElrondNetwork/elrond-go/integrationTests/mock"
+	"github.com/ElrondNetwork/elrond-go/p2p"
+	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/process/interceptors"
+	interceptorFactory "github.com/ElrondNetwork/elrond-go/process/interceptors/factory"
+	interceptorsProcessor "github.com/ElrondNetwork/elrond-go/process/interceptors/processor"
+	processMock "github.com/ElrondNetwork/elrond-go/process/mock"
+	"github.com/ElrondNetwork/elrond-go/sharding"
+	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
+	"github.com/ElrondNetwork/elrond-go/storage/timecache"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/ElrondNetwork/elrond-go/testscommon/cryptoMocks"
+	dataRetrieverMock "github.com/ElrondNetwork/elrond-go/testscommon/dataRetriever"
+	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
+	trieMock "github.com/ElrondNetwork/elrond-go/testscommon/trie"
+)
+
+const (
+	defaultNodeName           = "heartbeatNode"
+	timeBetweenPeerAuths      = 10 * time.Second
+	timeBetweenHeartbeats     = 2 * time.Second
+	timeBetweenSendsWhenError = time.Second
+	thresholdBetweenSends     = 0.2
+
+	messagesInChunk         = 10
+	minPeersThreshold       = 1.0
+	delayBetweenRequests    = time.Second
+	maxTimeout              = time.Minute
+	maxMissingKeysInRequest = 1
+)
+
+// TestMarshaller represents the main marshaller
+var TestMarshaller = &testscommon.MarshalizerMock{}
+
+var TestThrottler = &processMock.InterceptorThrottlerStub{
+	CanProcessCalled: func() bool {
+		return true
+	},
+}
+
+// TestHeartbeatNode represents a container type of class used in integration tests
+// with all its fields exported
+type TestHeartbeatNode struct {
+	ShardCoordinator      sharding.Coordinator
+	NodesCoordinator      sharding.NodesCoordinator
+	PeerShardMapper       process.PeerShardMapper
+	Messenger             p2p.Messenger
+	NodeKeys              TestKeyPair
+	DataPool              dataRetriever.PoolsHolder
+	Sender                factory.HeartbeatV2Sender
+	PeerAuthInterceptor   *interceptors.MultiDataInterceptor
+	HeartbeatInterceptor  *interceptors.MultiDataInterceptor
+	PeerAuthResolver      dataRetriever.PeerAuthenticationResolver
+	PeerSigHandler        crypto.PeerSignatureHandler
+	WhiteListHandler      process.WhiteListHandler
+	Storage               dataRetriever.StorageService
+	ResolversContainer    dataRetriever.ResolversContainer
+	ResolverFinder        dataRetriever.ResolversFinder
+	RequestHandler        process.RequestHandler
+	RequestedItemsHandler dataRetriever.RequestedItemsHandler
+	RequestsProcessor     factory.PeerAuthenticationRequestsProcessor
+}
+
+// NewTestHeartbeatNode returns a new TestHeartbeatNode instance with a libp2p messenger
+func NewTestHeartbeatNode(
+	maxShards uint32,
+	nodeShardId uint32,
+	minPeersWaiting int,
+) *TestHeartbeatNode {
+	keygen := signing.NewKeyGenerator(mcl.NewSuiteBLS12())
+	sk, pk := keygen.GeneratePair()
+
+	pksBytes := make(map[uint32][]byte, maxShards)
+	pksBytes[nodeShardId], _ = pk.ToByteArray()
+
+	nodesCoordinator := &mock.NodesCoordinatorMock{
+		GetAllValidatorsPublicKeysCalled: func() (map[uint32][][]byte, error) {
+			keys := make(map[uint32][][]byte)
+			for shardID := uint32(0); shardID < maxShards; shardID++ {
+				keys[shardID] = append(keys[shardID], pksBytes[shardID])
+			}
+
+			shardID := core.MetachainShardId
+			keys[shardID] = append(keys[shardID], pksBytes[shardID])
+
+			return keys, nil
+		},
+		GetValidatorWithPublicKeyCalled: func(publicKey []byte) (sharding.Validator, uint32, error) {
+			validator, _ := sharding.NewValidator(publicKey, defaultChancesSelection, 1)
+			return validator, 0, nil
+		},
+	}
+	singleSigner := singlesig.NewBlsSigner()
+
+	peerSigHandler := &cryptoMocks.PeerSignatureHandlerStub{
+		VerifyPeerSignatureCalled: func(pk []byte, pid core.PeerID, signature []byte) error {
+			senderPubKey, err := keygen.PublicKeyFromByteArray(pk)
+			if err != nil {
+				return err
+			}
+			return singleSigner.Verify(senderPubKey, pid.Bytes(), signature)
+		},
+		GetPeerSignatureCalled: func(privateKey crypto.PrivateKey, pid []byte) ([]byte, error) {
+			return singleSigner.Sign(privateKey, pid)
+		},
+	}
+
+	shardCoordinator, _ := sharding.NewMultiShardCoordinator(maxShards, nodeShardId)
+
+	messenger := CreateMessengerWithNoDiscovery()
+	peerShardMapper := mock.NewNetworkShardingCollectorMock()
+
+	thn := &TestHeartbeatNode{
+		ShardCoordinator: shardCoordinator,
+		NodesCoordinator: nodesCoordinator,
+		Messenger:        messenger,
+		PeerSigHandler:   peerSigHandler,
+		PeerShardMapper:  peerShardMapper,
+	}
+
+	thn.NodeKeys = TestKeyPair{
+		Sk: sk,
+		Pk: pk,
+	}
+
+	// start a go routine in order to allow peers to connect first
+	go thn.initTestHeartbeatNode(minPeersWaiting)
+
+	return thn
+}
+
+func (thn *TestHeartbeatNode) initTestHeartbeatNode(minPeersWaiting int) {
+	thn.initStorage()
+	thn.initDataPools()
+	thn.initRequestedItemsHandler()
+	thn.initResolvers()
+	thn.initInterceptors()
+
+	for len(thn.Messenger.Peers()) < minPeersWaiting {
+		time.Sleep(time.Second)
+	}
+
+	thn.initSender()
+	thn.initRequestsProcessor()
+}
+
+func (thn *TestHeartbeatNode) initDataPools() {
+	thn.DataPool = dataRetrieverMock.CreatePoolsHolder(1, thn.ShardCoordinator.SelfId())
+
+	cacherCfg := storageUnit.CacheConfig{Capacity: 10000, Type: storageUnit.LRUCache, Shards: 1}
+	cache, _ := storageUnit.NewCache(cacherCfg)
+	thn.WhiteListHandler, _ = interceptors.NewWhiteListDataVerifier(cache)
+}
+
+func (thn *TestHeartbeatNode) initStorage() {
+	thn.Storage = CreateStore(thn.ShardCoordinator.NumberOfShards())
+}
+
+func (thn *TestHeartbeatNode) initSender() {
+	identifierHeartbeat := common.HeartbeatV2Topic + thn.ShardCoordinator.CommunicationIdentifier(thn.ShardCoordinator.SelfId())
+	argsSender := sender.ArgSender{
+		Messenger:                          thn.Messenger,
+		Marshaller:                         TestMarshaller,
+		PeerAuthenticationTopic:            common.PeerAuthenticationTopic,
+		HeartbeatTopic:                     identifierHeartbeat,
+		PeerAuthenticationTimeBetweenSends: timeBetweenPeerAuths,
+		PeerAuthenticationTimeBetweenSendsWhenError: timeBetweenSendsWhenError,
+		PeerAuthenticationThresholdBetweenSends:     thresholdBetweenSends,
+		HeartbeatTimeBetweenSends:                   timeBetweenHeartbeats,
+		HeartbeatTimeBetweenSendsWhenError:          timeBetweenSendsWhenError,
+		HeartbeatThresholdBetweenSends:              thresholdBetweenSends,
+		VersionNumber:                               "v01",
+		NodeDisplayName:                             defaultNodeName,
+		Identity:                                    defaultNodeName + "_identity",
+		PeerSubType:                                 core.RegularPeer,
+		CurrentBlockProvider:                        &testscommon.ChainHandlerStub{},
+		PeerSignatureHandler:                        thn.PeerSigHandler,
+		PrivateKey:                                  thn.NodeKeys.Sk,
+		RedundancyHandler:                           &mock.RedundancyHandlerStub{},
+	}
+
+	thn.Sender, _ = sender.NewSender(argsSender)
+}
+
+func (thn *TestHeartbeatNode) initResolvers() {
+	dataPacker, _ := partitioning.NewSimpleDataPacker(TestMarshaller)
+
+	_ = thn.Messenger.CreateTopic(common.ConsensusTopic+thn.ShardCoordinator.CommunicationIdentifier(thn.ShardCoordinator.SelfId()), true)
+
+	resolverContainerFactory := resolverscontainer.FactoryArgs{
+		ShardCoordinator:         thn.ShardCoordinator,
+		Messenger:                thn.Messenger,
+		Store:                    thn.Storage,
+		Marshalizer:              TestMarshaller,
+		DataPools:                thn.DataPool,
+		Uint64ByteSliceConverter: TestUint64Converter,
+		DataPacker:               dataPacker,
+		TriesContainer: &mock.TriesHolderStub{
+			GetCalled: func(bytes []byte) common.Trie {
+				return &trieMock.TrieStub{}
+			},
+		},
+		SizeCheckDelta:              100,
+		InputAntifloodHandler:       &mock.NilAntifloodHandler{},
+		OutputAntifloodHandler:      &mock.NilAntifloodHandler{},
+		NumConcurrentResolvingJobs:  10,
+		CurrentNetworkEpochProvider: &mock.CurrentNetworkEpochProviderStub{},
+		PreferredPeersHolder:        &p2pmocks.PeersHolderStub{},
+		ResolverConfig: config.ResolverConfig{
+			NumCrossShardPeers:  2,
+			NumIntraShardPeers:  1,
+			NumFullHistoryPeers: 3,
+		},
+		NodesCoordinator:                     thn.NodesCoordinator,
+		MaxNumOfPeerAuthenticationInResponse: 5,
+		PeerShardMapper:                      thn.PeerShardMapper,
+	}
+
+	var err error
+	if thn.ShardCoordinator.SelfId() == core.MetachainShardId {
+		resolversContainerFactory, _ := resolverscontainer.NewMetaResolversContainerFactory(resolverContainerFactory)
+
+		thn.ResolversContainer, err = resolversContainerFactory.Create()
+		log.LogIfError(err)
+
+		thn.ResolverFinder, _ = containers.NewResolversFinder(thn.ResolversContainer, thn.ShardCoordinator)
+		thn.RequestHandler, _ = requestHandlers.NewResolverRequestHandler(
+			thn.ResolverFinder,
+			thn.RequestedItemsHandler,
+			thn.WhiteListHandler,
+			100,
+			thn.ShardCoordinator.SelfId(),
+			time.Second,
+		)
+	} else {
+		resolversContainerFactory, _ := resolverscontainer.NewShardResolversContainerFactory(resolverContainerFactory)
+
+		thn.ResolversContainer, err = resolversContainerFactory.Create()
+		log.LogIfError(err)
+
+		thn.ResolverFinder, _ = containers.NewResolversFinder(thn.ResolversContainer, thn.ShardCoordinator)
+		thn.RequestHandler, _ = requestHandlers.NewResolverRequestHandler(
+			thn.ResolverFinder,
+			thn.RequestedItemsHandler,
+			thn.WhiteListHandler,
+			100,
+			thn.ShardCoordinator.SelfId(),
+			time.Second,
+		)
+	}
+}
+
+func (thn *TestHeartbeatNode) initRequestedItemsHandler() {
+	thn.RequestedItemsHandler = timecache.NewTimeCache(roundDuration)
+}
+
+func (thn *TestHeartbeatNode) initInterceptors() {
+	argsFactory := interceptorFactory.ArgInterceptedDataFactory{
+		CoreComponents: &processMock.CoreComponentsMock{
+			IntMarsh: TestMarshaller,
+		},
+		NodesCoordinator:             thn.NodesCoordinator,
+		PeerSignatureHandler:         thn.PeerSigHandler,
+		SignaturesHandler:            &processMock.SignaturesHandlerStub{},
+		HeartbeatExpiryTimespanInSec: 10,
+		PeerID:                       thn.Messenger.ID(),
+	}
+
+	// PeerAuthentication interceptor
+	argPAProcessor := interceptorsProcessor.ArgPeerAuthenticationInterceptorProcessor{
+		PeerAuthenticationCacher: thn.DataPool.PeerAuthentications(),
+		PeerShardMapper:          thn.PeerShardMapper,
+	}
+	paProcessor, _ := interceptorsProcessor.NewPeerAuthenticationInterceptorProcessor(argPAProcessor)
+	paFactory, _ := interceptorFactory.NewInterceptedPeerAuthenticationDataFactory(argsFactory)
+	thn.PeerAuthInterceptor = thn.initMultiDataInterceptor(common.PeerAuthenticationTopic, paFactory, paProcessor)
+
+	// Heartbeat interceptor
+	argHBProcessor := interceptorsProcessor.ArgHeartbeatInterceptorProcessor{
+		HeartbeatCacher: thn.DataPool.Heartbeats(),
+	}
+	hbProcessor, _ := interceptorsProcessor.NewHeartbeatInterceptorProcessor(argHBProcessor)
+	hbFactory, _ := interceptorFactory.NewInterceptedHeartbeatDataFactory(argsFactory)
+	identifierHeartbeat := common.HeartbeatV2Topic + thn.ShardCoordinator.CommunicationIdentifier(thn.ShardCoordinator.SelfId())
+	thn.HeartbeatInterceptor = thn.initMultiDataInterceptor(identifierHeartbeat, hbFactory, hbProcessor)
+}
+
+func (thn *TestHeartbeatNode) initMultiDataInterceptor(topic string, dataFactory process.InterceptedDataFactory, processor process.InterceptorProcessor) *interceptors.MultiDataInterceptor {
+	mdInterceptor, _ := interceptors.NewMultiDataInterceptor(
+		interceptors.ArgMultiDataInterceptor{
+			Topic:            topic,
+			Marshalizer:      testscommon.MarshalizerMock{},
+			DataFactory:      dataFactory,
+			Processor:        processor,
+			Throttler:        TestThrottler,
+			AntifloodHandler: &mock.NilAntifloodHandler{},
+			WhiteListRequest: &testscommon.WhiteListHandlerStub{
+				IsWhiteListedCalled: func(interceptedData process.InterceptedData) bool {
+					return true
+				},
+			},
+			PreferredPeersHolder: &p2pmocks.PeersHolderStub{},
+			CurrentPeerId:        thn.Messenger.ID(),
+		},
+	)
+
+	_ = thn.Messenger.CreateTopic(topic, true)
+	_ = thn.Messenger.RegisterMessageProcessor(topic, common.DefaultInterceptorsIdentifier, mdInterceptor)
+
+	return mdInterceptor
+}
+
+func (thn *TestHeartbeatNode) initRequestsProcessor() {
+	args := processor.ArgPeerAuthenticationRequestsProcessor{
+		RequestHandler:          thn.RequestHandler,
+		NodesCoordinator:        thn.NodesCoordinator,
+		PeerAuthenticationPool:  thn.DataPool.PeerAuthentications(),
+		ShardId:                 thn.ShardCoordinator.SelfId(),
+		Epoch:                   0,
+		MessagesInChunk:         messagesInChunk,
+		MinPeersThreshold:       minPeersThreshold,
+		DelayBetweenRequests:    delayBetweenRequests,
+		MaxTimeout:              maxTimeout,
+		MaxMissingKeysInRequest: maxMissingKeysInRequest,
+		Randomizer:              &random.ConcurrentSafeIntRandomizer{},
+	}
+	thn.RequestsProcessor, _ = processor.NewPeerAuthenticationRequestsProcessor(args)
+}
+
+// ConnectTo will try to initiate a connection to the provided parameter
+func (thn *TestHeartbeatNode) ConnectTo(connectable Connectable) error {
+	if check.IfNil(connectable) {
+		return fmt.Errorf("trying to connect to a nil Connectable parameter")
+	}
+
+	return thn.Messenger.ConnectToPeer(connectable.GetConnectableAddress())
+}
+
+// GetConnectableAddress returns a non circuit, non windows default connectable p2p address
+func (thn *TestHeartbeatNode) GetConnectableAddress() string {
+	if thn == nil {
+		return "nil"
+	}
+
+	return GetConnectableAddress(thn.Messenger)
+}
+
+// Close -
+func (thn *TestHeartbeatNode) Close() {
+	_ = thn.Sender.Close()
+	_ = thn.PeerAuthInterceptor.Close()
+	_ = thn.RequestsProcessor.Close()
+	_ = thn.ResolversContainer.Close()
+	_ = thn.Messenger.Close()
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (thn *TestHeartbeatNode) IsInterfaceNil() bool {
+	return thn == nil
+}

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -232,6 +232,7 @@ type Connectable interface {
 type TestProcessorNode struct {
 	ShardCoordinator sharding.Coordinator
 	NodesCoordinator sharding.NodesCoordinator
+	PeerShardMapper  process.PeerShardMapper
 	NodesSetup       sharding.GenesisNodesSetupHandler
 	Messenger        p2p.Messenger
 
@@ -415,6 +416,7 @@ func newBaseTestProcessorNode(
 		ArwenChangeLocker:       &sync.RWMutex{},
 		TransactionLogProcessor: logsProcessor,
 		Bootstrapper:            mock.NewTestBootstrapperMock(),
+		PeerShardMapper:         mock.NewNetworkShardingCollectorMock(),
 	}
 
 	tpn.ScheduledMiniBlocksEnableEpoch = uint32(1000000)
@@ -1230,6 +1232,7 @@ func (tpn *TestProcessorNode) initInterceptors() {
 			PeerSignatureHandler:         &processMock.PeerSignatureHandlerStub{},
 			SignaturesHandler:            &processMock.SignaturesHandlerStub{},
 			HeartbeatExpiryTimespanInSec: 30,
+			PeerShardMapper:              tpn.PeerShardMapper,
 		}
 		interceptorContainerFactory, _ := interceptorscontainer.NewMetaInterceptorsContainerFactory(metaInterceptorContainerFactoryArgs)
 
@@ -1289,6 +1292,7 @@ func (tpn *TestProcessorNode) initInterceptors() {
 			PeerSignatureHandler:         &processMock.PeerSignatureHandlerStub{},
 			SignaturesHandler:            &processMock.SignaturesHandlerStub{},
 			HeartbeatExpiryTimespanInSec: 30,
+			PeerShardMapper:              tpn.PeerShardMapper,
 		}
 		interceptorContainerFactory, _ := interceptorscontainer.NewShardInterceptorsContainerFactory(shardIntereptorContainerFactoryArgs)
 
@@ -1326,6 +1330,7 @@ func (tpn *TestProcessorNode) initResolvers() {
 		},
 		NodesCoordinator:                     tpn.NodesCoordinator,
 		MaxNumOfPeerAuthenticationInResponse: 5,
+		PeerShardMapper:                      tpn.PeerShardMapper,
 	}
 
 	var err error

--- a/process/factory/interceptorscontainer/args.go
+++ b/process/factory/interceptorscontainer/args.go
@@ -36,4 +36,5 @@ type CommonInterceptorsContainerFactoryArgs struct {
 	PeerSignatureHandler         crypto.PeerSignatureHandler
 	SignaturesHandler            process.SignaturesHandler
 	HeartbeatExpiryTimespanInSec int64
+	PeerShardMapper              process.PeerShardMapper
 }

--- a/process/factory/interceptorscontainer/baseInterceptorsContainerFactory.go
+++ b/process/factory/interceptorscontainer/baseInterceptorsContainerFactory.go
@@ -40,6 +40,7 @@ type baseInterceptorsContainerFactory struct {
 	preferredPeersHolder   process.PreferredPeersHolderHandler
 	hasher                 hashing.Hasher
 	requestHandler         process.RequestHandler
+	peerShardMapper        process.PeerShardMapper
 }
 
 func checkBaseParams(
@@ -57,6 +58,7 @@ func checkBaseParams(
 	whiteListerVerifiedTxs process.WhiteListHandler,
 	preferredPeersHolder process.PreferredPeersHolderHandler,
 	requestHandler process.RequestHandler,
+	peerShardMapper process.PeerShardMapper,
 ) error {
 	if check.IfNil(coreComponents) {
 		return process.ErrNilCoreComponentsHolder
@@ -138,6 +140,9 @@ func checkBaseParams(
 	}
 	if check.IfNil(requestHandler) {
 		return process.ErrNilRequestHandler
+	}
+	if check.IfNil(peerShardMapper) {
+		return process.ErrNilPeerShardMapper
 	}
 
 	return nil
@@ -588,6 +593,7 @@ func (bicf *baseInterceptorsContainerFactory) generatePeerAuthenticationIntercep
 
 	argProcessor := processor.ArgPeerAuthenticationInterceptorProcessor{
 		PeerAuthenticationCacher: bicf.dataPool.PeerAuthentications(),
+		PeerShardMapper:          bicf.peerShardMapper,
 	}
 	peerAuthenticationProcessor, err := processor.NewPeerAuthenticationInterceptorProcessor(argProcessor)
 	if err != nil {

--- a/process/factory/interceptorscontainer/metaInterceptorsContainerFactory.go
+++ b/process/factory/interceptorscontainer/metaInterceptorsContainerFactory.go
@@ -39,6 +39,7 @@ func NewMetaInterceptorsContainerFactory(
 		args.WhiteListerVerifiedTxs,
 		args.PreferredPeersHolder,
 		args.RequestHandler,
+		args.PeerShardMapper,
 	)
 	if err != nil {
 		return nil, err
@@ -116,6 +117,7 @@ func NewMetaInterceptorsContainerFactory(
 		preferredPeersHolder:   args.PreferredPeersHolder,
 		hasher:                 args.CoreComponents.Hasher(),
 		requestHandler:         args.RequestHandler,
+		peerShardMapper:        args.PeerShardMapper,
 	}
 
 	icf := &metaInterceptorsContainerFactory{

--- a/process/factory/interceptorscontainer/metaInterceptorsContainerFactory_test.go
+++ b/process/factory/interceptorscontainer/metaInterceptorsContainerFactory_test.go
@@ -417,6 +417,18 @@ func TestNewMetaInterceptorsContainerFactory_NilRequestHandlerShouldErr(t *testi
 	assert.Equal(t, process.ErrNilRequestHandler, err)
 }
 
+func TestNewMetaInterceptorsContainerFactory_NilPeerShardMapperShouldErr(t *testing.T) {
+	t.Parallel()
+
+	coreComp, cryptoComp := createMockComponentHolders()
+	args := getArgumentsMeta(coreComp, cryptoComp)
+	args.PeerShardMapper = nil
+	icf, err := interceptorscontainer.NewMetaInterceptorsContainerFactory(args)
+
+	assert.Nil(t, icf)
+	assert.Equal(t, process.ErrNilPeerShardMapper, err)
+}
+
 func TestNewMetaInterceptorsContainerFactory_ShouldWork(t *testing.T) {
 	t.Parallel()
 
@@ -617,5 +629,6 @@ func getArgumentsMeta(
 		PeerSignatureHandler:         &mock.PeerSignatureHandlerStub{},
 		SignaturesHandler:            &mock.SignaturesHandlerStub{},
 		HeartbeatExpiryTimespanInSec: 30,
+		PeerShardMapper:              &p2pmocks.NetworkShardingCollectorStub{},
 	}
 }

--- a/process/factory/interceptorscontainer/shardInterceptorsContainerFactory.go
+++ b/process/factory/interceptorscontainer/shardInterceptorsContainerFactory.go
@@ -37,6 +37,7 @@ func NewShardInterceptorsContainerFactory(
 		args.WhiteListerVerifiedTxs,
 		args.PreferredPeersHolder,
 		args.RequestHandler,
+		args.PeerShardMapper,
 	)
 	if err != nil {
 		return nil, err
@@ -115,6 +116,7 @@ func NewShardInterceptorsContainerFactory(
 		preferredPeersHolder:   args.PreferredPeersHolder,
 		hasher:                 args.CoreComponents.Hasher(),
 		requestHandler:         args.RequestHandler,
+		peerShardMapper:        args.PeerShardMapper,
 	}
 
 	icf := &shardInterceptorsContainerFactory{

--- a/process/factory/interceptorscontainer/shardInterceptorsContainerFactory_test.go
+++ b/process/factory/interceptorscontainer/shardInterceptorsContainerFactory_test.go
@@ -374,6 +374,18 @@ func TestNewShardInterceptorsContainerFactory_EmptyEpochStartTriggerShouldErr(t 
 	assert.Equal(t, process.ErrNilEpochStartTrigger, err)
 }
 
+func TestNewShardInterceptorsContainerFactory_NilPeerShardMapperShouldErr(t *testing.T) {
+	t.Parallel()
+
+	coreComp, cryptoComp := createMockComponentHolders()
+	args := getArgumentsShard(coreComp, cryptoComp)
+	args.PeerShardMapper = nil
+	icf, err := interceptorscontainer.NewShardInterceptorsContainerFactory(args)
+
+	assert.Nil(t, icf)
+	assert.Equal(t, process.ErrNilPeerShardMapper, err)
+}
+
 func TestNewShardInterceptorsContainerFactory_ShouldWork(t *testing.T) {
 	t.Parallel()
 
@@ -697,5 +709,6 @@ func getArgumentsShard(
 		PeerSignatureHandler:         &mock.PeerSignatureHandlerStub{},
 		SignaturesHandler:            &mock.SignaturesHandlerStub{},
 		HeartbeatExpiryTimespanInSec: 30,
+		PeerShardMapper:              &p2pmocks.NetworkShardingCollectorStub{},
 	}
 }

--- a/process/heartbeat/interceptedHeartbeat.go
+++ b/process/heartbeat/interceptedHeartbeat.go
@@ -137,6 +137,11 @@ func (ihb *interceptedHeartbeat) String() string {
 		logger.DisplayByteSlice(ihb.heartbeat.Payload))
 }
 
+// Message returns the heartbeat message
+func (ihb *interceptedHeartbeat) Message() interface{} {
+	return ihb.heartbeat
+}
+
 // SizeInBytes returns the size in bytes held by this instance
 func (ihb *interceptedHeartbeat) SizeInBytes() int {
 	return len(ihb.heartbeat.Payload) +

--- a/process/heartbeat/interceptedPeerAuthentication.go
+++ b/process/heartbeat/interceptedPeerAuthentication.go
@@ -186,6 +186,11 @@ func (ipa *interceptedPeerAuthentication) PayloadSignature() []byte {
 	return ipa.peerAuthentication.PayloadSignature
 }
 
+// Message returns the peer authentication message
+func (ipa *interceptedPeerAuthentication) Message() interface{} {
+	return ipa.peerAuthentication
+}
+
 // String returns the most important fields as string
 func (ipa *interceptedPeerAuthentication) String() string {
 	return fmt.Sprintf("pk=%s, pid=%s, sig=%s, payload=%s, payloadSig=%s",

--- a/process/interceptors/processor/heartbeatInterceptorProcessor.go
+++ b/process/interceptors/processor/heartbeatInterceptorProcessor.go
@@ -36,12 +36,12 @@ func (hip *heartbeatInterceptorProcessor) Validate(_ process.InterceptedData, _ 
 
 // Save will save the intercepted heartbeat inside the heartbeat cacher
 func (hip *heartbeatInterceptorProcessor) Save(data process.InterceptedData, fromConnectedPeer core.PeerID, _ string) error {
-	interceptedHeartbeat, ok := data.(interceptedDataSizeHandler)
+	interceptedHeartbeat, ok := data.(interceptedDataMessageHandler)
 	if !ok {
 		return process.ErrWrongTypeAssertion
 	}
 
-	hip.heartbeatCacher.Put(fromConnectedPeer.Bytes(), interceptedHeartbeat, interceptedHeartbeat.SizeInBytes())
+	hip.heartbeatCacher.Put(fromConnectedPeer.Bytes(), interceptedHeartbeat.Message(), interceptedHeartbeat.SizeInBytes())
 	return nil
 }
 

--- a/process/interceptors/processor/interface.go
+++ b/process/interceptors/processor/interface.go
@@ -25,3 +25,8 @@ type ShardedPool interface {
 type interceptedDataSizeHandler interface {
 	SizeInBytes() int
 }
+
+type interceptedDataMessageHandler interface {
+	interceptedDataSizeHandler
+	Message() interface{}
+}

--- a/process/interceptors/processor/peerAuthenticationInterceptorProcessor.go
+++ b/process/interceptors/processor/peerAuthenticationInterceptorProcessor.go
@@ -36,12 +36,12 @@ func (paip *peerAuthenticationInterceptorProcessor) Validate(_ process.Intercept
 
 // Save will save the intercepted peer authentication inside the peer authentication cacher
 func (paip *peerAuthenticationInterceptorProcessor) Save(data process.InterceptedData, fromConnectedPeer core.PeerID, _ string) error {
-	interceptedPeerAuthenticationData, ok := data.(interceptedDataSizeHandler)
+	interceptedPeerAuthenticationData, ok := data.(interceptedDataMessageHandler)
 	if !ok {
 		return process.ErrWrongTypeAssertion
 	}
 
-	paip.peerAuthenticationCacher.Put(fromConnectedPeer.Bytes(), interceptedPeerAuthenticationData, interceptedPeerAuthenticationData.SizeInBytes())
+	paip.peerAuthenticationCacher.Put(fromConnectedPeer.Bytes(), interceptedPeerAuthenticationData.Message(), interceptedPeerAuthenticationData.SizeInBytes())
 	return nil
 }
 

--- a/process/interceptors/processor/peerAuthenticationInterceptorProcessor.go
+++ b/process/interceptors/processor/peerAuthenticationInterceptorProcessor.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go/heartbeat"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/storage"
 )
@@ -10,22 +11,37 @@ import (
 // ArgPeerAuthenticationInterceptorProcessor is the argument for the interceptor processor used for peer authentication
 type ArgPeerAuthenticationInterceptorProcessor struct {
 	PeerAuthenticationCacher storage.Cacher
+	PeerShardMapper          process.PeerShardMapper
 }
 
 // peerAuthenticationInterceptorProcessor is the processor used when intercepting peer authentication
 type peerAuthenticationInterceptorProcessor struct {
 	peerAuthenticationCacher storage.Cacher
+	peerShardMapper          process.PeerShardMapper
 }
 
 // NewPeerAuthenticationInterceptorProcessor creates a new peerAuthenticationInterceptorProcessor
-func NewPeerAuthenticationInterceptorProcessor(arg ArgPeerAuthenticationInterceptorProcessor) (*peerAuthenticationInterceptorProcessor, error) {
-	if check.IfNil(arg.PeerAuthenticationCacher) {
-		return nil, process.ErrNilPeerAuthenticationCacher
+func NewPeerAuthenticationInterceptorProcessor(args ArgPeerAuthenticationInterceptorProcessor) (*peerAuthenticationInterceptorProcessor, error) {
+	err := checkArgs(args)
+	if err != nil {
+		return nil, err
 	}
 
 	return &peerAuthenticationInterceptorProcessor{
-		peerAuthenticationCacher: arg.PeerAuthenticationCacher,
+		peerAuthenticationCacher: args.PeerAuthenticationCacher,
+		peerShardMapper:          args.PeerShardMapper,
 	}, nil
+}
+
+func checkArgs(args ArgPeerAuthenticationInterceptorProcessor) error {
+	if check.IfNil(args.PeerAuthenticationCacher) {
+		return process.ErrNilPeerAuthenticationCacher
+	}
+	if check.IfNil(args.PeerShardMapper) {
+		return process.ErrNilPeerShardMapper
+	}
+
+	return nil
 }
 
 // Validate checks if the intercepted data can be processed
@@ -42,6 +58,18 @@ func (paip *peerAuthenticationInterceptorProcessor) Save(data process.Intercepte
 	}
 
 	paip.peerAuthenticationCacher.Put(fromConnectedPeer.Bytes(), interceptedPeerAuthenticationData.Message(), interceptedPeerAuthenticationData.SizeInBytes())
+
+	return paip.updatePeerInfo(interceptedPeerAuthenticationData.Message())
+}
+
+func (paip *peerAuthenticationInterceptorProcessor) updatePeerInfo(message interface{}) error {
+	peerAuthenticationData, ok := message.(heartbeat.PeerAuthentication)
+	if !ok {
+		return process.ErrWrongTypeAssertion
+	}
+
+	paip.peerShardMapper.UpdatePeerIDPublicKeyPair(core.PeerID(peerAuthenticationData.GetPid()), peerAuthenticationData.GetPubkey())
+
 	return nil
 }
 

--- a/process/interceptors/processor/peerAuthenticationInterceptorProcessor_test.go
+++ b/process/interceptors/processor/peerAuthenticationInterceptorProcessor_test.go
@@ -16,11 +16,8 @@ import (
 )
 
 type interceptedDataHandler interface {
-	PeerID() core.PeerID
-	Payload() []byte
-	Signature() []byte
-	PayloadSignature() []byte
 	SizeInBytes() int
+	Message() interface{}
 }
 
 func createPeerAuthenticationInterceptorProcessArg() processor.ArgPeerAuthenticationInterceptorProcessor {
@@ -104,13 +101,14 @@ func TestPeerAuthenticationInterceptorProcessor_Save(t *testing.T) {
 		arg.PeerAuthenticationCacher = &testscommon.CacherStub{
 			PutCalled: func(key []byte, value interface{}, sizeInBytes int) (evicted bool) {
 				assert.True(t, bytes.Equal(providedPid.Bytes(), key))
-				ipa := value.(interceptedDataHandler)
+				ipa := value.(heartbeatMessages.PeerAuthentication)
 				providedIPAHandler := providedIPA.(interceptedDataHandler)
-				assert.Equal(t, providedIPAHandler.PeerID(), ipa.PeerID())
-				assert.Equal(t, providedIPAHandler.Payload(), ipa.Payload())
-				assert.Equal(t, providedIPAHandler.Signature(), ipa.Signature())
-				assert.Equal(t, providedIPAHandler.PayloadSignature(), ipa.PayloadSignature())
-				assert.Equal(t, providedIPAHandler.SizeInBytes(), ipa.SizeInBytes())
+				providedIPAMessage := providedIPAHandler.Message().(heartbeatMessages.PeerAuthentication)
+				assert.Equal(t, providedIPAMessage.Pid, ipa.Pid)
+				assert.Equal(t, providedIPAMessage.Payload, ipa.Payload)
+				assert.Equal(t, providedIPAMessage.Signature, ipa.Signature)
+				assert.Equal(t, providedIPAMessage.PayloadSignature, ipa.PayloadSignature)
+				assert.Equal(t, providedIPAMessage.Pubkey, ipa.Pubkey)
 				wasCalled = true
 				return false
 			},

--- a/process/interface.go
+++ b/process/interface.go
@@ -669,14 +669,18 @@ type PeerBlackListCacher interface {
 
 // PeerShardMapper can return the public key of a provided peer ID
 type PeerShardMapper interface {
+	UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte)
+	GetPeerID(pk []byte) (*core.PeerID, bool)
 	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo
 	IsInterfaceNil() bool
 }
 
 // NetworkShardingCollector defines the updating methods used by the network sharding component
 type NetworkShardingCollector interface {
+	UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte)
 	UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID uint32)
 	UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
+	GetPeerID(pk []byte) (*core.PeerID, bool)
 	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo
 	IsInterfaceNil() bool
 }

--- a/process/interface.go
+++ b/process/interface.go
@@ -670,7 +670,7 @@ type PeerBlackListCacher interface {
 // PeerShardMapper can return the public key of a provided peer ID
 type PeerShardMapper interface {
 	UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte)
-	GetPeerID(pk []byte) (*core.PeerID, bool)
+	GetLastKnownPeerID(pk []byte) (*core.PeerID, bool)
 	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo
 	IsInterfaceNil() bool
 }
@@ -680,7 +680,7 @@ type NetworkShardingCollector interface {
 	UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte)
 	UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID uint32)
 	UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
-	GetPeerID(pk []byte) (*core.PeerID, bool)
+	GetLastKnownPeerID(pk []byte) (*core.PeerID, bool)
 	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo
 	IsInterfaceNil() bool
 }

--- a/process/mock/peerShardMapperStub.go
+++ b/process/mock/peerShardMapperStub.go
@@ -4,7 +4,7 @@ import "github.com/ElrondNetwork/elrond-go-core/core"
 
 // PeerShardMapperStub -
 type PeerShardMapperStub struct {
-	GetPeerIDCalled                 func(pk []byte) (*core.PeerID, bool)
+	GetLastKnownPeerIDCalled        func(pk []byte) (*core.PeerID, bool)
 	GetPeerInfoCalled               func(pid core.PeerID) core.P2PPeerInfo
 	UpdatePeerIdPublicKeyCalled     func(pid core.PeerID, pk []byte)
 	UpdatePublicKeyShardIdCalled    func(pk []byte, shardId uint32)
@@ -12,10 +12,10 @@ type PeerShardMapperStub struct {
 	UpdatePeerIDPublicKeyPairCalled func(pid core.PeerID, pk []byte)
 }
 
-// GetPeerID -
-func (psms *PeerShardMapperStub) GetPeerID(pk []byte) (*core.PeerID, bool) {
-	if psms.GetPeerIDCalled != nil {
-		return psms.GetPeerIDCalled(pk)
+// GetLastKnownPeerID -
+func (psms *PeerShardMapperStub) GetLastKnownPeerID(pk []byte) (*core.PeerID, bool) {
+	if psms.GetLastKnownPeerIDCalled != nil {
+		return psms.GetLastKnownPeerIDCalled(pk)
 	}
 
 	return nil, false

--- a/process/mock/peerShardMapperStub.go
+++ b/process/mock/peerShardMapperStub.go
@@ -4,10 +4,21 @@ import "github.com/ElrondNetwork/elrond-go-core/core"
 
 // PeerShardMapperStub -
 type PeerShardMapperStub struct {
-	GetPeerInfoCalled            func(pid core.PeerID) core.P2PPeerInfo
-	UpdatePeerIdPublicKeyCalled  func(pid core.PeerID, pk []byte)
-	UpdatePublicKeyShardIdCalled func(pk []byte, shardId uint32)
-	UpdatePeerIdShardIdCalled    func(pid core.PeerID, shardId uint32)
+	GetPeerIDCalled                 func(pk []byte) (*core.PeerID, bool)
+	GetPeerInfoCalled               func(pid core.PeerID) core.P2PPeerInfo
+	UpdatePeerIdPublicKeyCalled     func(pid core.PeerID, pk []byte)
+	UpdatePublicKeyShardIdCalled    func(pk []byte, shardId uint32)
+	UpdatePeerIdShardIdCalled       func(pid core.PeerID, shardId uint32)
+	UpdatePeerIDPublicKeyPairCalled func(pid core.PeerID, pk []byte)
+}
+
+// GetPeerID -
+func (psms *PeerShardMapperStub) GetPeerID(pk []byte) (*core.PeerID, bool) {
+	if psms.GetPeerIDCalled != nil {
+		return psms.GetPeerIDCalled(pk)
+	}
+
+	return nil, false
 }
 
 // GetPeerInfo -
@@ -17,6 +28,13 @@ func (psms *PeerShardMapperStub) GetPeerInfo(pid core.PeerID) core.P2PPeerInfo {
 	}
 
 	return core.P2PPeerInfo{}
+}
+
+// UpdatePeerIDPublicKeyPair -
+func (psms *PeerShardMapperStub) UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte) {
+	if psms.UpdatePeerIDPublicKeyPairCalled != nil {
+		psms.UpdatePeerIDPublicKeyPairCalled(pid, pk)
+	}
 }
 
 // UpdatePeerIdPublicKey -

--- a/sharding/networksharding/peerShardMapper.go
+++ b/sharding/networksharding/peerShardMapper.go
@@ -234,8 +234,8 @@ func (psm *PeerShardMapper) getPeerInfoSearchingPidInFallbackCache(pid core.Peer
 	}
 }
 
-// GetPeerID returns the newest updated peer id for the given public key
-func (psm *PeerShardMapper) GetPeerID(pk []byte) (*core.PeerID, bool) {
+// GetLastKnownPeerID returns the newest updated peer id for the given public key
+func (psm *PeerShardMapper) GetLastKnownPeerID(pk []byte) (*core.PeerID, bool) {
 	objPidsQueue, found := psm.pkPeerIdCache.Get(pk)
 	if !found {
 		return nil, false
@@ -243,7 +243,7 @@ func (psm *PeerShardMapper) GetPeerID(pk []byte) (*core.PeerID, bool) {
 
 	pq, ok := objPidsQueue.(*pidQueue)
 	if !ok {
-		log.Warn("PeerShardMapper.GetPeerID: the contained element should have been of type pidQueue")
+		log.Warn("PeerShardMapper.GetLastKnownPeerID: the contained element should have been of type pidQueue")
 		return nil, false
 	}
 

--- a/sharding/networksharding/peerShardMapper_test.go
+++ b/sharding/networksharding/peerShardMapper_test.go
@@ -249,6 +249,24 @@ func TestPeerShardMapper_UpdatePeerIDInfoShouldWorkConcurrently(t *testing.T) {
 	assert.Equal(t, shardId, shardidRecovered)
 }
 
+// ------- UpdatePeerIDPublicKeyPair
+
+func TestPeerShardMapper_UpdatePeerIDPublicKeyPairShouldWork(t *testing.T) {
+	t.Parallel()
+
+	psm := createPeerShardMapper()
+	pid := core.PeerID("dummy peer ID")
+	pk := []byte("dummy pk")
+
+	psm.UpdatePeerIDPublicKeyPair(pid, pk)
+
+	pkRecovered := psm.GetPkFromPidPk(pid)
+	assert.Equal(t, pk, pkRecovered)
+
+	pidRecovered := psm.GetFromPkPeerId(pk)
+	assert.Equal(t, []core.PeerID{pid}, pidRecovered)
+}
+
 // ------- GetPeerInfo
 
 func TestPeerShardMapper_GetPeerInfoPkNotFoundShouldReturnUnknown(t *testing.T) {

--- a/testscommon/dataRetriever/poolFactory.go
+++ b/testscommon/dataRetriever/poolFactory.go
@@ -117,8 +117,8 @@ func CreatePoolsHolder(numShards uint32, selfShard uint32) dataRetriever.PoolsHo
 	panicIfError("CreatePoolsHolder", err)
 
 	peerAuthPool, err := mapTimeCache.NewMapTimeCache(mapTimeCache.ArgMapTimeCacher{
-		DefaultSpan: 10 * time.Second,
-		CacheExpiry: 10 * time.Second,
+		DefaultSpan: 20 * time.Second,
+		CacheExpiry: 20 * time.Second,
 	})
 	panicIfError("CreatePoolsHolder", err)
 

--- a/testscommon/p2pmocks/networkShardingCollectorStub.go
+++ b/testscommon/p2pmocks/networkShardingCollectorStub.go
@@ -9,7 +9,7 @@ type NetworkShardingCollectorStub struct {
 	UpdatePeerIDPublicKeyPairCalled func(pid core.PeerID, pk []byte)
 	UpdatePeerIDInfoCalled          func(pid core.PeerID, pk []byte, shardID uint32)
 	UpdatePeerIdSubTypeCalled       func(pid core.PeerID, peerSubType core.P2PPeerSubType)
-	GetPeerIDCalled                 func(pk []byte) (*core.PeerID, bool)
+	GetLastKnownPeerIDCalled        func(pk []byte) (*core.PeerID, bool)
 	GetPeerInfoCalled               func(pid core.PeerID) core.P2PPeerInfo
 }
 
@@ -34,10 +34,10 @@ func (nscs *NetworkShardingCollectorStub) UpdatePeerIdSubType(pid core.PeerID, p
 	}
 }
 
-// GetPeerID -
-func (nscs *NetworkShardingCollectorStub) GetPeerID(pk []byte) (*core.PeerID, bool) {
-	if nscs.GetPeerIDCalled != nil {
-		return nscs.GetPeerIDCalled(pk)
+// GetLastKnownPeerID -
+func (nscs *NetworkShardingCollectorStub) GetLastKnownPeerID(pk []byte) (*core.PeerID, bool) {
+	if nscs.GetLastKnownPeerIDCalled != nil {
+		return nscs.GetLastKnownPeerIDCalled(pk)
 	}
 
 	return nil, false

--- a/testscommon/p2pmocks/networkShardingCollectorStub.go
+++ b/testscommon/p2pmocks/networkShardingCollectorStub.go
@@ -6,9 +6,18 @@ import (
 
 // NetworkShardingCollectorStub -
 type NetworkShardingCollectorStub struct {
-	UpdatePeerIDInfoCalled    func(pid core.PeerID, pk []byte, shardID uint32)
-	UpdatePeerIdSubTypeCalled func(pid core.PeerID, peerSubType core.P2PPeerSubType)
-	GetPeerInfoCalled         func(pid core.PeerID) core.P2PPeerInfo
+	UpdatePeerIDPublicKeyPairCalled func(pid core.PeerID, pk []byte)
+	UpdatePeerIDInfoCalled          func(pid core.PeerID, pk []byte, shardID uint32)
+	UpdatePeerIdSubTypeCalled       func(pid core.PeerID, peerSubType core.P2PPeerSubType)
+	GetPeerIDCalled                 func(pk []byte) (*core.PeerID, bool)
+	GetPeerInfoCalled               func(pid core.PeerID) core.P2PPeerInfo
+}
+
+// UpdatePeerIDPublicKeyPair -
+func (nscs *NetworkShardingCollectorStub) UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte) {
+	if nscs.UpdatePeerIDPublicKeyPairCalled != nil {
+		nscs.UpdatePeerIDPublicKeyPairCalled(pid, pk)
+	}
 }
 
 // UpdatePeerIDInfo -
@@ -18,11 +27,20 @@ func (nscs *NetworkShardingCollectorStub) UpdatePeerIDInfo(pid core.PeerID, pk [
 	}
 }
 
-// UpdatePeerIdSubType
+// UpdatePeerIdSubType -
 func (nscs *NetworkShardingCollectorStub) UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
 	if nscs.UpdatePeerIdSubTypeCalled != nil {
 		nscs.UpdatePeerIdSubTypeCalled(pid, peerSubType)
 	}
+}
+
+// GetPeerID -
+func (nscs *NetworkShardingCollectorStub) GetPeerID(pk []byte) (*core.PeerID, bool) {
+	if nscs.GetPeerIDCalled != nil {
+		return nscs.GetPeerIDCalled(pk)
+	}
+
+	return nil, false
 }
 
 // GetPeerInfo -


### PR DESCRIPTION
#### Changes: 
- created `TestHeartbeatNode` structure to easily create and reuse a new node able to send/receive messages
- added integration test where all peers send messages
- added integration test with node connecting late and requesting messages from others
- small fixes:
   - senders now send data as batch in order to be compatible with multi data interceptor 
   - fixed casts from interceptor processors;
   - fixed RequestDataFromChunk, in order to have a valid batch for multi data interceptor;
   - now sending only first chunk when large data buff is requested;
   - fixed issues into resolver as the key used was not correct;