### PR TITLE
Bulk request size parameter elastic indexer

### DIFF
--- a/cmd/node/config/external.toml
+++ b/cmd/node/config/external.toml
@@ -4,15 +4,16 @@
     #the node might loose rating (even facing penalties) due to the fact that
     #the indexer is called synchronously and might block due to external causes.
     #Strongly suggested to activate this on a regular observer node.
-    Enabled           = false
-    IndexerCacheSize  = 0
-    URL               = "http://localhost:9200"
-    UseKibana         = false
-    Username          = ""
-    Password          = ""
+    Enabled            = false
+    IndexerCacheSize   = 0
+    BulkRequestMaxSize = 4000000 # 4MB
+    URL                = "http://localhost:9200"
+    UseKibana          = false
+    Username           = ""
+    Password           = ""
     # EnabledIndexes represents a slice of indexes that will be enabled for indexing. Full list is:
     # ["rating", "transactions", "blocks", "validators", "miniblocks", "rounds", "accounts", "accountshistory", "receipts", "scresults", "accountsesdt", "accountsesdthistory", "epochinfo", "scdeploys", "tokens", "tags", "logs", "delegators", "operations"]
-    EnabledIndexes    = ["rating", "transactions", "blocks", "validators", "miniblocks", "rounds", "accounts", "accountshistory", "receipts", "scresults", "accountsesdt", "accountsesdthistory", "epochinfo", "scdeploys", "tokens", "tags", "logs", "delegators", "operations"]
+    EnabledIndexes     = ["rating", "transactions", "blocks", "validators", "miniblocks", "rounds", "accounts", "accountshistory", "receipts", "scresults", "accountsesdt", "accountsesdthistory", "epochinfo", "scdeploys", "tokens", "tags", "logs", "delegators", "operations"]
 
 # EventNotifierConnector defines settings needed to configure and launch the event notifier component
 [EventNotifierConnector]

--- a/config/externalConfig.go
+++ b/config/externalConfig.go
@@ -9,13 +9,14 @@ type ExternalConfig struct {
 
 // ElasticSearchConfig will hold the configuration for the elastic search
 type ElasticSearchConfig struct {
-	Enabled          bool
-	IndexerCacheSize int
-	URL              string
-	UseKibana        bool
-	Username         string
-	Password         string
-	EnabledIndexes   []string
+	Enabled            bool
+	IndexerCacheSize   int
+	BulkRequestMaxSize int
+	URL                string
+	UseKibana          bool
+	Username           string
+	Password           string
+	EnabledIndexes     []string
 }
 
 // EventNotifierConfig will hold the configuration for the events notifier driver

--- a/factory/statusComponents.go
+++ b/factory/statusComponents.go
@@ -222,6 +222,7 @@ func (scf *statusComponentsFactory) makeElasticIndexerArgs() *indexerFactory.Arg
 	return &indexerFactory.ArgsIndexerFactory{
 		Enabled:                  elasticSearchConfig.Enabled,
 		IndexerCacheSize:         elasticSearchConfig.IndexerCacheSize,
+		BulkRequestMaxSize:       elasticSearchConfig.BulkRequestMaxSize,
 		ShardCoordinator:         scf.shardCoordinator,
 		Url:                      elasticSearchConfig.URL,
 		UserName:                 elasticSearchConfig.Username,

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ElrondNetwork/arwen-wasm-vm/v1_4 v1.4.34-rc7
 	github.com/ElrondNetwork/concurrent-map v0.1.3
 	github.com/ElrondNetwork/covalent-indexer-go v1.0.6
-	github.com/ElrondNetwork/elastic-indexer-go v1.2.15
+	github.com/ElrondNetwork/elastic-indexer-go v1.2.16-0.20220321113307-9b755f6fd873
 	github.com/ElrondNetwork/elrond-go-core v1.1.14
 	github.com/ElrondNetwork/elrond-go-crypto v1.0.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/ElrondNetwork/concurrent-map v0.1.3 h1:j2LtPrNJuerannC1cQDE79STvi/P04
 github.com/ElrondNetwork/concurrent-map v0.1.3/go.mod h1:3XwSwn4JHI0lrKxWLZvtp53Emr8BXYTmNQGwcukHJEE=
 github.com/ElrondNetwork/covalent-indexer-go v1.0.6 h1:+LNKItUc+Pb7WuTbil3VuiLMmdQ1AY7lBJM476PtVNE=
 github.com/ElrondNetwork/covalent-indexer-go v1.0.6/go.mod h1:j3h2g96vqhJAuj3aEX2PWhomae2/o7YfXGEfweNXEeQ=
-github.com/ElrondNetwork/elastic-indexer-go v1.2.15 h1:beLJ0qx2PonDefYDG6pcEQYJTFDeMEiJ06GslKSOmnM=
-github.com/ElrondNetwork/elastic-indexer-go v1.2.15/go.mod h1:jrzgNlt92qgq+GAW5p+ZgW2Rkzama+Ufr9sQ8KDgZfk=
+github.com/ElrondNetwork/elastic-indexer-go v1.2.16-0.20220321113307-9b755f6fd873 h1:K9TzesaROzEb1+mtyBPpPuF49Zs8LdOmBtm5fOJpIA8=
+github.com/ElrondNetwork/elastic-indexer-go v1.2.16-0.20220321113307-9b755f6fd873/go.mod h1:jrzgNlt92qgq+GAW5p+ZgW2Rkzama+Ufr9sQ8KDgZfk=
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-core v1.1.6/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=


### PR DESCRIPTION
- Added an extra parameter in the `external.toml` config file in order to can configure the maximum size of an indexer bulk request.
- We need this parameter in order to can increase the indexing speed ( instead of doing multiple small bulk requests we will do fewer requests but bigger.