### PR TITLE
block VM Queries API calls right after node starts

### DIFF
--- a/common/channels.go
+++ b/common/channels.go
@@ -1,0 +1,9 @@
+package common
+
+// GetClosedUnbufferedChannel returns an instance of a 'chan struct{}' that is already written in
+func GetClosedUnbufferedChannel() chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+
+	return ch
+}

--- a/common/channels.go
+++ b/common/channels.go
@@ -1,6 +1,6 @@
 package common
 
-// GetClosedUnbufferedChannel returns an instance of a 'chan struct{}' that is already written in
+// GetClosedUnbufferedChannel returns an instance of a 'chan struct{}' that is already closed
 func GetClosedUnbufferedChannel() chan struct{} {
 	ch := make(chan struct{})
 	close(ch)

--- a/common/channels_test.go
+++ b/common/channels_test.go
@@ -11,8 +11,8 @@ func TestGetClosedUnbufferedChannel(t *testing.T) {
 
 	ch := GetClosedUnbufferedChannel()
 
-	require.True(t, didTriggerHappened(ch))
-	require.True(t, didTriggerHappened(ch))
+	require.True(t, didTriggerHappen(ch))
+	require.True(t, didTriggerHappen(ch))
 }
 
 func TestUsingUnbufferedChannelForNotifyingEvents(t *testing.T) {
@@ -20,15 +20,15 @@ func TestUsingUnbufferedChannelForNotifyingEvents(t *testing.T) {
 	// unbuffered channels can be used for notifying events
 	channelForTriggeringAction := make(chan struct{})
 
-	require.False(t, didTriggerHappened(channelForTriggeringAction))
-	require.False(t, didTriggerHappened(channelForTriggeringAction))
+	require.False(t, didTriggerHappen(channelForTriggeringAction))
+	require.False(t, didTriggerHappen(channelForTriggeringAction))
 	close(channelForTriggeringAction)
-	require.True(t, didTriggerHappened(channelForTriggeringAction))
-	require.True(t, didTriggerHappened(channelForTriggeringAction))
+	require.True(t, didTriggerHappen(channelForTriggeringAction))
+	require.True(t, didTriggerHappen(channelForTriggeringAction))
 
 }
 
-func didTriggerHappened(ch chan struct{}) bool {
+func didTriggerHappen(ch chan struct{}) bool {
 	select {
 	case <-ch:
 		return true

--- a/common/channels_test.go
+++ b/common/channels_test.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetClosedUnbufferedChannel(t *testing.T) {
+	t.Parallel()
+
+	ch := GetClosedUnbufferedChannel()
+
+	require.True(t, didTriggerHappened(ch))
+	require.True(t, didTriggerHappened(ch))
+}
+
+func TestUsingUnbufferedChannelForNotifyingEvents(t *testing.T) {
+	// this test isn't related to the GetClosedUnbufferedChannel function, but rather demonstrates how
+	// unbuffered channels can be used for notifying events
+	channelForTriggeringAction := make(chan struct{})
+
+	require.False(t, didTriggerHappened(channelForTriggeringAction))
+	require.False(t, didTriggerHappened(channelForTriggeringAction))
+	close(channelForTriggeringAction)
+	require.True(t, didTriggerHappened(channelForTriggeringAction))
+	require.True(t, didTriggerHappened(channelForTriggeringAction))
+
+}
+
+func didTriggerHappened(ch chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}

--- a/genesis/process/metaGenesisBlockCreator.go
+++ b/genesis/process/metaGenesisBlockCreator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/common/forking"
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
@@ -503,12 +504,13 @@ func createProcessorsForMetaGenesisBlock(arg ArgsGenesisBlockCreator, enableEpoc
 	}
 
 	argsNewSCQueryService := smartContract.ArgsNewSCQueryService{
-		VmContainer:       vmContainer,
-		EconomicsFee:      arg.Economics,
-		BlockChainHook:    virtualMachineFactory.BlockChainHookImpl(),
-		BlockChain:        arg.Data.Blockchain(),
-		ArwenChangeLocker: &sync.RWMutex{},
-		Bootstrapper:      syncDisabled.NewDisabledBootstrapper(),
+		VmContainer:              vmContainer,
+		EconomicsFee:             arg.Economics,
+		BlockChainHook:           virtualMachineFactory.BlockChainHookImpl(),
+		BlockChain:               arg.Data.Blockchain(),
+		ArwenChangeLocker:        &sync.RWMutex{},
+		Bootstrapper:             syncDisabled.NewDisabledBootstrapper(),
+		AllowExternalQueriesChan: common.GetClosedUnbufferedChannel(),
 	}
 	queryService, err := smartContract.NewSCQueryService(argsNewSCQueryService)
 	if err != nil {

--- a/genesis/process/shardGenesisBlockCreator.go
+++ b/genesis/process/shardGenesisBlockCreator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	dataBlock "github.com/ElrondNetwork/elrond-go-core/data/block"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/common/forking"
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/genesis"
@@ -615,12 +616,13 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, enableEpo
 	}
 
 	argsNewSCQueryService := smartContract.ArgsNewSCQueryService{
-		VmContainer:       vmContainer,
-		EconomicsFee:      arg.Economics,
-		BlockChainHook:    vmFactoryImpl.BlockChainHookImpl(),
-		BlockChain:        arg.Data.Blockchain(),
-		ArwenChangeLocker: genesisArwenLocker,
-		Bootstrapper:      syncDisabled.NewDisabledBootstrapper(),
+		VmContainer:              vmContainer,
+		EconomicsFee:             arg.Economics,
+		BlockChainHook:           vmFactoryImpl.BlockChainHookImpl(),
+		BlockChain:               arg.Data.Blockchain(),
+		ArwenChangeLocker:        genesisArwenLocker,
+		Bootstrapper:             syncDisabled.NewDisabledBootstrapper(),
+		AllowExternalQueriesChan: common.GetClosedUnbufferedChannel(),
 	}
 	queryService, err := smartContract.NewSCQueryService(argsNewSCQueryService)
 	if err != nil {

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -541,12 +541,13 @@ func NewTestProcessorNodeWithFullGenesis(
 	tpn.initInterceptors()
 	tpn.initInnerProcessors(arwenConfig.MakeGasMapForTests())
 	argsNewScQueryService := smartContract.ArgsNewSCQueryService{
-		VmContainer:       tpn.VMContainer,
-		EconomicsFee:      tpn.EconomicsData,
-		BlockChainHook:    tpn.BlockchainHook,
-		BlockChain:        tpn.BlockChain,
-		ArwenChangeLocker: tpn.ArwenChangeLocker,
-		Bootstrapper:      tpn.Bootstrapper,
+		VmContainer:              tpn.VMContainer,
+		EconomicsFee:             tpn.EconomicsData,
+		BlockChainHook:           tpn.BlockchainHook,
+		BlockChain:               tpn.BlockChain,
+		ArwenChangeLocker:        tpn.ArwenChangeLocker,
+		Bootstrapper:             tpn.Bootstrapper,
+		AllowExternalQueriesChan: common.GetClosedUnbufferedChannel(),
 	}
 	tpn.SCQueryService, _ = smartContract.NewSCQueryService(argsNewScQueryService)
 	tpn.initBlockProcessor(stateCheckpointModulus)
@@ -733,12 +734,13 @@ func (tpn *TestProcessorNode) initTestNode() {
 	tpn.initInterceptors()
 	tpn.initInnerProcessors(arwenConfig.MakeGasMapForTests())
 	argsNewScQueryService := smartContract.ArgsNewSCQueryService{
-		VmContainer:       tpn.VMContainer,
-		EconomicsFee:      tpn.EconomicsData,
-		BlockChainHook:    tpn.BlockchainHook,
-		BlockChain:        tpn.BlockChain,
-		ArwenChangeLocker: tpn.ArwenChangeLocker,
-		Bootstrapper:      tpn.Bootstrapper,
+		VmContainer:              tpn.VMContainer,
+		EconomicsFee:             tpn.EconomicsData,
+		BlockChainHook:           tpn.BlockchainHook,
+		BlockChain:               tpn.BlockChain,
+		ArwenChangeLocker:        tpn.ArwenChangeLocker,
+		Bootstrapper:             tpn.Bootstrapper,
+		AllowExternalQueriesChan: common.GetClosedUnbufferedChannel(),
 	}
 	tpn.SCQueryService, _ = smartContract.NewSCQueryService(argsNewScQueryService)
 	tpn.initBlockProcessor(stateCheckpointModulus)
@@ -935,12 +937,13 @@ func (tpn *TestProcessorNode) createFullSCQueryService() {
 
 	_ = vmcommonBuiltInFunctions.SetPayableHandler(builtInFuncs, vmFactory.BlockChainHookImpl())
 	argsNewScQueryService := smartContract.ArgsNewSCQueryService{
-		VmContainer:       vmContainer,
-		EconomicsFee:      tpn.EconomicsData,
-		BlockChainHook:    vmFactory.BlockChainHookImpl(),
-		BlockChain:        tpn.BlockChain,
-		ArwenChangeLocker: tpn.ArwenChangeLocker,
-		Bootstrapper:      tpn.Bootstrapper,
+		VmContainer:              vmContainer,
+		EconomicsFee:             tpn.EconomicsData,
+		BlockChainHook:           vmFactory.BlockChainHookImpl(),
+		BlockChain:               tpn.BlockChain,
+		ArwenChangeLocker:        tpn.ArwenChangeLocker,
+		Bootstrapper:             tpn.Bootstrapper,
+		AllowExternalQueriesChan: common.GetClosedUnbufferedChannel(),
 	}
 	tpn.SCQueryService, _ = smartContract.NewSCQueryService(argsNewScQueryService)
 }
@@ -951,12 +954,13 @@ func (tpn *TestProcessorNode) InitializeProcessors(gasMap map[string]map[string]
 	tpn.initBlockTracker()
 	tpn.initInnerProcessors(gasMap)
 	argsNewScQueryService := smartContract.ArgsNewSCQueryService{
-		VmContainer:       tpn.VMContainer,
-		EconomicsFee:      tpn.EconomicsData,
-		BlockChainHook:    tpn.BlockchainHook,
-		BlockChain:        tpn.BlockChain,
-		ArwenChangeLocker: tpn.ArwenChangeLocker,
-		Bootstrapper:      tpn.Bootstrapper,
+		VmContainer:              tpn.VMContainer,
+		EconomicsFee:             tpn.EconomicsData,
+		BlockChainHook:           tpn.BlockchainHook,
+		BlockChain:               tpn.BlockChain,
+		ArwenChangeLocker:        tpn.ArwenChangeLocker,
+		Bootstrapper:             tpn.Bootstrapper,
+		AllowExternalQueriesChan: common.GetClosedUnbufferedChannel(),
 	}
 	tpn.SCQueryService, _ = smartContract.NewSCQueryService(argsNewScQueryService)
 	tpn.initBlockProcessor(stateCheckpointModulus)

--- a/integrationTests/testProcessorNodeWithStateCheckpointModulus.go
+++ b/integrationTests/testProcessorNodeWithStateCheckpointModulus.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	arwenConfig "github.com/ElrondNetwork/arwen-wasm-vm/v1_4/config"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/common/forking"
 	"github.com/ElrondNetwork/elrond-go/consensus/spos/sposFactory"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/mock"
@@ -117,12 +118,13 @@ func NewTestProcessorNodeWithStateCheckpointModulus(
 	tpn.initInterceptors()
 	tpn.initInnerProcessors(arwenConfig.MakeGasMapForTests())
 	argsNewScQueryService := smartContract.ArgsNewSCQueryService{
-		VmContainer:       tpn.VMContainer,
-		EconomicsFee:      tpn.EconomicsData,
-		BlockChainHook:    tpn.BlockchainHook,
-		BlockChain:        tpn.BlockChain,
-		ArwenChangeLocker: tpn.ArwenChangeLocker,
-		Bootstrapper:      tpn.Bootstrapper,
+		VmContainer:              tpn.VMContainer,
+		EconomicsFee:             tpn.EconomicsData,
+		BlockChainHook:           tpn.BlockchainHook,
+		BlockChain:               tpn.BlockChain,
+		ArwenChangeLocker:        tpn.ArwenChangeLocker,
+		Bootstrapper:             tpn.Bootstrapper,
+		AllowExternalQueriesChan: common.GetClosedUnbufferedChannel(),
 	}
 	tpn.SCQueryService, _ = smartContract.NewSCQueryService(argsNewScQueryService)
 	tpn.initBlockProcessor(stateCheckpointModulus)

--- a/integrationTests/testSyncNode.go
+++ b/integrationTests/testSyncNode.go
@@ -6,6 +6,7 @@ import (
 
 	arwenConfig "github.com/ElrondNetwork/arwen-wasm-vm/v1_4/config"
 	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/common/forking"
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/consensus/spos/sposFactory"
@@ -138,12 +139,13 @@ func (tpn *TestProcessorNode) initTestNodeWithSync() {
 	tpn.setGenesisBlock()
 	tpn.initNode()
 	argsNewScQueryService := smartContract.ArgsNewSCQueryService{
-		VmContainer:       tpn.VMContainer,
-		EconomicsFee:      tpn.EconomicsData,
-		BlockChainHook:    tpn.BlockchainHook,
-		BlockChain:        tpn.BlockChain,
-		ArwenChangeLocker: tpn.ArwenChangeLocker,
-		Bootstrapper:      tpn.Bootstrapper,
+		VmContainer:              tpn.VMContainer,
+		EconomicsFee:             tpn.EconomicsData,
+		BlockChainHook:           tpn.BlockchainHook,
+		BlockChain:               tpn.BlockChain,
+		ArwenChangeLocker:        tpn.ArwenChangeLocker,
+		Bootstrapper:             tpn.Bootstrapper,
+		AllowExternalQueriesChan: common.GetClosedUnbufferedChannel(),
 	}
 	tpn.SCQueryService, _ = smartContract.NewSCQueryService(argsNewScQueryService)
 	tpn.addHandlersForCounters()
@@ -216,7 +218,7 @@ func (tpn *TestProcessorNode) initBlockProcessorWithSync() {
 		BlockSizeThrottler:             TestBlockSizeThrottler,
 		HistoryRepository:              tpn.HistoryRepository,
 		EpochNotifier:                  tpn.EpochNotifier,
-		RoundNotifier:      coreComponents.RoundNotifier(),
+		RoundNotifier:                  coreComponents.RoundNotifier(),
 		GasHandler:                     tpn.GasHandler,
 		ScheduledTxsExecutionHandler:   &testscommon.ScheduledTxsExecutionStub{},
 		ScheduledMiniBlocksEnableEpoch: ScheduledMiniBlocksEnableEpoch,

--- a/integrationTests/vm/arwen/utils.go
+++ b/integrationTests/vm/arwen/utils.go
@@ -143,12 +143,13 @@ func SetupTestContext(t *testing.T) *TestContext {
 	context.initTxProcessorWithOneSCExecutorWithVMs()
 	context.ScAddress, _ = context.BlockchainHook.NewAddress(context.Owner.Address, context.Owner.Nonce, factory.ArwenVirtualMachine)
 	argsNewSCQueryService := smartContract.ArgsNewSCQueryService{
-		VmContainer:       context.VMContainer,
-		EconomicsFee:      context.EconomicsFee,
-		BlockChainHook:    context.BlockchainHook,
-		BlockChain:        &testscommon.ChainHandlerStub{},
-		ArwenChangeLocker: &sync.RWMutex{},
-		Bootstrapper:      disabled.NewDisabledBootstrapper(),
+		VmContainer:              context.VMContainer,
+		EconomicsFee:             context.EconomicsFee,
+		BlockChainHook:           context.BlockchainHook,
+		BlockChain:               &testscommon.ChainHandlerStub{},
+		ArwenChangeLocker:        &sync.RWMutex{},
+		Bootstrapper:             disabled.NewDisabledBootstrapper(),
+		AllowExternalQueriesChan: common.GetClosedUnbufferedChannel(),
 	}
 	context.QueryService, _ = smartContract.NewSCQueryService(argsNewSCQueryService)
 

--- a/integrationTests/vm/mockVM/vmGet/vmGet_test.go
+++ b/integrationTests/vm/mockVM/vmGet/vmGet_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	vmData "github.com/ElrondNetwork/elrond-go-core/data/vm"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/mock"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/vm"
@@ -38,10 +39,11 @@ func TestVmGetShouldReturnValue(t *testing.T) {
 				return uint64(math.MaxUint64)
 			},
 		},
-		BlockChainHook:    &mock.BlockChainHookHandlerMock{},
-		BlockChain:        &testscommon.ChainHandlerStub{},
-		ArwenChangeLocker: &sync.RWMutex{},
-		Bootstrapper:      disabled.NewDisabledBootstrapper(),
+		BlockChainHook:           &mock.BlockChainHookHandlerMock{},
+		BlockChain:               &testscommon.ChainHandlerStub{},
+		ArwenChangeLocker:        &sync.RWMutex{},
+		Bootstrapper:             disabled.NewDisabledBootstrapper(),
+		AllowExternalQueriesChan: common.GetClosedUnbufferedChannel(),
 	}
 	service, _ := smartContract.NewSCQueryService(argsNewSCQueryService)
 

--- a/integrationTests/vm/testInitializer.go
+++ b/integrationTests/vm/testInitializer.go
@@ -237,12 +237,13 @@ func (vmTestContext *VMTestContext) GetVMOutputWithTransientVM(funcName string, 
 	}
 
 	argsNewSCQueryService := smartContract.ArgsNewSCQueryService{
-		VmContainer:       vmContainer,
-		EconomicsFee:      feeHandler,
-		BlockChainHook:    blockChainHook,
-		BlockChain:        &testscommon.ChainHandlerStub{},
-		ArwenChangeLocker: &sync.RWMutex{},
-		Bootstrapper:      syncDisabled.NewDisabledBootstrapper(),
+		VmContainer:              vmContainer,
+		EconomicsFee:             feeHandler,
+		BlockChainHook:           blockChainHook,
+		BlockChain:               &testscommon.ChainHandlerStub{},
+		ArwenChangeLocker:        &sync.RWMutex{},
+		Bootstrapper:             syncDisabled.NewDisabledBootstrapper(),
+		AllowExternalQueriesChan: common.GetClosedUnbufferedChannel(),
 	}
 	scQueryService, _ := smartContract.NewSCQueryService(argsNewSCQueryService)
 
@@ -1309,12 +1310,13 @@ func GetVmOutput(gasSchedule map[string]map[string]uint64, accnts state.Accounts
 	}
 
 	argsNewSCQueryService := smartContract.ArgsNewSCQueryService{
-		VmContainer:       vmContainer,
-		EconomicsFee:      feeHandler,
-		BlockChainHook:    blockChainHook,
-		BlockChain:        &testscommon.ChainHandlerStub{},
-		ArwenChangeLocker: &sync.RWMutex{},
-		Bootstrapper:      syncDisabled.NewDisabledBootstrapper(),
+		VmContainer:              vmContainer,
+		EconomicsFee:             feeHandler,
+		BlockChainHook:           blockChainHook,
+		BlockChain:               &testscommon.ChainHandlerStub{},
+		ArwenChangeLocker:        &sync.RWMutex{},
+		Bootstrapper:             syncDisabled.NewDisabledBootstrapper(),
+		AllowExternalQueriesChan: common.GetClosedUnbufferedChannel(),
 	}
 	scQueryService, _ := smartContract.NewSCQueryService(argsNewSCQueryService)
 
@@ -1352,8 +1354,9 @@ func ComputeGasLimit(gasSchedule map[string]map[string]uint64, testContext *VMTe
 				}
 			},
 		},
-		ArwenChangeLocker: &sync.RWMutex{},
-		Bootstrapper:      syncDisabled.NewDisabledBootstrapper(),
+		ArwenChangeLocker:        &sync.RWMutex{},
+		Bootstrapper:             syncDisabled.NewDisabledBootstrapper(),
+		AllowExternalQueriesChan: common.GetClosedUnbufferedChannel(),
 	}
 	scQueryService, _ := smartContract.NewSCQueryService(argsNewSCQueryService)
 

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -49,6 +49,10 @@ import (
 )
 
 const (
+	// TODO: remove this after better handling VM versions switching
+	// delayBeforeScQueriesStart represents the delay before the sc query processor should start to allow external queries
+	delayBeforeScQueriesStart = 2 * time.Minute
+
 	maxTimeToClose = 10 * time.Second
 	// SoftRestartMessage is the custom message used when the node does a soft restart operation
 	SoftRestartMessage = "Shuffled out - soft restart"
@@ -436,13 +440,23 @@ func (nr *nodeRunner) executeOneComponentCreationCycle(
 		)
 	}
 
+	// this channel will trigger the moment when the sc query service should be able to process VM Query requests
+	allowExternalVMQueriesChan := make(chan struct{})
+
 	log.Debug("updating the API service after creating the node facade")
-	ef, err := nr.createApiFacade(currentNode, webServerHandler, gasScheduleNotifier)
+	ef, err := nr.createApiFacade(currentNode, webServerHandler, gasScheduleNotifier, allowExternalVMQueriesChan)
 	if err != nil {
 		return true, err
 	}
 
 	log.Info("application is now running")
+
+	// TODO: remove this and treat better the VM versions switching
+	go func() {
+		time.Sleep(delayBeforeScQueriesStart)
+		close(allowExternalVMQueriesChan)
+	}()
+
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
@@ -466,6 +480,7 @@ func (nr *nodeRunner) createApiFacade(
 	currentNode *Node,
 	upgradableHttpServer shared.UpgradeableHttpServerHandler,
 	gasScheduleNotifier core.GasScheduleNotifier,
+	allowVMQueriesChan chan struct{},
 ) (closing.Closer, error) {
 	configs := nr.configs
 
@@ -481,6 +496,7 @@ func (nr *nodeRunner) createApiFacade(
 		ProcessComponents:   currentNode.processComponents,
 		GasScheduleNotifier: gasScheduleNotifier,
 		Bootstrapper:        currentNode.consensusComponents.Bootstrapper(),
+		AllowVMQueriesChan:  allowVMQueriesChan,
 	}
 
 	apiResolver, err := mainFactory.CreateApiResolver(apiResolverArgs)

--- a/process/errors.go
+++ b/process/errors.go
@@ -980,6 +980,12 @@ var ErrNilNumConnectedPeersProvider = errors.New("nil number of connected peers 
 // ErrNilLocker signals that a nil locker was provided
 var ErrNilLocker = errors.New("nil locker")
 
+// ErrNilAllowExternalQueriesChan signals that a nil channel for signaling the allowance of external queries provided is nil
+var ErrNilAllowExternalQueriesChan = errors.New("nil channel for signaling the allowance of external queries")
+
+// ErrQueriesNotAllowedYet signals that the node is not ready yet to process VM Queries
+var ErrQueriesNotAllowedYet = errors.New("node is not ready yet to process VM Queries")
+
 // ErrNilChunksProcessor signals that a nil chunks processor has been provided
 var ErrNilChunksProcessor = errors.New("nil chunks processor")
 

--- a/process/smartContract/scQueryService.go
+++ b/process/smartContract/scQueryService.go
@@ -102,12 +102,6 @@ func (service *SCQueryService) ExecuteQuery(query *process.SCQuery) (*vmcommon.V
 }
 
 func (service *SCQueryService) shouldAllowQueriesExecution() bool {
-	// TODO: analyze if we need this check. this was added because of the TestExecuteQuery_EmptyFunctionShouldErr test that
-	// has a nil instance, but the test still manages to work
-	if service == nil {
-		return true
-	}
-
 	select {
 	case <-service.allowExternalQueriesChan:
 		return true

--- a/process/smartContract/scQueryService_test.go
+++ b/process/smartContract/scQueryService_test.go
@@ -156,7 +156,7 @@ func TestExecuteQuery_EmptyFunctionShouldErr(t *testing.T) {
 func TestExecuteQuery_ShouldPerformActionsInRegardsToAllowanceChannel(t *testing.T) {
 	t.Parallel()
 
-	chanAllowedQueries := make(chan struct{}, 1)
+	chanAllowedQueries := make(chan struct{})
 	args := createMockArgumentsForSCQuery()
 	args.AllowExternalQueriesChan = chanAllowedQueries
 	target, _ := NewSCQueryService(args)
@@ -171,7 +171,7 @@ func TestExecuteQuery_ShouldPerformActionsInRegardsToAllowanceChannel(t *testing
 	assert.Equal(t, process.ErrQueriesNotAllowedYet, err)
 	assert.Nil(t, output)
 
-	chanAllowedQueries <- struct{}{}
+	close(chanAllowedQueries)
 	_, err = target.ExecuteQuery(&query)
 	assert.NoError(t, err)
 }

--- a/process/smartContract/scQueryService_test.go
+++ b/process/smartContract/scQueryService_test.go
@@ -25,13 +25,16 @@ import (
 const DummyScAddress = "00000000000000000500fabd9501b7e5353de57a4e319857c2fb99089770720a"
 
 func createMockArgumentsForSCQuery() ArgsNewSCQueryService {
+	writtenInChannel := make(chan struct{}, 1)
+	writtenInChannel <- struct{}{}
 	return ArgsNewSCQueryService{
-		VmContainer:       &mock.VMContainerMock{},
-		EconomicsFee:      &mock.FeeHandlerStub{},
-		BlockChainHook:    &mock.BlockChainHookHandlerMock{},
-		BlockChain:        &testscommon.ChainHandlerStub{},
-		ArwenChangeLocker: &sync.RWMutex{},
-		Bootstrapper:      &mock.BootstrapperStub{},
+		VmContainer:              &mock.VMContainerMock{},
+		EconomicsFee:             &mock.FeeHandlerStub{},
+		BlockChainHook:           &mock.BlockChainHookHandlerMock{},
+		BlockChain:               &testscommon.ChainHandlerStub{},
+		ArwenChangeLocker:        &sync.RWMutex{},
+		Bootstrapper:             &mock.BootstrapperStub{},
+		AllowExternalQueriesChan: writtenInChannel,
 	}
 }
 
@@ -148,6 +151,75 @@ func TestExecuteQuery_EmptyFunctionShouldErr(t *testing.T) {
 
 	assert.Nil(t, output)
 	assert.Equal(t, process.ErrEmptyFunctionName, err)
+}
+
+func TestExecuteQuery_ShouldPerformActionsInRegardsToAllowanceChannel(t *testing.T) {
+	t.Parallel()
+
+	chanAllowedQueries := make(chan struct{}, 1)
+	args := createMockArgumentsForSCQuery()
+	args.AllowExternalQueriesChan = chanAllowedQueries
+	target, _ := NewSCQueryService(args)
+
+	query := process.SCQuery{
+		ScAddress: []byte(DummyScAddress),
+		FuncName:  "func",
+		Arguments: [][]byte{},
+	}
+
+	output, err := target.ExecuteQuery(&query)
+	assert.Equal(t, process.ErrQueriesNotAllowedYet, err)
+	assert.Nil(t, output)
+
+	chanAllowedQueries <- struct{}{}
+	_, err = target.ExecuteQuery(&query)
+	assert.NoError(t, err)
+}
+
+func TestExecuteQuery_AllowanceChannelShouldWorkUnderConcurrentRequests(t *testing.T) {
+	t.Parallel()
+
+	chanAllowedQueries := make(chan struct{})
+	args := createMockArgumentsForSCQuery()
+	args.AllowExternalQueriesChan = chanAllowedQueries
+	target, _ := NewSCQueryService(args)
+
+	query := process.SCQuery{
+		ScAddress: []byte(DummyScAddress),
+		FuncName:  "func",
+		Arguments: [][]byte{},
+	}
+
+	defer func() {
+		r := recover()
+		assert.Nil(t, r)
+	}()
+
+	numTries := 200
+	wg := sync.WaitGroup{}
+	wg.Add(numTries)
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		close(chanAllowedQueries)
+	}()
+
+	for i := 0; i < numTries; i++ {
+		go func(idx int) {
+			select {
+			case <-chanAllowedQueries:
+				_, err := target.ExecuteQuery(&query)
+				assert.NoError(t, err)
+			default:
+				output, err := target.ExecuteQuery(&query)
+				assert.Equal(t, process.ErrQueriesNotAllowedYet, err)
+				assert.Nil(t, output)
+			}
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
 }
 
 func TestExecuteQuery_ShouldReceiveQueryCorrectly(t *testing.T) {
@@ -592,11 +664,12 @@ func TestNewSCQueryService_CloseShouldWork(t *testing.T) {
 				return nil
 			},
 		},
-		EconomicsFee:      &mock.FeeHandlerStub{},
-		BlockChainHook:    &mock.BlockChainHookHandlerMock{},
-		BlockChain:        &testscommon.ChainHandlerStub{},
-		ArwenChangeLocker: &sync.RWMutex{},
-		Bootstrapper:      &mock.BootstrapperStub{},
+		EconomicsFee:             &mock.FeeHandlerStub{},
+		BlockChainHook:           &mock.BlockChainHookHandlerMock{},
+		BlockChain:               &testscommon.ChainHandlerStub{},
+		ArwenChangeLocker:        &sync.RWMutex{},
+		Bootstrapper:             &mock.BootstrapperStub{},
+		AllowExternalQueriesChan: common.GetClosedUnbufferedChannel(),
 	}
 
 	target, _ := NewSCQueryService(argsNewSCQueryService)

--- a/process/smartContract/scQueryService_test.go
+++ b/process/smartContract/scQueryService_test.go
@@ -25,8 +25,6 @@ import (
 const DummyScAddress = "00000000000000000500fabd9501b7e5353de57a4e319857c2fb99089770720a"
 
 func createMockArgumentsForSCQuery() ArgsNewSCQueryService {
-	writtenInChannel := make(chan struct{}, 1)
-	writtenInChannel <- struct{}{}
 	return ArgsNewSCQueryService{
 		VmContainer:              &mock.VMContainerMock{},
 		EconomicsFee:             &mock.FeeHandlerStub{},
@@ -34,7 +32,7 @@ func createMockArgumentsForSCQuery() ArgsNewSCQueryService {
 		BlockChain:               &testscommon.ChainHandlerStub{},
 		ArwenChangeLocker:        &sync.RWMutex{},
 		Bootstrapper:             &mock.BootstrapperStub{},
-		AllowExternalQueriesChan: writtenInChannel,
+		AllowExternalQueriesChan: common.GetClosedUnbufferedChannel(),
 	}
 }
 

--- a/process/smartContract/scQueryService_test.go
+++ b/process/smartContract/scQueryService_test.go
@@ -117,7 +117,6 @@ func TestExecuteQuery_GetNilAddressShouldErr(t *testing.T) {
 	t.Parallel()
 
 	args := createMockArgumentsForSCQuery()
-	args.VmContainer = nil
 	target, _ := NewSCQueryService(args)
 
 	query := process.SCQuery{
@@ -136,7 +135,6 @@ func TestExecuteQuery_EmptyFunctionShouldErr(t *testing.T) {
 	t.Parallel()
 
 	args := createMockArgumentsForSCQuery()
-	args.VmContainer = nil
 	target, _ := NewSCQueryService(args)
 
 	query := process.SCQuery{


### PR DESCRIPTION
temporary improvement for observers that have struggles syncing with the network after a restart when multiple VM Query API calls occur. 