### PR TITLE
FIX block API

### DIFF
--- a/node/external/transactionAPI/apiTransactionResults.go
+++ b/node/external/transactionAPI/apiTransactionResults.go
@@ -158,19 +158,19 @@ func (arp *apiTransactionResultsProcessor) adaptSmartContractResult(scrHash []by
 		ReturnMessage:  string(scr.ReturnMessage),
 	}
 
-	if len(scr.SndAddr) != arp.addressPubKeyConverter.Len() {
+	if len(scr.SndAddr) == arp.addressPubKeyConverter.Len() {
 		apiSCR.SndAddr = arp.addressPubKeyConverter.Encode(scr.SndAddr)
 	}
 
-	if len(scr.RcvAddr) != arp.addressPubKeyConverter.Len() {
+	if len(scr.RcvAddr) == arp.addressPubKeyConverter.Len() {
 		apiSCR.RcvAddr = arp.addressPubKeyConverter.Encode(scr.RcvAddr)
 	}
 
-	if len(scr.RelayerAddr) != arp.addressPubKeyConverter.Len() {
+	if len(scr.RelayerAddr) == arp.addressPubKeyConverter.Len() {
 		apiSCR.RelayerAddr = arp.addressPubKeyConverter.Encode(scr.RelayerAddr)
 	}
 
-	if len(scr.OriginalSender) != arp.addressPubKeyConverter.Len() {
+	if len(scr.OriginalSender) == arp.addressPubKeyConverter.Len() {
 		apiSCR.OriginalSender = arp.addressPubKeyConverter.Encode(scr.OriginalSender)
 	}
 

--- a/node/external/transactionAPI/apiTransactionResults_test.go
+++ b/node/external/transactionAPI/apiTransactionResults_test.go
@@ -81,11 +81,11 @@ func TestPutEventsInTransactionSmartContractResults(t *testing.T) {
 
 	scr1 := &smartContractResult.SmartContractResult{
 		OriginalTxHash: txHash,
-		RelayerAddr:    []byte("relayer"),
-		OriginalSender: []byte("originalSender"),
+		RelayerAddr:    []byte("rlr"),
+		OriginalSender: []byte("osn"),
 		PrevTxHash:     []byte("prevTxHash"),
-		SndAddr:        []byte("sender"),
-		RcvAddr:        []byte("receiver"),
+		SndAddr:        []byte("snd"),
+		RcvAddr:        []byte("rcv"),
 		Nonce:          1,
 		Value:          big.NewInt(1000),
 		GasLimit:       1,
@@ -156,7 +156,7 @@ func TestPutEventsInTransactionSmartContractResults(t *testing.T) {
 		},
 	}
 
-	pubKeyConverter := &mock.PubkeyConverterMock{}
+	pubKeyConverter := mock.NewPubkeyConverterMock(3)
 	txUnmarshalerAndPreparer := newTransactionUnmarshaller(marshalizerdMock, pubKeyConverter)
 	n := newAPITransactionResultProcessor(pubKeyConverter, historyRepo, dataStore, marshalizerdMock, txUnmarshalerAndPreparer, 0)
 


### PR DESCRIPTION
- Fix the check there is set `sender` and `receiver` address for smart contract results