### PR TITLE
Rename api output format

### DIFF
--- a/api/groups/internalGroup.go
+++ b/api/groups/internalGroup.go
@@ -15,22 +15,22 @@ import (
 )
 
 const (
-	getRawMetaBlockByNoncePath           = "/raw/metablock/by-nonce/:nonce"
-	getRawMetaBlockByHashPath            = "/raw/metablock/by-hash/:hash"
-	getRawMetaBlockByRoundPath           = "/raw/metablock/by-round/:round"
-	getRawStartOfEpochMetaBlockPath      = "/raw/startofepoch/metablock/by-epoch/:epoch"
-	getRawShardBlockByNoncePath          = "/raw/shardblock/by-nonce/:nonce"
-	getRawShardBlockByHashPath           = "/raw/shardblock/by-hash/:hash"
-	getRawShardBlockByRoundPath          = "/raw/shardblock/by-round/:round"
-	getInternalMetaBlockByNoncePath      = "/json/metablock/by-nonce/:nonce"
-	getInternalMetaBlockByHashPath       = "/json/metablock/by-hash/:hash"
-	getInternalMetaBlockByRoundPath      = "/json/metablock/by-round/:round"
-	getInternalStartOfEpochMetaBlockPath = "/json/startofepoch/metablock/by-epoch/:epoch"
-	getInternalShardBlockByNoncePath     = "/json/shardblock/by-nonce/:nonce"
-	getInternalShardBlockByHashPath      = "/json/shardblock/by-hash/:hash"
-	getInternalShardBlockByRoundPath     = "/json/shardblock/by-round/:round"
-	getRawMiniBlockByHashPath            = "/raw/miniblock/by-hash/:hash/epoch/:epoch"
-	getInternalMiniBlockByHashPath       = "/json/miniblock/by-hash/:hash/epoch/:epoch"
+	getRawMetaBlockByNoncePath       = "/raw/metablock/by-nonce/:nonce"
+	getRawMetaBlockByHashPath        = "/raw/metablock/by-hash/:hash"
+	getRawMetaBlockByRoundPath       = "/raw/metablock/by-round/:round"
+	getRawStartOfEpochMetaBlockPath  = "/raw/startofepoch/metablock/by-epoch/:epoch"
+	getRawShardBlockByNoncePath      = "/raw/shardblock/by-nonce/:nonce"
+	getRawShardBlockByHashPath       = "/raw/shardblock/by-hash/:hash"
+	getRawShardBlockByRoundPath      = "/raw/shardblock/by-round/:round"
+	getJSONMetaBlockByNoncePath      = "/json/metablock/by-nonce/:nonce"
+	getJSONMetaBlockByHashPath       = "/json/metablock/by-hash/:hash"
+	getJSONMetaBlockByRoundPath      = "/json/metablock/by-round/:round"
+	getJSONStartOfEpochMetaBlockPath = "/json/startofepoch/metablock/by-epoch/:epoch"
+	getJSONShardBlockByNoncePath     = "/json/shardblock/by-nonce/:nonce"
+	getJSONShardBlockByHashPath      = "/json/shardblock/by-hash/:hash"
+	getJSONShardBlockByRoundPath     = "/json/shardblock/by-round/:round"
+	getRawMiniBlockByHashPath        = "/raw/miniblock/by-hash/:hash/epoch/:epoch"
+	getJSONMiniBlockByHashPath       = "/json/miniblock/by-hash/:hash/epoch/:epoch"
 )
 
 // internalBlockFacadeHandler defines the methods to be implemented by a facade for handling block requests
