### PR TITLE
process: add global shard stuck condition for chain recovery

### DIFF
--- a/factory/mock/blockTrackerStub.go
+++ b/factory/mock/blockTrackerStub.go
@@ -27,7 +27,7 @@ type BlockTrackerStub struct {
 	GetTrackedHeadersForAllShardsCalled                func() map[uint32][]data.HeaderHandler
 	GetTrackedHeadersWithNonceCalled                   func(shardID uint32, nonce uint64) ([]data.HeaderHandler, [][]byte)
 	IsShardStuckCalled                                 func(shardId uint32) bool
-	ShouldNotCreateMiniBlocksFromSelfCalled            func() bool
+	ShouldSkipMiniBlocksCreationFromSelfCalled         func() bool
 	RegisterCrossNotarizedHeadersHandlerCalled         func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedFromCrossHeadersHandlerCalled func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedHeadersHandlerCalled          func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
@@ -210,10 +210,10 @@ func (bts *BlockTrackerStub) IsShardStuck(shardId uint32) bool {
 	return false
 }
 
-// ShouldNotCreateMiniBlocksFromSelf -
-func (bts *BlockTrackerStub) ShouldNotCreateMiniBlocksFromSelf() bool {
-	if bts.ShouldNotCreateMiniBlocksFromSelfCalled != nil {
-		return bts.ShouldNotCreateMiniBlocksFromSelfCalled()
+// ShouldSkipMiniBlocksCreationFromSelf -
+func (bts *BlockTrackerStub) ShouldSkipMiniBlocksCreationFromSelf() bool {
+	if bts.ShouldSkipMiniBlocksCreationFromSelfCalled != nil {
+		return bts.ShouldSkipMiniBlocksCreationFromSelfCalled()
 	}
 
 	return false

--- a/factory/mock/blockTrackerStub.go
+++ b/factory/mock/blockTrackerStub.go
@@ -27,6 +27,7 @@ type BlockTrackerStub struct {
 	GetTrackedHeadersForAllShardsCalled                func() map[uint32][]data.HeaderHandler
 	GetTrackedHeadersWithNonceCalled                   func(shardID uint32, nonce uint64) ([]data.HeaderHandler, [][]byte)
 	IsShardStuckCalled                                 func(shardId uint32) bool
+	ShouldNotCreateMiniBlocksFromSelfCalled            func() bool
 	RegisterCrossNotarizedHeadersHandlerCalled         func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedFromCrossHeadersHandlerCalled func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedHeadersHandlerCalled          func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
@@ -204,6 +205,15 @@ func (bts *BlockTrackerStub) GetTrackedHeadersWithNonce(shardID uint32, nonce ui
 func (bts *BlockTrackerStub) IsShardStuck(shardId uint32) bool {
 	if bts.IsShardStuckCalled != nil {
 		return bts.IsShardStuckCalled(shardId)
+	}
+
+	return false
+}
+
+// ShouldNotCreateMiniBlocksFromSelf -
+func (bts *BlockTrackerStub) ShouldNotCreateMiniBlocksFromSelf() bool {
+	if bts.ShouldNotCreateMiniBlocksFromSelfCalled != nil {
+		return bts.ShouldNotCreateMiniBlocksFromSelfCalled()
 	}
 
 	return false

--- a/genesis/process/disabled/blockTracker.go
+++ b/genesis/process/disabled/blockTracker.go
@@ -9,8 +9,8 @@ func (b *BlockTracker) IsShardStuck(_ uint32) bool {
 	return false
 }
 
-// ShouldNotCreateMiniBlocksFromSelf returns false as this is a disabled implementation
-func (b *BlockTracker) ShouldNotCreateMiniBlocksFromSelf() bool {
+// ShouldSkipMiniBlocksCreationFromSelf returns false as this is a disabled implementation
+func (b *BlockTracker) ShouldSkipMiniBlocksCreationFromSelf() bool {
 	return false
 }
 

--- a/genesis/process/disabled/blockTracker.go
+++ b/genesis/process/disabled/blockTracker.go
@@ -9,6 +9,11 @@ func (b *BlockTracker) IsShardStuck(_ uint32) bool {
 	return false
 }
 
+// ShouldNotCreateMiniBlocksFromSelf returns false as this is a disabled implementation
+func (b *BlockTracker) ShouldNotCreateMiniBlocksFromSelf() bool {
+	return false
+}
+
 // IsInterfaceNil returns true if underlying object is nil
 func (b *BlockTracker) IsInterfaceNil() bool {
 	return b == nil

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ElrondNetwork/concurrent-map v0.1.3
 	github.com/ElrondNetwork/covalent-indexer-go v1.0.6
 	github.com/ElrondNetwork/elastic-indexer-go v1.1.37
-	github.com/ElrondNetwork/elrond-go-core v1.1.14
+	github.com/ElrondNetwork/elrond-go-core v1.1.15-0.20220316125754-b5ee1f265897
 	github.com/ElrondNetwork/elrond-go-crypto v1.0.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.5
 	github.com/ElrondNetwork/elrond-vm-common v1.2.12

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,9 @@ github.com/ElrondNetwork/elastic-indexer-go v1.1.37/go.mod h1:zLa7vRvTJXjGXZuOy0
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-core v1.1.6/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
-github.com/ElrondNetwork/elrond-go-core v1.1.14 h1:JKpeI+1US4FuE8NwN3dqe0HUTYKLQuYKvwbTqhGt334=
 github.com/ElrondNetwork/elrond-go-core v1.1.14/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
+github.com/ElrondNetwork/elrond-go-core v1.1.15-0.20220316125754-b5ee1f265897 h1:p+tvDVsgtC/zHzAy/BOS9dQjgrZP62fi7yOaU5st5Ag=
+github.com/ElrondNetwork/elrond-go-core v1.1.15-0.20220316125754-b5ee1f265897/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.0/go.mod h1:DGiR7/j1xv729Xg8SsjYaUzWXL5svMd44REXjWS/gAc=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.1 h1:xJUUshIZQ7h+rG7Art/9QHVyaPRV1wEjrxXYBdpmRlM=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.1/go.mod h1:uunsvweBrrhVojL8uiQSaTPsl3YIQ9iBqtYGM6xs4s0=

--- a/integrationTests/mock/blockTrackerStub.go
+++ b/integrationTests/mock/blockTrackerStub.go
@@ -28,7 +28,7 @@ type BlockTrackerStub struct {
 	GetTrackedHeadersForAllShardsCalled                func() map[uint32][]data.HeaderHandler
 	GetTrackedHeadersWithNonceCalled                   func(shardID uint32, nonce uint64) ([]data.HeaderHandler, [][]byte)
 	IsShardStuckCalled                                 func(shardId uint32) bool
-	ShouldNotCreateMiniBlocksFromSelfCalled            func() bool
+	ShouldSkipMiniBlocksCreationFromSelfCalled         func() bool
 	RegisterCrossNotarizedHeadersHandlerCalled         func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedFromCrossHeadersHandlerCalled func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedHeadersHandlerCalled          func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
@@ -211,10 +211,10 @@ func (bts *BlockTrackerStub) IsShardStuck(shardId uint32) bool {
 	return false
 }
 
-// ShouldNotCreateMiniBlocksFromSelf -
-func (bts *BlockTrackerStub) ShouldNotCreateMiniBlocksFromSelf() bool {
-	if bts.ShouldNotCreateMiniBlocksFromSelfCalled != nil {
-		return bts.ShouldNotCreateMiniBlocksFromSelfCalled()
+// ShouldSkipMiniBlocksCreationFromSelf -
+func (bts *BlockTrackerStub) ShouldSkipMiniBlocksCreationFromSelf() bool {
+	if bts.ShouldSkipMiniBlocksCreationFromSelfCalled != nil {
+		return bts.ShouldSkipMiniBlocksCreationFromSelfCalled()
 	}
 	return false
 }

--- a/integrationTests/mock/blockTrackerStub.go
+++ b/integrationTests/mock/blockTrackerStub.go
@@ -28,6 +28,7 @@ type BlockTrackerStub struct {
 	GetTrackedHeadersForAllShardsCalled                func() map[uint32][]data.HeaderHandler
 	GetTrackedHeadersWithNonceCalled                   func(shardID uint32, nonce uint64) ([]data.HeaderHandler, [][]byte)
 	IsShardStuckCalled                                 func(shardId uint32) bool
+	ShouldNotCreateMiniBlocksFromSelfCalled            func() bool
 	RegisterCrossNotarizedHeadersHandlerCalled         func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedFromCrossHeadersHandlerCalled func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedHeadersHandlerCalled          func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
@@ -207,6 +208,14 @@ func (bts *BlockTrackerStub) IsShardStuck(shardId uint32) bool {
 		return bts.IsShardStuckCalled(shardId)
 	}
 
+	return false
+}
+
+// ShouldNotCreateMiniBlocksFromSelf -
+func (bts *BlockTrackerStub) ShouldNotCreateMiniBlocksFromSelf() bool {
+	if bts.ShouldNotCreateMiniBlocksFromSelfCalled != nil {
+		return bts.ShouldNotCreateMiniBlocksFromSelfCalled()
+	}
 	return false
 }
 

--- a/node/mock/blockTrackerStub.go
+++ b/node/mock/blockTrackerStub.go
@@ -27,7 +27,7 @@ type BlockTrackerStub struct {
 	GetTrackedHeadersForAllShardsCalled                func() map[uint32][]data.HeaderHandler
 	GetTrackedHeadersWithNonceCalled                   func(shardID uint32, nonce uint64) ([]data.HeaderHandler, [][]byte)
 	IsShardStuckCalled                                 func(shardId uint32) bool
-	ShouldNotCreateMiniBlocksFromSelfCalled            func() bool
+	ShouldSkipMiniBlocksCreationFromSelfCalled         func() bool
 	RegisterCrossNotarizedHeadersHandlerCalled         func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedFromCrossHeadersHandlerCalled func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedHeadersHandlerCalled          func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
@@ -210,10 +210,10 @@ func (bts *BlockTrackerStub) IsShardStuck(shardId uint32) bool {
 	return false
 }
 
-// ShouldNotCreateMiniBlocksFromSelf -
-func (bts *BlockTrackerStub) ShouldNotCreateMiniBlocksFromSelf() bool {
-	if bts.ShouldNotCreateMiniBlocksFromSelfCalled != nil {
-		return bts.ShouldNotCreateMiniBlocksFromSelfCalled()
+// ShouldSkipMiniBlocksCreationFromSelf -
+func (bts *BlockTrackerStub) ShouldSkipMiniBlocksCreationFromSelf() bool {
+	if bts.ShouldSkipMiniBlocksCreationFromSelfCalled != nil {
+		return bts.ShouldSkipMiniBlocksCreationFromSelfCalled()
 	}
 
 	return false

--- a/node/mock/blockTrackerStub.go
+++ b/node/mock/blockTrackerStub.go
@@ -27,6 +27,7 @@ type BlockTrackerStub struct {
 	GetTrackedHeadersForAllShardsCalled                func() map[uint32][]data.HeaderHandler
 	GetTrackedHeadersWithNonceCalled                   func(shardID uint32, nonce uint64) ([]data.HeaderHandler, [][]byte)
 	IsShardStuckCalled                                 func(shardId uint32) bool
+	ShouldNotCreateMiniBlocksFromSelfCalled            func() bool
 	RegisterCrossNotarizedHeadersHandlerCalled         func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedFromCrossHeadersHandlerCalled func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedHeadersHandlerCalled          func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
@@ -204,6 +205,15 @@ func (bts *BlockTrackerStub) GetTrackedHeadersWithNonce(shardID uint32, nonce ui
 func (bts *BlockTrackerStub) IsShardStuck(shardId uint32) bool {
 	if bts.IsShardStuckCalled != nil {
 		return bts.IsShardStuckCalled(shardId)
+	}
+
+	return false
+}
+
+// ShouldNotCreateMiniBlocksFromSelf -
+func (bts *BlockTrackerStub) ShouldNotCreateMiniBlocksFromSelf() bool {
+	if bts.ShouldNotCreateMiniBlocksFromSelfCalled != nil {
+		return bts.ShouldNotCreateMiniBlocksFromSelfCalled()
 	}
 
 	return false

--- a/process/block/preprocess/interfaces.go
+++ b/process/block/preprocess/interfaces.go
@@ -23,7 +23,7 @@ type TxCache interface {
 // BlockTracker defines the functionality for node to track the blocks which are received from network
 type BlockTracker interface {
 	IsShardStuck(shardID uint32) bool
-	ShouldNotCreateMiniBlocksFromSelf() bool
+	ShouldSkipMiniBlocksCreationFromSelf() bool
 	IsInterfaceNil() bool
 }
 

--- a/process/block/preprocess/interfaces.go
+++ b/process/block/preprocess/interfaces.go
@@ -23,6 +23,7 @@ type TxCache interface {
 // BlockTracker defines the functionality for node to track the blocks which are received from network
 type BlockTracker interface {
 	IsShardStuck(shardID uint32) bool
+	ShouldNotCreateMiniBlocksFromSelf() bool
 	IsInterfaceNil() bool
 }
 

--- a/process/block/preprocess/transactions.go
+++ b/process/block/preprocess/transactions.go
@@ -1010,7 +1010,7 @@ func (txs *transactions) CreateAndProcessMiniBlocks(haveTime func() bool, random
 		"time [s]", elapsedTime,
 	)
 
-	if txs.blockTracker.ShouldNotCreateMiniBlocksFromSelf() {
+	if txs.blockTracker.ShouldSkipMiniBlocksCreationFromSelf() {
 		log.Debug("CreateAndProcessMiniBlocks global stuck")
 		return make(block.MiniBlockSlice, 0), nil
 	}

--- a/process/block/preprocess/transactions.go
+++ b/process/block/preprocess/transactions.go
@@ -777,7 +777,7 @@ func (txs *transactions) AddTransactions(txHandlers []data.TransactionHandler) {
 		senderShardID := txs.getShardFromAddress(tx.GetSndAddr())
 		receiverShardID := txs.getShardFromAddress(tx.GetRcvAddr())
 		txShardInfoToSet := &txShardInfo{senderShardID: senderShardID, receiverShardID: receiverShardID}
-		txHash, err:= core.CalculateHash(txs.marshalizer, txs.hasher, tx)
+		txHash, err := core.CalculateHash(txs.marshalizer, txs.hasher, tx)
 		if err != nil {
 			log.Warn("transactions.AddTransactions CalculateHash", "error", err.Error())
 			continue
@@ -1009,6 +1009,11 @@ func (txs *transactions) CreateAndProcessMiniBlocks(haveTime func() bool, random
 		"num txs", len(sortedTxs),
 		"time [s]", elapsedTime,
 	)
+
+	if txs.blockTracker.ShouldNotCreateMiniBlocksFromSelf() {
+		log.Debug("CreateAndProcessMiniBlocks global stuck")
+		return make(block.MiniBlockSlice, 0), nil
+	}
 
 	startTime = time.Now()
 	miniBlocks, remainingTxs, mapSCTxs, err := txs.createAndProcessMiniBlocksFromMe(

--- a/process/constants.go
+++ b/process/constants.go
@@ -88,6 +88,10 @@ const MinForkRound = uint64(0)
 // nonce before a shard is considered stuck
 const MaxMetaNoncesBehind = 15
 
+// MaxMetaNoncesBehindForGlobalStuck defines the maximum difference between the current meta block nonce and the processed
+// meta block nonce for any shard, where the chain is considered stuck and enters recovery
+const MaxMetaNoncesBehindForGlobalStuck = 30
+
 // MaxShardNoncesBehind defines the maximum difference between the current shard block nonce and the last notarized
 // shard block nonce by meta, before meta is considered stuck
 const MaxShardNoncesBehind = 15

--- a/process/interface.go
+++ b/process/interface.go
@@ -785,6 +785,7 @@ type BlockTracker interface {
 	GetTrackedHeadersForAllShards() map[uint32][]data.HeaderHandler
 	GetTrackedHeadersWithNonce(shardID uint32, nonce uint64) ([]data.HeaderHandler, [][]byte)
 	IsShardStuck(shardID uint32) bool
+	ShouldNotCreateMiniBlocksFromSelf() bool
 	RegisterCrossNotarizedHeadersHandler(func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedFromCrossHeadersHandler(func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedHeadersHandler(func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))

--- a/process/interface.go
+++ b/process/interface.go
@@ -785,7 +785,7 @@ type BlockTracker interface {
 	GetTrackedHeadersForAllShards() map[uint32][]data.HeaderHandler
 	GetTrackedHeadersWithNonce(shardID uint32, nonce uint64) ([]data.HeaderHandler, [][]byte)
 	IsShardStuck(shardID uint32) bool
-	ShouldNotCreateMiniBlocksFromSelf() bool
+	ShouldSkipMiniBlocksCreationFromSelf() bool
 	RegisterCrossNotarizedHeadersHandler(func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedFromCrossHeadersHandler(func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedHeadersHandler(func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))

--- a/process/mock/blockTrackerMock.go
+++ b/process/mock/blockTrackerMock.go
@@ -40,7 +40,7 @@ type BlockTrackerMock struct {
 	GetTrackedHeadersCalled                            func(shardID uint32) ([]data.HeaderHandler, [][]byte)
 	GetTrackedHeadersForAllShardsCalled                func() map[uint32][]data.HeaderHandler
 	GetTrackedHeadersWithNonceCalled                   func(shardID uint32, nonce uint64) ([]data.HeaderHandler, [][]byte)
-	ShouldNotCreateMiniBlocksFromSelfCalled            func() bool
+	ShouldSkipMiniBlocksCreationFromSelfCalled         func() bool
 	IsShardStuckCalled                                 func(shardId uint32) bool
 	RegisterCrossNotarizedHeadersHandlerCalled         func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedFromCrossHeadersHandlerCalled func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
@@ -453,10 +453,10 @@ func (btm *BlockTrackerMock) IsShardStuck(shardId uint32) bool {
 	return false
 }
 
-// ShouldNotCreateMiniBlocksFromSelf -
-func (btm *BlockTrackerMock) ShouldNotCreateMiniBlocksFromSelf() bool {
-	if btm.ShouldNotCreateMiniBlocksFromSelfCalled != nil {
-		return btm.ShouldNotCreateMiniBlocksFromSelfCalled()
+// ShouldSkipMiniBlocksCreationFromSelf -
+func (btm *BlockTrackerMock) ShouldSkipMiniBlocksCreationFromSelf() bool {
+	if btm.ShouldSkipMiniBlocksCreationFromSelfCalled != nil {
+		return btm.ShouldSkipMiniBlocksCreationFromSelfCalled()
 	}
 
 	return false

--- a/process/mock/blockTrackerMock.go
+++ b/process/mock/blockTrackerMock.go
@@ -40,6 +40,7 @@ type BlockTrackerMock struct {
 	GetTrackedHeadersCalled                            func(shardID uint32) ([]data.HeaderHandler, [][]byte)
 	GetTrackedHeadersForAllShardsCalled                func() map[uint32][]data.HeaderHandler
 	GetTrackedHeadersWithNonceCalled                   func(shardID uint32, nonce uint64) ([]data.HeaderHandler, [][]byte)
+	ShouldNotCreateMiniBlocksFromSelfCalled            func() bool
 	IsShardStuckCalled                                 func(shardId uint32) bool
 	RegisterCrossNotarizedHeadersHandlerCalled         func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
 	RegisterSelfNotarizedFromCrossHeadersHandlerCalled func(handler func(shardID uint32, headers []data.HeaderHandler, headersHashes [][]byte))
@@ -447,6 +448,15 @@ func (btm *BlockTrackerMock) GetTrackedHeadersWithNonce(shardID uint32, nonce ui
 func (btm *BlockTrackerMock) IsShardStuck(shardId uint32) bool {
 	if btm.IsShardStuckCalled != nil {
 		return btm.IsShardStuckCalled(shardId)
+	}
+
+	return false
+}
+
+// ShouldNotCreateMiniBlocksFromSelf -
+func (btm *BlockTrackerMock) ShouldNotCreateMiniBlocksFromSelf() bool {
+	if btm.ShouldNotCreateMiniBlocksFromSelfCalled != nil {
+		return btm.ShouldNotCreateMiniBlocksFromSelfCalled()
 	}
 
 	return false

--- a/process/track/baseBlockTrack.go
+++ b/process/track/baseBlockTrack.go
@@ -607,6 +607,23 @@ func (bbt *baseBlockTrack) GetTrackedHeadersWithNonce(shardID uint32, nonce uint
 	return headers, headersHashes
 }
 
+// ShouldNotCreateMiniBlocksFromSelf returns true if there are many pending miniBlocks and all shards
+// should stop producing miniBlocks so that the chain gets the chance to recover
+func (bbt *baseBlockTrack) ShouldNotCreateMiniBlocksFromSelf() bool {
+	if bbt.shardCoordinator.SelfId() == core.MetachainShardId {
+		return false
+	}
+
+	shards := bbt.shardCoordinator.NumberOfShards()
+	for shardID := uint32(0); shardID < shards; shardID++ {
+		if bbt.isShardBehind(shardID, process.MaxMetaNoncesBehindForGlobalStuck) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IsShardStuck returns true if the given shard is stuck
 func (bbt *baseBlockTrack) IsShardStuck(shardID uint32) bool {
 	if bbt.shardCoordinator.SelfId() == core.MetachainShardId {
@@ -617,34 +634,56 @@ func (bbt *baseBlockTrack) IsShardStuck(shardID uint32) bool {
 		return bbt.isMetaStuck()
 	}
 
-	numPendingMiniBlocks := uint64(bbt.blockBalancer.GetNumPendingMiniBlocks(shardID))
-	lastShardProcessedMetaNonce := bbt.blockBalancer.GetLastShardProcessedMetaNonce(shardID)
-
-	isMetaDifferenceTooLarge := false
-	shouldCheckLastMetaNonceProcessed := lastShardProcessedMetaNonce > 0
-	if shouldCheckLastMetaNonceProcessed {
-		metaHeaders, _ := bbt.GetTrackedHeaders(core.MetachainShardId)
-		numMetaHeaders := len(metaHeaders)
-		if numMetaHeaders > 0 {
-			lastMetaHeader := metaHeaders[numMetaHeaders-1]
-			metaDiff := lastMetaHeader.GetNonce() - lastShardProcessedMetaNonce
-			isMetaDifferenceTooLarge = metaDiff > process.MaxMetaNoncesBehind
-		}
-	}
-
-	maxNumMiniBlocksForSameReceiverInOneBlock := bbt.feeHandler.MaxGasLimitPerBlockForSafeCrossShard() / bbt.feeHandler.MaxGasLimitPerMiniBlockForSafeCrossShard()
-	maxNumPendingMiniBlocks := maxNumMiniBlocksForSameReceiverInOneBlock * process.MaxMetaNoncesBehind * uint64(bbt.shardCoordinator.NumberOfShards())
-	isShardStuck := numPendingMiniBlocks >= maxNumPendingMiniBlocks || isMetaDifferenceTooLarge
-	return isShardStuck
+	return bbt.isShardBehind(shardID, process.MaxMetaNoncesBehind)
 }
 
-func (bbt *baseBlockTrack) isMetaStuck() bool {
+func (bbt *baseBlockTrack) isShardBehind(shardID uint32, maxMetaNoncesBehind uint64) bool {
+	metaDiff := bbt.computeMetaBlocksDifferenceForShard(shardID)
+	if metaDiff > int64(maxMetaNoncesBehind) {
+		return true
+	}
+
+	return bbt.tooManyPendingMiniBlocks(shardID, maxMetaNoncesBehind)
+}
+
+func (bbt *baseBlockTrack) tooManyPendingMiniBlocks(shardID uint32, maxMetaNoncesBehind uint64) bool {
+	maxNumPendingMiniBlocks := bbt.computeMaxPendingMiniBlocks(maxMetaNoncesBehind)
+	numPendingMiniBlocks := uint64(bbt.blockBalancer.GetNumPendingMiniBlocks(shardID))
+	return numPendingMiniBlocks >= maxNumPendingMiniBlocks
+}
+
+func (bbt *baseBlockTrack) computeMaxPendingMiniBlocks(maxMetaNoncesBehind uint64) uint64 {
+	maxNumMiniBlocksForSameReceiverInOneBlock := bbt.feeHandler.MaxGasLimitPerBlockForSafeCrossShard() / bbt.feeHandler.MaxGasLimitPerMiniBlockForSafeCrossShard()
+	maxNumPendingMiniBlocks := maxNumMiniBlocksForSameReceiverInOneBlock * maxMetaNoncesBehind * uint64(bbt.shardCoordinator.NumberOfShards())
+
+	return maxNumPendingMiniBlocks
+}
+
+func (bbt *baseBlockTrack) computeMetaBlocksDifferenceForShard(shardID uint32) int64 {
+	var metaDiff int64
+	lastShardProcessedMetaNonce := bbt.blockBalancer.GetLastShardProcessedMetaNonce(shardID)
+
+	if lastShardProcessedMetaNonce == 0 {
+		return 0
+	}
+
+	metaHeaders, _ := bbt.GetTrackedHeaders(core.MetachainShardId)
+	numMetaHeaders := len(metaHeaders)
+	if numMetaHeaders > 0 {
+		lastMetaHeader := metaHeaders[numMetaHeaders-1]
+		metaDiff = int64(lastMetaHeader.GetNonce()) - int64(lastShardProcessedMetaNonce)
+	}
+
+	return metaDiff
+}
+
+func (bbt *baseBlockTrack) computeMetaBlocksBehind() int64 {
 	selfHdrNotarizedByItself, _, err := bbt.GetLastSelfNotarizedHeader(bbt.shardCoordinator.SelfId())
 	if err != nil {
 		log.Debug("isMetaStuck.GetLastSelfNotarizedHeader",
 			"shard", bbt.shardCoordinator.SelfId(),
 			"error", err.Error())
-		return false
+		return 0
 	}
 
 	selfHdrNotarizedByMeta, _, err := bbt.GetLastSelfNotarizedHeader(core.MetachainShardId)
@@ -652,10 +691,15 @@ func (bbt *baseBlockTrack) isMetaStuck() bool {
 		log.Debug("isMetaStuck.GetLastSelfNotarizedHeader",
 			"shard", core.MetachainShardId,
 			"error", err.Error())
-		return false
+		return 0
 	}
 
-	isMetaStuck := selfHdrNotarizedByItself.GetNonce() > selfHdrNotarizedByMeta.GetNonce()+process.MaxShardNoncesBehind
+	return int64(selfHdrNotarizedByItself.GetNonce()) - int64(selfHdrNotarizedByMeta.GetNonce())
+}
+
+func (bbt *baseBlockTrack) isMetaStuck() bool {
+	noncesBehind := bbt.computeMetaBlocksBehind()
+	isMetaStuck := noncesBehind > process.MaxShardNoncesBehind
 	return isMetaStuck
 }
 

--- a/process/track/baseBlockTrack.go
+++ b/process/track/baseBlockTrack.go
@@ -607,9 +607,9 @@ func (bbt *baseBlockTrack) GetTrackedHeadersWithNonce(shardID uint32, nonce uint
 	return headers, headersHashes
 }
 
-// ShouldNotCreateMiniBlocksFromSelf returns true if there are many pending miniBlocks and all shards
+// ShouldSkipMiniBlocksCreationFromSelf returns true if there are many pending miniBlocks and all shards
 // should stop producing miniBlocks so that the chain gets the chance to recover
-func (bbt *baseBlockTrack) ShouldNotCreateMiniBlocksFromSelf() bool {
+func (bbt *baseBlockTrack) ShouldSkipMiniBlocksCreationFromSelf() bool {
 	if bbt.shardCoordinator.SelfId() == core.MetachainShardId {
 		return false
 	}

--- a/process/track/shardBlockTrack.go
+++ b/process/track/shardBlockTrack.go
@@ -163,6 +163,6 @@ func (sbt *shardBlockTrack) ComputeCrossInfo(headers []data.HeaderHandler) {
 			"pending miniblocks", sbt.blockBalancer.GetNumPendingMiniBlocks(shardID),
 			"last meta nonce processed", sbt.blockBalancer.GetLastShardProcessedMetaNonce(shardID),
 			"shard is stuck", sbt.IsShardStuck(shardID),
-			"global chain stuck", sbt.ShouldNotCreateMiniBlocksFromSelf())
+			"global chain stuck", sbt.ShouldSkipMiniBlocksCreationFromSelf())
 	}
 }

--- a/process/track/shardBlockTrack.go
+++ b/process/track/shardBlockTrack.go
@@ -161,6 +161,8 @@ func (sbt *shardBlockTrack) ComputeCrossInfo(headers []data.HeaderHandler) {
 		log.Debug("cross info",
 			"shard", shardID,
 			"pending miniblocks", sbt.blockBalancer.GetNumPendingMiniBlocks(shardID),
-			"last meta nonce processed", sbt.blockBalancer.GetLastShardProcessedMetaNonce(shardID))
+			"last meta nonce processed", sbt.blockBalancer.GetLastShardProcessedMetaNonce(shardID),
+			"shard is stuck", sbt.IsShardStuck(shardID),
+			"global chain stuck", sbt.ShouldNotCreateMiniBlocksFromSelf())
 	}
 }

--- a/testscommon/headerHandlerStub.go
+++ b/testscommon/headerHandlerStub.go
@@ -24,6 +24,8 @@ type HeaderHandlerStub struct {
 	CheckChainIDCalled                     func(reference []byte) error
 	GetReservedCalled                      func() []byte
 	IsStartOfEpochBlockCalled              func() bool
+	HasScheduledMiniBlocksCalled           func() bool
+	GetNonceCalled                         func() uint64
 }
 
 // GetAccumulatedFees -
@@ -77,6 +79,9 @@ func (hhs *HeaderHandlerStub) GetShardID() uint32 {
 
 // GetNonce -
 func (hhs *HeaderHandlerStub) GetNonce() uint64 {
+	if hhs.GetNonceCalled != nil {
+		return hhs.GetNonceCalled()
+	}
 	return 1
 }
 
@@ -352,4 +357,12 @@ func (hhs *HeaderHandlerStub) HasScheduledSupport() bool {
 // MapMiniBlockHashesToShards -
 func (hhs *HeaderHandlerStub) MapMiniBlockHashesToShards() map[string]uint32 {
 	panic("implement me")
+}
+
+// HasScheduledMiniBlocks -
+func (hhs *HeaderHandlerStub) HasScheduledMiniBlocks() bool {
+	if hhs.HasScheduledMiniBlocksCalled != nil {
+		return hhs.HasScheduledMiniBlocksCalled()
+	}
+	return false
 }


### PR DESCRIPTION
This PR adds another layer of protection for stuck shard extreme scenarios.
In case there are a lot of cross shard transactions for one shard, the previous condition was not sufficient to allow the shard to catch up with processing the metachain blocks. 
To ensure the recovery, another condition was added to stop all shard originating transactions while the pending miniblocks or delta metachain block nonces are above a new defined threshold.