### PR TITLE
Fix partial mini blocks execution

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.45.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -36,7 +36,7 @@
     VersionsByEpochs = [
         { StartEpoch = 0, Version = "*" },
         # The value of StartEpoch parameter for version 2 should be the same with the ScheduledMiniBlocksEnableEpoch flag from enableEpoch.toml file
-        { StartEpoch = 2, Version = "2" },
+        { StartEpoch = 1, Version = "2" },
     ]
     [Versions.Cache]
         Name = "VersionsCache"
@@ -498,6 +498,7 @@
 [TrieSyncStorage]
     Capacity = 300000
     SizeInBytes = 104857600 #100MB
+    EnableDB = false
     [TrieSyncStorage.DB]
         FilePath = "TrieSyncStorageDB"
         Type = "LvlDBSerial"

--- a/cmd/node/config/economics.toml
+++ b/cmd/node/config/economics.toml
@@ -40,8 +40,7 @@
 [FeeSettings]
     GasLimitSettings = [
         {EnableEpoch = 0, MaxGasLimitPerBlock = "1500000000", MaxGasLimitPerMiniBlock = "1500000000", MaxGasLimitPerMetaBlock = "15000000000", MaxGasLimitPerMetaMiniBlock = "15000000000", MaxGasLimitPerTx = "1500000000", MinGasLimit = "50000"},
-        {EnableEpoch = 1, MaxGasLimitPerBlock = "1500000000", MaxGasLimitPerMiniBlock = "600000000", MaxGasLimitPerMetaBlock = "15000000000", MaxGasLimitPerMetaMiniBlock = "600000000", MaxGasLimitPerTx = "600000000", MinGasLimit = "50000"},
-        {EnableEpoch = 2, MaxGasLimitPerBlock = "1500000000", MaxGasLimitPerMiniBlock = "250000000", MaxGasLimitPerMetaBlock = "15000000000", MaxGasLimitPerMetaMiniBlock = "250000000", MaxGasLimitPerTx = "600000000", MinGasLimit = "50000"},
+        {EnableEpoch = 1, MaxGasLimitPerBlock = "1500000000", MaxGasLimitPerMiniBlock = "250000000", MaxGasLimitPerMetaBlock = "15000000000", MaxGasLimitPerMetaMiniBlock = "250000000", MaxGasLimitPerTx = "600000000", MinGasLimit = "50000"},
     ]
     MinGasPrice             = "1000000000" #will yield min tx fee of 0.00005 eGLD
     GasPriceModifier        = 0.01

--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -145,50 +145,50 @@
     RemoveNonUpdatedStorageEnableEpoch = 1
 
     # OptimizeNFTStoreEnableEpoch represents the epoch when optimizations on NFT metadata store and send are enabled
-    OptimizeNFTStoreEnableEpoch = 3
+    OptimizeNFTStoreEnableEpoch = 1
 
     # CreateNFTThroughExecByCallerEnableEpoch represents the epoch when nft creation through execution on destination by caller is enabled
-    CreateNFTThroughExecByCallerEnableEpoch = 3
+    CreateNFTThroughExecByCallerEnableEpoch = 1
 
     # StopDecreasingValidatorRatingWhenStuckEnableEpoch represents the epoch when we should stop decreasing validator's rating if, for instance, a shard gets stuck
-    StopDecreasingValidatorRatingWhenStuckEnableEpoch = 2
+    StopDecreasingValidatorRatingWhenStuckEnableEpoch = 1
 
     # FrontRunningProtectionEnableEpoch represents the epoch when the first version of protection against front running is enabled
-    FrontRunningProtectionEnableEpoch = 4
+    FrontRunningProtectionEnableEpoch = 1
 
     # DisableOldTrieStorageEpoch represents the epoch when the old trie storage implementation will be disabled
-    DisableOldTrieStorageEpoch = 4
+    DisableOldTrieStorageEpoch = 2
 
     # IsPayableBySCEnableEpoch represents the epoch when a new flag isPayable by SC is enabled
-    IsPayableBySCEnableEpoch = 3
+    IsPayableBySCEnableEpoch = 1
 
     # CleanUpInformativeSCRsEnableEpoch represents the epoch when the informative-only scrs are cleaned from miniblocks and logs are created from them
-    CleanUpInformativeSCRsEnableEpoch = 3
+    CleanUpInformativeSCRsEnableEpoch = 1
 
     # StorageAPICostOptimizationEnableEpoch represents the epoch when new storage helper functions are enabled and cost is reduced in Arwen
-    StorageAPICostOptimizationEnableEpoch = 3
+    StorageAPICostOptimizationEnableEpoch = 1
 
     # TransformToMultiShardCreateEnableEpoch represents the epoch when the new function on esdt system sc is enabled to transfer create role into multishard