@@ -100,39 +100,39 @@ func NewInternalBlockGroup(facade internalBlockFacadeHandler) (*internalBlockGro
 			Handler: ib.getRawShardBlockByRound,
 		},
 		{
-			Path:    getInternalMetaBlockByNoncePath,
+			Path:    getJSONMetaBlockByNoncePath,
 			Method:  http.MethodGet,
-			Handler: ib.getInternalMetaBlockByNonce,
+			Handler: ib.getJSONMetaBlockByNonce,
 		},
 		{
-			Path:    getInternalMetaBlockByHashPath,
+			Path:    getJSONMetaBlockByHashPath,
 			Method:  http.MethodGet,
-			Handler: ib.getInternalMetaBlockByHash,
+			Handler: ib.getJSONMetaBlockByHash,
 		},
 		{
-			Path:    getInternalMetaBlockByRoundPath,
+			Path:    getJSONMetaBlockByRoundPath,
 			Method:  http.MethodGet,
-			Handler: ib.getInternalMetaBlockByRound,
+			Handler: ib.getJSONMetaBlockByRound,
 		},
 		{
-			Path:    getInternalStartOfEpochMetaBlockPath,
+			Path:    getJSONStartOfEpochMetaBlockPath,
 			Method:  http.MethodGet,
-			Handler: ib.getInternalStartOfEpochMetaBlock,
+			Handler: ib.getJSONStartOfEpochMetaBlock,
 		},
 		{
-			Path:    getInternalShardBlockByNoncePath,
+			Path:    getJSONShardBlockByNoncePath,
 			Method:  http.MethodGet,
-			Handler: ib.getInternalShardBlockByNonce,
+			Handler: ib.getJSONShardBlockByNonce,
 		},
 		{
-			Path:    getInternalShardBlockByHashPath,
+			Path:    getJSONShardBlockByHashPath,
 			Method:  http.MethodGet,
-			Handler: ib.getInternalShardBlockByHash,
+			Handler: ib.getJSONShardBlockByHash,
 		},
 		{
-			Path:    getInternalShardBlockByRoundPath,
+			Path:    getJSONShardBlockByRoundPath,
 			Method:  http.MethodGet,
-			Handler: ib.getInternalShardBlockByRound,
+			Handler: ib.getJSONShardBlockByRound,
 		},
 		{
 			Path:    getRawMiniBlockByHashPath,
@@ -140,9 +140,9 @@ func NewInternalBlockGroup(facade internalBlockFacadeHandler) (*internalBlockGro
 			Handler: ib.getRawMiniBlockByHash,
 		},
 		{
-			Path:    getInternalMiniBlockByHashPath,
+			Path:    getJSONMiniBlockByHashPath,
 			Method:  http.MethodGet,
-			Handler: ib.getInternalMiniBlockByHash,
+			Handler: ib.getJSONMiniBlockByHash,
 		},
 	}
 	ib.endpoints = endpoints
@@ -332,7 +332,7 @@ func (ib *internalBlockGroup) getRawShardBlockByRound(c *gin.Context) {
 	shared.RespondWith(c, http.StatusOK, gin.H{"block": rawBlock}, "", shared.ReturnCodeSuccess)
 }
 
