### PR TITLE
Network sharding integration tests & some fixes

### DIFF
--- a/consensus/interface.go
+++ b/consensus/interface.go
@@ -80,7 +80,7 @@ type P2PMessenger interface {
 // The interface assures that the collected data will be used by the p2p network sharding components
 type NetworkShardingCollector interface {
 	UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID uint32)
-	UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
+	PutPeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
 	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo
 	IsInterfaceNil() bool
 }

--- a/dataRetriever/factory/resolverscontainer/baseResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/baseResolversContainerFactory.go
@@ -269,7 +269,7 @@ func (brcf *baseResolversContainerFactory) createMiniBlocksResolver(
 }
 
 func (brcf *baseResolversContainerFactory) generatePeerAuthenticationResolver() error {
-	identifierPeerAuth := factory.PeerAuthenticationTopic
+	identifierPeerAuth := common.PeerAuthenticationTopic
 	shardC := brcf.shardCoordinator
 	resolverSender, err := brcf.createOneResolverSender(identifierPeerAuth, EmptyExcludePeersOnTopic, shardC.SelfId())
 	if err != nil {

--- a/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory_test.go
+++ b/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory_test.go
@@ -335,7 +335,7 @@ func TestShardResolversContainerFactory_CreateRegisterPeerAuthenticationShouldEr
 	t.Parallel()
 
 	args := getArgumentsShard()
-	args.Messenger = createStubTopicMessageHandlerForShard("", factory.PeerAuthenticationTopic)
+	args.Messenger = createStubTopicMessageHandlerForShard("", common.PeerAuthenticationTopic)
 	rcf, _ := resolverscontainer.NewShardResolversContainerFactory(args)
 
 	container, err := rcf.Create()

--- a/dataRetriever/requestHandlers/requestHandler.go
+++ b/dataRetriever/requestHandlers/requestHandler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/core/partitioning"
 	"github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/epochStart"
 	"github.com/ElrondNetwork/elrond-go/process/factory"
@@ -720,17 +721,17 @@ func (rrh *resolverRequestHandler) GetNumPeersToQuery(key string) (int, int, err
 // RequestPeerAuthenticationsChunk asks for a chunk of peer authentication messages from connected peers
 func (rrh *resolverRequestHandler) RequestPeerAuthenticationsChunk(destShardID uint32, chunkIndex uint32) {
 	log.Debug("requesting peer authentication messages from network",
-		"topic", factory.PeerAuthenticationTopic,
+		"topic", common.PeerAuthenticationTopic,
 		"shard", destShardID,
 		"chunk", chunkIndex,
 		"epoch", rrh.epoch,
 	)
 
-	resolver, err := rrh.resolversFinder.MetaChainResolver(factory.PeerAuthenticationTopic)
+	resolver, err := rrh.resolversFinder.MetaChainResolver(common.PeerAuthenticationTopic)
 	if err != nil {
 		log.Error("RequestPeerAuthenticationsChunk.CrossShardResolver",
 			"error", err.Error(),
-			"topic", factory.PeerAuthenticationTopic,
+			"topic", common.PeerAuthenticationTopic,
 			"shard", destShardID,
 			"chunk", chunkIndex,
 			"epoch", rrh.epoch,
@@ -748,7 +749,7 @@ func (rrh *resolverRequestHandler) RequestPeerAuthenticationsChunk(destShardID u
 	if err != nil {
 		log.Debug("RequestPeerAuthenticationsChunk.RequestDataFromChunk",
 			"error", err.Error(),
-			"topic", factory.PeerAuthenticationTopic,
+			"topic", common.PeerAuthenticationTopic,
 			"shard", destShardID,
 			"chunk", chunkIndex,
 			"epoch", rrh.epoch,
@@ -759,15 +760,15 @@ func (rrh *resolverRequestHandler) RequestPeerAuthenticationsChunk(destShardID u
 // RequestPeerAuthenticationsByHashes asks for peer authentication messages from specific peers hashes
 func (rrh *resolverRequestHandler) RequestPeerAuthenticationsByHashes(destShardID uint32, hashes [][]byte) {
 	log.Debug("requesting peer authentication messages from network",
-		"topic", factory.PeerAuthenticationTopic,
+		"topic", common.PeerAuthenticationTopic,
 		"shard", destShardID,
 	)
 
-	resolver, err := rrh.resolversFinder.MetaChainResolver(factory.PeerAuthenticationTopic)
+	resolver, err := rrh.resolversFinder.MetaChainResolver(common.PeerAuthenticationTopic)
 	if err != nil {
 		log.Error("RequestPeerAuthenticationsChunk.CrossShardResolver",
 			"error", err.Error(),
-			"topic", factory.PeerAuthenticationTopic,
+			"topic", common.PeerAuthenticationTopic,
 			"shard", destShardID,
 		)
 		return
@@ -783,7 +784,7 @@ func (rrh *resolverRequestHandler) RequestPeerAuthenticationsByHashes(destShardI
 	if err != nil {
 		log.Debug("RequestPeerAuthenticationsChunk.RequestDataFromChunk",
 			"error", err.Error(),
-			"topic", factory.PeerAuthenticationTopic,
+			"topic", common.PeerAuthenticationTopic,
 			"shard", destShardID,
 		)
 	}

--- a/dataRetriever/requestHandlers/requestHandler_test.go
+++ b/dataRetriever/requestHandlers/requestHandler_test.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/mock"
-	"github.com/ElrondNetwork/elrond-go/process/factory"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1172,7 +1172,7 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsChunk(t *testing.T) {
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
 				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
-					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
+					assert.Equal(t, common.PeerAuthenticationTopic, baseTopic)
 					return paResolver, errExpected
 				},
 			},
@@ -1199,7 +1199,7 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsChunk(t *testing.T) {
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
 				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
-					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
+					assert.Equal(t, common.PeerAuthenticationTopic, baseTopic)
 					return mbResolver, nil
 				},
 			},
@@ -1227,7 +1227,7 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsChunk(t *testing.T) {
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
 				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
-					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
+					assert.Equal(t, common.PeerAuthenticationTopic, baseTopic)
 					return paResolver, nil
 				},
 			},
@@ -1262,7 +1262,7 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsChunk(t *testing.T) {
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
 				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
-					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
+					assert.Equal(t, common.PeerAuthenticationTopic, baseTopic)
 					return paResolver, nil
 				},
 			},
@@ -1296,7 +1296,7 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsByHashes(t *testing.T)
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
 				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
-					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
+					assert.Equal(t, common.PeerAuthenticationTopic, baseTopic)
 					return paResolver, errExpected
 				},
 			},
@@ -1323,7 +1323,7 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsByHashes(t *testing.T)
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
 				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
-					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
+					assert.Equal(t, common.PeerAuthenticationTopic, baseTopic)
 					return mbResolver, errExpected
 				},
 			},
@@ -1351,7 +1351,7 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsByHashes(t *testing.T)
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
 				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
-					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
+					assert.Equal(t, common.PeerAuthenticationTopic, baseTopic)
 					return paResolver, nil
 				},
 			},
@@ -1386,7 +1386,7 @@ func TestResolverRequestHandler_RequestPeerAuthenticationsByHashes(t *testing.T)
 		rrh, _ := NewResolverRequestHandler(
 			&mock.ResolversFinderStub{
 				MetaChainResolverCalled: func(baseTopic string) (dataRetriever.Resolver, error) {
-					assert.Equal(t, factory.PeerAuthenticationTopic, baseTopic)
+					assert.Equal(t, common.PeerAuthenticationTopic, baseTopic)
 					return paResolver, nil
 				},
 			},

--- a/epochStart/bootstrap/disabled/disabledPeerShardMapper.go
+++ b/epochStart/bootstrap/disabled/disabledPeerShardMapper.go
@@ -20,6 +20,14 @@ func (p *peerShardMapper) GetLastKnownPeerID(_ []byte) (*core.PeerID, bool) {
 func (p *peerShardMapper) UpdatePeerIDPublicKeyPair(_ core.PeerID, _ []byte) {
 }
 
+// UpdatePeerIdShardId does nothing
+func (p *peerShardMapper) UpdatePeerIdShardId(_ core.PeerID, _ uint32) {
+}
+
+// UpdatePeerIdSubType does nothing
+func (p *peerShardMapper) UpdatePeerIdSubType(_ core.PeerID, _ core.P2PPeerSubType) {
+}
+
 // GetPeerInfo returns default instance
 func (p *peerShardMapper) GetPeerInfo(_ core.PeerID) core.P2PPeerInfo {
 	return core.P2PPeerInfo{}

--- a/epochStart/bootstrap/disabled/disabledPeerShardMapper.go
+++ b/epochStart/bootstrap/disabled/disabledPeerShardMapper.go
@@ -20,12 +20,12 @@ func (p *peerShardMapper) GetLastKnownPeerID(_ []byte) (*core.PeerID, bool) {
 func (p *peerShardMapper) UpdatePeerIDPublicKeyPair(_ core.PeerID, _ []byte) {
 }
 
-// UpdatePeerIdShardId does nothing
-func (p *peerShardMapper) UpdatePeerIdShardId(_ core.PeerID, _ uint32) {
+// PutPeerIdShardId does nothing
+func (p *peerShardMapper) PutPeerIdShardId(_ core.PeerID, _ uint32) {
 }
 
-// UpdatePeerIdSubType does nothing
-func (p *peerShardMapper) UpdatePeerIdSubType(_ core.PeerID, _ core.P2PPeerSubType) {
+// PutPeerIdSubType does nothing
+func (p *peerShardMapper) PutPeerIdSubType(_ core.PeerID, _ core.P2PPeerSubType) {
 }
 
 // GetPeerInfo returns default instance

--- a/heartbeat/interface.go
+++ b/heartbeat/interface.go
@@ -54,7 +54,7 @@ type HeartbeatStorageHandler interface {
 // The interface assures that the collected data will be used by the p2p network sharding components
 type NetworkShardingCollector interface {
 	UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID uint32)
-	UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
+	PutPeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
 	IsInterfaceNil() bool
 }
 

--- a/heartbeat/process/messageProcessor.go
+++ b/heartbeat/process/messageProcessor.go
@@ -68,7 +68,7 @@ func (mp *MessageProcessor) CreateHeartbeatFromP2PMessage(message p2p.MessageP2P
 	}
 
 	mp.networkShardingCollector.UpdatePeerIDInfo(message.Peer(), hbRecv.Pubkey, hbRecv.ShardID)
-	mp.networkShardingCollector.UpdatePeerIdSubType(message.Peer(), core.P2PPeerSubType(hbRecv.PeerSubType))
+	mp.networkShardingCollector.PutPeerIdSubType(message.Peer(), core.P2PPeerSubType(hbRecv.PeerSubType))
 
 	return hbRecv, nil
 }

--- a/heartbeat/process/messageProcessor_test.go
+++ b/heartbeat/process/messageProcessor_test.go
@@ -237,7 +237,7 @@ func TestNewMessageProcessor_CreateHeartbeatFromP2PMessage(t *testing.T) {
 			UpdatePeerIDInfoCalled: func(pid core.PeerID, pk []byte, shardID uint32) {
 				updatePeerInfoWasCalled = true
 			},
-			UpdatePeerIdSubTypeCalled: func(pid core.PeerID, peerSubType core.P2PPeerSubType) {
+			PutPeerIdSubTypeCalled: func(pid core.PeerID, peerSubType core.P2PPeerSubType) {
 				updatePidSubTypeCalled = true
 			},
 		},

--- a/heartbeat/processor/crossShardStatusProcessor.go
+++ b/heartbeat/processor/crossShardStatusProcessor.go
@@ -1,0 +1,128 @@
+package processor
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go/heartbeat"
+	"github.com/ElrondNetwork/elrond-go/p2p"
+	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/process/factory"
+	"github.com/ElrondNetwork/elrond-go/sharding"
+)
+
+// ArgCrossShardStatusProcessor represents the arguments for the cross shard status processor
+type ArgCrossShardStatusProcessor struct {
+	Messenger            p2p.Messenger
+	PeerShardMapper      process.PeerShardMapper
+	ShardCoordinator     sharding.Coordinator
+	DelayBetweenRequests time.Duration
+}
+
+type crossShardStatusProcessor struct {
+	messenger            p2p.Messenger
+	peerShardMapper      process.PeerShardMapper
+	shardCoordinator     sharding.Coordinator
+	delayBetweenRequests time.Duration
+	cancel               func()
+}
+
+// NewCrossShardStatusProcessor creates a new instance of crossShardStatusProcessor
+func NewCrossShardStatusProcessor(args ArgCrossShardStatusProcessor) (*crossShardStatusProcessor, error) {
+	err := checkArgsCrossShardStatusProcessor(args)
+	if err != nil {
+		return nil, err
+	}
+
+	cssp := &crossShardStatusProcessor{
+		messenger:            args.Messenger,
+		peerShardMapper:      args.PeerShardMapper,
+		shardCoordinator:     args.ShardCoordinator,
+		delayBetweenRequests: args.DelayBetweenRequests,
+	}
+
+	var ctx context.Context
+	ctx, cssp.cancel = context.WithCancel(context.Background())
+
+	go cssp.startProcessLoop(ctx)
+
+	return cssp, nil
+}
+
+func checkArgsCrossShardStatusProcessor(args ArgCrossShardStatusProcessor) error {
+	if check.IfNil(args.Messenger) {
+		return process.ErrNilMessenger
+	}
+	if check.IfNil(args.PeerShardMapper) {
+		return process.ErrNilPeerShardMapper
+	}
+	if check.IfNil(args.ShardCoordinator) {
+		return process.ErrNilShardCoordinator
+	}
+	if args.DelayBetweenRequests < minDelayBetweenRequests {
+		return fmt.Errorf("%w for DelayBetweenRequests, provided %d, min expected %d",
+			heartbeat.ErrInvalidTimeDuration, args.DelayBetweenRequests, minDelayBetweenRequests)
+	}
+
+	return nil
+}
+
+func (cssp *crossShardStatusProcessor) startProcessLoop(ctx context.Context) {
+	defer cssp.cancel()
+
+	requestedTopicsMap := cssp.computeTopicsMap()
+
+	timer := time.NewTimer(cssp.delayBetweenRequests)
+	for {
+		timer.Reset(cssp.delayBetweenRequests)
+
+		select {
+		case <-timer.C:
+			cssp.updatePeersInfo(requestedTopicsMap)
+		case <-ctx.Done():
+			log.Debug("closing crossShardStatusProcessor go routine")
+			return
+		}
+	}
+}
+
+func (cssp *crossShardStatusProcessor) computeTopicsMap() map[uint32]string {
+	requestedTopicsMap := make(map[uint32]string, 0)
+
+	numOfShards := cssp.shardCoordinator.NumberOfShards()
+	for shard := uint32(0); shard < numOfShards; shard++ {
+		topicIdentifier := factory.TransactionTopic + cssp.shardCoordinator.CommunicationIdentifier(shard)
+		requestedTopicsMap[shard] = topicIdentifier
+	}
+
+	metaIdentifier := factory.TransactionTopic + cssp.shardCoordinator.CommunicationIdentifier(core.MetachainShardId)
+	requestedTopicsMap[core.MetachainShardId] = metaIdentifier
+
+	return requestedTopicsMap
+}
+
+func (cssp *crossShardStatusProcessor) updatePeersInfo(requestedTopicsMap map[uint32]string) {
+	for shard, topic := range requestedTopicsMap {
+		connectedPids := cssp.messenger.ConnectedPeersOnTopic(topic)
+
+		for _, pid := range connectedPids {
+			cssp.peerShardMapper.UpdatePeerIdShardId(pid, shard)
+		}
+	}
+}
+
+// Close closes the internal goroutine
+func (cssp *crossShardStatusProcessor) Close() error {
+	log.Debug("closing crossShardStatusProcessor...")
+	cssp.cancel()
+
+	return nil
+}
+
+// IsInterfaceNil returns true if there is no value under interface
+func (cssp *crossShardStatusProcessor) IsInterfaceNil() bool {
+	return cssp == nil
+}

--- a/heartbeat/processor/crossShardStatusProcessor.go
+++ b/heartbeat/processor/crossShardStatusProcessor.go
@@ -74,11 +74,7 @@ func checkArgsCrossShardStatusProcessor(args ArgCrossShardStatusProcessor) error
 
 func (cssp *crossShardStatusProcessor) startProcessLoop(ctx context.Context) {
 	timer := time.NewTimer(cssp.delayBetweenRequests)
-
-	defer func() {
-		cssp.cancel()
-		timer.Stop()
-	}()
+	defer timer.Stop()
 
 	requestedTopicsMap := cssp.computeTopicsMap()
 
@@ -96,7 +92,7 @@ func (cssp *crossShardStatusProcessor) startProcessLoop(ctx context.Context) {
 }
 
 func (cssp *crossShardStatusProcessor) computeTopicsMap() map[uint32]string {
-	requestedTopicsMap := make(map[uint32]string, 0)
+	requestedTopicsMap := make(map[uint32]string)
 
 	numOfShards := cssp.shardCoordinator.NumberOfShards()
 	for shard := uint32(0); shard < numOfShards; shard++ {
@@ -114,7 +110,7 @@ func (cssp *crossShardStatusProcessor) computeTopicsMap() map[uint32]string {
 }
 
 func (cssp *crossShardStatusProcessor) updatePeersInfo(requestedTopicsMap map[uint32]string) {
-	cssp.LatestKnownPeers = make(map[string][]core.PeerID, 0)
+	cssp.LatestKnownPeers = make(map[string][]core.PeerID)
 
 	intraShardPeersMap := cssp.getIntraShardConnectedPeers()
 
@@ -126,7 +122,7 @@ func (cssp *crossShardStatusProcessor) updatePeersInfo(requestedTopicsMap map[ui
 				continue
 			}
 
-			cssp.peerShardMapper.UpdatePeerIdShardId(pid, shard)
+			cssp.peerShardMapper.PutPeerIdShardId(pid, shard)
 
 			// todo remove this - tests only
 			cssp.LatestKnownPeers[topic] = append(cssp.LatestKnownPeers[topic], pid)
@@ -139,7 +135,7 @@ func (cssp *crossShardStatusProcessor) getIntraShardConnectedPeers() map[core.Pe
 	intraShardTopic := factory.TransactionTopic + cssp.shardCoordinator.CommunicationIdentifier(selfShard)
 	intraShardPeers := cssp.messenger.ConnectedPeersOnTopic(intraShardTopic)
 
-	intraShardPeersMap := make(map[core.PeerID]struct{}, 0)
+	intraShardPeersMap := make(map[core.PeerID]struct{})
 	for _, pid := range intraShardPeers {
 		intraShardPeersMap[pid] = struct{}{}
 	}
@@ -152,7 +148,7 @@ func (cssp *crossShardStatusProcessor) GetLatestKnownPeers() map[string][]core.P
 	return cssp.LatestKnownPeers
 }
 
-// Close closes the internal goroutine
+// Close triggers the closing of the internal goroutine
 func (cssp *crossShardStatusProcessor) Close() error {
 	log.Debug("closing crossShardStatusProcessor...")
 	cssp.cancel()
@@ -160,7 +156,7 @@ func (cssp *crossShardStatusProcessor) Close() error {
 	return nil
 }
 
-// IsInterfaceNil returns true if there is no value under interface
+// IsInterfaceNil returns true if there is no value under the interface
 func (cssp *crossShardStatusProcessor) IsInterfaceNil() bool {
 	return cssp == nil
 }

--- a/heartbeat/processor/crossShardStatusProcessor_test.go
+++ b/heartbeat/processor/crossShardStatusProcessor_test.go
@@ -109,7 +109,7 @@ func TestNewCrossShardStatusProcessor(t *testing.T) {
 		assert.Nil(t, err)
 
 		topicsMap := processor.computeTopicsMap()
-		assert.Equal(t, expectedNumberOfShards+1, uint32(len(topicsMap)))
+		assert.Equal(t, expectedNumberOfShards, uint32(len(topicsMap)))
 
 		metaTopic, ok := topicsMap[core.MetachainShardId]
 		assert.True(t, ok)

--- a/heartbeat/processor/crossShardStatusProcessor_test.go
+++ b/heartbeat/processor/crossShardStatusProcessor_test.go
@@ -1,0 +1,125 @@
+package processor
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go/heartbeat"
+	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/process/factory"
+	"github.com/ElrondNetwork/elrond-go/process/mock"
+	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func createMockArgCrossShardStatusProcessor() ArgCrossShardStatusProcessor {
+	return ArgCrossShardStatusProcessor{
+		Messenger:            &p2pmocks.MessengerStub{},
+		PeerShardMapper:      &p2pmocks.NetworkShardingCollectorStub{},
+		ShardCoordinator:     &mock.ShardCoordinatorStub{},
+		DelayBetweenRequests: time.Second,
+	}
+}
+
+func TestNewCrossShardStatusProcessor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil messenger should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgCrossShardStatusProcessor()
+		args.Messenger = nil
+
+		processor, err := NewCrossShardStatusProcessor(args)
+		assert.True(t, check.IfNil(processor))
+		assert.Equal(t, process.ErrNilMessenger, err)
+	})
+	t.Run("nil peer shard mapper should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgCrossShardStatusProcessor()
+		args.PeerShardMapper = nil
+
+		processor, err := NewCrossShardStatusProcessor(args)
+		assert.True(t, check.IfNil(processor))
+		assert.Equal(t, process.ErrNilPeerShardMapper, err)
+	})
+	t.Run("nil shard coordinator should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgCrossShardStatusProcessor()
+		args.ShardCoordinator = nil
+
+		processor, err := NewCrossShardStatusProcessor(args)
+		assert.True(t, check.IfNil(processor))
+		assert.Equal(t, process.ErrNilShardCoordinator, err)
+	})
+	t.Run("invalid delay between requests should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgCrossShardStatusProcessor()
+		args.DelayBetweenRequests = time.Second - time.Nanosecond
+
+		processor, err := NewCrossShardStatusProcessor(args)
+		assert.True(t, check.IfNil(processor))
+		assert.True(t, errors.Is(err, heartbeat.ErrInvalidTimeDuration))
+		assert.True(t, strings.Contains(err.Error(), "DelayBetweenRequests"))
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		expectedSuffix := "test"
+		expectedNumberOfShards := uint32(1)
+		args := createMockArgCrossShardStatusProcessor()
+		args.ShardCoordinator = &mock.ShardCoordinatorStub{
+			NumberOfShardsCalled: func() uint32 {
+				return expectedNumberOfShards
+			},
+			CommunicationIdentifierCalled: func(destShardID uint32) string {
+				return expectedSuffix
+			},
+		}
+
+		providedPid := core.PeerID("provided pid")
+		args.Messenger = &p2pmocks.MessengerStub{
+			ConnectedPeersOnTopicCalled: func(topic string) []core.PeerID {
+				return []core.PeerID{providedPid}
+			},
+		}
+
+		args.PeerShardMapper = &p2pmocks.NetworkShardingCollectorStub{
+			UpdatePeerIdShardIdCalled: func(pid core.PeerID, shardId uint32) {
+				assert.Equal(t, providedPid, pid)
+			},
+		}
+
+		processor, err := NewCrossShardStatusProcessor(args)
+		assert.False(t, check.IfNil(processor))
+		assert.Nil(t, err)
+
+		// for coverage, to make sure a loop is finished
+		time.Sleep(args.DelayBetweenRequests * 2)
+
+		// close the internal go routine
+		err = processor.Close()
+		assert.Nil(t, err)
+
+		topicsMap := processor.computeTopicsMap()
+		assert.Equal(t, expectedNumberOfShards+1, uint32(len(topicsMap)))
+
+		metaTopic, ok := topicsMap[core.MetachainShardId]
+		assert.True(t, ok)
+		assert.Equal(t, factory.TransactionTopic+expectedSuffix, metaTopic)
+
+		delete(topicsMap, core.MetachainShardId)
+
+		expectedTopic := factory.TransactionTopic + expectedSuffix
+		for _, shardTopic := range topicsMap {
+			assert.Equal(t, expectedTopic, shardTopic)
+		}
+	})
+}

--- a/heartbeat/processor/crossShardStatusProcessor_test.go
+++ b/heartbeat/processor/crossShardStatusProcessor_test.go
@@ -84,16 +84,23 @@ func TestNewCrossShardStatusProcessor(t *testing.T) {
 			},
 		}
 
-		providedPid := core.PeerID("provided pid")
+		providedFirstPid := core.PeerID("first pid")
+		providedSecondPid := core.PeerID("second pid")
+		counter := 0
 		args.Messenger = &p2pmocks.MessengerStub{
 			ConnectedPeersOnTopicCalled: func(topic string) []core.PeerID {
-				return []core.PeerID{providedPid}
+				if counter == 0 {
+					counter++
+					return []core.PeerID{providedFirstPid}
+				}
+
+				return []core.PeerID{providedSecondPid}
 			},
 		}
 
 		args.PeerShardMapper = &p2pmocks.NetworkShardingCollectorStub{
 			PutPeerIdShardIdCalled: func(pid core.PeerID, shardId uint32) {
-				assert.Equal(t, providedPid, pid)
+				assert.Equal(t, providedSecondPid, pid)
 			},
 		}
 

--- a/heartbeat/processor/crossShardStatusProcessor_test.go
+++ b/heartbeat/processor/crossShardStatusProcessor_test.go
@@ -92,7 +92,7 @@ func TestNewCrossShardStatusProcessor(t *testing.T) {
 		}
 
 		args.PeerShardMapper = &p2pmocks.NetworkShardingCollectorStub{
-			UpdatePeerIdShardIdCalled: func(pid core.PeerID, shardId uint32) {
+			PutPeerIdShardIdCalled: func(pid core.PeerID, shardId uint32) {
 				assert.Equal(t, providedPid, pid)
 			},
 		}

--- a/integrationTests/interface.go
+++ b/integrationTests/interface.go
@@ -48,6 +48,7 @@ type NetworkShardingUpdater interface {
 	GetLastKnownPeerID(pk []byte) (*core.PeerID, bool)
 	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo
 	UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte)
+	UpdatePeerIdShardId(pid core.PeerID, shardID uint32)
 	UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID uint32)
 	UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
 	IsInterfaceNil() bool

--- a/integrationTests/interface.go
+++ b/integrationTests/interface.go
@@ -48,9 +48,9 @@ type NetworkShardingUpdater interface {
 	GetLastKnownPeerID(pk []byte) (*core.PeerID, bool)
 	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo
 	UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte)
-	UpdatePeerIdShardId(pid core.PeerID, shardID uint32)
+	PutPeerIdShardId(pid core.PeerID, shardID uint32)
 	UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID uint32)
-	UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
+	PutPeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
 	IsInterfaceNil() bool
 }
 

--- a/integrationTests/mock/networkShardingCollectorMock.go
+++ b/integrationTests/mock/networkShardingCollectorMock.go
@@ -67,6 +67,13 @@ func (nscm *networkShardingCollectorMock) UpdatePeerIdSubType(pid core.PeerID, p
 	nscm.mutPeerIdSubType.Unlock()
 }
 
+// UpdatePeerIdShardId -
+func (nscm *networkShardingCollectorMock) UpdatePeerIdShardId(pid core.PeerID, shardID uint32) {
+	nscm.mutFallbackPidShardMap.Lock()
+	nscm.fallbackPidShardMap[string(pid)] = shardID
+	nscm.mutFallbackPidShardMap.Unlock()
+}
+
 // GetPeerInfo -
 func (nscm *networkShardingCollectorMock) GetPeerInfo(pid core.PeerID) core.P2PPeerInfo {
 	nscm.mutPeerIdSubType.Lock()

--- a/integrationTests/mock/networkShardingCollectorMock.go
+++ b/integrationTests/mock/networkShardingCollectorMock.go
@@ -60,15 +60,15 @@ func (nscm *networkShardingCollectorMock) UpdatePeerIDInfo(pid core.PeerID, pk [
 	nscm.mutFallbackPidShardMap.Unlock()
 }
 
-// UpdatePeerIdSubType -
-func (nscm *networkShardingCollectorMock) UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
+// PutPeerIdSubType -
+func (nscm *networkShardingCollectorMock) PutPeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
 	nscm.mutPeerIdSubType.Lock()
 	nscm.peerIdSubType[pid] = uint32(peerSubType)
 	nscm.mutPeerIdSubType.Unlock()
 }
 
-// UpdatePeerIdShardId -
-func (nscm *networkShardingCollectorMock) UpdatePeerIdShardId(pid core.PeerID, shardID uint32) {
+// PutPeerIdShardId -
+func (nscm *networkShardingCollectorMock) PutPeerIdShardId(pid core.PeerID, shardID uint32) {
 	nscm.mutFallbackPidShardMap.Lock()
 	nscm.fallbackPidShardMap[string(pid)] = shardID
 	nscm.mutFallbackPidShardMap.Unlock()

--- a/integrationTests/mock/peerShardMapperStub.go
+++ b/integrationTests/mock/peerShardMapperStub.go
@@ -6,12 +6,28 @@ import "github.com/ElrondNetwork/elrond-go-core/core"
 type PeerShardMapperStub struct {
 	GetLastKnownPeerIDCalled        func(pk []byte) (*core.PeerID, bool)
 	UpdatePeerIDPublicKeyPairCalled func(pid core.PeerID, pk []byte)
+	UpdatePeerIdShardIdCalled       func(pid core.PeerID, shardID uint32)
+	UpdatePeerIdSubTypeCalled       func(pid core.PeerID, peerSubType core.P2PPeerSubType)
 }
 
 // UpdatePeerIDPublicKeyPair -
 func (psms *PeerShardMapperStub) UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte) {
 	if psms.UpdatePeerIDPublicKeyPairCalled != nil {
 		psms.UpdatePeerIDPublicKeyPairCalled(pid, pk)
+	}
+}
+
+// UpdatePeerIdShardId -
+func (psms *PeerShardMapperStub) UpdatePeerIdShardId(pid core.PeerID, shardID uint32) {
+	if psms.UpdatePeerIdShardIdCalled != nil {
+		psms.UpdatePeerIdShardIdCalled(pid, shardID)
+	}
+}
+
+// UpdatePeerIdSubType -
+func (psms *PeerShardMapperStub) UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
+	if psms.UpdatePeerIdSubTypeCalled != nil {
+		psms.UpdatePeerIdSubTypeCalled(pid, peerSubType)
 	}
 }
 

--- a/integrationTests/mock/peerShardMapperStub.go
+++ b/integrationTests/mock/peerShardMapperStub.go
@@ -6,8 +6,8 @@ import "github.com/ElrondNetwork/elrond-go-core/core"
 type PeerShardMapperStub struct {
 	GetLastKnownPeerIDCalled        func(pk []byte) (*core.PeerID, bool)
 	UpdatePeerIDPublicKeyPairCalled func(pid core.PeerID, pk []byte)
-	UpdatePeerIdShardIdCalled       func(pid core.PeerID, shardID uint32)
-	UpdatePeerIdSubTypeCalled       func(pid core.PeerID, peerSubType core.P2PPeerSubType)
+	PutPeerIdShardIdCalled          func(pid core.PeerID, shardID uint32)
+	PutPeerIdSubTypeCalled          func(pid core.PeerID, peerSubType core.P2PPeerSubType)
 }
 
 // UpdatePeerIDPublicKeyPair -
@@ -17,17 +17,17 @@ func (psms *PeerShardMapperStub) UpdatePeerIDPublicKeyPair(pid core.PeerID, pk [
 	}
 }
 
-// UpdatePeerIdShardId -
-func (psms *PeerShardMapperStub) UpdatePeerIdShardId(pid core.PeerID, shardID uint32) {
-	if psms.UpdatePeerIdShardIdCalled != nil {
-		psms.UpdatePeerIdShardIdCalled(pid, shardID)
+// PutPeerIdShardId -
+func (psms *PeerShardMapperStub) PutPeerIdShardId(pid core.PeerID, shardID uint32) {
+	if psms.PutPeerIdShardIdCalled != nil {
+		psms.PutPeerIdShardIdCalled(pid, shardID)
 	}
 }
 
-// UpdatePeerIdSubType -
-func (psms *PeerShardMapperStub) UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
-	if psms.UpdatePeerIdSubTypeCalled != nil {
-		psms.UpdatePeerIdSubTypeCalled(pid, peerSubType)
+// PutPeerIdSubType -
+func (psms *PeerShardMapperStub) PutPeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
+	if psms.PutPeerIdSubTypeCalled != nil {
+		psms.PutPeerIdSubTypeCalled(pid, peerSubType)
 	}
 }
 

--- a/integrationTests/node/heartbeatV2/heartbeatV2_test.go
+++ b/integrationTests/node/heartbeatV2/heartbeatV2_test.go
@@ -16,8 +16,9 @@ func TestHeartbeatV2_AllPeersSendMessages(t *testing.T) {
 
 	interactingNodes := 3
 	nodes := make([]*integrationTests.TestHeartbeatNode, interactingNodes)
+	p2pConfig := integrationTests.CreateP2PConfigWithNoDiscovery()
 	for i := 0; i < interactingNodes; i++ {
-		nodes[i] = integrationTests.NewTestHeartbeatNode(3, 0, interactingNodes)
+		nodes[i] = integrationTests.NewTestHeartbeatNode(3, 0, interactingNodes, p2pConfig)
 	}
 	assert.Equal(t, interactingNodes, len(nodes))
 
@@ -42,8 +43,9 @@ func TestHeartbeatV2_PeerJoiningLate(t *testing.T) {
 
 	interactingNodes := 3
 	nodes := make([]*integrationTests.TestHeartbeatNode, interactingNodes)
+	p2pConfig := integrationTests.CreateP2PConfigWithNoDiscovery()
 	for i := 0; i < interactingNodes; i++ {
-		nodes[i] = integrationTests.NewTestHeartbeatNode(3, 0, interactingNodes)
+		nodes[i] = integrationTests.NewTestHeartbeatNode(3, 0, interactingNodes, p2pConfig)
 	}
 	assert.Equal(t, interactingNodes, len(nodes))
 
@@ -57,7 +59,7 @@ func TestHeartbeatV2_PeerJoiningLate(t *testing.T) {
 	checkMessages(t, nodes, maxMessageAgeAllowed)
 
 	// Add new delayed node which requests messages
-	delayedNode := integrationTests.NewTestHeartbeatNode(3, 0, interactingNodes+1)
+	delayedNode := integrationTests.NewTestHeartbeatNode(3, 0, interactingNodes+1, p2pConfig)
 	nodes = append(nodes, delayedNode)
 	connectNodes(nodes, len(nodes))
 	// Wait for messages to broadcast and requests to finish

--- a/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
+++ b/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
@@ -220,6 +220,7 @@ func testUnknownSeederPeers(
 
 	for _, nodes := range nodesMap {
 		for _, n := range nodes {
+			// todo activate this after fix
 			//assert.Equal(t, 0, len(n.Messenger.GetConnectedPeersInfo().UnknownPeers))
 			assert.Equal(t, 1, len(n.Messenger.GetConnectedPeersInfo().Seeders))
 
@@ -274,6 +275,11 @@ func printDebugInfo(node *integrationTests.TestHeartbeatNode) {
 		data += "\n"
 	}
 
+	peerAuths := node.DataPool.PeerAuthentications()
+	hbs := node.DataPool.Heartbeats()
+
 	data += "----------\n"
 	println(data)
+	println(peerAuths.Len())
+	println(hbs.Len())
 }

--- a/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
+++ b/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
@@ -5,11 +5,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/integrationTests"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 	"github.com/stretchr/testify/assert"
 )
+
+// todo remove this - tests only
+type LatestKnownPeersHolder interface {
+	GetLatestKnownPeers() map[string][]core.PeerID
+}
 
 var p2pBootstrapStepDelay = 2 * time.Second
 
@@ -214,8 +220,60 @@ func testUnknownSeederPeers(
 
 	for _, nodes := range nodesMap {
 		for _, n := range nodes {
-			assert.Equal(t, 0, len(n.Messenger.GetConnectedPeersInfo().UnknownPeers))
+			//assert.Equal(t, 0, len(n.Messenger.GetConnectedPeersInfo().UnknownPeers))
 			assert.Equal(t, 1, len(n.Messenger.GetConnectedPeersInfo().Seeders))
+
+			// todo remove this - tests only
+			printDebugInfo(n)
 		}
 	}
+}
+
+func printDebugInfo(node *integrationTests.TestHeartbeatNode) {
+	latestKnownPeers := node.CrossShardStatusProcessor.(LatestKnownPeersHolder).GetLatestKnownPeers()
+
+	selfShard := node.ShardCoordinator.SelfId()
+	selfPid := node.Messenger.ID()
+	prettyPid := selfPid.Pretty()
+	data := "----------\n"
+	info := node.PeerShardMapper.GetPeerInfo(selfPid)
+	data += fmt.Sprintf("PID: %s, shard: %d, PSM info: shard %d, type %s\n", prettyPid[len(prettyPid)-6:], node.ShardCoordinator.SelfId(), info.ShardID, info.PeerType)
+
+	for topic, peers := range latestKnownPeers {
+		data += fmt.Sprintf("topic: %s, connected crossshard pids:\n", topic)
+		for _, peer := range peers {
+			prettyPid = peer.Pretty()
+			info = node.PeerShardMapper.GetPeerInfo(peer)
+			data += fmt.Sprintf("   pid: %s, PSM info: shard %d, type %s\n", prettyPid[len(prettyPid)-6:], info.ShardID, info.PeerType)
+		}
+	}
+
+	connectedPeersInfo := node.Messenger.GetConnectedPeersInfo()
+	data += "connected peers from messenger...\n"
+	if len(connectedPeersInfo.IntraShardValidators[selfShard]) > 0 {
+		data += fmt.Sprintf("intraval %d:", len(connectedPeersInfo.IntraShardValidators[selfShard]))
+		for _, val := range connectedPeersInfo.IntraShardValidators[selfShard] {
+			data += fmt.Sprintf(" %s,", val[len(val)-6:])
+		}
+		data += "\n"
+	}
+
+	if len(connectedPeersInfo.IntraShardObservers[selfShard]) > 0 {
+		data += fmt.Sprintf("intraobs %d:", len(connectedPeersInfo.IntraShardObservers[selfShard]))
+		for _, obs := range connectedPeersInfo.IntraShardObservers[selfShard] {
+			data += fmt.Sprintf(" %s,", obs[len(obs)-6:])
+		}
+		data += "\n"
+	}
+
+	if len(connectedPeersInfo.UnknownPeers) > 0 {
+		data += fmt.Sprintf("unknown %d:", len(connectedPeersInfo.UnknownPeers))
+		for _, unknown := range connectedPeersInfo.UnknownPeers {
+			data += fmt.Sprintf(" %s,", unknown[len(unknown)-6:])
+		}
+		data += "\n"
+	}
+
+	data += "----------\n"
+	println(data)
 }

--- a/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
+++ b/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
@@ -90,7 +90,16 @@ func testConnectionsInNetworkSharding(t *testing.T, p2pConfig config.P2PConfig) 
 	fmt.Println("Delaying for node bootstrap and topic announcement...")
 	time.Sleep(p2pBootstrapStepDelay)
 
-	for i := 0; i < 15; i++ {
+	for i := 0; i < 3; i++ {
+		fmt.Println("\n" + integrationTests.MakeDisplayTableForHeartbeatNodes(nodesMap))
+
+		time.Sleep(time.Second)
+	}
+
+	fmt.Println("Initializing nodes components...")
+	initNodes(nodesMap)
+
+	for i := 0; i < 10; i++ {
 		fmt.Println("\n" + integrationTests.MakeDisplayTableForHeartbeatNodes(nodesMap))
 
 		time.Sleep(time.Second)
@@ -123,6 +132,14 @@ func startNodes(nodesMap map[uint32][]*integrationTests.TestHeartbeatNode) {
 	for _, nodes := range nodesMap {
 		for _, n := range nodes {
 			_ = n.Messenger.Bootstrap()
+		}
+	}
+}
+
+func initNodes(nodesMap map[uint32][]*integrationTests.TestHeartbeatNode) {
+	for _, nodes := range nodesMap {
+		for _, n := range nodes {
+			n.InitTestHeartbeatNode(0)
 		}
 	}
 }

--- a/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
+++ b/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
@@ -1,0 +1,203 @@
+package networkSharding
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/integrationTests"
+	"github.com/ElrondNetwork/elrond-go/p2p"
+	"github.com/stretchr/testify/assert"
+)
+
+var p2pBootstrapStepDelay = 2 * time.Second
+
+func createDefaultConfig() config.P2PConfig {
+	return config.P2PConfig{
+		Node: config.NodeConfig{
+			Port:                  "0",
+			ConnectionWatcherType: "print",
+		},
+		KadDhtPeerDiscovery: config.KadDhtPeerDiscoveryConfig{
+			Enabled:                          true,
+			Type:                             "optimized",
+			RefreshIntervalInSec:             1,
+			RoutingTableRefreshIntervalInSec: 1,
+			ProtocolID:                       "/erd/kad/1.0.0",
+			InitialPeerList:                  nil,
+			BucketSize:                       100,
+		},
+	}
+}
+
+func TestConnectionsInNetworkShardingWithShardingWithLists(t *testing.T) {
+	p2pConfig := createDefaultConfig()
+	p2pConfig.Sharding = config.ShardingConfig{
+		TargetPeerCount:         12,
+		MaxIntraShardValidators: 6,
+		MaxCrossShardValidators: 1,
+		MaxIntraShardObservers:  1,
+		MaxCrossShardObservers:  1,
+		MaxSeeders:              1,
+		Type:                    p2p.ListsSharder,
+		AdditionalConnections: config.AdditionalConnectionsConfig{
+			MaxFullHistoryObservers: 1,
+		},
+	}
+
+	testConnectionsInNetworkSharding(t, p2pConfig)
+}
+
+func testConnectionsInNetworkSharding(t *testing.T, p2pConfig config.P2PConfig) {
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	nodesPerShard := 8
+	numMetaNodes := 8
+	numObserversOnShard := 2
+	numShards := 2
+	consensusGroupSize := 2
+
+	advertiser := integrationTests.CreateMessengerWithKadDht("")
+	_ = advertiser.Bootstrap()
+	seedAddress := integrationTests.GetConnectableAddress(advertiser)
+
+	p2pConfig.KadDhtPeerDiscovery.InitialPeerList = []string{seedAddress}
+
+	// create map of shard - testHeartbeatNodes for metachain and shard chain
+	nodesMap := integrationTests.CreateNodesWithTestP2PNodes(
+		nodesPerShard,
+		numMetaNodes,
+		numShards,
+		consensusGroupSize,
+		numMetaNodes,
+		numObserversOnShard,
+		p2pConfig,
+	)
+
+	defer func() {
+		stopNodes(advertiser, nodesMap)
+	}()
+
+	createTestInterceptorForEachNode(nodesMap)
+
+	time.Sleep(time.Second * 2)
+
+	startNodes(nodesMap)
+
+	fmt.Println("Delaying for node bootstrap and topic announcement...")
+	time.Sleep(p2pBootstrapStepDelay)
+
+	for i := 0; i < 15; i++ {
+		fmt.Println("\n" + integrationTests.MakeDisplayTableForP2PNodes(nodesMap))
+
+		time.Sleep(time.Second)
+	}
+
+	sendMessageOnGlobalTopic(nodesMap)
+	sendMessagesOnIntraShardTopic(nodesMap)
+	sendMessagesOnCrossShardTopic(nodesMap)
+
+	for i := 0; i < 10; i++ {
+		fmt.Println("\n" + integrationTests.MakeDisplayTableForP2PNodes(nodesMap))
+
+		time.Sleep(time.Second)
+	}
+
+	testCounters(t, nodesMap, 1, 1, numShards*2)
+	testUnknownSeederPeers(t, nodesMap)
+}
+
+func stopNodes(advertiser p2p.Messenger, nodesMap map[uint32][]*integrationTests.TestP2PNode) {
+	_ = advertiser.Close()
+	for _, nodes := range nodesMap {
+		for _, n := range nodes {
+			_ = n.Messenger.Close()
+		}
+	}
+}
+
+func startNodes(nodesMap map[uint32][]*integrationTests.TestP2PNode) {
+	for _, nodes := range nodesMap {
+		for _, n := range nodes {
+			_ = n.Messenger.Bootstrap()
+		}
+	}
+}
+
+func createTestInterceptorForEachNode(nodesMap map[uint32][]*integrationTests.TestP2PNode) {
+	for _, nodes := range nodesMap {
+		for _, n := range nodes {
+			n.CreateTestInterceptors()
+		}
+	}
+}
+
+func sendMessageOnGlobalTopic(nodesMap map[uint32][]*integrationTests.TestP2PNode) {
+	fmt.Println("sending a message on global topic")
+	nodesMap[0][0].Messenger.Broadcast(integrationTests.GlobalTopic, []byte("global message"))
+	time.Sleep(time.Second)
+}
+
+func sendMessagesOnIntraShardTopic(nodesMap map[uint32][]*integrationTests.TestP2PNode) {
+	fmt.Println("sending a message on intra shard topic")
+	for _, nodes := range nodesMap {
+		n := nodes[0]
+
+		identifier := integrationTests.ShardTopic +
+			n.ShardCoordinator.CommunicationIdentifier(n.ShardCoordinator.SelfId())
+		nodes[0].Messenger.Broadcast(identifier, []byte("intra shard message"))
+	}
+	time.Sleep(time.Second)
+}
+
+func sendMessagesOnCrossShardTopic(nodesMap map[uint32][]*integrationTests.TestP2PNode) {
+	fmt.Println("sending messages on cross shard topics")
+
+	for shardIdSrc, nodes := range nodesMap {
+		n := nodes[0]
+
+		for shardIdDest := range nodesMap {
+			if shardIdDest == shardIdSrc {
+				continue
+			}
+
+			identifier := integrationTests.ShardTopic +
+				n.ShardCoordinator.CommunicationIdentifier(shardIdDest)
+			nodes[0].Messenger.Broadcast(identifier, []byte("cross shard message"))
+		}
+	}
+	time.Sleep(time.Second)
+}
+
+func testCounters(
+	t *testing.T,
+	nodesMap map[uint32][]*integrationTests.TestP2PNode,
+	globalTopicMessagesCount int,
+	intraTopicMessagesCount int,
+	crossTopicMessagesCount int,
+) {
+
+	for _, nodes := range nodesMap {
+		for _, n := range nodes {
+			assert.Equal(t, globalTopicMessagesCount, n.CountGlobalMessages())
+			assert.Equal(t, intraTopicMessagesCount, n.CountIntraShardMessages())
+			assert.Equal(t, crossTopicMessagesCount, n.CountCrossShardMessages())
+		}
+	}
+}
+
+func testUnknownSeederPeers(
+	t *testing.T,
+	nodesMap map[uint32][]*integrationTests.TestP2PNode,
+) {
+
+	for _, nodes := range nodesMap {
+		for _, n := range nodes {
+			assert.Equal(t, 0, len(n.Messenger.GetConnectedPeersInfo().UnknownPeers))
+			assert.Equal(t, 1, len(n.Messenger.GetConnectedPeersInfo().Seeders))
+		}
+	}
+}

--- a/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
+++ b/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
@@ -90,7 +90,7 @@ func testConnectionsInNetworkSharding(t *testing.T, p2pConfig config.P2PConfig) 
 	fmt.Println("Delaying for node bootstrap and topic announcement...")
 	time.Sleep(p2pBootstrapStepDelay)
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 5; i++ {
 		fmt.Println("\n" + integrationTests.MakeDisplayTableForHeartbeatNodes(nodesMap))
 
 		time.Sleep(time.Second)
@@ -99,7 +99,7 @@ func testConnectionsInNetworkSharding(t *testing.T, p2pConfig config.P2PConfig) 
 	fmt.Println("Initializing nodes components...")
 	initNodes(nodesMap)
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		fmt.Println("\n" + integrationTests.MakeDisplayTableForHeartbeatNodes(nodesMap))
 
 		time.Sleep(time.Second)
@@ -109,7 +109,7 @@ func testConnectionsInNetworkSharding(t *testing.T, p2pConfig config.P2PConfig) 
 	sendMessagesOnIntraShardTopic(nodesMap)
 	sendMessagesOnCrossShardTopic(nodesMap)
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		fmt.Println("\n" + integrationTests.MakeDisplayTableForHeartbeatNodes(nodesMap))
 
 		time.Sleep(time.Second)
@@ -148,6 +148,7 @@ func createTestInterceptorForEachNode(nodesMap map[uint32][]*integrationTests.Te
 	for _, nodes := range nodesMap {
 		for _, n := range nodes {
 			n.CreateTestInterceptors()
+			n.CreateTxInterceptors()
 		}
 	}
 }

--- a/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
+++ b/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
@@ -245,7 +245,7 @@ func printDebugInfo(node *integrationTests.TestHeartbeatNode) {
 		for _, peer := range peers {
 			prettyPid = peer.Pretty()
 			info = node.PeerShardMapper.GetPeerInfo(peer)
-			data += fmt.Sprintf("   pid: %s, PSM info: shard %d, type %s\n", prettyPid[len(prettyPid)-6:], info.ShardID, info.PeerType)
+			data += fmt.Sprintf("\tpid: %s, PSM info: shard %d, type %s\n", prettyPid[len(prettyPid)-6:], info.ShardID, info.PeerType)
 		}
 	}
 

--- a/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
+++ b/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
@@ -67,7 +67,7 @@ func testConnectionsInNetworkSharding(t *testing.T, p2pConfig config.P2PConfig) 
 	p2pConfig.KadDhtPeerDiscovery.InitialPeerList = []string{seedAddress}
 
 	// create map of shard - testHeartbeatNodes for metachain and shard chain
-	nodesMap := integrationTests.CreateNodesWithTestP2PNodes(
+	nodesMap := integrationTests.CreateNodesWithTestHeartbeatNode(
 		nodesPerShard,
 		numMetaNodes,
 		numShards,
@@ -91,7 +91,7 @@ func testConnectionsInNetworkSharding(t *testing.T, p2pConfig config.P2PConfig) 
 	time.Sleep(p2pBootstrapStepDelay)
 
 	for i := 0; i < 15; i++ {
-		fmt.Println("\n" + integrationTests.MakeDisplayTableForP2PNodes(nodesMap))
+		fmt.Println("\n" + integrationTests.MakeDisplayTableForHeartbeatNodes(nodesMap))
 
 		time.Sleep(time.Second)
 	}
@@ -101,7 +101,7 @@ func testConnectionsInNetworkSharding(t *testing.T, p2pConfig config.P2PConfig) 
 	sendMessagesOnCrossShardTopic(nodesMap)
 
 	for i := 0; i < 10; i++ {
-		fmt.Println("\n" + integrationTests.MakeDisplayTableForP2PNodes(nodesMap))
+		fmt.Println("\n" + integrationTests.MakeDisplayTableForHeartbeatNodes(nodesMap))
 
 		time.Sleep(time.Second)
 	}
@@ -110,7 +110,7 @@ func testConnectionsInNetworkSharding(t *testing.T, p2pConfig config.P2PConfig) 
 	testUnknownSeederPeers(t, nodesMap)
 }
 
-func stopNodes(advertiser p2p.Messenger, nodesMap map[uint32][]*integrationTests.TestP2PNode) {
+func stopNodes(advertiser p2p.Messenger, nodesMap map[uint32][]*integrationTests.TestHeartbeatNode) {
 	_ = advertiser.Close()
 	for _, nodes := range nodesMap {
 		for _, n := range nodes {
@@ -119,7 +119,7 @@ func stopNodes(advertiser p2p.Messenger, nodesMap map[uint32][]*integrationTests
 	}
 }
 
-func startNodes(nodesMap map[uint32][]*integrationTests.TestP2PNode) {
+func startNodes(nodesMap map[uint32][]*integrationTests.TestHeartbeatNode) {
 	for _, nodes := range nodesMap {
 		for _, n := range nodes {
 			_ = n.Messenger.Bootstrap()
@@ -127,7 +127,7 @@ func startNodes(nodesMap map[uint32][]*integrationTests.TestP2PNode) {
 	}
 }
 
-func createTestInterceptorForEachNode(nodesMap map[uint32][]*integrationTests.TestP2PNode) {
+func createTestInterceptorForEachNode(nodesMap map[uint32][]*integrationTests.TestHeartbeatNode) {
 	for _, nodes := range nodesMap {
 		for _, n := range nodes {
 			n.CreateTestInterceptors()
@@ -135,13 +135,13 @@ func createTestInterceptorForEachNode(nodesMap map[uint32][]*integrationTests.Te
 	}
 }
 
-func sendMessageOnGlobalTopic(nodesMap map[uint32][]*integrationTests.TestP2PNode) {
+func sendMessageOnGlobalTopic(nodesMap map[uint32][]*integrationTests.TestHeartbeatNode) {
 	fmt.Println("sending a message on global topic")
 	nodesMap[0][0].Messenger.Broadcast(integrationTests.GlobalTopic, []byte("global message"))
 	time.Sleep(time.Second)
 }
 
-func sendMessagesOnIntraShardTopic(nodesMap map[uint32][]*integrationTests.TestP2PNode) {
+func sendMessagesOnIntraShardTopic(nodesMap map[uint32][]*integrationTests.TestHeartbeatNode) {
 	fmt.Println("sending a message on intra shard topic")
 	for _, nodes := range nodesMap {
 		n := nodes[0]
@@ -153,7 +153,7 @@ func sendMessagesOnIntraShardTopic(nodesMap map[uint32][]*integrationTests.TestP
 	time.Sleep(time.Second)
 }
 
-func sendMessagesOnCrossShardTopic(nodesMap map[uint32][]*integrationTests.TestP2PNode) {
+func sendMessagesOnCrossShardTopic(nodesMap map[uint32][]*integrationTests.TestHeartbeatNode) {
 	fmt.Println("sending messages on cross shard topics")
 
 	for shardIdSrc, nodes := range nodesMap {
@@ -174,7 +174,7 @@ func sendMessagesOnCrossShardTopic(nodesMap map[uint32][]*integrationTests.TestP
 
 func testCounters(
 	t *testing.T,
-	nodesMap map[uint32][]*integrationTests.TestP2PNode,
+	nodesMap map[uint32][]*integrationTests.TestHeartbeatNode,
 	globalTopicMessagesCount int,
 	intraTopicMessagesCount int,
 	crossTopicMessagesCount int,
@@ -191,7 +191,7 @@ func testCounters(
 
 func testUnknownSeederPeers(
 	t *testing.T,
-	nodesMap map[uint32][]*integrationTests.TestP2PNode,
+	nodesMap map[uint32][]*integrationTests.TestHeartbeatNode,
 ) {
 
 	for _, nodes := range nodesMap {

--- a/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
+++ b/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
@@ -275,11 +275,6 @@ func printDebugInfo(node *integrationTests.TestHeartbeatNode) {
 		data += "\n"
 	}
 
-	peerAuths := node.DataPool.PeerAuthentications()
-	hbs := node.DataPool.Heartbeats()
-
 	data += "----------\n"
 	println(data)
-	println(peerAuths.Len())
-	println(hbs.Len())
 }

--- a/integrationTests/testHeartbeatNode.go
+++ b/integrationTests/testHeartbeatNode.go
@@ -591,7 +591,7 @@ func (thn *TestHeartbeatNode) GetConnectableAddress() string {
 	return GetConnectableAddress(thn.Messenger)
 }
 
-// MakeDisplayTableForHeartbeatNodes will output a string containing counters for received messages for all provided test nodes
+// MakeDisplayTableForHeartbeatNodes returns a string containing counters for received messages for all provided test nodes
 func MakeDisplayTableForHeartbeatNodes(nodes map[uint32][]*TestHeartbeatNode) string {
 	header := []string{"pk", "pid", "shard ID", "messages global", "messages intra", "messages cross", "conns Total/IntraVal/CrossVal/IntraObs/CrossObs/FullObs/Unk/Sed"}
 	dataLines := make([]*display.LineData, 0)

--- a/integrationTests/testHeartbeatNode.go
+++ b/integrationTests/testHeartbeatNode.go
@@ -48,14 +48,14 @@ import (
 
 const (
 	defaultNodeName           = "heartbeatNode"
-	timeBetweenPeerAuths      = 10 * time.Second
-	timeBetweenHeartbeats     = 2 * time.Second
+	timeBetweenPeerAuths      = 15 * time.Second
+	timeBetweenHeartbeats     = 5 * time.Second
 	timeBetweenSendsWhenError = time.Second
 	thresholdBetweenSends     = 0.2
 
 	messagesInChunk         = 10
 	minPeersThreshold       = 1.0
-	delayBetweenRequests    = time.Second
+	delayBetweenRequests    = time.Second * 5
 	maxTimeout              = time.Minute
 	maxMissingKeysInRequest = 1
 )
@@ -567,7 +567,7 @@ func (thn *TestHeartbeatNode) initCrossShardStatusProcessor() {
 		Messenger:            thn.Messenger,
 		PeerShardMapper:      thn.PeerShardMapper,
 		ShardCoordinator:     thn.ShardCoordinator,
-		DelayBetweenRequests: time.Second * 3,
+		DelayBetweenRequests: delayBetweenRequests,
 	}
 
 	thn.CrossShardStatusProcessor, _ = processor.NewCrossShardStatusProcessor(args)

--- a/integrationTests/testHeartbeatNode.go
+++ b/integrationTests/testHeartbeatNode.go
@@ -174,7 +174,7 @@ func NewTestHeartbeatNode(
 	}
 
 	// start a go routine in order to allow peers to connect first
-	go thn.initTestHeartbeatNode(minPeersWaiting)
+	go thn.InitTestHeartbeatNode(minPeersWaiting)
 
 	return thn
 }
@@ -184,7 +184,6 @@ func NewTestHeartbeatNode(
 func NewTestHeartbeatNodeWithCoordinator(
 	maxShards uint32,
 	nodeShardId uint32,
-	minPeersWaiting int,
 	p2pConfig config.P2PConfig,
 	coordinator sharding.NodesCoordinator,
 	keys TestKeyPair,
@@ -247,13 +246,11 @@ func NewTestHeartbeatNodeWithCoordinator(
 
 	thn.NodeKeys = keys
 
-	// start a go routine in order to allow peers to connect first
-	go thn.initTestHeartbeatNode(minPeersWaiting)
-
 	return thn
 }
 
-func (thn *TestHeartbeatNode) initTestHeartbeatNode(minPeersWaiting int) {
+// InitTestHeartbeatNode initializes all the components and starts sender
+func (thn *TestHeartbeatNode) InitTestHeartbeatNode(minPeersWaiting int) {
 	thn.initStorage()
 	thn.initDataPools()
 	thn.initRequestedItemsHandler()

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -372,7 +372,6 @@ func CreateNodesWithTestHeartbeatNode(
 			nodesList[i] = NewTestHeartbeatNodeWithCoordinator(
 				uint32(numShards),
 				shardId,
-				0,
 				p2pConfig,
 				nodesCoordinator,
 				*kp,
@@ -415,7 +414,6 @@ func CreateNodesWithTestHeartbeatNode(
 			n := NewTestHeartbeatNodeWithCoordinator(
 				uint32(numShards),
 				shardId,
-				0,
 				p2pConfig,
 				nodesCoordinator,
 				createCryptoPair(),

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -210,7 +210,7 @@ func CreateMessengerFromConfig(p2pConfig config.P2PConfig) p2p.Messenger {
 	return libP2PMes
 }
 
-// CreateP2PConfigWithNoDiscovery -
+// CreateP2PConfigWithNoDiscovery creates a new libp2p messenger with no peer discovery
 func CreateP2PConfigWithNoDiscovery() config.P2PConfig {
 	return config.P2PConfig{
 		Node: config.NodeConfig{

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -19,6 +20,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	dataBlock "github.com/ElrondNetwork/elrond-go-core/data/block"
+	"github.com/ElrondNetwork/elrond-go-core/data/endProcess"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/elrond-go-core/data/typeConverters"
 	"github.com/ElrondNetwork/elrond-go-core/display"
@@ -36,6 +38,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/blockchain"
+	"github.com/ElrondNetwork/elrond-go/epochStart/notifier"
 	"github.com/ElrondNetwork/elrond-go/genesis"
 	"github.com/ElrondNetwork/elrond-go/genesis/parsing"
 	genesisProcess "github.com/ElrondNetwork/elrond-go/genesis/process"
@@ -62,6 +65,7 @@ import (
 	dataRetrieverMock "github.com/ElrondNetwork/elrond-go/testscommon/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/testscommon/epochNotifier"
 	"github.com/ElrondNetwork/elrond-go/testscommon/genesisMocks"
+	"github.com/ElrondNetwork/elrond-go/testscommon/nodeTypeProviderMock"
 	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	statusHandlerMock "github.com/ElrondNetwork/elrond-go/testscommon/statusHandler"
 	"github.com/ElrondNetwork/elrond-go/trie"
@@ -316,6 +320,112 @@ func connectPeerToOthers(peers []p2p.Messenger, idx int, connectToIdxes []int) e
 	}
 
 	return nil
+}
+
+// CreateNodesWithTestHeartbeatNode returns a map with nodes per shard each using a real nodes coordinator
+// and TestHeartbeatNode
+func CreateNodesWithTestHeartbeatNode(
+	nodesPerShard int,
+	numMetaNodes int,
+	numShards int,
+	shardConsensusGroupSize int,
+	metaConsensusGroupSize int,
+	numObserversOnShard int,
+	p2pConfig config.P2PConfig,
+) map[uint32][]*TestHeartbeatNode {
+
+	cp := CreateCryptoParams(nodesPerShard, numMetaNodes, uint32(numShards))
+	pubKeys := PubKeysMapFromKeysMap(cp.Keys)
+	validatorsMap := GenValidatorsFromPubKeys(pubKeys, uint32(numShards))
+	validatorsForNodesCoordinator, _ := sharding.NodesInfoToValidators(validatorsMap)
+	nodesMap := make(map[uint32][]*TestHeartbeatNode)
+	cacherCfg := storageUnit.CacheConfig{Capacity: 10000, Type: storageUnit.LRUCache, Shards: 1}
+	cache, _ := storageUnit.NewCache(cacherCfg)
+	for shardId, validatorList := range validatorsMap {
+		argumentsNodesCoordinator := sharding.ArgNodesCoordinator{
+			ShardConsensusGroupSize:    shardConsensusGroupSize,
+			MetaConsensusGroupSize:     metaConsensusGroupSize,
+			Marshalizer:                TestMarshalizer,
+			Hasher:                     TestHasher,
+			ShardIDAsObserver:          shardId,
+			NbShards:                   uint32(numShards),
+			EligibleNodes:              validatorsForNodesCoordinator,
+			SelfPublicKey:              []byte(strconv.Itoa(int(shardId))),
+			ConsensusGroupCache:        cache,
+			Shuffler:                   &mock.NodeShufflerMock{},
+			BootStorer:                 CreateMemUnit(),
+			WaitingNodes:               make(map[uint32][]sharding.Validator),
+			Epoch:                      0,
+			EpochStartNotifier:         notifier.NewEpochStartSubscriptionHandler(),
+			ShuffledOutHandler:         &mock.ShuffledOutHandlerStub{},
+			WaitingListFixEnabledEpoch: 0,
+			ChanStopNode:               endProcess.GetDummyEndProcessChannel(),
+			NodeTypeProvider:           &nodeTypeProviderMock.NodeTypeProviderStub{},
+			IsFullArchive:              false,
+		}
+		nodesCoordinator, err := sharding.NewIndexHashedNodesCoordinator(argumentsNodesCoordinator)
+		log.LogIfError(err)
+
+		nodesList := make([]*TestHeartbeatNode, len(validatorList))
+		for i := range validatorList {
+			kp := cp.Keys[shardId][i]
+			nodesList[i] = NewTestHeartbeatNodeWithCoordinator(
+				uint32(numShards),
+				shardId,
+				0,
+				p2pConfig,
+				nodesCoordinator,
+				*kp,
+			)
+		}
+		nodesMap[shardId] = nodesList
+	}
+
+	for counter := uint32(0); counter < uint32(numShards+1); counter++ {
+		for j := 0; j < numObserversOnShard; j++ {
+			shardId := counter
+			if shardId == uint32(numShards) {
+				shardId = core.MetachainShardId
+			}
+
+			argumentsNodesCoordinator := sharding.ArgNodesCoordinator{
+				ShardConsensusGroupSize:    shardConsensusGroupSize,
+				MetaConsensusGroupSize:     metaConsensusGroupSize,
+				Marshalizer:                TestMarshalizer,
+				Hasher:                     TestHasher,
+				ShardIDAsObserver:          shardId,
+				NbShards:                   uint32(numShards),
+				EligibleNodes:              validatorsForNodesCoordinator,
+				SelfPublicKey:              []byte(strconv.Itoa(int(shardId))),
+				ConsensusGroupCache:        cache,
+				Shuffler:                   &mock.NodeShufflerMock{},
+				BootStorer:                 CreateMemUnit(),
+				WaitingNodes:               make(map[uint32][]sharding.Validator),
+				Epoch:                      0,
+				EpochStartNotifier:         notifier.NewEpochStartSubscriptionHandler(),
+				ShuffledOutHandler:         &mock.ShuffledOutHandlerStub{},
+				WaitingListFixEnabledEpoch: 0,
+				ChanStopNode:               endProcess.GetDummyEndProcessChannel(),
+				NodeTypeProvider:           &nodeTypeProviderMock.NodeTypeProviderStub{},
+				IsFullArchive:              false,
+			}
+			nodesCoordinator, err := sharding.NewIndexHashedNodesCoordinator(argumentsNodesCoordinator)
+			log.LogIfError(err)
+
+			n := NewTestHeartbeatNodeWithCoordinator(
+				uint32(numShards),
+				shardId,
+				0,
+				p2pConfig,
+				nodesCoordinator,
+				createCryptoPair(),
+			)
+
+			nodesMap[shardId] = append(nodesMap[shardId], n)
+		}
+	}
+
+	return nodesMap
 }
 
 // ClosePeers calls Messenger.Close on the provided peers

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -210,9 +210,9 @@ func CreateMessengerFromConfig(p2pConfig config.P2PConfig) p2p.Messenger {
 	return libP2PMes
 }
 
-// CreateMessengerWithNoDiscovery creates a new libp2p messenger with no peer discovery
-func CreateMessengerWithNoDiscovery() p2p.Messenger {
-	p2pConfig := config.P2PConfig{
+// CreateP2PConfigWithNoDiscovery -
+func CreateP2PConfigWithNoDiscovery() config.P2PConfig {
+	return config.P2PConfig{
 		Node: config.NodeConfig{
 			Port:                  "0",
 			Seed:                  "",
@@ -225,6 +225,11 @@ func CreateMessengerWithNoDiscovery() p2p.Messenger {
 			Type: p2p.NilListSharder,
 		},
 	}
+}
+
+// CreateMessengerWithNoDiscovery creates a new libp2p messenger with no peer discovery
+func CreateMessengerWithNoDiscovery() p2p.Messenger {
+	p2pConfig := CreateP2PConfigWithNoDiscovery()
 
 	return CreateMessengerFromConfig(p2pConfig)
 }

--- a/node/interface.go
+++ b/node/interface.go
@@ -31,7 +31,7 @@ type P2PMessenger interface {
 // The interface assures that the collected data will be used by the p2p network sharding components
 type NetworkShardingCollector interface {
 	UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID uint32)
-	UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
+	PutPeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
 	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo
 	IsInterfaceNil() bool
 }

--- a/p2p/libp2p/netMessenger_test.go
+++ b/p2p/libp2p/netMessenger_test.go
@@ -116,21 +116,21 @@ func createMockNetworkOf3() (p2p.Messenger, p2p.Messenger, p2p.Messenger) {
 	_ = netw.LinkAll()
 
 	nscm1 := mock.NewNetworkShardingCollectorMock()
-	nscm1.UpdatePeerIdSubType(messenger1.ID(), core.FullHistoryObserver)
-	nscm1.UpdatePeerIdSubType(messenger2.ID(), core.FullHistoryObserver)
-	nscm1.UpdatePeerIdSubType(messenger3.ID(), core.RegularPeer)
+	nscm1.PutPeerIdSubType(messenger1.ID(), core.FullHistoryObserver)
+	nscm1.PutPeerIdSubType(messenger2.ID(), core.FullHistoryObserver)
+	nscm1.PutPeerIdSubType(messenger3.ID(), core.RegularPeer)
 	_ = messenger1.SetPeerShardResolver(nscm1)
 
 	nscm2 := mock.NewNetworkShardingCollectorMock()
-	nscm2.UpdatePeerIdSubType(messenger1.ID(), core.FullHistoryObserver)
-	nscm2.UpdatePeerIdSubType(messenger2.ID(), core.FullHistoryObserver)
-	nscm2.UpdatePeerIdSubType(messenger3.ID(), core.RegularPeer)
+	nscm2.PutPeerIdSubType(messenger1.ID(), core.FullHistoryObserver)
+	nscm2.PutPeerIdSubType(messenger2.ID(), core.FullHistoryObserver)
+	nscm2.PutPeerIdSubType(messenger3.ID(), core.RegularPeer)
 	_ = messenger2.SetPeerShardResolver(nscm2)
 
 	nscm3 := mock.NewNetworkShardingCollectorMock()
-	nscm3.UpdatePeerIdSubType(messenger1.ID(), core.FullHistoryObserver)
-	nscm3.UpdatePeerIdSubType(messenger2.ID(), core.FullHistoryObserver)
-	nscm3.UpdatePeerIdSubType(messenger3.ID(), core.RegularPeer)
+	nscm3.PutPeerIdSubType(messenger1.ID(), core.FullHistoryObserver)
+	nscm3.PutPeerIdSubType(messenger2.ID(), core.FullHistoryObserver)
+	nscm3.PutPeerIdSubType(messenger3.ID(), core.RegularPeer)
 	_ = messenger3.SetPeerShardResolver(nscm3)
 
 	return messenger1, messenger2, messenger3

--- a/p2p/mock/networkShardingCollectorMock.go
+++ b/p2p/mock/networkShardingCollectorMock.go
@@ -49,8 +49,8 @@ func (nscm *networkShardingCollectorMock) UpdatePeerIDInfo(pid core.PeerID, pk [
 	nscm.mutFallbackPidShardMap.Unlock()
 }
 
-// UpdatePeerIdSubType -
-func (nscm *networkShardingCollectorMock) UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
+// PutPeerIdSubType -
+func (nscm *networkShardingCollectorMock) PutPeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
 	nscm.mutPeerIdSubType.Lock()
 	nscm.peerIdSubType[pid] = uint32(peerSubType)
 	nscm.mutPeerIdSubType.Unlock()

--- a/process/factory/factory.go
+++ b/process/factory/factory.go
@@ -19,10 +19,6 @@ const (
 	AccountTrieNodesTopic = "accountTrieNodes"
 	// ValidatorTrieNodesTopic is used for sharding validator state trie nodes
 	ValidatorTrieNodesTopic = "validatorTrieNodes"
-	// PeerAuthenticationTopic is used for sharing peer authentication messages
-	PeerAuthenticationTopic = "peerAuthentication"
-	// HeartbeatTopic is used for sharing heartbeat messages
-	HeartbeatTopic = "heartbeat"
 )
 
 // SystemVirtualMachine is a byte array identifier for the smart contract address created for system VM

--- a/process/factory/interceptorscontainer/baseInterceptorsContainerFactory.go
+++ b/process/factory/interceptorscontainer/baseInterceptorsContainerFactory.go
@@ -589,7 +589,7 @@ func (bicf *baseInterceptorsContainerFactory) generateUnsignedTxsInterceptors() 
 //------- PeerAuthentication interceptor
 
 func (bicf *baseInterceptorsContainerFactory) generatePeerAuthenticationInterceptor() error {
-	identifierPeerAuthentication := factory.PeerAuthenticationTopic
+	identifierPeerAuthentication := common.PeerAuthenticationTopic
 
 	argProcessor := processor.ArgPeerAuthenticationInterceptorProcessor{
 		PeerAuthenticationCacher: bicf.dataPool.PeerAuthentications(),
@@ -635,10 +635,12 @@ func (bicf *baseInterceptorsContainerFactory) generatePeerAuthenticationIntercep
 
 func (bicf *baseInterceptorsContainerFactory) generateHeartbeatInterceptor() error {
 	shardC := bicf.shardCoordinator
-	identifierHeartbeat := factory.HeartbeatTopic + shardC.CommunicationIdentifier(shardC.SelfId())
+	identifierHeartbeat := common.HeartbeatV2Topic + shardC.CommunicationIdentifier(shardC.SelfId())
 
 	argHeartbeatProcessor := processor.ArgHeartbeatInterceptorProcessor{
-		HeartbeatCacher: bicf.dataPool.Heartbeats(),
+		HeartbeatCacher:  bicf.dataPool.Heartbeats(),
+		ShardCoordinator: shardC,
+		PeerShardMapper:  bicf.peerShardMapper,
 	}
 	heartbeatProcessor, err := processor.NewHeartbeatInterceptorProcessor(argHeartbeatProcessor)
 	if err != nil {

--- a/process/interceptors/processor/heartbeatInterceptorProcessor.go
+++ b/process/interceptors/processor/heartbeatInterceptorProcessor.go
@@ -75,8 +75,8 @@ func (hip *heartbeatInterceptorProcessor) updatePeerInfo(message interface{}, fr
 		return process.ErrWrongTypeAssertion
 	}
 
-	hip.peerShardMapper.UpdatePeerIdShardId(fromConnectedPeer, hip.shardCoordinator.SelfId())
-	hip.peerShardMapper.UpdatePeerIdSubType(fromConnectedPeer, core.P2PPeerSubType(heartbeatData.GetPeerSubType()))
+	hip.peerShardMapper.PutPeerIdShardId(fromConnectedPeer, hip.shardCoordinator.SelfId())
+	hip.peerShardMapper.PutPeerIdSubType(fromConnectedPeer, core.P2PPeerSubType(heartbeatData.GetPeerSubType()))
 
 	return nil
 }

--- a/process/interceptors/processor/heartbeatInterceptorProcessor_test.go
+++ b/process/interceptors/processor/heartbeatInterceptorProcessor_test.go
@@ -109,15 +109,15 @@ func TestHeartbeatInterceptorProcessor_Save(t *testing.T) {
 		t.Parallel()
 
 		providedData := createMockInterceptedPeerAuthentication() // unable to cast to intercepted heartbeat
-		wasUpdatePeerIdShardIdCalled := false
-		wasUpdatePeerIdSubTypeCalled := false
+		wasPutPeerIdShardIdCalled := false
+		wasPutPeerIdSubTypeCalled := false
 		args := createHeartbeatInterceptorProcessArg()
 		args.PeerShardMapper = &p2pmocks.NetworkShardingCollectorStub{
-			UpdatePeerIdShardIdCalled: func(pid core.PeerID, shardId uint32) {
-				wasUpdatePeerIdShardIdCalled = true
+			PutPeerIdShardIdCalled: func(pid core.PeerID, shardId uint32) {
+				wasPutPeerIdShardIdCalled = true
 			},
-			UpdatePeerIdSubTypeCalled: func(pid core.PeerID, peerSubType core.P2PPeerSubType) {
-				wasUpdatePeerIdSubTypeCalled = true
+			PutPeerIdSubTypeCalled: func(pid core.PeerID, peerSubType core.P2PPeerSubType) {
+				wasPutPeerIdSubTypeCalled = true
 			},
 		}
 
@@ -125,8 +125,8 @@ func TestHeartbeatInterceptorProcessor_Save(t *testing.T) {
 		assert.Nil(t, err)
 		assert.False(t, paip.IsInterfaceNil())
 		assert.Equal(t, process.ErrWrongTypeAssertion, paip.Save(providedData, "", ""))
-		assert.False(t, wasUpdatePeerIdShardIdCalled)
-		assert.False(t, wasUpdatePeerIdSubTypeCalled)
+		assert.False(t, wasPutPeerIdShardIdCalled)
+		assert.False(t, wasPutPeerIdSubTypeCalled)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -151,15 +151,15 @@ func TestHeartbeatInterceptorProcessor_Save(t *testing.T) {
 				return false
 			},
 		}
-		wasUpdatePeerIdShardIdCalled := false
-		wasUpdatePeerIdSubTypeCalled := false
+		wasPutPeerIdShardIdCalled := false
+		wasPutPeerIdSubTypeCalled := false
 		arg.PeerShardMapper = &p2pmocks.NetworkShardingCollectorStub{
-			UpdatePeerIdShardIdCalled: func(pid core.PeerID, shardId uint32) {
-				wasUpdatePeerIdShardIdCalled = true
+			PutPeerIdShardIdCalled: func(pid core.PeerID, shardId uint32) {
+				wasPutPeerIdShardIdCalled = true
 				assert.Equal(t, providedPid, pid)
 			},
-			UpdatePeerIdSubTypeCalled: func(pid core.PeerID, peerSubType core.P2PPeerSubType) {
-				wasUpdatePeerIdSubTypeCalled = true
+			PutPeerIdSubTypeCalled: func(pid core.PeerID, peerSubType core.P2PPeerSubType) {
+				wasPutPeerIdSubTypeCalled = true
 				assert.Equal(t, providedPid, pid)
 			},
 		}
@@ -171,8 +171,8 @@ func TestHeartbeatInterceptorProcessor_Save(t *testing.T) {
 		err = hip.Save(providedHb, providedPid, "")
 		assert.Nil(t, err)
 		assert.True(t, wasCalled)
-		assert.True(t, wasUpdatePeerIdShardIdCalled)
-		assert.True(t, wasUpdatePeerIdSubTypeCalled)
+		assert.True(t, wasPutPeerIdShardIdCalled)
+		assert.True(t, wasPutPeerIdSubTypeCalled)
 	})
 }
 

--- a/process/interceptors/processor/heartbeatInterceptorProcessor_test.go
+++ b/process/interceptors/processor/heartbeatInterceptorProcessor_test.go
@@ -12,12 +12,15 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process/interceptors/processor"
 	"github.com/ElrondNetwork/elrond-go/process/mock"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	"github.com/stretchr/testify/assert"
 )
 
 func createHeartbeatInterceptorProcessArg() processor.ArgHeartbeatInterceptorProcessor {
 	return processor.ArgHeartbeatInterceptorProcessor{
-		HeartbeatCacher: testscommon.NewCacherStub(),
+		HeartbeatCacher:  testscommon.NewCacherStub(),
+		ShardCoordinator: &testscommon.ShardsCoordinatorMock{},
+		PeerShardMapper:  &p2pmocks.NetworkShardingCollectorStub{},
 	}
 }
 
@@ -64,6 +67,24 @@ func TestNewHeartbeatInterceptorProcessor(t *testing.T) {
 		assert.Equal(t, process.ErrNilHeartbeatCacher, err)
 		assert.Nil(t, hip)
 	})
+	t.Run("nil shard coordinator should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createHeartbeatInterceptorProcessArg()
+		arg.ShardCoordinator = nil
+		hip, err := processor.NewHeartbeatInterceptorProcessor(arg)
+		assert.Equal(t, process.ErrNilShardCoordinator, err)
+		assert.Nil(t, hip)
+	})
+	t.Run("nil peer shard mapper should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createHeartbeatInterceptorProcessArg()
+		arg.PeerShardMapper = nil
+		hip, err := processor.NewHeartbeatInterceptorProcessor(arg)
+		assert.Equal(t, process.ErrNilPeerShardMapper, err)
+		assert.Nil(t, hip)
+	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
@@ -83,6 +104,29 @@ func TestHeartbeatInterceptorProcessor_Save(t *testing.T) {
 		assert.Nil(t, err)
 		assert.False(t, hip.IsInterfaceNil())
 		assert.Equal(t, process.ErrWrongTypeAssertion, hip.Save(nil, "", ""))
+	})
+	t.Run("invalid heartbeat data should error", func(t *testing.T) {
+		t.Parallel()
+
+		providedData := createMockInterceptedPeerAuthentication() // unable to cast to intercepted heartbeat
+		wasUpdatePeerIdShardIdCalled := false
+		wasUpdatePeerIdSubTypeCalled := false
+		args := createHeartbeatInterceptorProcessArg()
+		args.PeerShardMapper = &p2pmocks.NetworkShardingCollectorStub{
+			UpdatePeerIdShardIdCalled: func(pid core.PeerID, shardId uint32) {
+				wasUpdatePeerIdShardIdCalled = true
+			},
+			UpdatePeerIdSubTypeCalled: func(pid core.PeerID, peerSubType core.P2PPeerSubType) {
+				wasUpdatePeerIdSubTypeCalled = true
+			},
+		}
+
+		paip, err := processor.NewHeartbeatInterceptorProcessor(args)
+		assert.Nil(t, err)
+		assert.False(t, paip.IsInterfaceNil())
+		assert.Equal(t, process.ErrWrongTypeAssertion, paip.Save(providedData, "", ""))
+		assert.False(t, wasUpdatePeerIdShardIdCalled)
+		assert.False(t, wasUpdatePeerIdSubTypeCalled)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -107,6 +151,19 @@ func TestHeartbeatInterceptorProcessor_Save(t *testing.T) {
 				return false
 			},
 		}
+		wasUpdatePeerIdShardIdCalled := false
+		wasUpdatePeerIdSubTypeCalled := false
+		arg.PeerShardMapper = &p2pmocks.NetworkShardingCollectorStub{
+			UpdatePeerIdShardIdCalled: func(pid core.PeerID, shardId uint32) {
+				wasUpdatePeerIdShardIdCalled = true
+				assert.Equal(t, providedPid, pid)
+			},
+			UpdatePeerIdSubTypeCalled: func(pid core.PeerID, peerSubType core.P2PPeerSubType) {
+				wasUpdatePeerIdSubTypeCalled = true
+				assert.Equal(t, providedPid, pid)
+			},
+		}
+
 		hip, err := processor.NewHeartbeatInterceptorProcessor(arg)
 		assert.Nil(t, err)
 		assert.False(t, hip.IsInterfaceNil())
@@ -114,6 +171,8 @@ func TestHeartbeatInterceptorProcessor_Save(t *testing.T) {
 		err = hip.Save(providedHb, providedPid, "")
 		assert.Nil(t, err)
 		assert.True(t, wasCalled)
+		assert.True(t, wasUpdatePeerIdShardIdCalled)
+		assert.True(t, wasUpdatePeerIdSubTypeCalled)
 	})
 }
 

--- a/process/interceptors/processor/peerAuthenticationInterceptorProcessor.go
+++ b/process/interceptors/processor/peerAuthenticationInterceptorProcessor.go
@@ -22,7 +22,7 @@ type peerAuthenticationInterceptorProcessor struct {
 
 // NewPeerAuthenticationInterceptorProcessor creates a new peerAuthenticationInterceptorProcessor
 func NewPeerAuthenticationInterceptorProcessor(args ArgPeerAuthenticationInterceptorProcessor) (*peerAuthenticationInterceptorProcessor, error) {
-	err := checkArgs(args)
+	err := checkArgsPeerAuthentication(args)
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func NewPeerAuthenticationInterceptorProcessor(args ArgPeerAuthenticationInterce
 	}, nil
 }
 
-func checkArgs(args ArgPeerAuthenticationInterceptorProcessor) error {
+func checkArgsPeerAuthentication(args ArgPeerAuthenticationInterceptorProcessor) error {
 	if check.IfNil(args.PeerAuthenticationCacher) {
 		return process.ErrNilPeerAuthenticationCacher
 	}

--- a/process/interface.go
+++ b/process/interface.go
@@ -670,6 +670,8 @@ type PeerBlackListCacher interface {
 // PeerShardMapper can return the public key of a provided peer ID
 type PeerShardMapper interface {
 	UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte)
+	UpdatePeerIdShardId(pid core.PeerID, shardID uint32)
+	UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
 	GetLastKnownPeerID(pk []byte) (*core.PeerID, bool)
 	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo
 	IsInterfaceNil() bool
@@ -679,6 +681,7 @@ type PeerShardMapper interface {
 type NetworkShardingCollector interface {
 	UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte)
 	UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID uint32)
+	UpdatePeerIdShardId(pid core.PeerID, shardID uint32)
 	UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
 	GetLastKnownPeerID(pk []byte) (*core.PeerID, bool)
 	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo

--- a/process/interface.go
+++ b/process/interface.go
@@ -670,8 +670,8 @@ type PeerBlackListCacher interface {
 // PeerShardMapper can return the public key of a provided peer ID
 type PeerShardMapper interface {
 	UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte)
-	UpdatePeerIdShardId(pid core.PeerID, shardID uint32)
-	UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
+	PutPeerIdShardId(pid core.PeerID, shardID uint32)
+	PutPeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
 	GetLastKnownPeerID(pk []byte) (*core.PeerID, bool)
 	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo
 	IsInterfaceNil() bool
@@ -681,8 +681,8 @@ type PeerShardMapper interface {
 type NetworkShardingCollector interface {
 	UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte)
 	UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID uint32)
-	UpdatePeerIdShardId(pid core.PeerID, shardID uint32)
-	UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
+	PutPeerIdShardId(pid core.PeerID, shardID uint32)
+	PutPeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType)
 	GetLastKnownPeerID(pk []byte) (*core.PeerID, bool)
 	GetPeerInfo(pid core.PeerID) core.P2PPeerInfo
 	IsInterfaceNil() bool

--- a/process/mock/peerShardMapperStub.go
+++ b/process/mock/peerShardMapperStub.go
@@ -8,9 +8,9 @@ type PeerShardMapperStub struct {
 	GetPeerInfoCalled               func(pid core.PeerID) core.P2PPeerInfo
 	UpdatePeerIdPublicKeyCalled     func(pid core.PeerID, pk []byte)
 	UpdatePublicKeyShardIdCalled    func(pk []byte, shardId uint32)
-	UpdatePeerIdShardIdCalled       func(pid core.PeerID, shardId uint32)
+	PutPeerIdShardIdCalled          func(pid core.PeerID, shardId uint32)
 	UpdatePeerIDPublicKeyPairCalled func(pid core.PeerID, pk []byte)
-	UpdatePeerIdSubTypeCalled       func(pid core.PeerID, peerSubType core.P2PPeerSubType)
+	PutPeerIdSubTypeCalled          func(pid core.PeerID, peerSubType core.P2PPeerSubType)
 }
 
 // GetLastKnownPeerID -
@@ -52,17 +52,17 @@ func (psms *PeerShardMapperStub) UpdatePublicKeyShardId(pk []byte, shardId uint3
 	}
 }
 
-// UpdatePeerIdShardId -
-func (psms *PeerShardMapperStub) UpdatePeerIdShardId(pid core.PeerID, shardId uint32) {
-	if psms.UpdatePeerIdShardIdCalled != nil {
-		psms.UpdatePeerIdShardIdCalled(pid, shardId)
+// PutPeerIdShardId -
+func (psms *PeerShardMapperStub) PutPeerIdShardId(pid core.PeerID, shardId uint32) {
+	if psms.PutPeerIdShardIdCalled != nil {
+		psms.PutPeerIdShardIdCalled(pid, shardId)
 	}
 }
 
-// UpdatePeerIdSubType -
-func (psms *PeerShardMapperStub) UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
-	if psms.UpdatePeerIdSubTypeCalled != nil {
-		psms.UpdatePeerIdSubTypeCalled(pid, peerSubType)
+// PutPeerIdSubType -
+func (psms *PeerShardMapperStub) PutPeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
+	if psms.PutPeerIdSubTypeCalled != nil {
+		psms.PutPeerIdSubTypeCalled(pid, peerSubType)
 	}
 }
 

--- a/process/mock/peerShardMapperStub.go
+++ b/process/mock/peerShardMapperStub.go
@@ -10,6 +10,7 @@ type PeerShardMapperStub struct {
 	UpdatePublicKeyShardIdCalled    func(pk []byte, shardId uint32)
 	UpdatePeerIdShardIdCalled       func(pid core.PeerID, shardId uint32)
 	UpdatePeerIDPublicKeyPairCalled func(pid core.PeerID, pk []byte)
+	UpdatePeerIdSubTypeCalled       func(pid core.PeerID, peerSubType core.P2PPeerSubType)
 }
 
 // GetLastKnownPeerID -
@@ -55,6 +56,13 @@ func (psms *PeerShardMapperStub) UpdatePublicKeyShardId(pk []byte, shardId uint3
 func (psms *PeerShardMapperStub) UpdatePeerIdShardId(pid core.PeerID, shardId uint32) {
 	if psms.UpdatePeerIdShardIdCalled != nil {
 		psms.UpdatePeerIdShardIdCalled(pid, shardId)
+	}
+}
+
+// UpdatePeerIdSubType -
+func (psms *PeerShardMapperStub) UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
+	if psms.UpdatePeerIdSubTypeCalled != nil {
+		psms.UpdatePeerIdSubTypeCalled(pid, peerSubType)
 	}
 }
 

--- a/sharding/networksharding/peerShardMapper.go
+++ b/sharding/networksharding/peerShardMapper.go
@@ -287,12 +287,12 @@ func (psm *PeerShardMapper) UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID
 }
 
 func (psm *PeerShardMapper) updatePublicKeyShardId(pk []byte, shardId uint32) {
-	psm.fallbackPkShardCache.HasOrAdd(pk, shardId, uint32Size)
+	psm.fallbackPkShardCache.Put(pk, shardId, uint32Size)
 }
 
 // UpdatePeerIdShardId adds the peer ID and shard ID into fallback cache in case it does not exists
 func (psm *PeerShardMapper) UpdatePeerIdShardId(pid core.PeerID, shardId uint32) {
-	psm.fallbackPidShardCache.HasOrAdd([]byte(pid), shardId, uint32Size)
+	psm.fallbackPidShardCache.Put([]byte(pid), shardId, uint32Size)
 }
 
 // updatePeerIDPublicKey will update the pid <-> pk mapping, returning true if the pair is a new known pair
@@ -377,7 +377,7 @@ func (psm *PeerShardMapper) removePidAssociation(pid core.PeerID) []byte {
 
 // UpdatePeerIdSubType updates the peerIdSubType search map containing peer IDs and peer subtypes
 func (psm *PeerShardMapper) UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
-	psm.peerIdSubTypeCache.HasOrAdd([]byte(pid), peerSubType, uint32Size)
+	psm.peerIdSubTypeCache.Put([]byte(pid), peerSubType, uint32Size)
 }
 
 // EpochStartAction is the method called whenever an action needs to be undertaken in respect to the epoch change

--- a/sharding/networksharding/peerShardMapper.go
+++ b/sharding/networksharding/peerShardMapper.go
@@ -281,17 +281,17 @@ func (psm *PeerShardMapper) UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID
 	if shardID == core.AllShardId {
 		return
 	}
-	psm.updatePublicKeyShardId(pk, shardID)
-	psm.UpdatePeerIdShardId(pid, shardID)
+	psm.putPublicKeyShardId(pk, shardID)
+	psm.PutPeerIdShardId(pid, shardID)
 	psm.preferredPeersHolder.Put(pk, pid, shardID)
 }
 
-func (psm *PeerShardMapper) updatePublicKeyShardId(pk []byte, shardId uint32) {
+func (psm *PeerShardMapper) putPublicKeyShardId(pk []byte, shardId uint32) {
 	psm.fallbackPkShardCache.Put(pk, shardId, uint32Size)
 }
 
-// UpdatePeerIdShardId adds the peer ID and shard ID into fallback cache in case it does not exists
-func (psm *PeerShardMapper) UpdatePeerIdShardId(pid core.PeerID, shardId uint32) {
+// PutPeerIdShardId puts the peer ID and shard ID into fallback cache in case it does not exists
+func (psm *PeerShardMapper) PutPeerIdShardId(pid core.PeerID, shardId uint32) {
 	psm.fallbackPidShardCache.Put([]byte(pid), shardId, uint32Size)
 }
 
@@ -375,8 +375,8 @@ func (psm *PeerShardMapper) removePidAssociation(pid core.PeerID) []byte {
 	return oldPkBuff
 }
 
-// UpdatePeerIdSubType updates the peerIdSubType search map containing peer IDs and peer subtypes
-func (psm *PeerShardMapper) UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
+// PutPeerIdSubType puts the peerIdSubType search map containing peer IDs and peer subtypes
+func (psm *PeerShardMapper) PutPeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
 	psm.peerIdSubTypeCache.Put([]byte(pid), peerSubType, uint32Size)
 }
 

--- a/sharding/networksharding/peerShardMapper.go
+++ b/sharding/networksharding/peerShardMapper.go
@@ -201,7 +201,7 @@ func (psm *PeerShardMapper) getPeerSubType(pid core.PeerID) core.P2PPeerSubType 
 
 	subType, ok := subTypeObj.(core.P2PPeerSubType)
 	if !ok {
-		log.Warn("PeerShardMapper.getPeerInfoSearchingPidInFallbackCache: the contained element should have been of type core.P2PPeerSubType")
+		log.Warn("PeerShardMapper.getPeerSubType: the contained element should have been of type core.P2PPeerSubType")
 		return core.RegularPeer
 	}
 
@@ -219,7 +219,7 @@ func (psm *PeerShardMapper) getPeerInfoSearchingPidInFallbackCache(pid core.Peer
 
 	shard, ok := shardObj.(uint32)
 	if !ok {
-		log.Warn("PeerShardMapper.getShardIDSearchingPidInFallbackCache: the contained element should have been of type uint32")
+		log.Warn("PeerShardMapper.getPeerInfoSearchingPidInFallbackCache: the contained element should have been of type uint32")
 
 		return &core.P2PPeerInfo{
 			PeerType: core.UnknownPeer,

--- a/sharding/networksharding/peerShardMapper.go
+++ b/sharding/networksharding/peerShardMapper.go
@@ -149,7 +149,7 @@ func (psm *PeerShardMapper) getPeerInfoWithNodesCoordinator(pid core.PeerID) (*c
 
 	pkBuff, ok := pkObj.([]byte)
 	if !ok {
-		log.Warn("PeerShardMapper.getShardIDWithNodesCoordinator: the contained element should have been of type []byte")
+		log.Warn("PeerShardMapper.getPeerInfoWithNodesCoordinator: the contained element should have been of type []byte")
 
 		return &core.P2PPeerInfo{
 			PeerType: core.UnknownPeer,
@@ -251,7 +251,7 @@ func (psm *PeerShardMapper) GetLastKnownPeerID(pk []byte) (*core.PeerID, bool) {
 	}
 
 	if len(pq.data) == 0 {
-		log.Warn("PeerShardMapper.GetPeerID: empty pidQueue element")
+		log.Warn("PeerShardMapper.GetLastKnownPeerID: empty pidQueue element")
 		return nil, false
 	}
 

--- a/sharding/networksharding/peerShardMapper.go
+++ b/sharding/networksharding/peerShardMapper.go
@@ -269,7 +269,7 @@ func (psm *PeerShardMapper) UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte
 	}
 }
 
-// UpdatePeerIDInfo updates the public keys and the shard ID for the peer IDin the corresponding maps
+// UpdatePeerIDInfo updates the public keys and the shard ID for the peer ID in the corresponding maps
 // It also uses the intermediate pkPeerId cache that will prevent having thousands of peer ID's with
 // the same Elrond PK that will make the node prone to an eclipse attack
 func (psm *PeerShardMapper) UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID uint32) {
@@ -282,7 +282,7 @@ func (psm *PeerShardMapper) UpdatePeerIDInfo(pid core.PeerID, pk []byte, shardID
 		return
 	}
 	psm.updatePublicKeyShardId(pk, shardID)
-	psm.updatePeerIdShardId(pid, shardID)
+	psm.UpdatePeerIdShardId(pid, shardID)
 	psm.preferredPeersHolder.Put(pk, pid, shardID)
 }
 
@@ -290,7 +290,8 @@ func (psm *PeerShardMapper) updatePublicKeyShardId(pk []byte, shardId uint32) {
 	psm.fallbackPkShardCache.HasOrAdd(pk, shardId, uint32Size)
 }
 
-func (psm *PeerShardMapper) updatePeerIdShardId(pid core.PeerID, shardId uint32) {
+// UpdatePeerIdShardId adds the peer ID and shard ID into fallback cache in case it does not exists
+func (psm *PeerShardMapper) UpdatePeerIdShardId(pid core.PeerID, shardId uint32) {
 	psm.fallbackPidShardCache.HasOrAdd([]byte(pid), shardId, uint32Size)
 }
 

--- a/sharding/networksharding/peerShardMapper_test.go
+++ b/sharding/networksharding/peerShardMapper_test.go
@@ -599,3 +599,46 @@ func TestPeerShardMapper_UpdatePeerIDPublicKey(t *testing.T) {
 		assert.False(t, psm.UpdatePeerIDPublicKey(pid2, pk1))
 	})
 }
+
+func TestPeerShardMapper_GetLastKnownPeerID(t *testing.T) {
+	t.Parallel()
+
+	pid1 := core.PeerID("pid1")
+	pid2 := core.PeerID("pid2")
+	pk1 := []byte("pk1")
+	pk2 := []byte("pk2")
+
+	t.Run("no pk in cache should return false", func(t *testing.T) {
+		t.Parallel()
+
+		psm := createPeerShardMapper()
+		pid, ok := psm.GetLastKnownPeerID(pk1)
+		assert.Nil(t, pid)
+		assert.False(t, ok)
+	})
+	t.Run("cast error should return false", func(t *testing.T) {
+		t.Parallel()
+
+		psm := createPeerShardMapper()
+		dummyData := "dummy data"
+		psm.PkPeerId().Put(pk1, dummyData, len(dummyData))
+
+		pid, ok := psm.GetLastKnownPeerID(pk1)
+		assert.Nil(t, pid)
+		assert.False(t, ok)
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		psm := createPeerShardMapper()
+		psm.UpdatePeerIDPublicKeyPair(pid1, pk1)
+		pid, ok := psm.GetLastKnownPeerID(pk1)
+		assert.True(t, ok)
+		assert.Equal(t, &pid1, pid)
+
+		psm.UpdatePeerIDPublicKeyPair(pid2, pk2)
+		pid, ok = psm.GetLastKnownPeerID(pk2)
+		assert.True(t, ok)
+		assert.Equal(t, &pid2, pid)
+	})
+}

--- a/sharding/networksharding/pidQueue.go
+++ b/sharding/networksharding/pidQueue.go
@@ -61,7 +61,7 @@ func (pq *pidQueue) remove(pid core.PeerID) {
 	pq.data = newData
 }
 
-func (pq *pidQueue) size() int {
+func (pq *pidQueue) dataSizeInBytes() int {
 	sum := 0
 	for _, pid := range pq.data {
 		sum += len(pid)

--- a/sharding/networksharding/pidQueue_test.go
+++ b/sharding/networksharding/pidQueue_test.go
@@ -138,18 +138,18 @@ func TestPidQueue_RemoveShouldWork(t *testing.T) {
 	assert.Equal(t, 1, pq.indexOf(pid2))
 }
 
-func TestPidQueue_Size(t *testing.T) {
+func TestPidQueue_dataSizeInBytes(t *testing.T) {
 	t.Parallel()
 
 	pq := newPidQueue()
-	assert.Equal(t, 0, pq.size())
+	assert.Equal(t, 0, pq.dataSizeInBytes())
 
 	pq.push("pid 0")
-	assert.Equal(t, 5, pq.size())
+	assert.Equal(t, 5, pq.dataSizeInBytes())
 
 	pq.push("pid 1")
-	assert.Equal(t, 10, pq.size())
+	assert.Equal(t, 10, pq.dataSizeInBytes())
 
 	pq.push("0")
-	assert.Equal(t, 11, pq.size())
+	assert.Equal(t, 11, pq.dataSizeInBytes())
 }

--- a/testscommon/dataRetriever/poolFactory.go
+++ b/testscommon/dataRetriever/poolFactory.go
@@ -117,8 +117,8 @@ func CreatePoolsHolder(numShards uint32, selfShard uint32) dataRetriever.PoolsHo
 	panicIfError("CreatePoolsHolder", err)
 
 	peerAuthPool, err := mapTimeCache.NewMapTimeCache(mapTimeCache.ArgMapTimeCacher{
-		DefaultSpan: 20 * time.Second,
-		CacheExpiry: 20 * time.Second,
+		DefaultSpan: 60 * time.Second,
+		CacheExpiry: 60 * time.Second,
 	})
 	panicIfError("CreatePoolsHolder", err)
 

--- a/testscommon/p2pmocks/networkShardingCollectorStub.go
+++ b/testscommon/p2pmocks/networkShardingCollectorStub.go
@@ -8,6 +8,7 @@ import (
 type NetworkShardingCollectorStub struct {
 	UpdatePeerIDPublicKeyPairCalled func(pid core.PeerID, pk []byte)
 	UpdatePeerIDInfoCalled          func(pid core.PeerID, pk []byte, shardID uint32)
+	UpdatePeerIdShardIdCalled       func(pid core.PeerID, shardId uint32)
 	UpdatePeerIdSubTypeCalled       func(pid core.PeerID, peerSubType core.P2PPeerSubType)
 	GetLastKnownPeerIDCalled        func(pk []byte) (*core.PeerID, bool)
 	GetPeerInfoCalled               func(pid core.PeerID) core.P2PPeerInfo
@@ -17,6 +18,13 @@ type NetworkShardingCollectorStub struct {
 func (nscs *NetworkShardingCollectorStub) UpdatePeerIDPublicKeyPair(pid core.PeerID, pk []byte) {
 	if nscs.UpdatePeerIDPublicKeyPairCalled != nil {
 		nscs.UpdatePeerIDPublicKeyPairCalled(pid, pk)
+	}
+}
+
+// UpdatePeerIdShardId -
+func (nscs *NetworkShardingCollectorStub) UpdatePeerIdShardId(pid core.PeerID, shardID uint32) {
+	if nscs.UpdatePeerIdShardIdCalled != nil {
+		nscs.UpdatePeerIdShardIdCalled(pid, shardID)
 	}
 }
 

--- a/testscommon/p2pmocks/networkShardingCollectorStub.go
+++ b/testscommon/p2pmocks/networkShardingCollectorStub.go
@@ -8,8 +8,8 @@ import (
 type NetworkShardingCollectorStub struct {
 	UpdatePeerIDPublicKeyPairCalled func(pid core.PeerID, pk []byte)
 	UpdatePeerIDInfoCalled          func(pid core.PeerID, pk []byte, shardID uint32)
-	UpdatePeerIdShardIdCalled       func(pid core.PeerID, shardId uint32)
-	UpdatePeerIdSubTypeCalled       func(pid core.PeerID, peerSubType core.P2PPeerSubType)
+	PutPeerIdShardIdCalled          func(pid core.PeerID, shardId uint32)
+	PutPeerIdSubTypeCalled          func(pid core.PeerID, peerSubType core.P2PPeerSubType)
 	GetLastKnownPeerIDCalled        func(pk []byte) (*core.PeerID, bool)
 	GetPeerInfoCalled               func(pid core.PeerID) core.P2PPeerInfo
 }
@@ -21,10 +21,10 @@ func (nscs *NetworkShardingCollectorStub) UpdatePeerIDPublicKeyPair(pid core.Pee
 	}
 }
 
-// UpdatePeerIdShardId -
-func (nscs *NetworkShardingCollectorStub) UpdatePeerIdShardId(pid core.PeerID, shardID uint32) {
-	if nscs.UpdatePeerIdShardIdCalled != nil {
-		nscs.UpdatePeerIdShardIdCalled(pid, shardID)
+// PutPeerIdShardId -
+func (nscs *NetworkShardingCollectorStub) PutPeerIdShardId(pid core.PeerID, shardID uint32) {
+	if nscs.PutPeerIdShardIdCalled != nil {
+		nscs.PutPeerIdShardIdCalled(pid, shardID)
 	}
 }
 
@@ -35,10 +35,10 @@ func (nscs *NetworkShardingCollectorStub) UpdatePeerIDInfo(pid core.PeerID, pk [
 	}
 }
 
-// UpdatePeerIdSubType -
-func (nscs *NetworkShardingCollectorStub) UpdatePeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
-	if nscs.UpdatePeerIdSubTypeCalled != nil {
-		nscs.UpdatePeerIdSubTypeCalled(pid, peerSubType)
+// PutPeerIdSubType -
+func (nscs *NetworkShardingCollectorStub) PutPeerIdSubType(pid core.PeerID, peerSubType core.P2PPeerSubType) {
+	if nscs.PutPeerIdSubTypeCalled != nil {
+		nscs.PutPeerIdSubTypeCalled(pid, peerSubType)
 	}
 }
 


### PR DESCRIPTION
- new network sharding integration tests
- added `crossShardStatusProcessor` component which should feed the peerdShardMapper with connected pids(this may be replaced by another mechanism in a further PR)
- `heartbeatInterceptorProcessor` now feeds the peerShardMapper with the known info
- added mutex protection on `GetLastKnownPeerID`
- fixed usage of `.Size` in peerShardMapper and replaced all `HasOrAdd` with `Put` in order to have the most recent data saved