### PR TITLE
Rename network/genesisnodes to network/genesis-nodes

### DIFF
--- a/api/groups/networkGroup.go
+++ b/api/groups/networkGroup.go
@@ -29,7 +29,7 @@ const (
 	directStakedInfoPath   = "/direct-staked-info"
 	delegatedInfoPath      = "/delegated-info"
 	ratingsPath            = "/ratings"
-	genesisNodesConfigPath = "/genesisnodes"
+	genesisNodesConfigPath = "/genesis-nodes"
 )
 
 // networkFacadeHandler defines the methods to be implemented by a facade for handling network requests

--- a/api/groups/networkGroup_test.go
+++ b/api/groups/networkGroup_test.go
@@ -502,7 +502,7 @@ func TestGetGenesisNodes(t *testing.T) {
 
 		ws := startWebServer(networkGroup, "network", getNetworkRoutesConfig())
 
-		req, _ := http.NewRequest("GET", "/network/genesisnodes", nil)
+		req, _ := http.NewRequest("GET", "/network/genesis-nodes", nil)
 		resp := httptest.NewRecorder()
 		ws.ServeHTTP(resp, req)
 
@@ -539,7 +539,7 @@ func TestGetGenesisNodes(t *testing.T) {
 
 		ws := startWebServer(networkGroup, "network", getNetworkRoutesConfig())
 
-		req, _ := http.NewRequest("GET", "/network/genesisnodes", nil)
+		req, _ := http.NewRequest("GET", "/network/genesis-nodes", nil)
 		resp := httptest.NewRecorder()
 		ws.ServeHTTP(resp, req)
 
@@ -566,7 +566,7 @@ func getNetworkRoutesConfig() config.ApiRoutesConfig {
 					{Name: "/direct-staked-info", Open: true},
 					{Name: "/delegated-info", Open: true},
 					{Name: "/esdt/supply/:token", Open: true},
-					{Name: "/genesisnodes", Open: true},
+					{Name: "/genesis-nodes", Open: true},
 				},
 			},
 		},

--- a/cmd/node/config/api.toml
+++ b/cmd/node/config/api.toml
@@ -115,8 +115,8 @@
         # /network/ratings will return metrics related to ratings config
         { Name = "/ratings", Open = true },
 
-        # /network/genesisnodes will return the genesis nodes public keys
-        { Name = "/genesisnodes", Open = true }
+        # /network/genesis-nodes will return the genesis nodes public keys
+        { Name = "/genesis-nodes", Open = true }
     ]
 
 [APIPackages.log]


### PR DESCRIPTION
Rename `network/genesisnodes` endpoint to `network/genesis-nodes`