-func (ib *internalBlockGroup) getInternalMetaBlockByNonce(c *gin.Context) {
+func (ib *internalBlockGroup) getJSONMetaBlockByNonce(c *gin.Context) {
 	nonce, err := getQueryParamNonce(c)
 	if err != nil {
 		shared.RespondWithValidationError(
@@ -342,7 +342,7 @@ func (ib *internalBlockGroup) getInternalMetaBlockByNonce(c *gin.Context) {
 	}
 
 	start := time.Now()
-	block, err := ib.getFacade().GetInternalMetaBlockByNonce(common.ApiOutputFormatInternal, nonce)
+	block, err := ib.getFacade().GetInternalMetaBlockByNonce(common.ApiOutputFormatJSON, nonce)
 	log.Debug(fmt.Sprintf("GetInternalMetaBlockByNonce took %s", time.Since(start)))
 	if err != nil {
 		shared.RespondWith(
@@ -358,7 +358,7 @@ func (ib *internalBlockGroup) getInternalMetaBlockByNonce(c *gin.Context) {
 	shared.RespondWith(c, http.StatusOK, gin.H{"block": block}, "", shared.ReturnCodeSuccess)
 }
 
-func (ib *internalBlockGroup) getInternalMetaBlockByHash(c *gin.Context) {
+func (ib *internalBlockGroup) getJSONMetaBlockByHash(c *gin.Context) {
 	hash := c.Param("hash")
 	if hash == "" {
 		shared.RespondWithValidationError(
@@ -368,7 +368,7 @@ func (ib *internalBlockGroup) getInternalMetaBlockByHash(c *gin.Context) {
 	}
 
 	start := time.Now()
-	block, err := ib.getFacade().GetInternalMetaBlockByHash(common.ApiOutputFormatInternal, hash)
+	block, err := ib.getFacade().GetInternalMetaBlockByHash(common.ApiOutputFormatJSON, hash)
 	log.Debug(fmt.Sprintf("GetInternalMetaBlockByHash took %s", time.Since(start)))
 	if err != nil {
 		shared.RespondWith(
@@ -384,7 +384,7 @@ func (ib *internalBlockGroup) getInternalMetaBlockByHash(c *gin.Context) {
 	shared.RespondWith(c, http.StatusOK, gin.H{"block": block}, "", shared.ReturnCodeSuccess)
 }
 
-func (ib *internalBlockGroup) getInternalMetaBlockByRound(c *gin.Context) {
+func (ib *internalBlockGroup) getJSONMetaBlockByRound(c *gin.Context) {
 	round, err := getQueryParamRound(c)
 	if err != nil {
 		shared.RespondWithValidationError(
@@ -394,7 +394,7 @@ func (ib *internalBlockGroup) getInternalMetaBlockByRound(c *gin.Context) {
 	}
 
 	start := time.Now()
-	block, err := ib.getFacade().GetInternalMetaBlockByRound(common.ApiOutputFormatInternal, round)
+	block, err := ib.getFacade().GetInternalMetaBlockByRound(common.ApiOutputFormatJSON, round)
 	log.Debug(fmt.Sprintf("GetInternalMetaBlockByRound took %s", time.Since(start)))
 	if err != nil {
 		shared.RespondWith(
@@ -410,7 +410,7 @@ func (ib *internalBlockGroup) getInternalMetaBlockByRound(c *gin.Context) {
 	shared.RespondWith(c, http.StatusOK, gin.H{"block": block}, "", shared.ReturnCodeSuccess)
 }
 
-func (ib *internalBlockGroup) getInternalStartOfEpochMetaBlock(c *gin.Context) {
+func (ib *internalBlockGroup) getJSONStartOfEpochMetaBlock(c *gin.Context) {
 	epoch, err := getQueryParamEpoch(c)
 	if err != nil {
 		shared.RespondWithValidationError(
@@ -420,7 +420,7 @@ func (ib *internalBlockGroup) getInternalStartOfEpochMetaBlock(c *gin.Context) {
 	}
 
 	start := time.Now()
-	block, err := ib.getFacade().GetInternalStartOfEpochMetaBlock(common.ApiOutputFormatInternal, epoch)
+	block, err := ib.getFacade().GetInternalStartOfEpochMetaBlock(common.ApiOutputFormatJSON, epoch)
 	log.Debug(fmt.Sprintf("GetInternalStartOfEpochMetaBlock took %s", time.Since(start)))
 	if err != nil {
 		shared.RespondWith(
@@ -436,7 +436,7 @@ func (ib *internalBlockGroup) getInternalStartOfEpochMetaBlock(c *gin.Context) {
 	shared.RespondWith(c, http.StatusOK, gin.H{"block": block}, "", shared.ReturnCodeSuccess)
 }
 
-func (ib *internalBlockGroup) getInternalShardBlockByNonce(c *gin.Context) {
+func (ib *internalBlockGroup) getJSONShardBlockByNonce(c *gin.Context) {
 	nonce, err := getQueryParamNonce(c)
 	if err != nil {
 		shared.RespondWithValidationError(
@@ -446,7 +446,7 @@ func (ib *internalBlockGroup) getInternalShardBlockByNonce(c *gin.Context) {
 	}
 
 	start := time.Now()
-	block, err := ib.getFacade().GetInternalShardBlockByNonce(common.ApiOutputFormatInternal, nonce)
+	block, err := ib.getFacade().GetInternalShardBlockByNonce(common.ApiOutputFormatJSON, nonce)
 	log.Debug(fmt.Sprintf("GetInternalShardBlockByNonce took %s", time.Since(start)))
 	if err != nil {
 		shared.RespondWith(
@@ -462,7 +462,7 @@ func (ib *internalBlockGroup) getInternalShardBlockByNonce(c *gin.Context) {
 	shared.RespondWith(c, http.StatusOK, gin.H{"block": block}, "", shared.ReturnCodeSuccess)
 }
 
-func (ib *internalBlockGroup) getInternalShardBlockByHash(c *gin.Context) {
+func (ib *internalBlockGroup) getJSONShardBlockByHash(c *gin.Context) {
 	hash := c.Param("hash")
 	if hash == "" {
 		shared.RespondWithValidationError(
@@ -472,7 +472,7 @@ func (ib *internalBlockGroup) getInternalShardBlockByHash(c *gin.Context) {
 	}
 
 	start := time.Now()
-	block, err := ib.getFacade().GetInternalShardBlockByHash(common.ApiOutputFormatInternal, hash)
+	block, err := ib.getFacade().GetInternalShardBlockByHash(common.ApiOutputFormatJSON, hash)
 	log.Debug(fmt.Sprintf("GetInternalShardBlockByHash took %s", time.Since(start)))
 	if err != nil {
 		shared.RespondWith(
@@ -488,7 +488,7 @@ func (ib *internalBlockGroup) getInternalShardBlockByHash(c *gin.Context) {
 	shared.RespondWith(c, http.StatusOK, gin.H{"block": block}, "", shared.ReturnCodeSuccess)
 }
 
-func (ib *internalBlockGroup) getInternalShardBlockByRound(c *gin.Context) {
+func (ib *internalBlockGroup) getJSONShardBlockByRound(c *gin.Context) {
 	round, err := getQueryParamRound(c)
 	if err != nil {
 		shared.RespondWithValidationError(
@@ -498,7 +498,7 @@ func (ib *internalBlockGroup) getInternalShardBlockByRound(c *gin.Context) {
 	}
 
 	start := time.Now()
-	block, err := ib.getFacade().GetInternalShardBlockByRound(common.ApiOutputFormatInternal, round)
+	block, err := ib.getFacade().GetInternalShardBlockByRound(common.ApiOutputFormatJSON, round)
 	log.Debug(fmt.Sprintf("GetInternalShardBlockByRound took %s", time.Since(start)))
 	if err != nil {
 		shared.RespondWith(
@@ -548,7 +548,7 @@ func (ib *internalBlockGroup) getRawMiniBlockByHash(c *gin.Context) {
 	shared.RespondWith(c, http.StatusOK, gin.H{"miniblock": miniBlock}, "", shared.ReturnCodeSuccess)
 }
 
-func (ib *internalBlockGroup) getInternalMiniBlockByHash(c *gin.Context) {
+func (ib *internalBlockGroup) getJSONMiniBlockByHash(c *gin.Context) {
 	hash := c.Param("hash")
 	if hash == "" {
 		shared.RespondWithValidationError(
@@ -566,7 +566,7 @@ func (ib *internalBlockGroup) getInternalMiniBlockByHash(c *gin.Context) {
 	}
 
 	start := time.Now()
-	miniBlock, err := ib.getFacade().GetInternalMiniBlockByHash(common.ApiOutputFormatInternal, hash, epoch)
+	miniBlock, err := ib.getFacade().GetInternalMiniBlockByHash(common.ApiOutputFormatJSON, hash, epoch)
 	log.Debug(fmt.Sprintf("GetInternalMiniBlockByHash took %s", time.Since(start)))
 	if err != nil {
 		shared.RespondWith(

--- a/common/constants.go
+++ b/common/constants.go
@@ -803,8 +803,8 @@ const (
 type ApiOutputFormat uint8
 
 const (
-	// ApiOutputFormatInternal outport format returns struct directly, will be serialized into JSON by gin
-	ApiOutputFormatInternal ApiOutputFormat = 0
+	// ApiOutputFormatJSON outport format returns struct directly, will be serialized into JSON by gin
+	ApiOutputFormatJSON ApiOutputFormat = 0
 
 	// ApiOutputFormatProto outport format returns the bytes of the proto object
 	ApiOutputFormatProto ApiOutputFormat = 1

--- a/node/external/blockAPI/internalBlock.go
+++ b/node/external/blockAPI/internalBlock.go
@@ -94,7 +94,7 @@ func (ibp *internalBlockProcessor) convertShardBlockBytesToInternalBlock(blockBy
 
 func (ibp *internalBlockProcessor) convertShardBlockBytesByOutputFormat(format common.ApiOutputFormat, blockBytes []byte) (interface{}, error) {
 	switch format {
-	case common.ApiOutputFormatInternal:
+	case common.ApiOutputFormatJSON:
 		return ibp.convertShardBlockBytesToInternalBlock(blockBytes)
 	case common.ApiOutputFormatProto:
 		return blockBytes, nil
@@ -182,7 +182,7 @@ func (ibp *internalBlockProcessor) convertMetaBlockBytesToInternalBlock(blockByt
 
 func (ibp *internalBlockProcessor) convertMetaBlockBytesByOutputFormat(format common.ApiOutputFormat, blockBytes []byte) (interface{}, error) {
 	switch format {
-	case common.ApiOutputFormatInternal:
+	case common.ApiOutputFormatJSON:
 		return ibp.convertMetaBlockBytesToInternalBlock(blockBytes)
 	case common.ApiOutputFormatProto:
 		return blockBytes, nil
@@ -204,7 +204,7 @@ func (ibp *internalBlockProcessor) GetInternalMiniBlock(format common.ApiOutputF
 
 func (ibp *internalBlockProcessor) convertMiniBlockBytesByOutportFormat(format common.ApiOutputFormat, blockBytes []byte) (interface{}, error) {
 	switch format {
-	case common.ApiOutputFormatInternal:
+	case common.ApiOutputFormatJSON:
 		miniBlock := &block.MiniBlock{}
 		err := ibp.marshalizer.Unmarshal(miniBlock, blockBytes)
 		if err != nil {

--- a/node/external/blockAPI/internalBlock_test.go
+++ b/node/external/blockAPI/internalBlock_test.go
@@ -121,7 +121,7 @@ func TestInternalBlockProcessor_ConvertShardBlockBytesByOutputFormat(t *testing.
 	t.Run("internal format, should work", func(t *testing.T) {
 		t.Parallel()
 
-		headerOutput, err := ibp.convertShardBlockBytesByOutputFormat(common.ApiOutputFormatInternal, headerBytes)
+		headerOutput, err := ibp.convertShardBlockBytesByOutputFormat(common.ApiOutputFormatJSON, headerBytes)
 		require.Nil(t, err)
 		assert.Equal(t, header, headerOutput)
 	})
@@ -158,7 +158,7 @@ func TestInternalBlockProcessor_GetInternalShardBlockShouldFail(t *testing.T) {
 	t.Run("provided hash not in storer", func(t *testing.T) {
 		t.Parallel()
 
-		blk, err := ibp.GetInternalShardBlockByHash(common.ApiOutputFormatInternal, []byte("invalidHash"))
+		blk, err := ibp.GetInternalShardBlockByHash(common.ApiOutputFormatJSON, []byte("invalidHash"))
 		assert.Nil(t, blk)
 		assert.Equal(t, expectedErr, err)
 	})
@@ -166,7 +166,7 @@ func TestInternalBlockProcessor_GetInternalShardBlockShouldFail(t *testing.T) {
 	t.Run("provided nonce not in storer", func(t *testing.T) {
 		t.Parallel()
 
-		blk, err := ibp.GetInternalShardBlockByNonce(common.ApiOutputFormatInternal, 100)
+		blk, err := ibp.GetInternalShardBlockByNonce(common.ApiOutputFormatJSON, 100)
 		assert.Nil(t, blk)
 		assert.Equal(t, expectedErr, err)
 	})
@@ -174,7 +174,7 @@ func TestInternalBlockProcessor_GetInternalShardBlockShouldFail(t *testing.T) {
 	t.Run("provided round not in storer", func(t *testing.T) {
 		t.Parallel()
 
-		blk, err := ibp.GetInternalShardBlockByRound(common.ApiOutputFormatInternal, 100)
+		blk, err := ibp.GetInternalShardBlockByRound(common.ApiOutputFormatJSON, 100)
 		assert.Nil(t, blk)
 		assert.Equal(t, expectedErr, err)
 	})
@@ -192,7 +192,7 @@ func TestInternalBlockProcessor_GetInternalShardBlockByHash(t *testing.T) {
 	err := json.Unmarshal(headerBytes, header)
 	require.Nil(t, err)
 
-	blk, err := ibp.GetInternalShardBlockByHash(common.ApiOutputFormatInternal, headerHash)
+	blk, err := ibp.GetInternalShardBlockByHash(common.ApiOutputFormatJSON, headerHash)
 	assert.Nil(t, err)
 	assert.Equal(t, header, blk)
 }
@@ -223,7 +223,7 @@ func TestInternalBlockProcessor_GetInternalShardBlockByNonce(t *testing.T) {
 	err := json.Unmarshal(headerBytes, header)
 	require.Nil(t, err)
 
-	blk, err := ibp.GetInternalShardBlockByNonce(common.ApiOutputFormatInternal, nonce)
+	blk, err := ibp.GetInternalShardBlockByNonce(common.ApiOutputFormatJSON, nonce)
 	assert.Nil(t, err)
 	assert.Equal(t, header, blk)
 }
@@ -254,7 +254,7 @@ func TestInternalBlockProcessor_GetInternalShardBlockByRound(t *testing.T) {
 	err := json.Unmarshal(headerBytes, header)
 	require.Nil(t, err)
 
-	blk, err := ibp.GetInternalShardBlockByRound(common.ApiOutputFormatInternal, round)
+	blk, err := ibp.GetInternalShardBlockByRound(common.ApiOutputFormatJSON, round)
 	assert.Nil(t, err)
 	assert.Equal(t, header, blk)
 }
@@ -367,7 +367,7 @@ func TestInternalBlockProcessor_ConvertMetaBlockBytesByOutputFormat(t *testing.T
 	t.Run("internal format, should work", func(t *testing.T) {
 		t.Parallel()
 
-		headerOutput, err := ibp.convertMetaBlockBytesByOutputFormat(common.ApiOutputFormatInternal, headerBytes)
+		headerOutput, err := ibp.convertMetaBlockBytesByOutputFormat(common.ApiOutputFormatJSON, headerBytes)
 		require.Nil(t, err)
 		assert.Equal(t, header, headerOutput)
 	})
@@ -404,7 +404,7 @@ func TestInternalBlockProcessor_GetInternalMetaBlockShouldFail(t *testing.T) {
 	t.Run("provided hash not in storer", func(t *testing.T) {
 		t.Parallel()
 
-		blk, err := ibp.GetInternalMetaBlockByHash(common.ApiOutputFormatInternal, []byte("invalidHash"))
+		blk, err := ibp.GetInternalMetaBlockByHash(common.ApiOutputFormatJSON, []byte("invalidHash"))
 		assert.Nil(t, blk)
 		assert.Equal(t, expectedErr, err)
 	})
@@ -412,7 +412,7 @@ func TestInternalBlockProcessor_GetInternalMetaBlockShouldFail(t *testing.T) {
 	t.Run("provided nonce not in storer", func(t *testing.T) {
 		t.Parallel()
 
-		blk, err := ibp.GetInternalMetaBlockByNonce(common.ApiOutputFormatInternal, 100)
+		blk, err := ibp.GetInternalMetaBlockByNonce(common.ApiOutputFormatJSON, 100)
 		assert.Nil(t, blk)
 		assert.Equal(t, expectedErr, err)
 	})
@@ -420,7 +420,7 @@ func TestInternalBlockProcessor_GetInternalMetaBlockShouldFail(t *testing.T) {
 	t.Run("provided round not in storer", func(t *testing.T) {
 		t.Parallel()
 
-		blk, err := ibp.GetInternalMetaBlockByRound(common.ApiOutputFormatInternal, 100)
+		blk, err := ibp.GetInternalMetaBlockByRound(common.ApiOutputFormatJSON, 100)
 		assert.Nil(t, blk)
 		assert.Equal(t, expectedErr, err)
 	})
@@ -438,7 +438,7 @@ func TestInternalBlockProcessor_GetInternalMetaBlockByHash(t *testing.T) {
 	err := json.Unmarshal(headerBytes, header)
 	require.Nil(t, err)
 
-	blk, err := ibp.GetInternalMetaBlockByHash(common.ApiOutputFormatInternal, headerHash)
+	blk, err := ibp.GetInternalMetaBlockByHash(common.ApiOutputFormatJSON, headerHash)
 	assert.Nil(t, err)
 	assert.Equal(t, header, blk)
 }
@@ -469,7 +469,7 @@ func TestInternalBlockProcessor_GetInternalMetaBlockByNonce(t *testing.T) {
 	err := json.Unmarshal(headerBytes, header)
 	require.Nil(t, err)
 
-	blk, err := ibp.GetInternalMetaBlockByNonce(common.ApiOutputFormatInternal, nonce)
+	blk, err := ibp.GetInternalMetaBlockByNonce(common.ApiOutputFormatJSON, nonce)
 	assert.Nil(t, err)
 	assert.Equal(t, header, blk)
 }
@@ -500,7 +500,7 @@ func TestInternalBlockProcessor_GetInternalMetaBlockByRound(t *testing.T) {
 	err := json.Unmarshal(headerBytes, header)
 	require.Nil(t, err)
 
-	blk, err := ibp.GetInternalMetaBlockByRound(common.ApiOutputFormatInternal, nonce)
+	blk, err := ibp.GetInternalMetaBlockByRound(common.ApiOutputFormatJSON, nonce)
 	assert.Nil(t, err)
 	assert.Equal(t, header, blk)
 }
@@ -575,12 +575,12 @@ func TestInternalBlockProcessor_GetInternalMiniBlockByHash(t *testing.T) {
 				HistoryRepo:              &dblookupext.HistoryRepositoryStub{},
 			}, nil)
 
-		blk, err := ibp.GetInternalMiniBlock(common.ApiOutputFormatInternal, []byte("invalidHash"), 1)
+		blk, err := ibp.GetInternalMiniBlock(common.ApiOutputFormatJSON, []byte("invalidHash"), 1)
 		assert.Nil(t, blk)
 		assert.Equal(t, expectedErr, err)
 	})
 
-	t.Run("raw data mini block, should work", func(t *testing.T) {
+	t.Run("proto raw data mini block, should work", func(t *testing.T) {
 		t.Parallel()
 
 		mb := &block.MiniBlock{
@@ -642,7 +642,7 @@ func TestInternalBlockProcessor_GetInternalMiniBlockByHash(t *testing.T) {
 				HistoryRepo:              &dblookupext.HistoryRepositoryStub{},
 			}, nil)
 
-		blk, err := ibp.GetInternalMiniBlock(common.ApiOutputFormatInternal, miniBlockHash, expEpoch)
+		blk, err := ibp.GetInternalMiniBlock(common.ApiOutputFormatJSON, miniBlockHash, expEpoch)
 		assert.Nil(t, err)
 		assert.Equal(t, mb, blk)
 	})
@@ -670,7 +670,7 @@ func TestInternalBlockProcessor_GetInternalStartOfEpochMetaBlock(t *testing.T) {
 				HistoryRepo:              &dblookupext.HistoryRepositoryStub{},
 			}, nil)
 
-		blk, err := ibp.GetInternalStartOfEpochMetaBlock(common.ApiOutputFormatInternal, expEpoch)
+		blk, err := ibp.GetInternalStartOfEpochMetaBlock(common.ApiOutputFormatJSON, expEpoch)
 		assert.Nil(t, blk)
 		assert.Equal(t, ErrMetachainOnlyEndpoint, err)
 	})
@@ -698,12 +698,12 @@ func TestInternalBlockProcessor_GetInternalStartOfEpochMetaBlock(t *testing.T) {
 				HistoryRepo:              &dblookupext.HistoryRepositoryStub{},
 			}, nil)
 
-		blk, err := ibp.GetInternalStartOfEpochMetaBlock(common.ApiOutputFormatInternal, expEpoch)
+		blk, err := ibp.GetInternalStartOfEpochMetaBlock(common.ApiOutputFormatJSON, expEpoch)
 		assert.Nil(t, blk)
 		assert.Equal(t, expectedErr, err)
 	})
 
-	t.Run("raw data meta block, should work", func(t *testing.T) {
+	t.Run("proto raw data meta block, should work", func(t *testing.T) {
 		t.Parallel()
 
 		storerMock := &storageMocks.StorerStub{
@@ -754,7 +754,7 @@ func TestInternalBlockProcessor_GetInternalStartOfEpochMetaBlock(t *testing.T) {
 				HistoryRepo:              &dblookupext.HistoryRepositoryStub{},
 			}, nil)
 
-		blk, err := ibp.GetInternalStartOfEpochMetaBlock(common.ApiOutputFormatInternal, expEpoch)
+		blk, err := ibp.GetInternalStartOfEpochMetaBlock(common.ApiOutputFormatJSON, expEpoch)
 		assert.Nil(t, err)
 		assert.Equal(t, header, blk)
 	})


### PR DESCRIPTION
Renaming as following:
`ApiOutputFormatInternal` -> `ApiOutputFormatJSON`
`ApiOutputFormatProto` remains the same