### PR TITLE
[esdt supply api] set minted for create

### DIFF
--- a/dblookupext/esdtSupply/esdtSuppliesProcessor_test.go
+++ b/dblookupext/esdtSupply/esdtSuppliesProcessor_test.go
@@ -17,6 +17,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testNftCreateValue = 10
+	testAddQuantityValue = 50
+	testBurnValue = 30
+)
+
 func TestNewSuppliesProcessor(t *testing.T) {
 	t.Parallel()
 
@@ -50,19 +56,19 @@ func TestProcessLogsSaveSupply(t *testing.T) {
 					{
 						Identifier: []byte(core.BuiltInFunctionESDTNFTCreate),
 						Topics: [][]byte{
-							token, big.NewInt(2).Bytes(), big.NewInt(10).Bytes(),
+							token, big.NewInt(2).Bytes(), big.NewInt(testNftCreateValue).Bytes(),
 						},
 					},
 					{
 						Identifier: []byte(core.BuiltInFunctionESDTNFTAddQuantity),
 						Topics: [][]byte{
-							token, big.NewInt(2).Bytes(), big.NewInt(50).Bytes(),
+							token, big.NewInt(2).Bytes(), big.NewInt(testAddQuantityValue).Bytes(),
 						},
 					},
 					{
 						Identifier: []byte(core.BuiltInFunctionESDTNFTBurn),
 						Topics: [][]byte{
-							token, big.NewInt(2).Bytes(), big.NewInt(30).Bytes(),
+							token, big.NewInt(2).Bytes(), big.NewInt(testBurnValue).Bytes(),
 						},
 					},
 				},
@@ -127,7 +133,7 @@ func TestProcessLogsSaveSupplyShouldUpdateSupplyMintedAndBurned(t *testing.T) {
 					{
 						Identifier: []byte(core.BuiltInFunctionESDTNFTCreate),
 						Topics: [][]byte{
-							token, big.NewInt(2).Bytes(), big.NewInt(10).Bytes(),
+							token, big.NewInt(2).Bytes(), big.NewInt(testNftCreateValue).Bytes(),
 						},
 					},
 				},
@@ -148,7 +154,7 @@ func TestProcessLogsSaveSupplyShouldUpdateSupplyMintedAndBurned(t *testing.T) {
 					{
 						Identifier: []byte(core.BuiltInFunctionESDTNFTAddQuantity),
 						Topics: [][]byte{
-							token, big.NewInt(2).Bytes(), big.NewInt(50).Bytes(),
+							token, big.NewInt(2).Bytes(), big.NewInt(testAddQuantityValue).Bytes(),
 						},
 					},
 				},
@@ -170,7 +176,7 @@ func TestProcessLogsSaveSupplyShouldUpdateSupplyMintedAndBurned(t *testing.T) {
 					{
 						Identifier: []byte(core.BuiltInFunctionESDTNFTBurn),
 						Topics: [][]byte{
-							token, big.NewInt(2).Bytes(), big.NewInt(30).Bytes(),
+							token, big.NewInt(2).Bytes(), big.NewInt(testBurnValue).Bytes(),
 						},
 					},
 				},
@@ -207,19 +213,19 @@ func TestProcessLogsSaveSupplyShouldUpdateSupplyMintedAndBurned(t *testing.T) {
 				switch numTimesCalled {
 				case 0:
 					supplyEsdt := getSupplyESDT(marshalizer, data)
-					require.Equal(t, big.NewInt(10), supplyEsdt.Supply)
+					require.Equal(t, big.NewInt(testNftCreateValue), supplyEsdt.Supply)
 					require.Equal(t, big.NewInt(0), supplyEsdt.Burned)
-					require.Equal(t, big.NewInt(10), supplyEsdt.Minted)
+					require.Equal(t, big.NewInt(testNftCreateValue), supplyEsdt.Minted)
 				case 1:
 					supplyEsdt := getSupplyESDT(marshalizer, data)
-					require.Equal(t, big.NewInt(60), supplyEsdt.Supply)
+					require.Equal(t, big.NewInt(testNftCreateValue + testAddQuantityValue), supplyEsdt.Supply)
 					require.Equal(t, big.NewInt(0), supplyEsdt.Burned)
-					require.Equal(t, big.NewInt(60), supplyEsdt.Minted)
+					require.Equal(t, big.NewInt(testNftCreateValue + testAddQuantityValue), supplyEsdt.Minted)
 				case 2:
 					supplyEsdt := getSupplyESDT(marshalizer, data)
-					require.Equal(t, big.NewInt(30), supplyEsdt.Supply)
-					require.Equal(t, big.NewInt(30), supplyEsdt.Burned)
-					require.Equal(t, big.NewInt(60), supplyEsdt.Minted)
+					require.Equal(t, big.NewInt(testNftCreateValue + testAddQuantityValue - testBurnValue), supplyEsdt.Supply)
+					require.Equal(t, big.NewInt(testBurnValue), supplyEsdt.Burned)
+					require.Equal(t, big.NewInt(testNftCreateValue + testAddQuantityValue), supplyEsdt.Minted)
 				}
 
 				_ = membDB.Put(key, data)

--- a/dblookupext/esdtSupply/esdtSuppliesProcessor_test.go
+++ b/dblookupext/esdtSupply/esdtSuppliesProcessor_test.go
@@ -1,6 +1,7 @@
 package esdtSupply
 
 import (
+	"encoding/hex"
 	"errors"
 	"math/big"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 
 	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
@@ -71,18 +73,31 @@ func TestProcessLogsSaveSupply(t *testing.T) {
 		},
 	}
 
+	wasPutCalled := false
 	marshalizer := testscommon.MarshalizerMock{}
 	suppliesStorer := &storageStubs.StorerStub{
 		GetCalled: func(key []byte) ([]byte, error) {
+			if string(key) == "processed-block" {
+				pbn := ProcessedBlockNonce{Nonce: 5}
+				pbnB, _ := marshalizer.Marshal(pbn)
+				return pbnB, nil
+			}
+
 			return nil, storage.ErrKeyNotFound
 		},
 		PutCalled: func(key, data []byte) error {
-			supplyKey := string(token) + "-" + string(big.NewInt(2).Bytes())
+			if string(key) == "processed-block" {
+				return nil
+			}
+
+			supplyKey := string(token) + "-" + hex.EncodeToString(big.NewInt(2).Bytes())
 			require.Equal(t, supplyKey, string(key))
 
 			var supplyESDT SupplyESDT
 			_ = marshalizer.Unmarshal(&supplyESDT, data)
 			require.Equal(t, big.NewInt(30), supplyESDT.Supply)
+
+			wasPutCalled = true
 
 			return nil
 		},
@@ -91,8 +106,153 @@ func TestProcessLogsSaveSupply(t *testing.T) {
 	suppliesProc, err := NewSuppliesProcessor(marshalizer, suppliesStorer, &storageStubs.StorerStub{})
 	require.Nil(t, err)
 
-	err = suppliesProc.ProcessLogs(0, logs)
+	err = suppliesProc.ProcessLogs(6, logs)
 	require.Nil(t, err)
+
+	require.True(t, wasPutCalled)
+}
+
+func TestProcessLogsSaveSupplyShouldUpdateSupplyMintedAndBurned(t *testing.T) {
+	t.Parallel()
+
+	token := []byte("nft-0001")
+	logsCreate := []*data.LogData{
+		{
+			TxHash: "txLog",
+			LogHandler: &transaction.Log{
+				Events: []*transaction.Event{
+					{
+						Identifier: []byte("something"),
+					},
+					{
+						Identifier: []byte(core.BuiltInFunctionESDTNFTCreate),
+						Topics: [][]byte{
+							token, big.NewInt(2).Bytes(), big.NewInt(10).Bytes(),
+						},
+					},
+				},
+			},
+		},
+		{
+			TxHash: "log",
+		},
+	}
+	logsAddQuantity := []*data.LogData{
+		{
+			TxHash: "txLog",
+			LogHandler: &transaction.Log{
+				Events: []*transaction.Event{
+					{
+						Identifier: []byte("something"),
+					},
+					{
+						Identifier: []byte(core.BuiltInFunctionESDTNFTAddQuantity),
+						Topics: [][]byte{
+							token, big.NewInt(2).Bytes(), big.NewInt(50).Bytes(),
+						},
+					},
+				},
+			},
+		},
+		{
+			TxHash: "log",
+		},
+	}
+
+	logsBurn := []*data.LogData{
+		{
+			TxHash: "txLog",
+			LogHandler: &transaction.Log{
+				Events: []*transaction.Event{
+					{
+						Identifier: []byte("something"),
+					},
+					{
+						Identifier: []byte(core.BuiltInFunctionESDTNFTBurn),
+						Topics: [][]byte{
+							token, big.NewInt(2).Bytes(), big.NewInt(30).Bytes(),
+						},
+					},
+				},
+			},
+		},
+		{
+			TxHash: "log",
+		},
+	}
+
+	membDB := testscommon.NewMemDbMock()
+	marshalizer := testscommon.MarshalizerMock{}
+	numTimesCalled := 0
+	suppliesStorer := &storageStubs.StorerStub{
+		GetCalled: func(key []byte) ([]byte, error) {
+			if string(key) == "processed-block" {
+				pbn := ProcessedBlockNonce{Nonce: 5}
+				pbnB, _ := marshalizer.Marshal(pbn)
+				return pbnB, nil
+			}
+			supplyKey := string(token) + "-" + hex.EncodeToString(big.NewInt(2).Bytes())
+			if string(key) == supplyKey {
+				val, err := membDB.Get(key)
+				if err != nil {
+					return nil, storage.ErrKeyNotFound
+				}
+				return val, nil
+			}
+			return nil, storage.ErrKeyNotFound
+		},
+		PutCalled: func(key, data []byte) error {
+			supplyKey := string(token) + "-" + hex.EncodeToString(big.NewInt(2).Bytes())
+			if string(key) == supplyKey {
+				switch numTimesCalled {
+				case 0:
+					supplyEsdt := getSupplyESDT(marshalizer, data)
+					require.Equal(t, big.NewInt(10), supplyEsdt.Supply)
+					require.Equal(t, big.NewInt(0), supplyEsdt.Burned)
+					require.Equal(t, big.NewInt(10), supplyEsdt.Minted)
+				case 1:
+					supplyEsdt := getSupplyESDT(marshalizer, data)
+					require.Equal(t, big.NewInt(60), supplyEsdt.Supply)
+					require.Equal(t, big.NewInt(0), supplyEsdt.Burned)
+					require.Equal(t, big.NewInt(60), supplyEsdt.Minted)
+				case 2:
+					supplyEsdt := getSupplyESDT(marshalizer, data)
+					require.Equal(t, big.NewInt(30), supplyEsdt.Supply)
+					require.Equal(t, big.NewInt(30), supplyEsdt.Burned)
+					require.Equal(t, big.NewInt(60), supplyEsdt.Minted)
+				}
+
+				_ = membDB.Put(key, data)
+				numTimesCalled++
+
+				return nil
+			}
+
+			return nil
+		},
+	}
+
+	suppliesProc, err := NewSuppliesProcessor(marshalizer, suppliesStorer, &storageStubs.StorerStub{})
+	require.Nil(t, err)
+
+	err = suppliesProc.ProcessLogs(6, logsCreate)
+	require.Nil(t, err)
+
+	err = suppliesProc.ProcessLogs(7, logsAddQuantity)
+	require.Nil(t, err)
+
+	err = suppliesProc.ProcessLogs(8, logsBurn)
+	require.Nil(t, err)
+
+	require.Equal(t, 3, numTimesCalled)
+}
+
+func getSupplyESDT(marshalizer marshal.Marshalizer, data []byte) SupplyESDT {
+	var supplyESDT SupplyESDT
+	_ = marshalizer.Unmarshal(&supplyESDT, data)
+
+	makePropertiesNotNil(&supplyESDT)
+	return supplyESDT
 }
 
 func TestSupplyESDT_GetSupply(t *testing.T) {

--- a/dblookupext/esdtSupply/logsProcessor.go
+++ b/dblookupext/esdtSupply/logsProcessor.go
@@ -163,7 +163,9 @@ func (lp *logsProcessor) updateTokenSupply(tokenSupply *SupplyESDT, valueFromEve
 	switch {
 	case isBurnOP:
 		tokenSupply.Burned.Add(tokenSupply.Burned, valueFromEvent)
-	case eventIdentifier == core.BuiltInFunctionESDTNFTAddQuantity || eventIdentifier == core.BuiltInFunctionESDTLocalMint:
+	case eventIdentifier == core.BuiltInFunctionESDTNFTAddQuantity ||
+		eventIdentifier == core.BuiltInFunctionESDTLocalMint ||
+		eventIdentifier == core.BuiltInFunctionESDTNFTCreate:
 		tokenSupply.Minted.Add(tokenSupply.Minted, valueFromEvent)
 	}
 


### PR DESCRIPTION
Fixed the situation when the initial quantity wasn't added as minted value as well for the ESDT supply endpoint 
+ added unit test to confirm the behaviour