-    TransformToMultiShardCreateEnableEpoch = 3
+    TransformToMultiShardCreateEnableEpoch = 1
 
     # ESDTRegisterAndSetAllRolesEnableEpoch represents the epoch when new function to register tickerID and set all roles is enabled
-    ESDTRegisterAndSetAllRolesEnableEpoch = 3
+    ESDTRegisterAndSetAllRolesEnableEpoch = 1
 
     # ScheduledMiniBlocksEnableEpoch represents the epoch when scheduled mini blocks would be created if needed
-    ScheduledMiniBlocksEnableEpoch = 2
+    ScheduledMiniBlocksEnableEpoch = 1
 
     # CorrectJailedNotUnstakedEpoch represents the epoch when the jailed validators will also be unstaked if the queue is empty
-    CorrectJailedNotUnstakedEmptyQueueEpoch = 2
+    CorrectJailedNotUnstakedEmptyQueueEpoch = 1
 
     # DoNotReturnOldBlockInBlockchainHookEnableEpoch represents the epoch when the fetch old block operation is
     # disabled in the blockchain hook component
-    DoNotReturnOldBlockInBlockchainHookEnableEpoch = 2
+    DoNotReturnOldBlockInBlockchainHookEnableEpoch = 1
 
     # AddFailedRelayedTxToInvalidMBsDisableEpoch represents the epoch when adding the failed relayed txs to invalid miniblocks is disabled
-    AddFailedRelayedTxToInvalidMBsDisableEpoch = 2
+    AddFailedRelayedTxToInvalidMBsDisableEpoch = 1
 
     # SCRSizeInvariantOnBuiltInResultEnableEpoch represents the epoch when scr size invariant on built in result is enabled
-    SCRSizeInvariantOnBuiltInResultEnableEpoch = 2
+    SCRSizeInvariantOnBuiltInResultEnableEpoch = 1
 
    	# FailExecutionOnEveryAPIErrorEnableEpoch represent the epoch when new protection in VM is enabled to fail all wrong API calls
    	FailExecutionOnEveryAPIErrorEnableEpoch = 3
@@ -205,6 +205,5 @@
 [GasSchedule]
     GasScheduleByEpochs = [
         { StartEpoch = 0, FileName = "gasScheduleV1.toml" },
-        { StartEpoch = 1, FileName = "gasScheduleV5.toml" },
-        { StartEpoch = 3, FileName = "gasScheduleV6.toml" },
+        { StartEpoch = 1, FileName = "gasScheduleV6.toml" },
     ]

