### PR TITLE
Miniblocks cache size tweak

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -402,7 +402,7 @@
 
 [TxBlockBodyDataPool]
     Name = "TxBlockBodyDataPool"
-    Capacity = 1000
+    Capacity = 100000
     Type = "SizeLRU"
     SizeInBytes = 314572800 #300MB
 

--- a/process/constants.go
+++ b/process/constants.go
@@ -113,10 +113,12 @@ const MaxNumOfTxsToSelect = 30000
 const MaxGasBandwidthPerBatchPerSender = 5000000
 
 // MaxRoundsToKeepUnprocessedMiniBlocks defines the maximum number of rounds for which unprocessed miniblocks are kept in pool
-const MaxRoundsToKeepUnprocessedMiniBlocks = 100
+// TODO extract this in configs (EN-11896)
+const MaxRoundsToKeepUnprocessedMiniBlocks = 300
 
 // MaxRoundsToKeepUnprocessedTransactions defines the maximum number of rounds for which unprocessed transactions are kept in pool
-const MaxRoundsToKeepUnprocessedTransactions = 100
+// TODO extract this in configs (EN-11896)
+const MaxRoundsToKeepUnprocessedTransactions = 300
 
 // MaxHeadersToWhitelistInAdvance defines the maximum number of headers whose miniblocks will be whitelisted in advance
 const MaxHeadersToWhitelistInAdvance = 300


### PR DESCRIPTION
- miniblocks cache size tweak
- higher timeout duration for transactions & miniblocks before they are cleaned from pool