### PR TITLE
Close network components first

### DIFF
--- a/factory/statusComponentsHandler.go
+++ b/factory/statusComponentsHandler.go
@@ -203,9 +203,13 @@ func registerPollConnectedPeers(
 		if check.IfNil(networkComponents) {
 			return
 		}
+		netMessenger := networkComponents.NetworkMessenger()
+		if check.IfNil(netMessenger) {
+			return
+		}
 
-		computeNumConnectedPeers(appStatusHandler, networkComponents)
-		computeConnectedPeers(appStatusHandler, networkComponents)
+		computeNumConnectedPeers(appStatusHandler, netMessenger)
+		computeConnectedPeers(appStatusHandler, netMessenger)
 	}
 
 	err := appStatusPollingHandler.RegisterPollingFunc(p2pMetricsHandlerFunc)
@@ -239,17 +243,17 @@ func registerShardsInformation(
 
 func computeNumConnectedPeers(
 	appStatusHandler core.AppStatusHandler,
-	networkComponents NetworkComponentsHolder,
+	netMessenger p2p.Messenger,
 ) {
-	numOfConnectedPeers := uint64(len(networkComponents.NetworkMessenger().ConnectedAddresses()))
+	numOfConnectedPeers := uint64(len(netMessenger.ConnectedAddresses()))
 	appStatusHandler.SetUInt64Value(common.MetricNumConnectedPeers, numOfConnectedPeers)
 }
 
 func computeConnectedPeers(
 	appStatusHandler core.AppStatusHandler,
-	networkComponents NetworkComponentsHolder,
+	netMessenger p2p.Messenger,
 ) {
-	peersInfo := networkComponents.NetworkMessenger().GetConnectedPeersInfo()
+	peersInfo := netMessenger.GetConnectedPeersInfo()
 
 	peerClassification := fmt.Sprintf("intraVal:%d,crossVal:%d,intraObs:%d,crossObs:%d,fullObs:%d,unknown:%d,",
 		len(peersInfo.IntraShardValidators),
@@ -263,7 +267,7 @@ func computeConnectedPeers(
 	appStatusHandler.SetStringValue(common.MetricP2PNumConnectedPeersClassification, peerClassification)
 
 	setP2pConnectedPeersMetrics(appStatusHandler, peersInfo)
-	setCurrentP2pNodeAddresses(appStatusHandler, networkComponents)
+	setCurrentP2pNodeAddresses(appStatusHandler, netMessenger)
 }
 
 func setP2pConnectedPeersMetrics(appStatusHandler core.AppStatusHandler, info *p2p.ConnectedPeersInfo) {
@@ -299,9 +303,9 @@ func mapToString(input map[uint32][]string) string {
 
 func setCurrentP2pNodeAddresses(
 	appStatusHandler core.AppStatusHandler,
-	networkComponents NetworkComponentsHolder,
+	netMessenger p2p.Messenger,
 ) {
-	appStatusHandler.SetStringValue(common.MetricP2PPeerInfo, sliceToString(networkComponents.NetworkMessenger().Addresses()))
+	appStatusHandler.SetStringValue(common.MetricP2PPeerInfo, sliceToString(netMessenger.Addresses()))
 }
 
 func registerPollProbableHighestNonce(

--- a/factory/statusComponentsHandler.go
+++ b/factory/statusComponentsHandler.go
@@ -200,6 +200,10 @@ func registerPollConnectedPeers(
 ) error {
 
 	p2pMetricsHandlerFunc := func(appStatusHandler core.AppStatusHandler) {
+		if check.IfNil(networkComponents) {
+			return
+		}
+
 		computeNumConnectedPeers(appStatusHandler, networkComponents)
 		computeConnectedPeers(appStatusHandler, networkComponents)
 	}

--- a/node/nodeHelper.go
+++ b/node/nodeHelper.go
@@ -190,7 +190,6 @@ func CreateNode(
 	nd, err = NewNode(
 		WithCoreComponents(coreComponents),
 		WithCryptoComponents(cryptoComponents),
-		WithNetworkComponents(networkComponents),
 		WithBootstrapComponents(bootstrapComponents),
 		WithStateComponents(stateComponents),
 		WithDataComponents(dataComponents),
@@ -198,6 +197,7 @@ func CreateNode(
 		WithProcessComponents(processComponents),
 		WithHeartbeatComponents(heartbeatComponents),
 		WithConsensusComponents(consensusComponents),
+		WithNetworkComponents(networkComponents),
 		WithInitialNodesPubKeys(coreComponents.GenesisNodesSetup().InitialNodesPubKeys()),
 		WithRoundDuration(coreComponents.GenesisNodesSetup().GetRoundDuration()),
 		WithConsensusGroupSize(consensusGroupSize),


### PR DESCRIPTION
Changed closable components order on close: set network components to be closed at first, so that network traffic will not be initiated while data and state components are still active.

Added nil checks for status handler goroutine which will try to fetch network components metric:
- nil check for network messenger component