--- a/config/config.go
+++ b/config/config.go
@@ -35,9 +35,10 @@ type StorageConfig struct {
 
 // TrieSyncStorageConfig will map trie sync storage configuration
 type TrieSyncStorageConfig struct {
-	DB          DBConfig
 	Capacity    uint32
 	SizeInBytes uint64
+	EnableDB    bool
+	DB          DBConfig
 }
 
 // PubkeyConfig will map the public key configuration

--- a/dataRetriever/factory/dataPoolFactory_test.go
+++ b/dataRetriever/factory/dataPoolFactory_test.go
@@ -105,6 +105,7 @@ func TestNewDataPoolFromConfig_BadConfigShouldErr(t *testing.T) {
 	require.True(t, strings.Contains(err.Error(), "the cache for the trie nodes"))
 
 	args = getGoodArgs()
+	args.Config.TrieSyncStorage.EnableDB = true
 	args.Config.TrieSyncStorage.DB.Type = "invalid DB type"
 	holder, err = NewDataPoolFromConfig(args)
 	require.Nil(t, holder)

--- a/epochStart/bootstrap/shardStorageHandler_test.go
+++ b/epochStart/bootstrap/shardStorageHandler_test.go
@@ -120,7 +120,7 @@ func TestShardStorageHandler_SaveDataToStorage(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func Test_getNewPendingMiniBlockHeadersForDst(t *testing.T) {
+func Test_getMiniBlockHeadersForDest(t *testing.T) {
 	t.Parallel()
 
 	hash1 := []byte("hash1")
@@ -144,7 +144,7 @@ func Test_getNewPendingMiniBlockHeadersForDst(t *testing.T) {
 		},
 	}
 
-	shardMbHeaders := getNewPendingMiniBlockHeadersForDest(metablock, 0)
+	shardMbHeaders := getMiniBlockHeadersForDest(metablock, 0)
 	assert.Equal(t, shardMbHeaders[string(hash1)], shardMiniBlockHeader)
 	assert.NotNil(t, shardMbHeaders[string(hash2)])
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ElrondNetwork/arwen-wasm-vm/v1_4 v1.4.45
 	github.com/ElrondNetwork/concurrent-map v0.1.3
 	github.com/ElrondNetwork/covalent-indexer-go v1.0.6
-	github.com/ElrondNetwork/elastic-indexer-go v1.1.34
+	github.com/ElrondNetwork/elastic-indexer-go v1.1.39
 	github.com/ElrondNetwork/elrond-go-core v1.1.15-0.20220324203250-7056b6a42bd9
 	github.com/ElrondNetwork/elrond-go-crypto v1.0.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/ElrondNetwork/concurrent-map v0.1.3 h1:j2LtPrNJuerannC1cQDE79STvi/P04
 github.com/ElrondNetwork/concurrent-map v0.1.3/go.mod h1:3XwSwn4JHI0lrKxWLZvtp53Emr8BXYTmNQGwcukHJEE=
 github.com/ElrondNetwork/covalent-indexer-go v1.0.6 h1:+LNKItUc+Pb7WuTbil3VuiLMmdQ1AY7lBJM476PtVNE=
 github.com/ElrondNetwork/covalent-indexer-go v1.0.6/go.mod h1:j3h2g96vqhJAuj3aEX2PWhomae2/o7YfXGEfweNXEeQ=
-github.com/ElrondNetwork/elastic-indexer-go v1.1.34 h1:oVYVGTfLnFKA0buh6oMbbl36fCy33PFQEPcj6RlkHo4=
-github.com/ElrondNetwork/elastic-indexer-go v1.1.34/go.mod h1:2XJCGXNCOv9MIhbZeGNtXCiOAoZwTAjH16MVA+5Alj8=
+github.com/ElrondNetwork/elastic-indexer-go v1.1.39 h1:YKkj9ztASxS28C3JEpzvV7N/tua3Pnbijph9W+EcZ+c=
+github.com/ElrondNetwork/elastic-indexer-go v1.1.39/go.mod h1:zLa7vRvTJXjGXZuOy0BId3v+fvn5LSibOC2BeTsCqvs=
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-core v1.1.6/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=

--- a/process/block/preprocess/miniBlockBuilder.go
+++ b/process/block/preprocess/miniBlockBuilder.go
@@ -393,7 +393,7 @@ func (mbb *miniBlocksBuilder) handleCrossShardScCallOrSpecialTx() {
 		mbb.stats.firstCrossShardScCallOrSpecialTxFound = true
 		mbb.blockSizeComputation.AddNumMiniBlocks(1)
 	}
-	//we need to increment this as to account for the corresponding SCR hash
+	// we need to increment this as to account for the corresponding SCR hash
 	mbb.blockSizeComputation.AddNumTxs(common.AdditionalScrForEachScCallOrSpecialTx)
 	mbb.stats.numCrossShardSCCallsOrSpecialTxs++
 }

--- a/process/block/preprocess/scheduledTxsExecution.go
+++ b/process/block/preprocess/scheduledTxsExecution.go
@@ -268,6 +268,15 @@ func (ste *scheduledTxsExecution) removeInvalidTxsFromScheduledMiniBlocks(interm
 		}
 	}
 
+	resultedScheduledMbs := make(block.MiniBlockSlice, 0)
+	for _, miniBlock := range ste.scheduledMbs {
+		if len(miniBlock.TxHashes) == 0 {
+			continue
+		}
+		resultedScheduledMbs = append(resultedScheduledMbs, miniBlock)
+	}
+	ste.scheduledMbs = resultedScheduledMbs
+
 	log.Debug("scheduledTxsExecution.removeInvalidTxsFromScheduledMiniBlocks", "num of invalid txs removed", numInvalidTxsRemoved)
 }
 
@@ -630,9 +639,9 @@ func (ste *scheduledTxsExecution) IsScheduledTx(txHash []byte) bool {
 
 // IsMiniBlockExecuted returns true if the given mini block is already executed
 func (ste *scheduledTxsExecution) IsMiniBlockExecuted(mbHash []byte) bool {
-	//TODO: This method and also ste.mapScheduledMbHashes could be removed when we will have mini block header IsFinal method later,
-	//but only when we could differentiate between the final mini blocks executed as scheduled in the last block and the normal mini blocks
-	//from the current block which are also final, but not yet executed
+	// TODO: This method and also ste.mapScheduledMbHashes could be removed when we will have mini block header IsFinal method later,
+	// but only when we could differentiate between the final mini blocks executed as scheduled in the last block and the normal mini blocks
+	// from the current block which are also final, but not yet executed
 	ste.mutScheduledTxs.RLock()
 	_, ok := ste.mapScheduledMbHashes[string(mbHash)]
 	ste.mutScheduledTxs.RUnlock()

--- a/process/block/preprocess/scheduledTxsExecution_test.go
+++ b/process/block/preprocess/scheduledTxsExecution_test.go
@@ -1525,12 +1525,13 @@ func TestScheduledTxsExecution_removeInvalidTxsFromScheduledMiniBlocks(t *testin
 	scheduledTxsExec.scheduledMbs = mbs
 	scheduledTxsExec.removeInvalidTxsFromScheduledMiniBlocks(scrsInfo)
 
-	//TODO: check if a scheduledMB should have no TxHashes inside
-	expectedLen := 0
-	assert.Equal(t, expectedLen, len(scheduledTxsExec.scheduledMbs[1].TxHashes))
+	// a scheduled miniBlock without any txs is removed completely
+	expectedNumScheduledMiniBlocks := 1
+	assert.Equal(t, expectedNumScheduledMiniBlocks, len(scheduledTxsExec.scheduledMbs))
 
-	expectedLen = 2
+	expectedLen := 2
 	assert.Equal(t, expectedLen, len(scheduledTxsExec.scheduledMbs[0].TxHashes))
+
 	remainingTxHashes := scheduledTxsExec.scheduledMbs[0].TxHashes
 	assert.True(t, bytes.Equal(txHash2, remainingTxHashes[0]))
 	assert.True(t, bytes.Equal(txHash4, remainingTxHashes[1]))

--- a/process/block/preprocess/transactions.go
+++ b/process/block/preprocess/transactions.go
@@ -254,7 +254,7 @@ func (txs *transactions) RestoreBlockDataIntoPools(
 			continue
 		}
 
-		strCache := process.ShardCacherIdentifier(miniBlock.SenderShardID, miniBlock.ReceiverShardID)
+		miniBlockStrCache := process.ShardCacherIdentifier(miniBlock.SenderShardID, miniBlock.ReceiverShardID)
 		txsBuff, err := txs.storage.GetAll(dataRetriever.TransactionUnit, miniBlock.TxHashes)
 		if err != nil {
 			log.Debug("tx from mini block was not found in TransactionUnit",
@@ -273,6 +273,7 @@ func (txs *transactions) RestoreBlockDataIntoPools(
 				return txsRestored, err
 			}
 
+			strCache := txs.computeCacheIdentifier(miniBlockStrCache, &tx, miniBlock.Type)
 			txs.txPool.AddData([]byte(txHash), &tx, tx.Size(), strCache)
 		}
 
@@ -289,6 +290,23 @@ func (txs *transactions) RestoreBlockDataIntoPools(
 	}
 
 	return txsRestored, nil
+}
+
+func (txs *transactions) computeCacheIdentifier(miniBlockStrCache string, tx *transaction.Transaction, miniBlockType block.Type) string {
+	if miniBlockType != block.InvalidBlock {
+		return miniBlockStrCache
+	}
+	if !txs.flagScheduledMiniBlocks.IsSet() {
+		return miniBlockStrCache
+	}
+
+	// scheduled miniblocks feature requires that the transactions are properly restored in the correct cache, not the one
+	// provided by the containing miniblock (think of how invalid transactions are executed and stored)
+
+	senderShardID := txs.getShardFromAddress(tx.GetSndAddr())
+	receiverShardID := txs.getShardFromAddress(tx.GetRcvAddr())
+
+	return process.ShardCacherIdentifier(senderShardID, receiverShardID)
 }
 
 // ProcessBlockTransactions processes all the transaction from the block.Body, updates the state

--- a/process/block/preprocess/transactions_test.go
+++ b/process/block/preprocess/transactions_test.go
@@ -27,20 +27,29 @@ import (
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/mock"
+	"github.com/ElrondNetwork/elrond-go/sharding"
 	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/ElrondNetwork/elrond-go/storage/txcache"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 	dataRetrieverMock "github.com/ElrondNetwork/elrond-go/testscommon/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/testscommon/economicsmocks"
 	"github.com/ElrondNetwork/elrond-go/testscommon/epochNotifier"
+	"github.com/ElrondNetwork/elrond-go/testscommon/genericMocks"
 	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	stateMock "github.com/ElrondNetwork/elrond-go/testscommon/state"
+	"github.com/ElrondNetwork/elrond-go/vm"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 const MaxGasLimitPerBlock = uint64(100000)
+
+type txInfoHolder struct {
+	hash []byte
+	buff []byte
+	tx   *transaction.Transaction
+}
 
 func feeHandlerMock() *mock.FeeHandlerStub {
 	return &mock.FeeHandlerStub{
@@ -1876,4 +1885,224 @@ func TestTransactions_EpochConfirmed(t *testing.T) {
 	assert.True(t, txs.flagFrontRunningProtection.IsSet())
 	assert.True(t, txs.flagOptimizeGasUsedInCrossMiniBlocks.IsSet())
 	assert.True(t, txs.flagScheduledMiniBlocks.IsSet())
+}
+
+func TestTransactions_ComputeCacheIdentifier(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not an invalid miniblock should return the original cache identifier", func(t *testing.T) {
+		t.Parallel()
+
+		txs := &transactions{}
+
+		types := []block.Type{block.TxBlock, block.StateBlock, block.PeerBlock, block.SmartContractResultBlock,
+			block.ReceiptBlock, block.RewardsBlock}
+
+		originalStrCache := "original"
+		for _, blockType := range types {
+			result := txs.computeCacheIdentifier(originalStrCache, nil, blockType)
+			assert.Equal(t, originalStrCache, result)
+		}
+	})
+	t.Run("invalid miniblock but flag not activated should return the original cache identifier", func(t *testing.T) {
+		t.Parallel()
+
+		txs := &transactions{}
+		txs.flagScheduledMiniBlocks.SetValue(false)
+
+		originalStrCache := "original"
+		result := txs.computeCacheIdentifier(originalStrCache, nil, block.InvalidBlock)
+		assert.Equal(t, originalStrCache, result)
+	})
+	t.Run("invalid miniblock with activated flag should recompute the identifier", func(t *testing.T) {
+		t.Parallel()
+
+		coordinator, err := sharding.NewMultiShardCoordinator(3, 1)
+		assert.Nil(t, err)
+		txs := &transactions{
+			basePreProcess: &basePreProcess{
+				gasTracker: gasTracker{
+					shardCoordinator: coordinator,
+				},
+			},
+		}
+		txs.flagScheduledMiniBlocks.SetValue(true)
+
+		originalStrCache := "original"
+		t.Run("shard 1 address with deploy address", func(t *testing.T) {
+			tx := &transaction.Transaction{
+				SndAddr: bytes.Repeat([]byte{0}, 32), // deploy address
+				RcvAddr: bytes.Repeat([]byte{1}, 32), // shard 1
+			}
+
+			result := txs.computeCacheIdentifier(originalStrCache, tx, block.InvalidBlock)
+			expected := "1"
+			assert.Equal(t, expected, result)
+		})
+		t.Run("shard 1 address with a shard 2 address", func(t *testing.T) {
+			tx := &transaction.Transaction{
+				SndAddr: bytes.Repeat([]byte{1}, 32), // shard 1
+				RcvAddr: bytes.Repeat([]byte{2}, 32), // shard 1
+			}
+
+			result := txs.computeCacheIdentifier(originalStrCache, tx, block.InvalidBlock)
+			expected := "1_2"
+			assert.Equal(t, expected, result)
+		})
+		t.Run("shard 1 address with ESDT contract address", func(t *testing.T) {
+			tx := &transaction.Transaction{
+				SndAddr: bytes.Repeat([]byte{1}, 32), // shard 1
+				RcvAddr: vm.ESDTSCAddress,            // metachain
+			}
+
+			result := txs.computeCacheIdentifier(originalStrCache, tx, block.InvalidBlock)
+			expected := "1_4294967295"
+			assert.Equal(t, expected, result)
+		})
+	})
+}
+
+func TestTransactions_RestoreBlockDataIntoPools(t *testing.T) {
+	t.Parallel()
+
+	args := createDefaultTransactionsProcessorArgs()
+	args.TxDataPool = testscommon.NewShardedDataCacheNotifierMock()
+	args.ShardCoordinator, _ = sharding.NewMultiShardCoordinator(3, 1)
+	args.Store = genericMocks.NewChainStorerMock(0)
+	txs, _ := NewTransactionPreprocessor(args)
+
+	mbPool := testscommon.NewCacherMock()
+
+	body, allTxs := createMockBlockBody()
+	addTxsInStorer(args.Store.GetStorer(dataRetriever.TransactionUnit), allTxs)
+
+	t.Run("nil block body should error", func(t *testing.T) {
+		numRestored, err := txs.RestoreBlockDataIntoPools(nil, mbPool)
+		assert.Equal(t, 0, numRestored)
+		assert.Equal(t, process.ErrNilBlockBody, err)
+	})
+	t.Run("nil cacher should error", func(t *testing.T) {
+		numRestored, err := txs.RestoreBlockDataIntoPools(body, nil)
+		assert.Equal(t, 0, numRestored)
+		assert.Equal(t, process.ErrNilMiniBlockPool, err)
+	})
+	t.Run("invalid miniblock should not restore", func(t *testing.T) {
+		wrongBody := &block.Body{
+			MiniBlocks: []*block.MiniBlock{
+				{
+					Type: block.SmartContractResultBlock,
+				},
+			},
+		}
+
+		numRestored, err := txs.RestoreBlockDataIntoPools(wrongBody, mbPool)
+		assert.Equal(t, 0, numRestored)
+		assert.Nil(t, err)
+		assert.Equal(t, 0, numRestored)
+		assert.Equal(t, 0, len(mbPool.Keys()))
+	})
+	t.Run("feat scheduled not activated", func(t *testing.T) {
+		txs.flagScheduledMiniBlocks.SetValue(false)
+
+		numRestored, err := txs.RestoreBlockDataIntoPools(body, mbPool)
+		assert.Nil(t, err)
+		assert.Equal(t, 6, numRestored)
+		assert.Equal(t, 1, len(mbPool.Keys())) // only 1 mb is cross shard where destination is me
+
+		assert.Equal(t, 4, len(args.TxDataPool.ShardDataStore("1").Keys())) // intrashard + invalid
+		assert.Equal(t, 2, len(args.TxDataPool.ShardDataStore("2_1").Keys()))
+	})
+
+	args.TxDataPool.Clear()
+	mbPool.Clear()
+
+	t.Run("feat scheduled activated", func(t *testing.T) {
+		txs.flagScheduledMiniBlocks.SetValue(true)
+
+		numRestored, err := txs.RestoreBlockDataIntoPools(body, mbPool)
+		assert.Nil(t, err)
+		assert.Equal(t, 6, numRestored)
+		assert.Equal(t, 1, len(mbPool.Keys())) // the cross miniblock
+
+		assert.Equal(t, 2, len(args.TxDataPool.ShardDataStore("1").Keys()))   // intrashard
+		assert.Equal(t, 2, len(args.TxDataPool.ShardDataStore("1_0").Keys())) // invalid
+		assert.Equal(t, 2, len(args.TxDataPool.ShardDataStore("2_1").Keys()))
+	})
+}
+
+func createMockBlockBody() (*block.Body, []*txInfoHolder) {
+	txsShard1 := createMockTransactions(2, 1, 1, 1000)
+	txsShard2to1 := createMockTransactions(2, 2, 1, 2000)
+	txsInvalid := createMockTransactions(2, 1, 0, 3000)
+
+	allTxs := append(txsShard1, txsShard2to1...)
+	allTxs = append(allTxs, txsInvalid...)
+
+	return &block.Body{
+		MiniBlocks: []*block.MiniBlock{
+			{
+				TxHashes:        getHashes(txsShard1),
+				ReceiverShardID: 1,
+				SenderShardID:   1,
+				Type:            block.TxBlock,
+			},
+			{
+				TxHashes:        getHashes(txsShard2to1),
+				ReceiverShardID: 1,
+				SenderShardID:   2,
+				Type:            block.TxBlock,
+			},
+			{
+				TxHashes:        getHashes(txsInvalid),
+				ReceiverShardID: 1, // because the tx block is invalid, the receiver shard ID is 1
+				SenderShardID:   1,
+				Type:            block.InvalidBlock,
+			},
+		},
+	}, allTxs
+}
+
+func addTxsInStorer(storer storage.Storer, txs []*txInfoHolder) {
+	for _, tx := range txs {
+		_ = storer.Put(tx.hash, tx.buff)
+	}
+}
+
+func getHashes(txs []*txInfoHolder) [][]byte {
+	hashes := make([][]byte, 0, len(txs))
+	for _, tx := range txs {
+		hashes = append(hashes, tx.hash)
+	}
+
+	return hashes
+}
+
+func createMockTransactions(numTxs int, sndShId byte, rcvShId byte, startNonce uint64) []*txInfoHolder {
+	marshaller := &mock.MarshalizerMock{}
+	hasher := &hashingMocks.HasherMock{}
+
+	txs := make([]*txInfoHolder, 0, numTxs)
+	for i := 0; i < numTxs; i++ {
+		sender := bytes.Repeat([]byte{sndShId}, 32)
+		sender[0] = byte(i + 1)
+		receiver := bytes.Repeat([]byte{rcvShId}, 32)
+		receiver[0] = byte(i + 1)
+
+		tx := &transaction.Transaction{
+			SndAddr: sender,
+			RcvAddr: receiver,
+			Nonce:   uint64(i) + startNonce,
+		}
+
+		buff, _ := marshaller.Marshal(tx)
+		hash := hasher.Compute(string(buff))
+
+		txs = append(txs, &txInfoHolder{
+			hash: hash,
+			buff: buff,
+			tx:   tx,
+		})
+	}
+
+	return txs
 }

--- a/process/smartContract/process.go
+++ b/process/smartContract/process.go
@@ -1038,9 +1038,9 @@ func (sc *scProcessor) doExecuteBuiltInFunction(
 	}
 
 	if sc.flagSCRSizeInvariantOnBuiltInResult.IsSet() {
-		err := sc.checkSCRSizeInvariant(scrResults)
-		if err != nil {
-			return vmcommon.UserError, sc.ProcessIfError(acntSnd, txHash, tx, err.Error(), []byte(err.Error()), snapshot, vmInput.GasLocked)
+		errCheck := sc.checkSCRSizeInvariant(scrResults)
+		if errCheck != nil {
+			return vmcommon.UserError, sc.ProcessIfError(acntSnd, txHash, tx, errCheck.Error(), []byte(errCheck.Error()), snapshot, vmInput.GasLocked)
 		}
 	}
 

--- a/storage/disabled/persister.go
+++ b/storage/disabled/persister.go
@@ -1,0 +1,53 @@
+package disabled
+
+import "github.com/ElrondNetwork/elrond-go/storage"
+
+type persister struct{}
+
+// NewPersister returns a new instance of this disabled persister
+func NewPersister() *persister {
+	return &persister{}
+}
+
+// Put returns nil
+func (p *persister) Put(_, _ []byte) error {
+	return nil
+}
+
+// Get returns nil and ErrKeyNotFound
+func (p *persister) Get(_ []byte) ([]byte, error) {
+	return nil, storage.ErrKeyNotFound
+}
+
+// Has returns ErrKeyNotFound
+func (p *persister) Has(_ []byte) error {
+	return storage.ErrKeyNotFound
+}
+
+// Close returns nil
+func (p *persister) Close() error {
+	return nil
+}
+
+// Remove returns nil
+func (p *persister) Remove(_ []byte) error {
+	return nil
+}
+
+// Destroy returns nil
+func (p *persister) Destroy() error {
+	return nil
+}
+
+// DestroyClosed returns nil
+func (p *persister) DestroyClosed() error {
+	return nil
+}
+
+// RangeKeys does nothing
+func (p *persister) RangeKeys(_ func(key []byte, val []byte) bool) {}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (p *persister) IsInterfaceNil() bool {
+	return p == nil
+}

--- a/storage/disabled/persister_test.go
+++ b/storage/disabled/persister_test.go
@@ -1,0 +1,35 @@
+package disabled
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPersister_MethodsDoNotPanic(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		r := recover()
+		if r != nil {
+			assert.Fail(t, fmt.Sprintf("should have not panicked: %v", r))
+		}
+	}()
+
+	p := NewPersister()
+	assert.False(t, check.IfNil(p))
+	assert.Nil(t, p.Put(nil, nil))
+	assert.Equal(t, storage.ErrKeyNotFound, p.Has(nil))
+	assert.Nil(t, p.Close())
+	assert.Nil(t, p.Remove(nil))
+	assert.Nil(t, p.Destroy())
+	assert.Nil(t, p.DestroyClosed())
+	p.RangeKeys(nil)
+
+	val, err := p.Get(nil)
+	assert.Nil(t, val)
+	assert.Equal(t, storage.ErrKeyNotFound, err)
+}

--- a/testscommon/genericMocks/chainStorerMock.go
+++ b/testscommon/genericMocks/chainStorerMock.go
@@ -64,8 +64,20 @@ func (sm *ChainStorerMock) Put(unitType dataRetriever.UnitType, key []byte, valu
 }
 
 // GetAll -
-func (sm *ChainStorerMock) GetAll(_ dataRetriever.UnitType, _ [][]byte) (map[string][]byte, error) {
-	panic("not supported")
+func (sm *ChainStorerMock) GetAll(unitType dataRetriever.UnitType, keys [][]byte) (map[string][]byte, error) {
+	storer := sm.GetStorer(unitType)
+
+	data := make(map[string][]byte)
+	for _, key := range keys {
+		buff, err := storer.Get(key)
+		if err != nil {
+			return nil, err
+		}
+
+		data[string(key)] = buff
+	}
+
+	return data, nil
 }
 
 // SetEpochForPutOperation -

--- a/testscommon/shardedDataCacheNotifierMock.go
+++ b/testscommon/shardedDataCacheNotifierMock.go
@@ -1,0 +1,116 @@
+package testscommon
+
+import (
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go-core/core/counting"
+	"github.com/ElrondNetwork/elrond-go/storage"
+)
+
+// ShardedDataCacheNotifierMock -
+type ShardedDataCacheNotifierMock struct {
+	mutCaches sync.RWMutex
+	caches    map[string]storage.Cacher
+}
+
+// NewShardedDataCacheNotifierMock -
+func NewShardedDataCacheNotifierMock() *ShardedDataCacheNotifierMock {
+	return &ShardedDataCacheNotifierMock{
+		caches: make(map[string]storage.Cacher),
+	}
+}
+
+// RegisterOnAdded -
+func (mock *ShardedDataCacheNotifierMock) RegisterOnAdded(_ func(key []byte, value interface{})) {
+}
+
+// ShardDataStore -
+func (mock *ShardedDataCacheNotifierMock) ShardDataStore(cacheId string) (c storage.Cacher) {
+	mock.mutCaches.Lock()
+	defer mock.mutCaches.Unlock()
+
+	cache, found := mock.caches[cacheId]
+	if !found {
+		cache = NewCacherMock()
+		mock.caches[cacheId] = cache
+	}
+
+	return cache
+}
+
+// AddData -
+func (mock *ShardedDataCacheNotifierMock) AddData(key []byte, data interface{}, sizeInBytes int, cacheId string) {
+	cache := mock.ShardDataStore(cacheId)
+	cache.HasOrAdd(key, data, sizeInBytes)
+}
+
+// SearchFirstData -
+func (mock *ShardedDataCacheNotifierMock) SearchFirstData(key []byte) (interface{}, bool) {
+	mock.mutCaches.RLock()
+	defer mock.mutCaches.RUnlock()
+
+	for _, cache := range mock.caches {
+		buff, ok := cache.Get(key)
+		if ok {
+			return buff, true
+		}
+	}
+
+	return nil, false
+}
+
+// RemoveData -
+func (mock *ShardedDataCacheNotifierMock) RemoveData(key []byte, cacheId string) {
+	cache := mock.ShardDataStore(cacheId)
+	cache.Remove(key)
+}
+
+// RemoveSetOfDataFromPool -
+func (mock *ShardedDataCacheNotifierMock) RemoveSetOfDataFromPool(keys [][]byte, cacheId string) {
+	cache := mock.ShardDataStore(cacheId)
+	for _, key := range keys {
+		cache.Remove(key)
+	}
+}
+
+// ImmunizeSetOfDataAgainstEviction -
+func (mock *ShardedDataCacheNotifierMock) ImmunizeSetOfDataAgainstEviction(_ [][]byte, _ string) {
+}
+
+// RemoveDataFromAllShards -
+func (mock *ShardedDataCacheNotifierMock) RemoveDataFromAllShards(key []byte) {
+	mock.mutCaches.RLock()
+	defer mock.mutCaches.RUnlock()
+
+	for _, cache := range mock.caches {
+		cache.Remove(key)
+	}
+}
+
+// MergeShardStores -
+func (mock *ShardedDataCacheNotifierMock) MergeShardStores(_, _ string) {
+}
+
+// Clear -
+func (mock *ShardedDataCacheNotifierMock) Clear() {
+	mock.mutCaches.Lock()
+	defer mock.mutCaches.Unlock()
+
+	mock.caches = make(map[string]storage.Cacher)
+}
+
+// ClearShardStore -
+func (mock *ShardedDataCacheNotifierMock) ClearShardStore(cacheId string) {
+	cache := mock.ShardDataStore(cacheId)
+	cache.Clear()
+}
+
+// GetCounts -
+func (mock *ShardedDataCacheNotifierMock) GetCounts() counting.CountsWithSize {
+	return nil
+}
+
+// IsInterfaceNil -
+func (mock *ShardedDataCacheNotifierMock) IsInterfaceNil() bool {
+	return mock == nil
+}

--- a/vm/systemSmartContracts/delegation.go
+++ b/vm/systemSmartContracts/delegation.go
@@ -723,7 +723,7 @@ func (d *delegation) delegateUser(
 		}
 	}
 
-	d.createAndAddLogEntryForDelegate(args, callValue, globalFund, delegator, dStatus, isNew)
+	d.createAndAddLogEntryForDelegate(args, delegationValue, globalFund, delegator, dStatus, isNew)
 
 	return d.finishDelegateUser(globalFund, delegator, dConfig, dStatus,
 		callerAddr, args.RecipientAddr, delegationValue, callValue, isNew, true)
@@ -1736,7 +1736,8 @@ func (d *delegation) unDelegate(args *vmcommon.ContractCallInput) vmcommon.Retur
 		return vmcommon.UserError
 	}
 
-	d.createAndAddLogEntry(args, valueToUnDelegate.Bytes(), remainedFund.Bytes(), globalFund.TotalActive.Bytes())
+	zeroValueByteSlice := make([]byte, 0)
+	d.createAndAddLogEntry(args, valueToUnDelegate.Bytes(), remainedFund.Bytes(), zeroValueByteSlice, globalFund.TotalActive.Bytes())
 
 	return vmcommon.Ok
 }

--- a/vm/systemSmartContracts/logs_test.go
+++ b/vm/systemSmartContracts/logs_test.go
@@ -50,7 +50,7 @@ func TestCreateLogEntryForDelegate(t *testing.T) {
 	)
 
 	require.Equal(t, &vmcommon.LogEntry{
-		Identifier: []byte("identifier"),
+		Identifier: []byte("delegate"),
 		Address:    []byte("caller"),
 		Topics:     [][]byte{delegationValue.Bytes(), big.NewInt(6000).Bytes(), big.NewInt(1).Bytes(), big.NewInt(1001000).Bytes()},
 	}, res)


### PR DESCRIPTION
* Fixed setting of processed mini blocks in start in epoch component, when scheduled is activated and it should roll back to previous header of the last notarized header