### PR TITLE
Fix for vm query api logs

### DIFF
--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -490,12 +490,12 @@ func (nf *nodeFacade) convertVmOutputToApiResponse(input *vmcommon.VMOutput) *vm
 			logAddress = ""
 		}
 
-		logs[i] = &vm.LogEntryApi{
+		logs = append(logs, &vm.LogEntryApi{
 			Identifier: originalLog.Identifier,
 			Address:    logAddress,
 			Topics:     originalLog.Topics,
 			Data:       originalLog.Data,
-		}
+		})
 	}
 
 	return &vm.VMOutputApi{


### PR DESCRIPTION
fixed the situation when VM queries that generate logs didn't return anything + added unit test that covers the entire conversion function