### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/common/logging/fileLogging_test.go
+++ b/common/logging/fileLogging_test.go
@@ -3,7 +3,6 @@ package logging
 import (
 	"errors"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -18,11 +17,7 @@ const logsDirectory = "logs"
 func TestNewFileLogging_ShouldWork(t *testing.T) {
 	t.Parallel()
 
-	dir, _ := ioutil.TempDir("", "file_logging")
-	defer func() {
-		err := os.RemoveAll(dir)
-		log.LogIfError(err)
-	}()
+	dir := t.TempDir()
 
 	fl, err := NewFileLogging(dir, logsDirectory, "elrond-go")
 
@@ -33,11 +28,7 @@ func TestNewFileLogging_ShouldWork(t *testing.T) {
 func TestNewFileLogging_CloseShouldStopCreatingLogFiles(t *testing.T) {
 	t.Parallel()
 
-	dir, _ := ioutil.TempDir("", "file_logging")
-	defer func() {
-		err := os.RemoveAll(dir)
-		log.LogIfError(err)
-	}()
+	dir := t.TempDir()
 
 	fl, _ := NewFileLogging(dir, logsDirectory, "elrond-go")
 	_ = fl.ChangeFileLifeSpan(time.Second)
@@ -58,11 +49,7 @@ func TestNewFileLogging_CloseShouldStopCreatingLogFiles(t *testing.T) {
 func TestNewFileLogging_CloseCallTwiceShouldWork(t *testing.T) {
 	t.Parallel()
 
-	dir, _ := ioutil.TempDir("", "file_logging")
-	defer func() {
-		err := os.RemoveAll(dir)
-		log.LogIfError(err)
-	}()
+	dir := t.TempDir()
 
 	fl, _ := NewFileLogging(dir, logsDirectory, "elrond-go")
 
@@ -76,11 +63,7 @@ func TestNewFileLogging_CloseCallTwiceShouldWork(t *testing.T) {
 func TestFileLogging_ChangeFileLifeSpanInvalidValueShouldErr(t *testing.T) {
 	t.Parallel()
 
-	dir, _ := ioutil.TempDir("", "file_logging")
-	defer func() {
-		err := os.RemoveAll(dir)
-		log.LogIfError(err)
-	}()
+	dir := t.TempDir()
 
 	fl, _ := NewFileLogging(dir, logsDirectory, "elrond-go")
 	err := fl.ChangeFileLifeSpan(time.Millisecond)
@@ -91,11 +74,7 @@ func TestFileLogging_ChangeFileLifeSpanInvalidValueShouldErr(t *testing.T) {
 func TestFileLogging_ChangeFileLifeSpanAfterCloseShouldErr(t *testing.T) {
 	t.Parallel()
 
-	dir, _ := ioutil.TempDir("", "file_logging")
-	defer func() {
-		err := os.RemoveAll(dir)
-		log.LogIfError(err)
-	}()
+	dir := t.TempDir()
 
 	fl, _ := NewFileLogging(dir, logsDirectory, "elrond-go")
 	err := fl.ChangeFileLifeSpan(time.Second)

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/big"
 	"os"
@@ -62,7 +61,7 @@ type testKeyPair struct {
 	validatorKey []byte
 }
 
-func createPhysicalUnit() (storage.Storer, string) {
+func createPhysicalUnit(t *testing.T) (storage.Storer, string) {
 	cacheConfig := storageUnit.CacheConfig{
 		Name:                 "test",
 		Type:                 "SizeLRU",
@@ -72,7 +71,7 @@ func createPhysicalUnit() (storage.Storer, string) {
 		SizePerSender:        0,
 		Shards:               0,
 	}
-	dir, _ := ioutil.TempDir("", "")
+	dir := t.TempDir()
 	persisterConfig := storageUnit.ArgDB{
 		Path:              dir,
 		DBType:            "LvlDBSerial",
@@ -363,7 +362,7 @@ func TestSystemSCProcessor_UpdateStakingV2ShouldWork(t *testing.T) {
 func TestSystemSCProcessor_UpdateStakingV2MoreKeysShouldWork(t *testing.T) {
 	t.Parallel()
 
-	db, dir := createPhysicalUnit()
+	db, dir := createPhysicalUnit(t)
 	require.False(t, check.IfNil(db))
 
 	log.Info("using temporary directory", "path", dir)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ElrondNetwork/elrond-go
 
-go 1.13
+go 1.15
 
 require (
 	github.com/ElrondNetwork/arwen-wasm-vm/v1_2 v1.2.35

--- a/integrationTests/longTests/storage/storagePutRemove_test.go
+++ b/integrationTests/longTests/storage/storagePutRemove_test.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"crypto/rand"
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -19,7 +18,7 @@ func TestPutRemove(t *testing.T) {
 	t.Skip("this is a long test")
 
 	cache, _ := storageUnit.NewCache(storageUnit.CacheConfig{Type: storageUnit.LRUCache, Capacity: 5000, Shards: 16, SizeInBytes: 0})
-	dir, _ := ioutil.TempDir("", "leveldb_temp")
+	dir := t.TempDir()
 	log.Info("opened in", "directory", dir)
 	lvdb1, err := leveldb.NewDB(dir, 2, 1000, 10)
 	assert.NoError(t, err)

--- a/integrationTests/multiShard/hardFork/hardFork_test.go
+++ b/integrationTests/multiShard/hardFork/hardFork_test.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/big"
-	"os"
 	"path"
 	"path/filepath"
 	"testing"
@@ -38,11 +36,7 @@ func TestHardForkWithoutTransactionInMultiShardedEnvironment(t *testing.T) {
 		t.Skip("this is not a short test")
 	}
 
-	exportBaseDirectory, err := ioutil.TempDir("", "export*")
-	require.Nil(t, err)
-	defer func() {
-		_ = os.RemoveAll(exportBaseDirectory)
-	}()
+	exportBaseDirectory := t.TempDir()
 
 	numOfShards := 1
 	nodesPerShard := 1
@@ -114,11 +108,7 @@ func TestHardForkWithContinuousTransactionsInMultiShardedEnvironment(t *testing.
 		t.Skip("this is not a short test")
 	}
 
-	exportBaseDirectory, err := ioutil.TempDir("", "export*")
-	require.Nil(t, err)
-	defer func() {
-		_ = os.RemoveAll(exportBaseDirectory)
-	}()
+	exportBaseDirectory := t.TempDir()
 
 	numOfShards := 1
 	nodesPerShard := 1
@@ -233,11 +223,7 @@ func TestHardForkEarlyEndOfEpochWithContinuousTransactionsInMultiShardedEnvironm
 		t.Skip("this is not a short test")
 	}
 
-	exportBaseDirectory, err := ioutil.TempDir("", "export*")
-	require.Nil(t, err)
-	defer func() {
-		_ = os.RemoveAll(exportBaseDirectory)
-	}()
+	exportBaseDirectory := t.TempDir()
 
 	numOfShards := 1
 	nodesPerShard := 1
@@ -312,7 +298,7 @@ func TestHardForkEarlyEndOfEpochWithContinuousTransactionsInMultiShardedEnvironm
 	for i := uint64(0); i < numRoundsBeforeHardfork+roundsForEarlyStartOfEpoch; i++ {
 		if i == numRoundsBeforeHardfork {
 			log.Info("triggering hardfork (with early end of epoch)")
-			err = hardforkTriggerNode.Node.DirectTrigger(1, true)
+			err := hardforkTriggerNode.Node.DirectTrigger(1, true)
 			log.LogIfError(err)
 		}
 

--- a/integrationTests/state/stateTrieSync/stateTrieSync_test.go
+++ b/integrationTests/state/stateTrieSync/stateTrieSync_test.go
@@ -3,7 +3,6 @@ package stateTrieSync
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"strconv"
 	"testing"
@@ -57,10 +56,8 @@ func createTestProcessorNodeAndTrieStorage(
 		MaxOpenFiles:      10,
 	}
 	persisterFactory := storageFactory.NewPersisterFactory(dbConfig)
-	tempDir, err := ioutil.TempDir("", "integrationTest")
-	require.Nil(t, err)
 
-	triePersister, err := persisterFactory.Create(tempDir)
+	triePersister, err := persisterFactory.Create(t.TempDir())
 	require.Nil(t, err)
 
 	trieStorage, err := storageUnit.NewStorageUnit(trieCache, triePersister)

--- a/storage/factory/directoryhandler/directoryReader_test.go
+++ b/storage/factory/directoryhandler/directoryReader_test.go
@@ -11,12 +11,7 @@ import (
 func TestDirectoryReaderListFilesAsString(t *testing.T) {
 	t.Parallel()
 
-	dirName := "./testDir1"
-	_ = os.Mkdir(dirName, os.ModePerm)
-	//remove created files
-	defer func() {
-		_ = os.RemoveAll(dirName)
-	}()
+	dirName := t.TempDir()
 
 	file1 := "file1"
 	file2 := "file2"
@@ -37,12 +32,7 @@ func TestDirectoryReaderListFilesAsString(t *testing.T) {
 func TestDirectoryReaderListDirectoriesAsString(t *testing.T) {
 	t.Parallel()
 
-	dirName := "./testDir2"
-	_ = os.Mkdir(dirName, os.ModePerm)
-	//remove created files
-	defer func() {
-		_ = os.RemoveAll(dirName)
-	}()
+	dirName := t.TempDir()
 
 	file1 := "file1"
 	file2 := "file2"
@@ -62,12 +52,7 @@ func TestDirectoryReaderListDirectoriesAsString(t *testing.T) {
 func TestDirectoryReaderListAllAsString(t *testing.T) {
 	t.Parallel()
 
-	dirName := "./testDir3"
-	_ = os.Mkdir(dirName, os.ModePerm)
-	//remove created files
-	defer func() {
-		_ = os.RemoveAll(dirName)
-	}()
+	dirName := t.TempDir()
 
 	file1 := "file1"
 	file2 := "file2"

--- a/storage/leveldb/leveldbSerial_test.go
+++ b/storage/leveldb/leveldbSerial_test.go
@@ -2,7 +2,6 @@ package leveldb_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -13,8 +12,7 @@ import (
 )
 
 func createSerialLevelDb(t *testing.T, batchDelaySeconds int, maxBatchSize int, maxOpenFiles int) (p *leveldb.SerialDB) {
-	dir, _ := ioutil.TempDir("", "leveldb_temp")
-	lvdb, err := leveldb.NewSerialDB(dir, batchDelaySeconds, maxBatchSize, maxOpenFiles)
+	lvdb, err := leveldb.NewSerialDB(t.TempDir(), batchDelaySeconds, maxBatchSize, maxOpenFiles)
 
 	assert.Nil(t, err, "Failed creating leveldb database file")
 	return lvdb

--- a/storage/leveldb/leveldb_test.go
+++ b/storage/leveldb/leveldb_test.go
@@ -3,7 +3,6 @@ package leveldb_test
 import (
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -16,18 +15,14 @@ import (
 )
 
 func createLevelDb(t *testing.T, batchDelaySeconds int, maxBatchSize int, maxOpenFiles int) (p *leveldb.DB) {
-	dir, _ := ioutil.TempDir("", "leveldb_temp")
-	lvdb, err := leveldb.NewDB(dir, batchDelaySeconds, maxBatchSize, maxOpenFiles)
+	lvdb, err := leveldb.NewDB(t.TempDir(), batchDelaySeconds, maxBatchSize, maxOpenFiles)
 
 	assert.Nil(t, err, "Failed creating leveldb database file")
 	return lvdb
 }
 
 func TestDB_CorruptdeDBShouldRecover(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "leveldb_temp")
-	defer func() {
-		_ = os.RemoveAll(dir)
-	}()
+	dir := t.TempDir()
 	db, err := leveldb.NewDB(dir, 10, 1, 10)
 	require.Nil(t, err)
 
@@ -54,13 +49,12 @@ func TestDB_CorruptdeDBShouldRecover(t *testing.T) {
 }
 
 func TestDB_DoubleOpenShouldError(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "leveldb_temp")
+	dir := t.TempDir()
 	lvdb1, err := leveldb.NewDB(dir, 10, 1, 10)
 	require.Nil(t, err)
 
 	defer func() {
 		_ = lvdb1.Close()
-		_ = os.RemoveAll(dir)
 	}()
 
 	_, err = leveldb.NewDB(dir, 10, 1, 10)
@@ -68,13 +62,12 @@ func TestDB_DoubleOpenShouldError(t *testing.T) {
 }
 
 func TestDB_DoubleOpenButClosedInTimeShouldWork(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "leveldb_temp")
+	dir := t.TempDir()
 	lvdb1, err := leveldb.NewDB(dir, 10, 1, 10)
 	require.Nil(t, err)
 
 	defer func() {
 		_ = lvdb1.Close()
-		_ = os.RemoveAll(dir)
 	}()
 
 	go func() {

--- a/storage/pruning/fullHistoryPruningStorer_test.go
+++ b/storage/pruning/fullHistoryPruningStorer_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"path/filepath"
 	"sync"
@@ -295,8 +294,7 @@ func TestFullHistoryPruningStorer_ConcurrentOperations(t *testing.T) {
 
 	_ = logger.SetLogLevel("*:DEBUG")
 	dbName := "db-concurrent-test"
-	testDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	testDir := t.TempDir()
 
 	fmt.Println(testDir)
 	args := getDefaultArgs()
@@ -307,6 +305,7 @@ func TestFullHistoryPruningStorer_ConcurrentOperations(t *testing.T) {
 		MaxOpenFiles:      10,
 		BatchDelaySeconds: 2,
 	})
+	var err error
 	args.PathManager, err = pathmanager.NewPathManager(testDir+"/epoch_[E]/shard_[S]/[I]", "shard_[S]/[I]", "db")
 	require.NoError(t, err)
 	fhArgs := &pruning.FullHistoryStorerArgs{

--- a/storage/pruning/pruningStorer_test.go
+++ b/storage/pruning/pruningStorer_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -837,8 +836,7 @@ func TestPruningStorer_ConcurrentOperations(t *testing.T) {
 	_ = logger.SetLogLevel("*:DEBUG")
 
 	dbName := "db-concurrent-test"
-	testDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	testDir := t.TempDir()
 
 	fmt.Println(testDir)
 	args := getDefaultArgs()
@@ -849,6 +847,7 @@ func TestPruningStorer_ConcurrentOperations(t *testing.T) {
 		MaxOpenFiles:      10,
 		BatchDelaySeconds: 2,
 	})
+	var err error
 	args.PathManager, err = pathmanager.NewPathManager(testDir+"/epoch_[E]/shard_[S]/[I]", "shard_[S]/[I]", "db")
 	require.NoError(t, err)
 

--- a/storage/storageUnit/storageunit_test.go
+++ b/storage/storageUnit/storageunit_test.go
@@ -2,7 +2,6 @@ package storageUnit_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -286,10 +285,9 @@ func TestCreateDBFromConfWrongFileNameLvlDB(t *testing.T) {
 }
 
 func TestCreateDBFromConfLvlDBOk(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "leveldb_temp")
 	arg := storageUnit.ArgDB{
 		DBType:            storageUnit.LvlDB,
-		Path:              dir,
+		Path:              t.TempDir(),
 		BatchDelaySeconds: 10,
 		MaxBatchSize:      10,
 		MaxOpenFiles:      10,

--- a/trie/doubleListSync_test.go
+++ b/trie/doubleListSync_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -38,10 +37,9 @@ func createMemUnit() storage.Storer {
 }
 
 // CreateTrieStorageManager creates the trie storage manager for the tests
-func createTrieStorageManager(store storage.Storer) (common.StorageManager, storage.Storer) {
-	tempDir, _ := ioutil.TempDir("", "trie")
+func createTrieStorageManager(t *testing.T, store storage.Storer) (common.StorageManager, storage.Storer) {
 	cfg := config.DBConfig{
-		FilePath:          tempDir,
+		FilePath:          t.TempDir(),
 		Type:              string(storageUnit.LvlDBSerial),
 		BatchDelaySeconds: 4,
 		MaxBatchSize:      10000,
@@ -69,22 +67,22 @@ func createTrieStorageManager(store storage.Storer) (common.StorageManager, stor
 	return tsm, store
 }
 
-func createInMemoryTrie() (common.Trie, storage.Storer) {
+func createInMemoryTrie(t *testing.T) (common.Trie, storage.Storer) {
 	memUnit := createMemUnit()
-	tsm, _ := createTrieStorageManager(memUnit)
+	tsm, _ := createTrieStorageManager(t, memUnit)
 	tr, _ := NewTrie(tsm, marshalizer, hasher, 6)
 
 	return tr, memUnit
 }
 
-func createInMemoryTrieFromDB(db storage.Persister) (common.Trie, storage.Storer) {
+func createInMemoryTrieFromDB(t *testing.T, db storage.Persister) (common.Trie, storage.Storer) {
 	capacity := uint32(10)
 	shards := uint32(1)
 	sizeInBytes := uint64(0)
 	cache, _ := storageUnit.NewCache(storageUnit.CacheConfig{Type: storageUnit.LRUCache, Capacity: capacity, Shards: shards, SizeInBytes: sizeInBytes})
 	unit, _ := storageUnit.NewStorageUnit(cache, db)
 
-	tsm, _ := createTrieStorageManager(unit)
+	tsm, _ := createTrieStorageManager(t, unit)
 	tr, _ := NewTrie(tsm, marshalizer, hasher, 6)
 
 	return tr, unit
@@ -184,7 +182,7 @@ func TestDoubleListTrieSyncer_StartSyncingNilContextShouldErr(t *testing.T) {
 
 func TestDoubleListTrieSyncer_StartSyncingCanTimeout(t *testing.T) {
 	numKeysValues := 10
-	trSource, _ := createInMemoryTrie()
+	trSource, _ := createInMemoryTrie(t)
 	addDataToTrie(numKeysValues, trSource)
 	_ = trSource.Commit()
 	roothash, _ := trSource.RootHash()
@@ -202,7 +200,7 @@ func TestDoubleListTrieSyncer_StartSyncingCanTimeout(t *testing.T) {
 
 func TestDoubleListTrieSyncer_StartSyncingTimeoutNoNodesReceived(t *testing.T) {
 	numKeysValues := 10
-	trSource, _ := createInMemoryTrie()
+	trSource, _ := createInMemoryTrie(t)
 	addDataToTrie(numKeysValues, trSource)
 	_ = trSource.Commit()
 	roothash, _ := trSource.RootHash()
@@ -218,7 +216,7 @@ func TestDoubleListTrieSyncer_StartSyncingTimeoutNoNodesReceived(t *testing.T) {
 
 func TestDoubleListTrieSyncer_StartSyncingNewTrieShouldWork(t *testing.T) {
 	numKeysValues := 100
-	trSource, _ := createInMemoryTrie()
+	trSource, _ := createInMemoryTrie(t)
 	addDataToTrie(numKeysValues, trSource)
 	_ = trSource.Commit()
 	roothash, _ := trSource.RootHash()
@@ -234,7 +232,7 @@ func TestDoubleListTrieSyncer_StartSyncingNewTrieShouldWork(t *testing.T) {
 	err := d.StartSyncing(roothash, ctx)
 	require.Nil(t, err)
 
-	trie, _ := createInMemoryTrieFromDB(arg.DB.(*testscommon.MemDbMock))
+	trie, _ := createInMemoryTrieFromDB(t, arg.DB.(*testscommon.MemDbMock))
 	trie, _ = trie.Recreate(roothash)
 	require.False(t, check.IfNil(trie))
 
@@ -259,7 +257,7 @@ func TestDoubleListTrieSyncer_StartSyncingNewTrieShouldWork(t *testing.T) {
 
 func TestDoubleListTrieSyncer_StartSyncingPartiallyFilledTrieShouldWork(t *testing.T) {
 	numKeysValues := 100
-	trSource, memUnitSource := createInMemoryTrie()
+	trSource, memUnitSource := createInMemoryTrie(t)
 	addDataToTrie(numKeysValues, trSource)
 	_ = trSource.Commit()
 	roothash, _ := trSource.RootHash()
@@ -291,7 +289,7 @@ func TestDoubleListTrieSyncer_StartSyncingPartiallyFilledTrieShouldWork(t *testi
 	err := d.StartSyncing(roothash, ctx)
 	require.Nil(t, err)
 
-	trie, _ := createInMemoryTrieFromDB(arg.DB.(*testscommon.MemDbMock))
+	trie, _ := createInMemoryTrieFromDB(t, arg.DB.(*testscommon.MemDbMock))
 	trie, _ = trie.Recreate(roothash)
 	require.False(t, check.IfNil(trie))
 

--- a/trie/interceptedNode_test.go
+++ b/trie/interceptedNode_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func getDefaultInterceptedTrieNodeParameters() ([]byte, marshal.Marshalizer, hashing.Hasher) {
-	tr := initTrie()
+func getDefaultInterceptedTrieNodeParameters(t *testing.T) ([]byte, marshal.Marshalizer, hashing.Hasher) {
+	tr := initTrie(t)
 	nodes, _ := getEncodedTrieNodesAndHashes(tr)
 
 	return nodes[0], &testscommon.ProtobufMarshalizerMock{}, &testscommon.KeccakMock{}
@@ -46,7 +46,7 @@ func getEncodedTrieNodesAndHashes(tr common.Trie) ([][]byte, [][]byte) {
 func TestNewInterceptedTrieNode_EmptyBufferShouldFail(t *testing.T) {
 	t.Parallel()
 
-	_, marsh, hasher := getDefaultInterceptedTrieNodeParameters()
+	_, marsh, hasher := getDefaultInterceptedTrieNodeParameters(t)
 	interceptedNode, err := trie.NewInterceptedTrieNode([]byte{}, marsh, hasher)
 	assert.True(t, check.IfNil(interceptedNode))
 	assert.Equal(t, trie.ErrValueTooShort, err)
@@ -55,7 +55,7 @@ func TestNewInterceptedTrieNode_EmptyBufferShouldFail(t *testing.T) {
 func TestNewInterceptedTrieNode_NilMarshalizerShouldFail(t *testing.T) {
 	t.Parallel()
 
-	buff, _, hasher := getDefaultInterceptedTrieNodeParameters()
+	buff, _, hasher := getDefaultInterceptedTrieNodeParameters(t)
 	interceptedNode, err := trie.NewInterceptedTrieNode(buff, nil, hasher)
 	assert.True(t, check.IfNil(interceptedNode))
 	assert.Equal(t, trie.ErrNilMarshalizer, err)
@@ -64,7 +64,7 @@ func TestNewInterceptedTrieNode_NilMarshalizerShouldFail(t *testing.T) {
 func TestNewInterceptedTrieNode_NilHasherShouldFail(t *testing.T) {
 	t.Parallel()
 
-	buff, marsh, _ := getDefaultInterceptedTrieNodeParameters()
+	buff, marsh, _ := getDefaultInterceptedTrieNodeParameters(t)
 	interceptedNode, err := trie.NewInterceptedTrieNode(buff, marsh, nil)
 	assert.True(t, check.IfNil(interceptedNode))
 	assert.Equal(t, trie.ErrNilHasher, err)
@@ -73,7 +73,7 @@ func TestNewInterceptedTrieNode_NilHasherShouldFail(t *testing.T) {
 func TestNewInterceptedTrieNode_OkParametersShouldWork(t *testing.T) {
 	t.Parallel()
 
-	interceptedNode, err := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters())
+	interceptedNode, err := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters(t))
 	assert.False(t, check.IfNil(interceptedNode))
 	assert.Nil(t, err)
 }
@@ -81,7 +81,7 @@ func TestNewInterceptedTrieNode_OkParametersShouldWork(t *testing.T) {
 func TestInterceptedTrieNode_CheckValidity(t *testing.T) {
 	t.Parallel()
 
-	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters())
+	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters(t))
 
 	err := interceptedNode.CheckValidity()
 	assert.Nil(t, err)
@@ -90,8 +90,8 @@ func TestInterceptedTrieNode_CheckValidity(t *testing.T) {
 func TestInterceptedTrieNode_Hash(t *testing.T) {
 	t.Parallel()
 
-	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters())
-	tr := initTrie()
+	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters(t))
+	tr := initTrie(t)
 	_, hashes := getEncodedTrieNodesAndHashes(tr)
 
 	hash := interceptedNode.Hash()
@@ -101,8 +101,8 @@ func TestInterceptedTrieNode_Hash(t *testing.T) {
 func TestInterceptedTrieNode_GetSerialized(t *testing.T) {
 	t.Parallel()
 
-	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters())
-	tr := initTrie()
+	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters(t))
+	tr := initTrie(t)
 	nodes, _ := getEncodedTrieNodesAndHashes(tr)
 
 	encNode := interceptedNode.GetSerialized()
@@ -112,7 +112,7 @@ func TestInterceptedTrieNode_GetSerialized(t *testing.T) {
 func TestInterceptedTrieNode_SetSerialized(t *testing.T) {
 	t.Parallel()
 
-	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters())
+	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters(t))
 	serializedNode := []byte("serialized node")
 
 	interceptedNode.SetSerialized(serializedNode)
@@ -122,69 +122,69 @@ func TestInterceptedTrieNode_SetSerialized(t *testing.T) {
 func TestInterceptedTrieNode_IsForCurrentShard(t *testing.T) {
 	t.Parallel()
 
-	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters())
+	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters(t))
 	assert.True(t, interceptedNode.IsForCurrentShard())
 }
 
 func TestInterceptedTrieNode_Type(t *testing.T) {
 	t.Parallel()
 
-	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters())
+	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters(t))
 	assert.Equal(t, "intercepted trie node", interceptedNode.Type())
 }
 
 func TestInterceptedTrieNode_String(t *testing.T) {
 	t.Parallel()
 
-	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters())
+	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters(t))
 	assert.NotEqual(t, 0, interceptedNode.String())
 }
 
 func TestInterceptedTrieNode_SenderShardId(t *testing.T) {
 	t.Parallel()
 
-	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters())
+	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters(t))
 	assert.NotEqual(t, 0, interceptedNode.SenderShardId())
 }
 
 func TestInterceptedTrieNode_ReceiverShardId(t *testing.T) {
 	t.Parallel()
 
-	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters())
+	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters(t))
 	assert.NotEqual(t, 0, interceptedNode.ReceiverShardId())
 }
 
 func TestInterceptedTrieNode_Nonce(t *testing.T) {
 	t.Parallel()
 
-	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters())
+	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters(t))
 	assert.NotEqual(t, 0, interceptedNode.Nonce())
 }
 
 func TestInterceptedTrieNode_SenderAddress(t *testing.T) {
 	t.Parallel()
 
-	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters())
+	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters(t))
 	assert.Nil(t, interceptedNode.SenderAddress())
 }
 
 func TestInterceptedTrieNode_Fee(t *testing.T) {
 	t.Parallel()
 
-	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters())
+	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters(t))
 	assert.Equal(t, big.NewInt(0), interceptedNode.Fee())
 }
 
 func TestInterceptedTrieNode_Identifiers(t *testing.T) {
 	t.Parallel()
 
-	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters())
+	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters(t))
 	assert.Equal(t, [][]byte{interceptedNode.Hash()}, interceptedNode.Identifiers())
 }
 
 func TestInterceptedTrieNode_SizeInBytes(t *testing.T) {
 	t.Parallel()
 
-	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters())
+	interceptedNode, _ := trie.NewInterceptedTrieNode(getDefaultInterceptedTrieNodeParameters(t))
 	assert.Equal(t, 380, interceptedNode.SizeInBytes())
 }

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -11,7 +11,7 @@ import (
 func TestNewIterator(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 
 	it, err := trie.NewIterator(tr)
 	assert.Nil(t, err)
@@ -31,7 +31,7 @@ func TestNewIteratorNilTrieShouldErr(t *testing.T) {
 func TestIterator_HasNext(t *testing.T) {
 	t.Parallel()
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 	_ = tr.Update([]byte("dog"), []byte("dog"))
 	it, _ := trie.NewIterator(tr)
 	assert.False(t, it.HasNext())
@@ -44,7 +44,7 @@ func TestIterator_HasNext(t *testing.T) {
 func TestIterator_Next(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 
 	it, _ := trie.NewIterator(tr)
 	for it.HasNext() {
@@ -56,7 +56,7 @@ func TestIterator_Next(t *testing.T) {
 func TestIterator_GetMarshalizedNode(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 	it, _ := trie.NewIterator(tr)
 
 	encNode, err := it.MarshalizedNode()
@@ -71,7 +71,7 @@ func TestIterator_GetMarshalizedNode(t *testing.T) {
 func TestIterator_GetHash(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 	rootHash, _ := tr.RootHash()
 	it, _ := trie.NewIterator(tr)
 

--- a/trie/patriciaMerkleTrie_test.go
+++ b/trie/patriciaMerkleTrie_test.go
@@ -3,7 +3,6 @@ package trie_test
 import (
 	cryptoRand "crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"strconv"
 	"sync"
@@ -26,21 +25,19 @@ import (
 
 var emptyTrieHash = make([]byte, 32)
 
-func emptyTrie() common.Trie {
-	tr, _ := trie.NewTrie(getDefaultTrieParameters())
+func emptyTrie(tb testing.TB) common.Trie {
+	tr, _ := trie.NewTrie(getDefaultTrieParameters(tb))
 
 	return tr
 }
 
-func getDefaultTrieParameters() (common.StorageManager, marshal.Marshalizer, hashing.Hasher, uint) {
+func getDefaultTrieParameters(tb testing.TB) (common.StorageManager, marshal.Marshalizer, hashing.Hasher, uint) {
 	db := testscommon.NewMemDbMock()
 	marshalizer := &testscommon.ProtobufMarshalizerMock{}
 	hasher := &testscommon.KeccakMock{}
 
-	tempDir, _ := ioutil.TempDir("", strconv.Itoa(rand.Intn(100000)))
-
 	cfg := config.DBConfig{
-		FilePath:          tempDir,
+		FilePath:          tb.TempDir(),
 		Type:              string(storageUnit.LvlDBSerial),
 		BatchDelaySeconds: 1,
 		MaxBatchSize:      1,
@@ -69,8 +66,8 @@ func getDefaultTrieParameters() (common.StorageManager, marshal.Marshalizer, has
 	return trieStorageManager, marshalizer, hasher, maxTrieLevelInMemory
 }
 
-func initTrieMultipleValues(nr int) (common.Trie, [][]byte) {
-	tr := emptyTrie()
+func initTrieMultipleValues(t *testing.T, nr int) (common.Trie, [][]byte) {
+	tr := emptyTrie(t)
 
 	var values [][]byte
 	hsh := keccak.NewKeccak()
@@ -83,8 +80,8 @@ func initTrieMultipleValues(nr int) (common.Trie, [][]byte) {
 	return tr, values
 }
 
-func initTrie() common.Trie {
-	tr := emptyTrie()
+func initTrie(t *testing.T) common.Trie {
+	tr := emptyTrie(t)
 	_ = tr.Update([]byte("doe"), []byte("reindeer"))
 	_ = tr.Update([]byte("dog"), []byte("puppy"))
 	_ = tr.Update([]byte("ddog"), []byte("cat"))
@@ -95,7 +92,7 @@ func initTrie() common.Trie {
 func TestNewTrieWithNilTrieStorage(t *testing.T) {
 	t.Parallel()
 
-	_, marshalizer, hasher, maxTrieLevelInMemory := getDefaultTrieParameters()
+	_, marshalizer, hasher, maxTrieLevelInMemory := getDefaultTrieParameters(t)
 	tr, err := trie.NewTrie(nil, marshalizer, hasher, maxTrieLevelInMemory)
 
 	assert.Nil(t, tr)
@@ -105,7 +102,7 @@ func TestNewTrieWithNilTrieStorage(t *testing.T) {
 func TestNewTrieWithNilMarshalizer(t *testing.T) {
 	t.Parallel()
 
-	trieStorage, _, hasher, maxTrieLevelInMemory := getDefaultTrieParameters()
+	trieStorage, _, hasher, maxTrieLevelInMemory := getDefaultTrieParameters(t)
 	tr, err := trie.NewTrie(trieStorage, nil, hasher, maxTrieLevelInMemory)
 
 	assert.Nil(t, tr)
@@ -115,7 +112,7 @@ func TestNewTrieWithNilMarshalizer(t *testing.T) {
 func TestNewTrieWithNilHasher(t *testing.T) {
 	t.Parallel()
 
-	trieStorage, marshalizer, _, maxTrieLevelInMemory := getDefaultTrieParameters()
+	trieStorage, marshalizer, _, maxTrieLevelInMemory := getDefaultTrieParameters(t)
 	tr, err := trie.NewTrie(trieStorage, marshalizer, nil, maxTrieLevelInMemory)
 
 	assert.Nil(t, tr)
@@ -125,7 +122,7 @@ func TestNewTrieWithNilHasher(t *testing.T) {
 func TestNewTrieWithInvalidMaxTrieLevelInMemory(t *testing.T) {
 	t.Parallel()
 
-	trieStorage, marshalizer, hasher, _ := getDefaultTrieParameters()
+	trieStorage, marshalizer, hasher, _ := getDefaultTrieParameters(t)
 	tr, err := trie.NewTrie(trieStorage, marshalizer, hasher, 0)
 
 	assert.Nil(t, tr)
@@ -135,7 +132,7 @@ func TestNewTrieWithInvalidMaxTrieLevelInMemory(t *testing.T) {
 func TestPatriciaMerkleTree_Get(t *testing.T) {
 	t.Parallel()
 
-	tr, val := initTrieMultipleValues(10000)
+	tr, val := initTrieMultipleValues(t, 10000)
 
 	for i := range val {
 		v, _ := tr.Get(val[i])
@@ -146,7 +143,7 @@ func TestPatriciaMerkleTree_Get(t *testing.T) {
 func TestPatriciaMerkleTree_GetEmptyTrie(t *testing.T) {
 	t.Parallel()
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 
 	val, err := tr.Get([]byte("dog"))
 	assert.Nil(t, err)
@@ -156,7 +153,7 @@ func TestPatriciaMerkleTree_GetEmptyTrie(t *testing.T) {
 func TestPatriciaMerkleTree_Update(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 
 	newVal := []byte("doge")
 	_ = tr.Update([]byte("dog"), newVal)
@@ -168,7 +165,7 @@ func TestPatriciaMerkleTree_Update(t *testing.T) {
 func TestPatriciaMerkleTree_UpdateEmptyVal(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 	var empty []byte
 
 	_ = tr.Update([]byte("doe"), []byte{})
@@ -180,7 +177,7 @@ func TestPatriciaMerkleTree_UpdateEmptyVal(t *testing.T) {
 func TestPatriciaMerkleTree_UpdateNotExisting(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 
 	_ = tr.Update([]byte("does"), []byte("this"))
 
@@ -191,7 +188,7 @@ func TestPatriciaMerkleTree_UpdateNotExisting(t *testing.T) {
 func TestPatriciaMerkleTree_Delete(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 	var empty []byte
 
 	_ = tr.Delete([]byte("doe"))
@@ -203,7 +200,7 @@ func TestPatriciaMerkleTree_Delete(t *testing.T) {
 func TestPatriciaMerkleTree_DeleteEmptyTrie(t *testing.T) {
 	t.Parallel()
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 
 	err := tr.Delete([]byte("dog"))
 	assert.Nil(t, err)
@@ -212,7 +209,7 @@ func TestPatriciaMerkleTree_DeleteEmptyTrie(t *testing.T) {
 func TestPatriciaMerkleTree_Root(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 
 	root, err := tr.RootHash()
 	assert.NotNil(t, root)
@@ -222,7 +219,7 @@ func TestPatriciaMerkleTree_Root(t *testing.T) {
 func TestPatriciaMerkleTree_NilRoot(t *testing.T) {
 	t.Parallel()
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 
 	root, err := tr.RootHash()
 	assert.Nil(t, err)
@@ -232,7 +229,7 @@ func TestPatriciaMerkleTree_NilRoot(t *testing.T) {
 func TestPatriciaMerkleTree_Consistency(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 	root1, _ := tr.RootHash()
 
 	_ = tr.Update([]byte("dodge"), []byte("viper"))
@@ -248,7 +245,7 @@ func TestPatriciaMerkleTree_Consistency(t *testing.T) {
 func TestPatriciaMerkleTrie_UpdateAndGetConcurrently(t *testing.T) {
 	t.Parallel()
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 	nrInserts := 100
 	wg := &sync.WaitGroup{}
 	wg.Add(nrInserts)
@@ -286,7 +283,7 @@ func TestPatriciaMerkleTrie_UpdateAndGetConcurrently(t *testing.T) {
 func TestPatriciaMerkleTree_Commit(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 
 	err := tr.Commit()
 	assert.Nil(t, err)
@@ -295,7 +292,7 @@ func TestPatriciaMerkleTree_Commit(t *testing.T) {
 func TestPatriciaMerkleTree_CommitCollapsesTrieOk(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 
 	_ = tr.Update([]byte("zebra"), []byte("zebra"))
 	_ = tr.Update([]byte("doggo"), []byte("doggo"))
@@ -308,7 +305,7 @@ func TestPatriciaMerkleTree_CommitCollapsesTrieOk(t *testing.T) {
 func TestPatriciaMerkleTree_CommitAfterCommit(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 
 	_ = tr.Commit()
 	err := tr.Commit()
@@ -318,7 +315,7 @@ func TestPatriciaMerkleTree_CommitAfterCommit(t *testing.T) {
 func TestPatriciaMerkleTree_CommitEmptyRoot(t *testing.T) {
 	t.Parallel()
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 
 	err := tr.Commit()
 	assert.Nil(t, err)
@@ -327,7 +324,7 @@ func TestPatriciaMerkleTree_CommitEmptyRoot(t *testing.T) {
 func TestPatriciaMerkleTree_GetAfterCommit(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 
 	err := tr.Commit()
 	assert.Nil(t, err)
@@ -340,8 +337,8 @@ func TestPatriciaMerkleTree_GetAfterCommit(t *testing.T) {
 func TestPatriciaMerkleTree_InsertAfterCommit(t *testing.T) {
 	t.Parallel()
 
-	tr1 := initTrie()
-	tr2 := initTrie()
+	tr1 := initTrie(t)
+	tr2 := initTrie(t)
 
 	err := tr1.Commit()
 	assert.Nil(t, err)
@@ -358,8 +355,8 @@ func TestPatriciaMerkleTree_InsertAfterCommit(t *testing.T) {
 func TestPatriciaMerkleTree_DeleteAfterCommit(t *testing.T) {
 	t.Parallel()
 
-	tr1 := initTrie()
-	tr2 := initTrie()
+	tr1 := initTrie(t)
+	tr2 := initTrie(t)
 
 	err := tr1.Commit()
 	assert.Nil(t, err)
@@ -376,7 +373,7 @@ func TestPatriciaMerkleTree_DeleteAfterCommit(t *testing.T) {
 func TestPatriciaMerkleTrie_Recreate(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 	rootHash, _ := tr.RootHash()
 	_ = tr.Commit()
 
@@ -391,7 +388,7 @@ func TestPatriciaMerkleTrie_Recreate(t *testing.T) {
 func TestPatriciaMerkleTrie_RecreateWithInvalidRootHash(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 
 	newTr, err := tr.Recreate(nil)
 	assert.Nil(t, err)
@@ -402,7 +399,7 @@ func TestPatriciaMerkleTrie_RecreateWithInvalidRootHash(t *testing.T) {
 func TestPatriciaMerkleTrie_GetSerializedNodes(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 	_ = tr.Commit()
 	rootHash, _ := tr.RootHash()
 
@@ -416,7 +413,7 @@ func TestPatriciaMerkleTrie_GetSerializedNodes(t *testing.T) {
 func TestPatriciaMerkleTrie_GetSerializedNodesTinyBufferShouldNotGetAllNodes(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 	_ = tr.Commit()
 	rootHash, _ := tr.RootHash()
 
@@ -430,7 +427,7 @@ func TestPatriciaMerkleTrie_GetSerializedNodesTinyBufferShouldNotGetAllNodes(t *
 func TestPatriciaMerkleTrie_GetSerializedNodesGetFromCheckpoint(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 	_ = tr.Commit()
 	rootHash, _ := tr.RootHash()
 
@@ -453,11 +450,11 @@ func TestPatriciaMerkleTrie_GetSerializedNodesGetFromCheckpoint(t *testing.T) {
 func TestPatriciaMerkleTrie_String(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 	str := tr.String()
 	assert.NotEqual(t, 0, len(str))
 
-	tr = emptyTrie()
+	tr = emptyTrie(t)
 	str = tr.String()
 	assert.Equal(t, "*** EMPTY TRIE ***\n", str)
 }
@@ -470,7 +467,7 @@ func TestPatriciaMerkleTree_reduceBranchNodeReturnsOldHashesCorrectly(t *testing
 	val1 := []byte("val1")
 	val2 := []byte("val2")
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 	_ = tr.Update(key1, val1)
 	_ = tr.Update(key2, val2)
 	_ = tr.Commit()
@@ -487,7 +484,7 @@ func TestPatriciaMerkleTree_reduceBranchNodeReturnsOldHashesCorrectly(t *testing
 func TestPatriciaMerkleTrie_GetAllHashesSetsHashes(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 
 	hashes, err := tr.GetAllHashes()
 	assert.Nil(t, err)
@@ -497,7 +494,7 @@ func TestPatriciaMerkleTrie_GetAllHashesSetsHashes(t *testing.T) {
 func TestPatriciaMerkleTrie_GetAllHashesEmtyTrie(t *testing.T) {
 	t.Parallel()
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 
 	hashes, err := tr.GetAllHashes()
 	assert.Nil(t, err)
@@ -507,7 +504,7 @@ func TestPatriciaMerkleTrie_GetAllHashesEmtyTrie(t *testing.T) {
 func TestPatriciaMerkleTrie_GetAllLeavesOnChannelEmptyTrie(t *testing.T) {
 	t.Parallel()
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 
 	leavesChannel, err := tr.GetAllLeavesOnChannel([]byte{})
 	assert.Nil(t, err)
@@ -520,7 +517,7 @@ func TestPatriciaMerkleTrie_GetAllLeavesOnChannelEmptyTrie(t *testing.T) {
 func TestPatriciaMerkleTrie_GetAllLeavesOnChannel(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 	leaves := map[string][]byte{
 		"doe":  []byte("reindeer"),
 		"dog":  []byte("puppy"),
@@ -543,7 +540,7 @@ func TestPatriciaMerkleTrie_GetAllLeavesOnChannel(t *testing.T) {
 func TestPatriciaMerkleTree_Prove(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 	rootHash, _ := tr.RootHash()
 
 	proof, value, err := tr.GetProof([]byte("dog"))
@@ -556,7 +553,7 @@ func TestPatriciaMerkleTree_Prove(t *testing.T) {
 func TestPatriciaMerkleTree_ProveCollapsedTrie(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 	_ = tr.Commit()
 	rootHash, _ := tr.RootHash()
 
@@ -569,7 +566,7 @@ func TestPatriciaMerkleTree_ProveCollapsedTrie(t *testing.T) {
 func TestPatriciaMerkleTree_ProveOnEmptyTrie(t *testing.T) {
 	t.Parallel()
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 
 	proof, _, err := tr.GetProof([]byte("dog"))
 	assert.Nil(t, proof)
@@ -579,7 +576,7 @@ func TestPatriciaMerkleTree_ProveOnEmptyTrie(t *testing.T) {
 func TestPatriciaMerkleTree_VerifyProof(t *testing.T) {
 	t.Parallel()
 
-	tr, val := initTrieMultipleValues(50)
+	tr, val := initTrieMultipleValues(t, 50)
 	rootHash, _ := tr.RootHash()
 
 	for i := range val {
@@ -598,7 +595,7 @@ func TestPatriciaMerkleTree_VerifyProof(t *testing.T) {
 func TestPatriciaMerkleTrie_VerifyProofBranchNodeWantHashShouldWork(t *testing.T) {
 	t.Parallel()
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 
 	_ = tr.Update([]byte("dog"), []byte("cat"))
 	_ = tr.Update([]byte("zebra"), []byte("horse"))
@@ -613,7 +610,7 @@ func TestPatriciaMerkleTrie_VerifyProofBranchNodeWantHashShouldWork(t *testing.T
 func TestPatriciaMerkleTrie_VerifyProofExtensionNodeWantHashShouldWork(t *testing.T) {
 	t.Parallel()
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 
 	_ = tr.Update([]byte("dog"), []byte("cat"))
 	_ = tr.Update([]byte("doe"), []byte("reindeer"))
@@ -628,7 +625,7 @@ func TestPatriciaMerkleTrie_VerifyProofExtensionNodeWantHashShouldWork(t *testin
 func TestPatriciaMerkleTree_VerifyProofNilProofs(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 	rootHash, _ := tr.RootHash()
 
 	ok, err := tr.VerifyProof(rootHash, []byte("dog"), nil)
@@ -639,7 +636,7 @@ func TestPatriciaMerkleTree_VerifyProofNilProofs(t *testing.T) {
 func TestPatriciaMerkleTree_VerifyProofEmptyProofs(t *testing.T) {
 	t.Parallel()
 
-	tr := initTrie()
+	tr := initTrie(t)
 	rootHash, _ := tr.RootHash()
 
 	ok, err := tr.VerifyProof(rootHash, []byte("dog"), [][]byte{})
@@ -650,8 +647,8 @@ func TestPatriciaMerkleTree_VerifyProofEmptyProofs(t *testing.T) {
 func TestPatriciaMerkleTrie_VerifyProofFromDifferentTrieShouldNotWork(t *testing.T) {
 	t.Parallel()
 
-	tr1 := emptyTrie()
-	tr2 := emptyTrie()
+	tr1 := emptyTrie(t)
+	tr2 := emptyTrie(t)
 
 	_ = tr1.Update([]byte("doe"), []byte("reindeer"))
 	_ = tr1.Update([]byte("dog"), []byte("puppy"))
@@ -670,7 +667,7 @@ func TestPatriciaMerkleTrie_VerifyProofFromDifferentTrieShouldNotWork(t *testing
 func TestPatriciaMerkleTrie_GetAndVerifyProof(t *testing.T) {
 	t.Parallel()
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 
 	nrLeaves := 10000
 	values := make([][]byte, nrLeaves)
@@ -715,7 +712,7 @@ func dumpTrieContents(tr common.Trie, values [][]byte) {
 func TestPatriciaMerkleTrie_GetNumNodesNilRootShouldReturnEmpty(t *testing.T) {
 	t.Parallel()
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 
 	numNodes := tr.GetNumNodes()
 	assert.Equal(t, common.NumNodesDTO{}, numNodes)
@@ -724,7 +721,7 @@ func TestPatriciaMerkleTrie_GetNumNodesNilRootShouldReturnEmpty(t *testing.T) {
 func TestPatriciaMerkleTrie_GetNumNodes(t *testing.T) {
 	t.Parallel()
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 	_ = tr.Update([]byte("eod"), []byte("reindeer"))
 	_ = tr.Update([]byte("god"), []byte("puppy"))
 	_ = tr.Update([]byte("eggod"), []byte("cat"))
@@ -739,7 +736,7 @@ func TestPatriciaMerkleTrie_GetNumNodes(t *testing.T) {
 func TestPatriciaMerkleTrie_GetOldRoot(t *testing.T) {
 	t.Parallel()
 
-	tr := emptyTrie()
+	tr := emptyTrie(t)
 	_ = tr.Update([]byte("eod"), []byte("reindeer"))
 	_ = tr.Update([]byte("god"), []byte("puppy"))
 	_ = tr.Commit()
@@ -750,7 +747,7 @@ func TestPatriciaMerkleTrie_GetOldRoot(t *testing.T) {
 }
 
 func BenchmarkPatriciaMerkleTree_Insert(b *testing.B) {
-	tr := emptyTrie()
+	tr := emptyTrie(b)
 	hsh := keccak.NewKeccak()
 
 	nrValuesInTrie := 1000000
@@ -772,7 +769,7 @@ func BenchmarkPatriciaMerkleTree_Insert(b *testing.B) {
 }
 
 func BenchmarkPatriciaMerkleTree_InsertCollapsedTrie(b *testing.B) {
-	tr := emptyTrie()
+	tr := emptyTrie(b)
 	hsh := keccak.NewKeccak()
 
 	nrValuesInTrie := 1000000
@@ -795,7 +792,7 @@ func BenchmarkPatriciaMerkleTree_InsertCollapsedTrie(b *testing.B) {
 }
 
 func BenchmarkPatriciaMerkleTree_Delete(b *testing.B) {
-	tr := emptyTrie()
+	tr := emptyTrie(b)
 	hsh := keccak.NewKeccak()
 
 	nrValuesInTrie := 3000000
@@ -813,7 +810,7 @@ func BenchmarkPatriciaMerkleTree_Delete(b *testing.B) {
 }
 
 func BenchmarkPatriciaMerkleTree_DeleteCollapsedTrie(b *testing.B) {
-	tr := emptyTrie()
+	tr := emptyTrie(b)
 	hsh := keccak.NewKeccak()
 
 	nrValuesInTrie := 1000000
@@ -833,7 +830,7 @@ func BenchmarkPatriciaMerkleTree_DeleteCollapsedTrie(b *testing.B) {
 }
 
 func BenchmarkPatriciaMerkleTree_Get(b *testing.B) {
-	tr := emptyTrie()
+	tr := emptyTrie(b)
 	hsh := keccak.NewKeccak()
 
 	nrValuesInTrie := 3000000
@@ -851,7 +848,7 @@ func BenchmarkPatriciaMerkleTree_Get(b *testing.B) {
 }
 
 func BenchmarkPatriciaMerkleTree_GetCollapsedTrie(b *testing.B) {
-	tr := emptyTrie()
+	tr := emptyTrie(b)
 	hsh := keccak.NewKeccak()
 
 	nrValuesInTrie := 1000000
@@ -874,7 +871,7 @@ func BenchmarkPatriciaMerkleTree_Commit(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
 		hsh := keccak.NewKeccak()
-		tr := emptyTrie()
+		tr := emptyTrie(b)
 		for j := 0; j < nrValuesInTrie; j++ {
 			hash := hsh.Compute(strconv.Itoa(j))
 			_ = tr.Update(hash, hash)
@@ -886,7 +883,7 @@ func BenchmarkPatriciaMerkleTree_Commit(b *testing.B) {
 }
 
 func BenchmarkPatriciaMerkleTrie_RootHashAfterChanging30000Nodes(b *testing.B) {
-	tr := emptyTrie()
+	tr := emptyTrie(b)
 	hsh := keccak.NewKeccak()
 
 	nrValuesInTrie := 2000000
@@ -914,7 +911,7 @@ func BenchmarkPatriciaMerkleTrie_RootHashAfterChanging30000Nodes(b *testing.B) {
 }
 
 func BenchmarkPatriciaMerkleTrie_RootHashAfterChanging30000NodesInBatchesOf200(b *testing.B) {
-	tr := emptyTrie()
+	tr := emptyTrie(b)
 	hsh := keccak.NewKeccak()
 
 	nrValuesInTrie := 2000000

--- a/trie/trieStorageManager_test.go
+++ b/trie/trieStorageManager_test.go
@@ -1,7 +1,6 @@
 package trie_test
 
 import (
-	"io/ioutil"
 	"strconv"
 	"strings"
 	"testing"
@@ -91,9 +90,8 @@ func TestNewTrieStorageManagerOkVals(t *testing.T) {
 func TestNewTrieStorageManagerWithExistingSnapshot(t *testing.T) {
 	t.Parallel()
 
-	tempDir, _ := ioutil.TempDir("", "leveldb_temp")
 	cfg := config.DBConfig{
-		FilePath:          tempDir,
+		FilePath:          t.TempDir(),
 		Type:              string(storageUnit.LvlDBSerial),
 		BatchDelaySeconds: 1,
 		MaxBatchSize:      1,
@@ -134,9 +132,8 @@ func TestNewTrieStorageManagerWithExistingSnapshot(t *testing.T) {
 func TestNewTrieStorageManagerLoadsSnapshotsInOrder(t *testing.T) {
 	t.Parallel()
 
-	tempDir, _ := ioutil.TempDir("", "leveldb_temp")
 	cfg := config.DBConfig{
-		FilePath:          tempDir,
+		FilePath:          t.TempDir(),
 		Type:              string(storageUnit.LvlDBSerial),
 		BatchDelaySeconds: 1,
 		MaxBatchSize:      1,

--- a/update/genesis/export_test.go
+++ b/update/genesis/export_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 	"github.com/ElrondNetwork/elrond-go/state"
-	trieMock "github.com/ElrondNetwork/elrond-go/testscommon/trie"
 	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
+	trieMock "github.com/ElrondNetwork/elrond-go/testscommon/trie"
 	"github.com/ElrondNetwork/elrond-go/update"
 	"github.com/ElrondNetwork/elrond-go/update/mock"
 	"github.com/stretchr/testify/assert"
@@ -286,12 +286,7 @@ func TestExportAll(t *testing.T) {
 func TestStateExport_ExportTrieShouldExportNodesSetupJson(t *testing.T) {
 	t.Parallel()
 
-	testFolderName := "testFilesExportNodes"
-	_ = os.Mkdir(testFolderName, 0777)
-
-	defer func() {
-		_ = os.RemoveAll(testFolderName)
-	}()
+	testFolderName := t.TempDir()
 
 	hs := &mock.HardforkStorerStub{
 		WriteCalled: func(identifier string, key []byte, value []byte) error {
@@ -349,12 +344,7 @@ func TestStateExport_ExportTrieShouldExportNodesSetupJson(t *testing.T) {
 func TestStateExport_ExportNodesSetupJsonShouldExportKeysInAlphabeticalOrder(t *testing.T) {
 	t.Parallel()
 
-	testFolderName := "testFilesExportNodes2"
-	_ = os.Mkdir(testFolderName, 0777)
-
-	defer func() {
-		_ = os.RemoveAll(testFolderName)
-	}()
+	testFolderName := t.TempDir()
 
 	hs := &mock.HardforkStorerStub{
 		WriteCalled: func(identifier string, key []byte, value []byte) error {

--- a/update/trigger/importStartHandler_test.go
+++ b/update/trigger/importStartHandler_test.go
@@ -1,8 +1,6 @@
 package trigger
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
@@ -37,12 +35,8 @@ func TestNewImportStartHandler(t *testing.T) {
 func TestImportStartHandler_SetGetRemove(t *testing.T) {
 	t.Parallel()
 
-	workingDir, _ := ioutil.TempDir("", "importstarthandler_temp")
-	defer func() {
-		_ = os.RemoveAll(workingDir)
-	}()
 	version := "v1"
-	ish, _ := NewImportStartHandler(workingDir, version)
+	ish, _ := NewImportStartHandler(t.TempDir(), version)
 
 	err := ish.SetStartImport()
 	assert.Nil(t, err)
@@ -64,12 +58,8 @@ func TestImportStartHandler_SetGetRemove(t *testing.T) {
 func TestImportStartHandler_DoubleSetShouldNotError(t *testing.T) {
 	t.Parallel()
 
-	workingDir, _ := ioutil.TempDir("", "importstarthandler_temp")
-	defer func() {
-		_ = os.RemoveAll(workingDir)
-	}()
 	version := "v1"
-	ish, _ := NewImportStartHandler(workingDir, version)
+	ish, _ := NewImportStartHandler(t.TempDir(), version)
 
 	err := ish.SetStartImport()
 	assert.Nil(t, err)


### PR DESCRIPTION
A testing enhancement.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

**Note:** `T.TempDir` requires Go 1.15 or higher, hence the `go` directive in `go.mod` is bumped to `1.15`.

Reference: https://pkg.go.dev/testing#T.TempDir