### PR TITLE
Peers rating handler

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -495,6 +495,10 @@
     Capacity = 10000
     Type = "LRU"
 
+[PeersRatingConfig]
+    TopRatedCacheCapacity = 5000
+    BadRatedCacheCapacity = 5000
+
 [TrieSyncStorage]
     Capacity = 300000
     SizeInBytes = 104857600 #100MB

--- a/cmd/seednode/main.go
+++ b/cmd/seednode/main.go
@@ -241,6 +241,7 @@ func createNode(p2pConfig config.P2PConfig, marshalizer marshal.Marshalizer) (p2
 		SyncTimer:            &libp2p.LocalSyncTimer{},
 		PreferredPeersHolder: disabled.NewPreferredPeersHolder(),
 		NodeOperationMode:    p2p.NormalOperation,
+		PeersRatingHandler:   disabled.NewDisabledPeersRatingHandler(),
 	}
 
 	return libp2p.NewNetworkMessenger(arg)

--- a/config/config.go
+++ b/config/config.go
@@ -187,6 +187,14 @@ type Config struct {
 	TrieSync              TrieSyncConfig
 	Resolvers             ResolverConfig
 	VMOutputCacher        CacheConfig
+
+	PeersRatingConfig PeersRatingConfig
+}
+
+// PeersRatingConfig will hold settings related to peers rating
+type PeersRatingConfig struct {
+	TopRatedCacheCapacity int
+	BadRatedCacheCapacity int
 }
 
 // LogsConfig will hold settings related to the logging sub-system

--- a/dataRetriever/errors.go
+++ b/dataRetriever/errors.go
@@ -140,6 +140,9 @@ var ErrInvalidMaxTxRequest = errors.New("max tx request number is invalid")
 // ErrNilPeerListCreator signals that a nil peer list creator implementation has been provided
 var ErrNilPeerListCreator = errors.New("nil peer list creator provided")
 
+// ErrNilPeersRatingHandler signals that a nil peers rating handler implementation has been provided
+var ErrNilPeersRatingHandler = errors.New("nil peers rating handler")
+
 // ErrNilTrieDataGetter signals that a nil trie data getter has been provided
 var ErrNilTrieDataGetter = errors.New("nil trie data getter provided")
 

--- a/dataRetriever/factory/resolverscontainer/args.go
+++ b/dataRetriever/factory/resolverscontainer/args.go
@@ -26,6 +26,7 @@ type FactoryArgs struct {
 	OutputAntifloodHandler      dataRetriever.P2PAntifloodHandler
 	CurrentNetworkEpochProvider dataRetriever.CurrentNetworkEpochProviderHandler
 	PreferredPeersHolder        p2p.PreferredPeersHolderHandler
+	PeersRatingHandler          dataRetriever.PeersRatingHandler
 	SizeCheckDelta              uint32
 	IsFullHistoryNode           bool
 }

--- a/dataRetriever/factory/resolverscontainer/baseResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/baseResolversContainerFactory.go
@@ -39,6 +39,7 @@ type baseResolversContainerFactory struct {
 	isFullHistoryNode           bool
 	currentNetworkEpochProvider dataRetriever.CurrentNetworkEpochProviderHandler
 	preferredPeersHolder        dataRetriever.PreferredPeersHolderHandler
+	peersRatingHandler          dataRetriever.PeersRatingHandler
 	numCrossShardPeers          int
 	numIntraShardPeers          int
 	numFullHistoryPeers         int
@@ -83,6 +84,9 @@ func (brcf *baseResolversContainerFactory) checkParams() error {
 	}
 	if check.IfNil(brcf.preferredPeersHolder) {
 		return dataRetriever.ErrNilPreferredPeersHolder
+	}
+	if check.IfNil(brcf.peersRatingHandler) {
+		return dataRetriever.ErrNilPeersRatingHandler
 	}
 	if brcf.numCrossShardPeers <= 0 {
 		return fmt.Errorf("%w for numCrossShardPeers", dataRetriever.ErrInvalidValue)
@@ -299,6 +303,7 @@ func (brcf *baseResolversContainerFactory) createOneResolverSenderWithSpecifiedN
 		CurrentNetworkEpochProvider: currentNetworkEpochProvider,
 		PreferredPeersHolder:        brcf.preferredPeersHolder,
 		SelfShardIdProvider:         brcf.shardCoordinator,
+		PeersRatingHandler:          brcf.peersRatingHandler,
 	}
 	// TODO instantiate topic sender resolver with the shard IDs for which this resolver is supposed to serve the data
 	// this will improve the serving of transactions as the searching will be done only on 2 sharded data units

--- a/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory.go
@@ -52,6 +52,7 @@ func NewMetaResolversContainerFactory(
 		isFullHistoryNode:           args.IsFullHistoryNode,
 		currentNetworkEpochProvider: args.CurrentNetworkEpochProvider,
 		preferredPeersHolder:        args.PreferredPeersHolder,
+		peersRatingHandler:          args.PeersRatingHandler,
 		numCrossShardPeers:          int(args.ResolverConfig.NumCrossShardPeers),
 		numIntraShardPeers:          int(args.ResolverConfig.NumIntraShardPeers),
 		numFullHistoryPeers:         int(args.ResolverConfig.NumFullHistoryPeers),

--- a/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory_test.go
+++ b/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory_test.go
@@ -168,6 +168,17 @@ func TestNewMetaResolversContainerFactory_NilPreferredPeersHolderShouldErr(t *te
 	assert.Equal(t, dataRetriever.ErrNilPreferredPeersHolder, err)
 }
 
+func TestNewMetaResolversContainerFactory_NilPeersRatingHandlerShouldErr(t *testing.T) {
+	t.Parallel()
+
+	args := getArgumentsMeta()
+	args.PeersRatingHandler = nil
+	rcf, err := resolverscontainer.NewMetaResolversContainerFactory(args)
+
+	assert.Nil(t, rcf)
+	assert.Equal(t, dataRetriever.ErrNilPeersRatingHandler, err)
+}
+
 func TestNewMetaResolversContainerFactory_NilUint64SliceConverterShouldErr(t *testing.T) {
 	t.Parallel()
 
@@ -292,5 +303,6 @@ func getArgumentsMeta() resolverscontainer.FactoryArgs {
 			NumIntraShardPeers:  2,
 			NumFullHistoryPeers: 3,
 		},
+		PeersRatingHandler: &p2pmocks.PeersRatingHandlerStub{},
 	}
 }

--- a/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory.go
@@ -50,6 +50,7 @@ func NewShardResolversContainerFactory(
 		isFullHistoryNode:           args.IsFullHistoryNode,
 		currentNetworkEpochProvider: args.CurrentNetworkEpochProvider,
 		preferredPeersHolder:        args.PreferredPeersHolder,
+		peersRatingHandler:          args.PeersRatingHandler,
 		numCrossShardPeers:          int(args.ResolverConfig.NumCrossShardPeers),
 		numIntraShardPeers:          int(args.ResolverConfig.NumIntraShardPeers),
 		numFullHistoryPeers:         int(args.ResolverConfig.NumFullHistoryPeers),

--- a/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory_test.go
+++ b/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory_test.go
@@ -197,6 +197,17 @@ func TestNewShardResolversContainerFactory_NilPreferredPeersHolderShouldErr(t *t
 	assert.Equal(t, dataRetriever.ErrNilPreferredPeersHolder, err)
 }
 
+func TestNewShardResolversContainerFactory_NilPeersRatingHandlerShouldErr(t *testing.T) {
+	t.Parallel()
+
+	args := getArgumentsShard()
+	args.PeersRatingHandler = nil
+	rcf, err := resolverscontainer.NewShardResolversContainerFactory(args)
+
+	assert.Nil(t, rcf)
+	assert.Equal(t, dataRetriever.ErrNilPeersRatingHandler, err)
+}
+
 func TestNewShardResolversContainerFactory_NilTriesContainerShouldErr(t *testing.T) {
 	t.Parallel()
 
@@ -370,5 +381,6 @@ func getArgumentsShard() resolverscontainer.FactoryArgs {
 			NumIntraShardPeers:  2,
 			NumFullHistoryPeers: 3,
 		},
+		PeersRatingHandler: &p2pmocks.PeersRatingHandlerStub{},
 	}
 }

--- a/dataRetriever/interface.go
+++ b/dataRetriever/interface.go
@@ -409,6 +409,15 @@ type PreferredPeersHolderHandler interface {
 	IsInterfaceNil() bool
 }
 
+// PeersRatingHandler represent an entity able to handle peers ratings
+type PeersRatingHandler interface {
+	AddPeer(pid core.PeerID)
+	IncreaseRating(pid core.PeerID)
+	DecreaseRating(pid core.PeerID)
+	GetTopRatedPeersFromList(peers []core.PeerID, numOfPeers int) []core.PeerID
+	IsInterfaceNil() bool
+}
+
 // SelfShardIDProvider defines the behavior of a component able to provide the self shard ID
 type SelfShardIDProvider interface {
 	SelfId() uint32

--- a/dataRetriever/interface.go
+++ b/dataRetriever/interface.go
@@ -414,7 +414,7 @@ type PeersRatingHandler interface {
 	AddPeer(pid core.PeerID)
 	IncreaseRating(pid core.PeerID)
 	DecreaseRating(pid core.PeerID)
-	GetTopRatedPeersFromList(peers []core.PeerID, numOfPeers int) []core.PeerID
+	GetTopRatedPeersFromList(peers []core.PeerID, minNumOfPeersExpected int) []core.PeerID
 	IsInterfaceNil() bool
 }
 

--- a/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
+++ b/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
-	"github.com/ElrondNetwork/elrond-go-core/core/random"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
@@ -19,7 +18,6 @@ const (
 	// topicRequestSuffix represents the topic name suffix
 	topicRequestSuffix = "_REQUEST"
 	minPeersToQuery    = 2
-	preferredPeerIndex = -1
 )
 
 var _ dataRetriever.TopicResolverSender = (*topicResolverSender)(nil)
@@ -39,6 +37,7 @@ type ArgTopicResolverSender struct {
 	CurrentNetworkEpochProvider dataRetriever.CurrentNetworkEpochProviderHandler
 	PreferredPeersHolder        dataRetriever.PreferredPeersHolderHandler
 	SelfShardIdProvider         dataRetriever.SelfShardIDProvider
+	PeersRatingHandler          dataRetriever.PeersRatingHandler
 	TargetShardId               uint32
 }
 
@@ -57,57 +56,23 @@ type topicResolverSender struct {
 	resolverDebugHandler               dataRetriever.ResolverDebugHandler
 	currentNetworkEpochProviderHandler dataRetriever.CurrentNetworkEpochProviderHandler
 	preferredPeersHolderHandler        dataRetriever.PreferredPeersHolderHandler
+	peersRatingHandler                 dataRetriever.PeersRatingHandler
 	selfShardId                        uint32
 	targetShardId                      uint32
 }
 
 // NewTopicResolverSender returns a new topic resolver instance
 func NewTopicResolverSender(arg ArgTopicResolverSender) (*topicResolverSender, error) {
-	if check.IfNil(arg.Messenger) {
-		return nil, dataRetriever.ErrNilMessenger
-	}
-	if check.IfNil(arg.Marshalizer) {
-		return nil, dataRetriever.ErrNilMarshalizer
-	}
-	if check.IfNil(arg.Randomizer) {
-		return nil, dataRetriever.ErrNilRandomizer
-	}
-	if check.IfNil(arg.PeerListCreator) {
-		return nil, dataRetriever.ErrNilPeerListCreator
-	}
-	if check.IfNil(arg.OutputAntiflooder) {
-		return nil, dataRetriever.ErrNilAntifloodHandler
-	}
-	if check.IfNil(arg.CurrentNetworkEpochProvider) {
-		return nil, dataRetriever.ErrNilCurrentNetworkEpochProvider
-	}
-	if check.IfNil(arg.PreferredPeersHolder) {
-		return nil, dataRetriever.ErrNilPreferredPeersHolder
-	}
-	if check.IfNil(arg.SelfShardIdProvider) {
-		return nil, dataRetriever.ErrNilSelfShardIDProvider
-	}
-	if arg.NumIntraShardPeers < 0 {
-		return nil, fmt.Errorf("%w for NumIntraShardPeers as the value should be greater or equal than 0",
-			dataRetriever.ErrInvalidValue)
-	}
-	if arg.NumCrossShardPeers < 0 {
-		return nil, fmt.Errorf("%w for NumCrossShardPeers as the value should be greater or equal than 0",
-			dataRetriever.ErrInvalidValue)
-	}
-	if arg.NumFullHistoryPeers < 0 {
-		return nil, fmt.Errorf("%w for NumFullHistoryPeers as the value should be greater or equal than 0",
-			dataRetriever.ErrInvalidValue)
-	}
-	if arg.NumCrossShardPeers+arg.NumIntraShardPeers < minPeersToQuery {
-		return nil, fmt.Errorf("%w for NumCrossShardPeers, NumIntraShardPeers as their sum should be greater or equal than %d",
-			dataRetriever.ErrInvalidValue, minPeersToQuery)
+	err := checkArgs(arg)
+	if err != nil {
+		return nil, err
 	}
 
 	resolver := &topicResolverSender{
 		messenger:                          arg.Messenger,
 		topicName:                          arg.TopicName,
 		peerListCreator:                    arg.PeerListCreator,
+		peersRatingHandler:                 arg.PeersRatingHandler,
 		marshalizer:                        arg.Marshalizer,
 		randomizer:                         arg.Randomizer,
 		targetShardId:                      arg.TargetShardId,
@@ -122,6 +87,56 @@ func NewTopicResolverSender(arg ArgTopicResolverSender) (*topicResolverSender, e
 	resolver.resolverDebugHandler = resolverDebug.NewDisabledInterceptorResolver()
 
 	return resolver, nil
+}
+
+func checkArgs(args ArgTopicResolverSender) error {
+	if check.IfNil(args.Messenger) {
+		return dataRetriever.ErrNilMessenger
+	}
+	if check.IfNil(args.Marshalizer) {
+		return dataRetriever.ErrNilMarshalizer
+	}
+	if check.IfNil(args.Randomizer) {
+		return dataRetriever.ErrNilRandomizer
+	}
+	if check.IfNil(args.PeerListCreator) {
+		return dataRetriever.ErrNilPeerListCreator
+	}
+	if check.IfNil(args.PeersRatingHandler) {
+		return dataRetriever.ErrNilPeersRatingHandler
+	}
+	if check.IfNil(args.OutputAntiflooder) {
+		return dataRetriever.ErrNilAntifloodHandler
+	}
+	if check.IfNil(args.CurrentNetworkEpochProvider) {
+		return dataRetriever.ErrNilCurrentNetworkEpochProvider
+	}
+	if check.IfNil(args.PreferredPeersHolder) {
+		return dataRetriever.ErrNilPreferredPeersHolder
+	}
+	if check.IfNil(args.PeersRatingHandler) {
+		return dataRetriever.ErrNilPeersRatingHandler
+	}
+	if check.IfNil(args.SelfShardIdProvider) {
+		return dataRetriever.ErrNilSelfShardIDProvider
+	}
+	if args.NumIntraShardPeers < 0 {
+		return fmt.Errorf("%w for NumIntraShardPeers as the value should be greater or equal than 0",
+			dataRetriever.ErrInvalidValue)
+	}
+	if args.NumCrossShardPeers < 0 {
+		return fmt.Errorf("%w for NumCrossShardPeers as the value should be greater or equal than 0",
+			dataRetriever.ErrInvalidValue)
+	}
+	if args.NumFullHistoryPeers < 0 {
+		return fmt.Errorf("%w for NumFullHistoryPeers as the value should be greater or equal than 0",
+			dataRetriever.ErrInvalidValue)
+	}
+	if args.NumCrossShardPeers+args.NumIntraShardPeers < minPeersToQuery {
+		return fmt.Errorf("%w for NumCrossShardPeers, NumIntraShardPeers as their sum should be greater or equal than %d",
+			dataRetriever.ErrInvalidValue, minPeersToQuery)
+	}
+	return nil
 }
 
 // SendOnRequestTopic is used to send request data over channels (topics) to other peers
@@ -143,8 +158,7 @@ func (trs *topicResolverSender) SendOnRequestTopic(rd *dataRetriever.RequestData
 		numSentCross = trs.sendOnTopic(crossPeers, preferredPeer, topicToSendRequest, buff, trs.numCrossShardPeers, core.CrossShardPeer.String())
 
 		intraPeers = trs.peerListCreator.IntraShardPeerList()
-		preferredPeer = trs.getPreferredPeer(trs.selfShardId)
-		numSentIntra = trs.sendOnTopic(intraPeers, preferredPeer, topicToSendRequest, buff, trs.numIntraShardPeers, core.IntraShardPeer.String())
+		numSentIntra = trs.sendOnTopic(intraPeers, "", topicToSendRequest, buff, trs.numIntraShardPeers, core.IntraShardPeer.String())
 	} else {
 		// TODO: select preferred peers of type full history as well.
 		fullHistoryPeers = trs.peerListCreator.FullHistoryList()
@@ -172,15 +186,6 @@ func (trs *topicResolverSender) callDebugHandler(originalHashes [][]byte, numSen
 	trs.resolverDebugHandler.LogRequestedData(trs.topicName, originalHashes, numSentIntra, numSentCross)
 }
 
-func createIndexList(listLength int) []int {
-	indexes := make([]int, listLength)
-	for i := 0; i < listLength; i++ {
-		indexes[i] = i
-	}
-
-	return indexes
-}
-
 func (trs *topicResolverSender) sendOnTopic(
 	peerList []core.PeerID,
 	preferredPeer core.PeerID,
@@ -195,22 +200,30 @@ func (trs *topicResolverSender) sendOnTopic(
 
 	histogramMap := make(map[string]int)
 
-	indexes := createIndexList(len(peerList))
-	shuffledIndexes := random.FisherYatesShuffle(indexes, trs.randomizer)
-	logData := make([]interface{}, 0)
-	msgSentCounter := 0
+	peersToSend := make([]core.PeerID, 0)
+
+	// first add preferred peer if exists
 	shouldSendToPreferredPeer := preferredPeer != "" && maxToSend > 1
 	if shouldSendToPreferredPeer {
-		shuffledIndexes = append([]int{preferredPeerIndex}, shuffledIndexes...)
+		peersToSend = append(peersToSend, preferredPeer)
 	}
 
-	for idx := 0; idx < len(shuffledIndexes); idx++ {
-		peer := getPeerID(shuffledIndexes[idx], peerList, preferredPeer, peerType, topicToSendRequest, histogramMap)
+	topRatedPeers := trs.peersRatingHandler.GetTopRatedPeersFromList(peerList, maxToSend)
+	peersToSend = append(peersToSend, topRatedPeers...)
+
+	logData := make([]interface{}, 0)
+	msgSentCounter := 0
+
+	for idx := 0; idx < len(peersToSend); idx++ {
+		peer := peersToSend[idx]
+		updateHistogramMap(peer, preferredPeer, peerType, topicToSendRequest, histogramMap)
 
 		err := trs.sendToConnectedPeer(topicToSendRequest, buff, peer)
 		if err != nil {
 			continue
 		}
+
+		trs.peersRatingHandler.DecreaseRating(peer)
 
 		logData = append(logData, peerType)
 		logData = append(logData, peer.Pretty())
@@ -225,16 +238,13 @@ func (trs *topicResolverSender) sendOnTopic(
 	return msgSentCounter
 }
 
-func getPeerID(index int, peersList []core.PeerID, preferredPeer core.PeerID, peerType string, topic string, histogramMap map[string]int) core.PeerID {
-	if index == preferredPeerIndex {
+func updateHistogramMap(peer core.PeerID, preferredPeer core.PeerID, peerType string, topic string, histogramMap map[string]int) {
+	if peer == preferredPeer {
 		histogramMap["preferred"]++
 		log.Trace("sending request to preferred peer", "peer", preferredPeer.Pretty(), "topic", topic, "peer type", peerType)
-
-		return preferredPeer
 	}
 
 	histogramMap[peerType]++
-	return peersList[index]
 }
 
 func (trs *topicResolverSender) getPreferredPeer(shardID uint32) core.PeerID {

--- a/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
+++ b/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
@@ -209,7 +209,9 @@ func (trs *topicResolverSender) sendOnTopic(
 
 	histogramMap := make(map[string]int)
 
-	indexes := createIndexList(len(peerList))
+	topRatedPeersList := trs.peersRatingHandler.GetTopRatedPeersFromList(peerList, maxToSend)
+
+	indexes := createIndexList(len(topRatedPeersList))
 	shuffledIndexes := random.FisherYatesShuffle(indexes, trs.randomizer)
 	logData := make([]interface{}, 0)
 	msgSentCounter := 0
@@ -219,7 +221,7 @@ func (trs *topicResolverSender) sendOnTopic(
 	}
 
 	for idx := 0; idx < len(shuffledIndexes); idx++ {
-		peer := getPeerID(shuffledIndexes[idx], peerList, preferredPeer, peerType, topicToSendRequest, histogramMap)
+		peer := getPeerID(shuffledIndexes[idx], topRatedPeersList, preferredPeer, peerType, topicToSendRequest, histogramMap)
 
 		err := trs.sendToConnectedPeer(topicToSendRequest, buff, peer)
 		if err != nil {

--- a/dataRetriever/resolvers/topicResolverSender/topicResolverSender_test.go
+++ b/dataRetriever/resolvers/topicResolverSender/topicResolverSender_test.go
@@ -39,6 +39,7 @@ func createMockArgTopicResolverSender() topicResolverSender.ArgTopicResolverSend
 				return map[uint32][]core.PeerID{}
 			},
 		},
+		PeersRatingHandler: &p2pmocks.PeersRatingHandlerStub{},
 	}
 }
 
@@ -372,7 +373,6 @@ func TestTopicResolverSender_SendOnRequestTopicShouldWorkAndSendToPreferredPeers
 
 	err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, countPrefPeersSh0)
 	assert.Equal(t, 1, countPrefPeersSh1)
 }
 
@@ -415,57 +415,6 @@ func TestTopicResolverSender_SendOnRequestTopicShouldWorkAndSendToCrossPreferred
 			return nil
 		},
 	}
-	trs, _ := topicResolverSender.NewTopicResolverSender(arg)
-
-	err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)
-	assert.Nil(t, err)
-	assert.True(t, sentToPreferredPeer)
-}
-
-func TestTopicResolverSender_SendOnRequestTopicShouldWorkAndSendToIntraPreferredPeerFirst(t *testing.T) {
-	t.Parallel()
-
-	selfShardID := uint32(37)
-	pIDPreferred := core.PeerID("preferred peer")
-	numTimesSent := 0
-	regularPeer0, regularPeer1 := core.PeerID("peer0"), core.PeerID("peer1")
-	sentToPreferredPeer := false
-
-	arg := createMockArgTopicResolverSender()
-	arg.TargetShardId = 0
-	arg.NumCrossShardPeers = 5
-	arg.PeerListCreator = &mock.PeerListCreatorStub{
-		CrossShardPeerListCalled: func() []core.PeerID {
-			return []core.PeerID{}
-		},
-		IntraShardPeerListCalled: func() []core.PeerID {
-			return []core.PeerID{regularPeer0, regularPeer1, regularPeer0, regularPeer1}
-		},
-	}
-	arg.PreferredPeersHolder = &p2pmocks.PeersHolderStub{
-		GetCalled: func() map[uint32][]core.PeerID {
-			return map[uint32][]core.PeerID{
-				selfShardID: {pIDPreferred},
-			}
-		},
-	}
-
-	arg.Messenger = &mock.MessageHandlerStub{
-		SendToConnectedPeerCalled: func(topic string, buff []byte, peerID core.PeerID) error {
-			if bytes.Equal(peerID.Bytes(), pIDPreferred.Bytes()) {
-				sentToPreferredPeer = true
-				require.Zero(t, numTimesSent)
-			}
-
-			numTimesSent++
-			return nil
-		},
-	}
-
-	selfShardIDProvider := mock.NewMultipleShardsCoordinatorMock()
-	selfShardIDProvider.CurrentShard = selfShardID
-	arg.SelfShardIdProvider = selfShardIDProvider
-
 	trs, _ := topicResolverSender.NewTopicResolverSender(arg)
 
 	err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)

--- a/epochStart/bootstrap/disabled/disabledPeersRatingHandler.go
+++ b/epochStart/bootstrap/disabled/disabledPeersRatingHandler.go
@@ -22,7 +22,7 @@ func (dprs *disabledPeersRatingHandler) IncreaseRating(_ core.PeerID) {
 func (dprs *disabledPeersRatingHandler) DecreaseRating(_ core.PeerID) {
 }
 
-// GetTopRatedPeersFromList returns an empty list of peers as it is disabled
+// GetTopRatedPeersFromList returns the provided peers list as it is disabled
 func (dprs *disabledPeersRatingHandler) GetTopRatedPeersFromList(peers []core.PeerID, _ int) []core.PeerID {
 	return peers
 }

--- a/epochStart/bootstrap/disabled/disabledPeersRatingHandler.go
+++ b/epochStart/bootstrap/disabled/disabledPeersRatingHandler.go
@@ -1,0 +1,33 @@
+package disabled
+
+import "github.com/ElrondNetwork/elrond-go-core/core"
+
+type disabledPeersRatingHandler struct {
+}
+
+// NewDisabledPeersRatingHandler returns a new instance of disabledPeersRatingHandler
+func NewDisabledPeersRatingHandler() *disabledPeersRatingHandler {
+	return &disabledPeersRatingHandler{}
+}
+
+// AddPeer does nothing as it is disabled
+func (dprs *disabledPeersRatingHandler) AddPeer(_ core.PeerID) {
+}
+
+// IncreaseRating does nothing as it is disabled
+func (dprs *disabledPeersRatingHandler) IncreaseRating(_ core.PeerID) {
+}
+
+// DecreaseRating does nothing as it is disabled
+func (dprs *disabledPeersRatingHandler) DecreaseRating(_ core.PeerID) {
+}
+
+// GetTopRatedPeersFromList returns an empty list of peers as it is disabled
+func (dprs *disabledPeersRatingHandler) GetTopRatedPeersFromList(peers []core.PeerID, _ int) []core.PeerID {
+	return peers
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (dprs *disabledPeersRatingHandler) IsInterfaceNil() bool {
+	return dprs == nil
+}

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -1119,6 +1119,7 @@ func (e *epochStartBootstrap) createRequestHandler() error {
 		CurrentNetworkEpochProvider: disabled.NewCurrentNetworkEpochProviderHandler(),
 		PreferredPeersHolder:        disabled.NewPreferredPeersHolder(),
 		ResolverConfig:              e.generalConfig.Resolvers,
+		PeersRatingHandler:          disabled.NewDisabledPeersRatingHandler(),
 	}
 	resolverFactory, err := resolverscontainer.NewMetaResolversContainerFactory(resolversContainerArgs)
 	if err != nil {

--- a/factory/coreComponents_test.go
+++ b/factory/coreComponents_test.go
@@ -323,6 +323,10 @@ func getCoreArgs() factory.CoreComponentsFactoryArgs {
 					Shards:   1,
 				},
 			},
+			PeersRatingConfig: config.PeersRatingConfig{
+				TopRatedCacheCapacity: 1000,
+				BadRatedCacheCapacity: 1000,
+			},
 		},
 		ConfigPathsHolder: config.ConfigurationPathsHolder{
 			GasScheduleDirectoryName: "../cmd/node/config/gasSchedules",

--- a/factory/interface.go
+++ b/factory/interface.go
@@ -214,6 +214,7 @@ type NetworkComponentsHolder interface {
 	PeerBlackListHandler() process.PeerBlackListCacher
 	PeerHonestyHandler() PeerHonestyHandler
 	PreferredPeersHolderHandler() PreferredPeersHolderHandler
+	PeersRatingHandler() p2p.PeersRatingHandler
 	IsInterfaceNil() bool
 }
 

--- a/factory/mock/networkComponentsMock.go
+++ b/factory/mock/networkComponentsMock.go
@@ -8,11 +8,12 @@ import (
 
 // NetworkComponentsMock -
 type NetworkComponentsMock struct {
-	Messenger            p2p.Messenger
-	InputAntiFlood       factory.P2PAntifloodHandler
-	OutputAntiFlood      factory.P2PAntifloodHandler
-	PeerBlackList        process.PeerBlackListCacher
-	PreferredPeersHolder factory.PreferredPeersHolderHandler
+	Messenger               p2p.Messenger
+	InputAntiFlood          factory.P2PAntifloodHandler
+	OutputAntiFlood         factory.P2PAntifloodHandler
+	PeerBlackList           process.PeerBlackListCacher
+	PreferredPeersHolder    factory.PreferredPeersHolderHandler
+	PeersRatingHandlerField p2p.PeersRatingHandler
 }
 
 // PubKeyCacher -
@@ -63,6 +64,11 @@ func (ncm *NetworkComponentsMock) PeerBlackListHandler() process.PeerBlackListCa
 // PreferredPeersHolderHandler -
 func (ncm *NetworkComponentsMock) PreferredPeersHolderHandler() factory.PreferredPeersHolderHandler {
 	return ncm.PreferredPeersHolder
+}
+
+// PeersRatingHandler -
+func (ncm *NetworkComponentsMock) PeersRatingHandler() p2p.PeersRatingHandler {
+	return ncm.PeersRatingHandlerField
 }
 
 // IsInterfaceNil -

--- a/factory/networkComponents.go
+++ b/factory/networkComponents.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process/rating/peerHonesty"
 	antifloodFactory "github.com/ElrondNetwork/elrond-go/process/throttle/antiflood/factory"
 	storageFactory "github.com/ElrondNetwork/elrond-go/storage/factory"
+	"github.com/ElrondNetwork/elrond-go/storage/lrucache"
 	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
 )
 
@@ -96,8 +97,18 @@ func NewNetworkComponentsFactory(
 
 // Create creates and returns the network components
 func (ncf *networkComponentsFactory) Create() (*networkComponents, error) {
+	topRatedCache, err := lrucache.NewCache(ncf.mainConfig.PeersRatingConfig.TopRatedCacheCapacity)
+	if err != nil {
+		return nil, err
+	}
+	badRatedCache, err := lrucache.NewCache(ncf.mainConfig.PeersRatingConfig.BadRatedCacheCapacity)
+	if err != nil {
+		return nil, err
+	}
 	argsPeersRatingHandler := rating.ArgPeersRatingHandler{
-		Randomizer: &random.ConcurrentSafeIntRandomizer{},
+		TopRatedCache: topRatedCache,
+		BadRatedCache: badRatedCache,
+		Randomizer:    &random.ConcurrentSafeIntRandomizer{},
 	}
 	peersRatingHandler, err := rating.NewPeersRatingHandler(argsPeersRatingHandler)
 	if err != nil {

--- a/factory/networkComponents.go
+++ b/factory/networkComponents.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/core/peersholder"
-	"github.com/ElrondNetwork/elrond-go-core/core/random"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/consensus"
@@ -108,7 +107,6 @@ func (ncf *networkComponentsFactory) Create() (*networkComponents, error) {
 	argsPeersRatingHandler := rating.ArgPeersRatingHandler{
 		TopRatedCache: topRatedCache,
 		BadRatedCache: badRatedCache,
-		Randomizer:    &random.ConcurrentSafeIntRandomizer{},
 	}
 	peersRatingHandler, err := rating.NewPeersRatingHandler(argsPeersRatingHandler)
 	if err != nil {

--- a/factory/networkComponentsHandler.go
+++ b/factory/networkComponentsHandler.go
@@ -164,7 +164,7 @@ func (mnc *managedNetworkComponents) PeerHonestyHandler() PeerHonestyHandler {
 	return mnc.networkComponents.peerHonestyHandler
 }
 
-// PreferredPeersHolder returns the preferred peers holder
+// PreferredPeersHolderHandler returns the preferred peers holder
 func (mnc *managedNetworkComponents) PreferredPeersHolderHandler() PreferredPeersHolderHandler {
 	mnc.mutNetworkComponents.RLock()
 	defer mnc.mutNetworkComponents.RUnlock()
@@ -174,6 +174,18 @@ func (mnc *managedNetworkComponents) PreferredPeersHolderHandler() PreferredPeer
 	}
 
 	return mnc.networkComponents.peersHolder
+}
+
+// PeersRatingHandler returns the peers rating handler
+func (mnc *managedNetworkComponents) PeersRatingHandler() p2p.PeersRatingHandler {
+	mnc.mutNetworkComponents.RLock()
+	defer mnc.mutNetworkComponents.RUnlock()
+
+	if mnc.networkComponents == nil {
+		return nil
+	}
+
+	return mnc.networkComponents.peersRatingHandler
 }
 
 // IsInterfaceNil returns true if the value under the interface is nil

--- a/factory/networkComponents_test.go
+++ b/factory/networkComponents_test.go
@@ -118,6 +118,10 @@ func getNetworkArgs() factory.NetworkComponentsFactoryArgs {
 				IntervalAutoPrintInSeconds: 1,
 			},
 		},
+		PeersRatingConfig: config.PeersRatingConfig{
+			TopRatedCacheCapacity: 1000,
+			BadRatedCacheCapacity: 1000,
+		},
 	}
 
 	appStatusHandler := statusHandlerMock.NewAppStatusHandlerMock()

--- a/factory/processComponents.go
+++ b/factory/processComponents.go
@@ -1041,6 +1041,7 @@ func (pcf *processComponentsFactory) newShardResolverContainerFactory(
 		CurrentNetworkEpochProvider: currentEpochProvider,
 		ResolverConfig:              pcf.config.Resolvers,
 		PreferredPeersHolder:        pcf.network.PreferredPeersHolderHandler(),
+		PeersRatingHandler:          pcf.network.PeersRatingHandler(),
 	}
 	resolversContainerFactory, err := resolverscontainer.NewShardResolversContainerFactory(resolversContainerFactoryArgs)
 	if err != nil {
@@ -1076,6 +1077,7 @@ func (pcf *processComponentsFactory) newMetaResolverContainerFactory(
 		CurrentNetworkEpochProvider: currentEpochProvider,
 		ResolverConfig:              pcf.config.Resolvers,
 		PreferredPeersHolder:        pcf.network.PreferredPeersHolderHandler(),
+		PeersRatingHandler:          pcf.network.PeersRatingHandler(),
 	}
 	resolversContainerFactory, err := resolverscontainer.NewMetaResolversContainerFactory(resolversContainerFactoryArgs)
 	if err != nil {

--- a/integrationTests/mock/networkComponentsMock.go
+++ b/integrationTests/mock/networkComponentsMock.go
@@ -8,12 +8,13 @@ import (
 
 // NetworkComponentsStub -
 type NetworkComponentsStub struct {
-	Messenger            p2p.Messenger
-	InputAntiFlood       factory.P2PAntifloodHandler
-	OutputAntiFlood      factory.P2PAntifloodHandler
-	PeerBlackList        process.PeerBlackListCacher
-	PeerHonesty          factory.PeerHonestyHandler
-	PreferredPeersHolder factory.PreferredPeersHolderHandler
+	Messenger               p2p.Messenger
+	InputAntiFlood          factory.P2PAntifloodHandler
+	OutputAntiFlood         factory.P2PAntifloodHandler
+	PeerBlackList           process.PeerBlackListCacher
+	PeerHonesty             factory.PeerHonestyHandler
+	PreferredPeersHolder    factory.PreferredPeersHolderHandler
+	PeersRatingHandlerField p2p.PeersRatingHandler
 }
 
 // PubKeyCacher -
@@ -64,6 +65,11 @@ func (ncs *NetworkComponentsStub) PeerBlackListHandler() process.PeerBlackListCa
 // PreferredPeersHolderHandler -
 func (ncs *NetworkComponentsStub) PreferredPeersHolderHandler() factory.PreferredPeersHolderHandler {
 	return ncs.PreferredPeersHolder
+}
+
+// PeersRatingHandler -
+func (ncs *NetworkComponentsStub) PeersRatingHandler() p2p.PeersRatingHandler {
+	return ncs.PeersRatingHandlerField
 }
 
 // String -

--- a/integrationTests/multiShard/hardFork/hardFork_test.go
+++ b/integrationTests/multiShard/hardFork/hardFork_test.go
@@ -23,7 +23,6 @@ import (
 	vmFactory "github.com/ElrondNetwork/elrond-go/process/factory"
 	"github.com/ElrondNetwork/elrond-go/state"
 	"github.com/ElrondNetwork/elrond-go/testscommon/genesisMocks"
-	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	"github.com/ElrondNetwork/elrond-go/update/factory"
 	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts/defaults"
 	"github.com/stretchr/testify/assert"
@@ -619,7 +618,7 @@ func createHardForkExporter(
 			MaxHardCapForMissingNodes: 500,
 			NumConcurrentTrieSyncers:  50,
 			TrieSyncerVersion:         2,
-			PeersRatingHandler:        &p2pmocks.PeersRatingHandlerStub{},
+			PeersRatingHandler:        node.PeersRatingHandler,
 		}
 
 		exportHandler, err := factory.NewExportHandlerFactory(argsExportHandler)

--- a/integrationTests/multiShard/hardFork/hardFork_test.go
+++ b/integrationTests/multiShard/hardFork/hardFork_test.go
@@ -23,6 +23,7 @@ import (
 	vmFactory "github.com/ElrondNetwork/elrond-go/process/factory"
 	"github.com/ElrondNetwork/elrond-go/state"
 	"github.com/ElrondNetwork/elrond-go/testscommon/genesisMocks"
+	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	"github.com/ElrondNetwork/elrond-go/update/factory"
 	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts/defaults"
 	"github.com/stretchr/testify/assert"
@@ -618,6 +619,7 @@ func createHardForkExporter(
 			MaxHardCapForMissingNodes: 500,
 			NumConcurrentTrieSyncers:  50,
 			TrieSyncerVersion:         2,
+			PeersRatingHandler:        &p2pmocks.PeersRatingHandlerStub{},
 		}
 
 		exportHandler, err := factory.NewExportHandlerFactory(argsExportHandler)

--- a/integrationTests/p2p/peerDisconnecting/peerDisconnecting_test.go
+++ b/integrationTests/p2p/peerDisconnecting/peerDisconnecting_test.go
@@ -69,6 +69,7 @@ func testPeerDisconnectionWithOneAdvertiser(t *testing.T, p2pConfig config.P2PCo
 		NodeOperationMode:    p2p.NormalOperation,
 		Marshalizer:          &testscommon.MarshalizerMock{},
 		SyncTimer:            &testscommon.SyncTimerStub{},
+		PeersRatingHandler:   &p2pmocks.PeersRatingHandlerStub{},
 	}
 	// Step 1. Create advertiser
 	advertiser, err := libp2p.NewMockMessenger(argSeeder, netw)
@@ -85,6 +86,7 @@ func testPeerDisconnectionWithOneAdvertiser(t *testing.T, p2pConfig config.P2PCo
 			NodeOperationMode:    p2p.NormalOperation,
 			Marshalizer:          &testscommon.MarshalizerMock{},
 			SyncTimer:            &testscommon.SyncTimerStub{},
+			PeersRatingHandler:   &p2pmocks.PeersRatingHandlerStub{},
 		}
 		node, errCreate := libp2p.NewMockMessenger(arg, netw)
 		require.Nil(t, errCreate)

--- a/integrationTests/p2p/peerDisconnecting/seedersDisconnecting_test.go
+++ b/integrationTests/p2p/peerDisconnecting/seedersDisconnecting_test.go
@@ -57,6 +57,7 @@ func TestSeedersDisconnectionWith2AdvertiserAnd3Peers(t *testing.T) {
 			NodeOperationMode:    p2p.NormalOperation,
 			Marshalizer:          &testscommon.MarshalizerMock{},
 			SyncTimer:            &testscommon.SyncTimerStub{},
+			PeersRatingHandler:   &p2pmocks.PeersRatingHandlerStub{},
 		}
 		node, err := libp2p.NewMockMessenger(arg, netw)
 		require.Nil(t, err)
@@ -129,6 +130,7 @@ func createBootstrappedSeeders(baseP2PConfig config.P2PConfig, numSeeders int, n
 		NodeOperationMode:    p2p.NormalOperation,
 		Marshalizer:          &testscommon.MarshalizerMock{},
 		SyncTimer:            &testscommon.SyncTimerStub{},
+		PeersRatingHandler:   &p2pmocks.PeersRatingHandlerStub{},
 	}
 	seeders[0], _ = libp2p.NewMockMessenger(argSeeder, netw)
 	_ = seeders[0].Bootstrap()
@@ -144,6 +146,7 @@ func createBootstrappedSeeders(baseP2PConfig config.P2PConfig, numSeeders int, n
 			NodeOperationMode:    p2p.NormalOperation,
 			Marshalizer:          &testscommon.MarshalizerMock{},
 			SyncTimer:            &testscommon.SyncTimerStub{},
+			PeersRatingHandler:   &p2pmocks.PeersRatingHandlerStub{},
 		}
 		seeders[i], _ = libp2p.NewMockMessenger(argSeeder, netw)
 		_ = netw.LinkAll()

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -217,6 +217,29 @@ func CreateMessengerFromConfig(p2pConfig config.P2PConfig) p2p.Messenger {
 	return libP2PMes
 }
 
+// CreateMessengerFromConfigWithPeersRatingHandler creates a new libp2p messenger with provided configuration
+func CreateMessengerFromConfigWithPeersRatingHandler(p2pConfig config.P2PConfig, peersRatingHandler p2p.PeersRatingHandler) p2p.Messenger {
+	arg := libp2p.ArgsNetworkMessenger{
+		Marshalizer:          TestMarshalizer,
+		ListenAddress:        libp2p.ListenLocalhostAddrWithIp4AndTcp,
+		P2pConfig:            p2pConfig,
+		SyncTimer:            &libp2p.LocalSyncTimer{},
+		PreferredPeersHolder: &p2pmocks.PeersHolderStub{},
+		NodeOperationMode:    p2p.NormalOperation,
+		PeersRatingHandler:   peersRatingHandler,
+	}
+
+	if p2pConfig.Sharding.AdditionalConnections.MaxFullHistoryObservers > 0 {
+		// we deliberately set this, automatically choose full archive node mode
+		arg.NodeOperationMode = p2p.FullArchiveMode
+	}
+
+	libP2PMes, err := libp2p.NewNetworkMessenger(arg)
+	log.LogIfError(err)
+
+	return libP2PMes
+}
+
 // CreateMessengerWithNoDiscovery creates a new libp2p messenger with no peer discovery
 func CreateMessengerWithNoDiscovery() p2p.Messenger {
 	p2pConfig := config.P2PConfig{
@@ -234,6 +257,25 @@ func CreateMessengerWithNoDiscovery() p2p.Messenger {
 	}
 
 	return CreateMessengerFromConfig(p2pConfig)
+}
+
+// CreateMessengerWithNoDiscoveryAndPeersRatingHandler creates a new libp2p messenger with no peer discovery
+func CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHanlder p2p.PeersRatingHandler) p2p.Messenger {
+	p2pConfig := config.P2PConfig{
+		Node: config.NodeConfig{
+			Port:                  "0",
+			Seed:                  "",
+			ConnectionWatcherType: "print",
+		},
+		KadDhtPeerDiscovery: config.KadDhtPeerDiscoveryConfig{
+			Enabled: false,
+		},
+		Sharding: config.ShardingConfig{
+			Type: p2p.NilListSharder,
+		},
+	}
+
+	return CreateMessengerFromConfigWithPeersRatingHandler(p2pConfig, peersRatingHanlder)
 }
 
 // CreateFixedNetworkOf8Peers assembles a network as following:

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -161,6 +161,7 @@ func CreateMessengerWithKadDht(initialAddr string) p2p.Messenger {
 		SyncTimer:            &libp2p.LocalSyncTimer{},
 		PreferredPeersHolder: &p2pmocks.PeersHolderStub{},
 		NodeOperationMode:    p2p.NormalOperation,
+		PeersRatingHandler:   &p2pmocks.PeersRatingHandlerStub{},
 	}
 
 	libP2PMes, err := libp2p.NewNetworkMessenger(arg)
@@ -184,6 +185,7 @@ func CreateMessengerWithKadDhtAndProtocolID(initialAddr string, protocolID strin
 		SyncTimer:            &libp2p.LocalSyncTimer{},
 		PreferredPeersHolder: &p2pmocks.PeersHolderStub{},
 		NodeOperationMode:    p2p.NormalOperation,
+		PeersRatingHandler:   &p2pmocks.PeersRatingHandlerStub{},
 	}
 
 	libP2PMes, err := libp2p.NewNetworkMessenger(arg)
@@ -201,6 +203,7 @@ func CreateMessengerFromConfig(p2pConfig config.P2PConfig) p2p.Messenger {
 		SyncTimer:            &libp2p.LocalSyncTimer{},
 		PreferredPeersHolder: &p2pmocks.PeersHolderStub{},
 		NodeOperationMode:    p2p.NormalOperation,
+		PeersRatingHandler:   &p2pmocks.PeersRatingHandlerStub{},
 	}
 
 	if p2pConfig.Sharding.AdditionalConnections.MaxFullHistoryObservers > 0 {

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -1333,6 +1333,7 @@ func (tpn *TestProcessorNode) initResolvers() {
 			NumIntraShardPeers:  1,
 			NumFullHistoryPeers: 3,
 		},
+		PeersRatingHandler: &p2pmocks.PeersRatingHandlerStub{},
 	}
 
 	var err error
@@ -3024,10 +3025,11 @@ func GetDefaultStateComponents() *testscommon.StateComponentsMock {
 // GetDefaultNetworkComponents -
 func GetDefaultNetworkComponents() *mock.NetworkComponentsStub {
 	return &mock.NetworkComponentsStub{
-		Messenger:       &p2pmocks.MessengerStub{},
-		InputAntiFlood:  &mock.P2PAntifloodHandlerStub{},
-		OutputAntiFlood: &mock.P2PAntifloodHandlerStub{},
-		PeerBlackList:   &mock.PeerBlackListCacherStub{},
+		Messenger:               &p2pmocks.MessengerStub{},
+		InputAntiFlood:          &mock.P2PAntifloodHandlerStub{},
+		OutputAntiFlood:         &mock.P2PAntifloodHandlerStub{},
+		PeerBlackList:           &mock.PeerBlackListCacherStub{},
+		PeersRatingHandlerField: &p2pmocks.PeersRatingHandlerStub{},
 	}
 }
 

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/core/partitioning"
 	"github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter"
-	"github.com/ElrondNetwork/elrond-go-core/core/random"
 	"github.com/ElrondNetwork/elrond-go-core/core/versioning"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	dataBlock "github.com/ElrondNetwork/elrond-go-core/data/block"
@@ -409,7 +408,6 @@ func newBaseTestProcessorNode(
 		p2pRating.ArgPeersRatingHandler{
 			TopRatedCache: testscommon.NewCacherMock(),
 			BadRatedCache: testscommon.NewCacherMock(),
-			Randomizer:    &random.ConcurrentSafeIntRandomizer{},
 		})
 
 	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
@@ -594,7 +592,6 @@ func NewTestProcessorNodeWithCustomDataPool(maxShards uint32, nodeShardId uint32
 		p2pRating.ArgPeersRatingHandler{
 			TopRatedCache: testscommon.NewCacherMock(),
 			BadRatedCache: testscommon.NewCacherMock(),
-			Randomizer:    &random.ConcurrentSafeIntRandomizer{},
 		})
 
 	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/core/partitioning"
 	"github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter"
+	"github.com/ElrondNetwork/elrond-go-core/core/random"
 	"github.com/ElrondNetwork/elrond-go-core/core/versioning"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	dataBlock "github.com/ElrondNetwork/elrond-go-core/data/block"
@@ -54,6 +55,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/node/external"
 	"github.com/ElrondNetwork/elrond-go/node/nodeDebugFactory"
 	"github.com/ElrondNetwork/elrond-go/p2p"
+	p2pRating "github.com/ElrondNetwork/elrond-go/p2p/rating"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/block"
 	"github.com/ElrondNetwork/elrond-go/process/block/bootstrapStorage"
@@ -327,6 +329,8 @@ type TestProcessorNode struct {
 
 	TransactionLogProcessor        process.TransactionLogProcessor
 	ScheduledMiniBlocksEnableEpoch uint32
+
+	PeersRatingHandler p2p.PeersRatingHandler
 }
 
 // CreatePkBytes creates 'numShards' public key-like byte slices
@@ -401,7 +405,9 @@ func newBaseTestProcessorNode(
 		},
 	}
 
-	messenger := CreateMessengerWithNoDiscovery()
+	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(p2pRating.ArgPeersRatingHandler{Randomizer: &random.ConcurrentSafeIntRandomizer{}})
+
+	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 
 	logsProcessor, _ := transactionLog.NewTxLogProcessor(transactionLog.ArgTxLogProcessor{Marshalizer: TestMarshalizer})
 	tpn := &TestProcessorNode{
@@ -418,6 +424,7 @@ func newBaseTestProcessorNode(
 		ArwenChangeLocker:       &sync.RWMutex{},
 		TransactionLogProcessor: logsProcessor,
 		Bootstrapper:            mock.NewTestBootstrapperMock(),
+		PeersRatingHandler:      peersRatingHandler,
 	}
 
 	tpn.ScheduledMiniBlocksEnableEpoch = uint32(1000000)
@@ -578,7 +585,9 @@ func NewTestProcessorNodeWithFullGenesis(
 func NewTestProcessorNodeWithCustomDataPool(maxShards uint32, nodeShardId uint32, txSignPrivKeyShardId uint32, dPool dataRetriever.PoolsHolder) *TestProcessorNode {
 	shardCoordinator, _ := sharding.NewMultiShardCoordinator(maxShards, nodeShardId)
 
-	messenger := CreateMessengerWithNoDiscovery()
+	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(p2pRating.ArgPeersRatingHandler{Randomizer: &random.ConcurrentSafeIntRandomizer{}})
+
+	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 	_ = messenger.SetThresholdMinConnectedPeers(minConnectedPeers)
 	nodesCoordinator := &shardingMocks.NodesCoordinatorMock{}
 	kg := &mock.KeyGenMock{}
@@ -602,6 +611,7 @@ func NewTestProcessorNodeWithCustomDataPool(maxShards uint32, nodeShardId uint32
 		EpochNotifier:           forking.NewGenericEpochNotifier(),
 		ArwenChangeLocker:       &sync.RWMutex{},
 		TransactionLogProcessor: logsProcessor,
+		PeersRatingHandler:      peersRatingHandler,
 	}
 
 	tpn.NodeKeys = &TestKeyPair{
@@ -1333,7 +1343,7 @@ func (tpn *TestProcessorNode) initResolvers() {
 			NumIntraShardPeers:  1,
 			NumFullHistoryPeers: 3,
 		},
-		PeersRatingHandler: &p2pmocks.PeersRatingHandlerStub{},
+		PeersRatingHandler: tpn.PeersRatingHandler,
 	}
 
 	var err error

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -405,7 +405,12 @@ func newBaseTestProcessorNode(
 		},
 	}
 
-	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(p2pRating.ArgPeersRatingHandler{Randomizer: &random.ConcurrentSafeIntRandomizer{}})
+	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(
+		p2pRating.ArgPeersRatingHandler{
+			TopRatedCache: testscommon.NewCacherMock(),
+			BadRatedCache: testscommon.NewCacherMock(),
+			Randomizer:    &random.ConcurrentSafeIntRandomizer{},
+		})
 
 	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 
@@ -585,7 +590,12 @@ func NewTestProcessorNodeWithFullGenesis(
 func NewTestProcessorNodeWithCustomDataPool(maxShards uint32, nodeShardId uint32, txSignPrivKeyShardId uint32, dPool dataRetriever.PoolsHolder) *TestProcessorNode {
 	shardCoordinator, _ := sharding.NewMultiShardCoordinator(maxShards, nodeShardId)
 
-	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(p2pRating.ArgPeersRatingHandler{Randomizer: &random.ConcurrentSafeIntRandomizer{}})
+	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(
+		p2pRating.ArgPeersRatingHandler{
+			TopRatedCache: testscommon.NewCacherMock(),
+			BadRatedCache: testscommon.NewCacherMock(),
+			Randomizer:    &random.ConcurrentSafeIntRandomizer{},
+		})
 
 	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 	_ = messenger.SetThresholdMinConnectedPeers(minConnectedPeers)

--- a/integrationTests/testProcessorNodeWithCoordinator.go
+++ b/integrationTests/testProcessorNodeWithCoordinator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/sharding"
 	"github.com/ElrondNetwork/elrond-go/sharding/nodesCoordinator"
 	"github.com/ElrondNetwork/elrond-go/storage/lrucache"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 )
 
 type nodeKeys struct {
@@ -203,7 +204,12 @@ func newTestProcessorNodeWithCustomNodesCoordinator(
 
 	shardCoordinator, _ := sharding.NewMultiShardCoordinator(maxShards, nodeShardId)
 
-	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(p2pRating.ArgPeersRatingHandler{Randomizer: &random.ConcurrentSafeIntRandomizer{}})
+	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(
+		p2pRating.ArgPeersRatingHandler{
+			TopRatedCache: testscommon.NewCacherMock(),
+			BadRatedCache: testscommon.NewCacherMock(),
+			Randomizer:    &random.ConcurrentSafeIntRandomizer{},
+		})
 
 	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 	tpn := &TestProcessorNode{

--- a/integrationTests/testProcessorNodeWithCoordinator.go
+++ b/integrationTests/testProcessorNodeWithCoordinator.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/random"
 	"github.com/ElrondNetwork/elrond-go-core/data/endProcess"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
 	"github.com/ElrondNetwork/elrond-go-core/hashing/blake2b"
@@ -16,6 +17,7 @@ import (
 	multisig2 "github.com/ElrondNetwork/elrond-go-crypto/signing/mcl/multisig"
 	"github.com/ElrondNetwork/elrond-go-crypto/signing/multisig"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/mock"
+	p2pRating "github.com/ElrondNetwork/elrond-go/p2p/rating"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 	"github.com/ElrondNetwork/elrond-go/sharding/nodesCoordinator"
 	"github.com/ElrondNetwork/elrond-go/storage/lrucache"
@@ -201,7 +203,9 @@ func newTestProcessorNodeWithCustomNodesCoordinator(
 
 	shardCoordinator, _ := sharding.NewMultiShardCoordinator(maxShards, nodeShardId)
 
-	messenger := CreateMessengerWithNoDiscovery()
+	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(p2pRating.ArgPeersRatingHandler{Randomizer: &random.ConcurrentSafeIntRandomizer{}})
+
+	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 	tpn := &TestProcessorNode{
 		ShardCoordinator:        shardCoordinator,
 		Messenger:               messenger,
@@ -211,6 +215,7 @@ func newTestProcessorNodeWithCustomNodesCoordinator(
 		ChainID:                 ChainID,
 		NodesSetup:              nodesSetup,
 		ArwenChangeLocker:       &sync.RWMutex{},
+		PeersRatingHandler:      peersRatingHandler,
 	}
 
 	tpn.NodeKeys = &TestKeyPair{

--- a/integrationTests/testProcessorNodeWithCoordinator.go
+++ b/integrationTests/testProcessorNodeWithCoordinator.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
-	"github.com/ElrondNetwork/elrond-go-core/core/random"
 	"github.com/ElrondNetwork/elrond-go-core/data/endProcess"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
 	"github.com/ElrondNetwork/elrond-go-core/hashing/blake2b"
@@ -208,7 +207,6 @@ func newTestProcessorNodeWithCustomNodesCoordinator(
 		p2pRating.ArgPeersRatingHandler{
 			TopRatedCache: testscommon.NewCacherMock(),
 			BadRatedCache: testscommon.NewCacherMock(),
-			Randomizer:    &random.ConcurrentSafeIntRandomizer{},
 		})
 
 	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)

--- a/integrationTests/testProcessorNodeWithMultisigner.go
+++ b/integrationTests/testProcessorNodeWithMultisigner.go
@@ -56,7 +56,12 @@ func NewTestProcessorNodeWithCustomNodesCoordinator(
 	shardCoordinator, _ := sharding.NewMultiShardCoordinator(maxShards, nodeShardId)
 
 	logsProcessor, _ := transactionLog.NewTxLogProcessor(transactionLog.ArgTxLogProcessor{Marshalizer: TestMarshalizer})
-	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(p2pRating.ArgPeersRatingHandler{Randomizer: &random.ConcurrentSafeIntRandomizer{}})
+	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(
+		p2pRating.ArgPeersRatingHandler{
+			TopRatedCache: testscommon.NewCacherMock(),
+			BadRatedCache: testscommon.NewCacherMock(),
+			Randomizer:    &random.ConcurrentSafeIntRandomizer{},
+		})
 	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 	tpn := &TestProcessorNode{
 		ShardCoordinator:        shardCoordinator,
@@ -245,7 +250,12 @@ func CreateNodeWithBLSAndTxKeys(
 	shardCoordinator, _ := sharding.NewMultiShardCoordinator(uint32(nbShards), shardId)
 
 	logsProcessor, _ := transactionLog.NewTxLogProcessor(transactionLog.ArgTxLogProcessor{Marshalizer: TestMarshalizer})
-	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(p2pRating.ArgPeersRatingHandler{Randomizer: &random.ConcurrentSafeIntRandomizer{}})
+	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(
+		p2pRating.ArgPeersRatingHandler{
+			TopRatedCache: testscommon.NewCacherMock(),
+			BadRatedCache: testscommon.NewCacherMock(),
+			Randomizer:    &random.ConcurrentSafeIntRandomizer{},
+		})
 	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 	tpn := &TestProcessorNode{
 		ShardCoordinator:        shardCoordinator,

--- a/integrationTests/testProcessorNodeWithMultisigner.go
+++ b/integrationTests/testProcessorNodeWithMultisigner.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
-	"github.com/ElrondNetwork/elrond-go-core/core/random"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/endProcess"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
@@ -60,7 +59,6 @@ func NewTestProcessorNodeWithCustomNodesCoordinator(
 		p2pRating.ArgPeersRatingHandler{
 			TopRatedCache: testscommon.NewCacherMock(),
 			BadRatedCache: testscommon.NewCacherMock(),
-			Randomizer:    &random.ConcurrentSafeIntRandomizer{},
 		})
 	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 	tpn := &TestProcessorNode{
@@ -254,7 +252,6 @@ func CreateNodeWithBLSAndTxKeys(
 		p2pRating.ArgPeersRatingHandler{
 			TopRatedCache: testscommon.NewCacherMock(),
 			BadRatedCache: testscommon.NewCacherMock(),
-			Randomizer:    &random.ConcurrentSafeIntRandomizer{},
 		})
 	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 	tpn := &TestProcessorNode{

--- a/integrationTests/testProcessorNodeWithMultisigner.go
+++ b/integrationTests/testProcessorNodeWithMultisigner.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/core/random"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/endProcess"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
@@ -22,6 +23,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/epochStart/notifier"
 	"github.com/ElrondNetwork/elrond-go/factory/peerSignatureHandler"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/mock"
+	p2pRating "github.com/ElrondNetwork/elrond-go/p2p/rating"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/headerCheck"
 	"github.com/ElrondNetwork/elrond-go/process/rating"
@@ -54,7 +56,8 @@ func NewTestProcessorNodeWithCustomNodesCoordinator(
 	shardCoordinator, _ := sharding.NewMultiShardCoordinator(maxShards, nodeShardId)
 
 	logsProcessor, _ := transactionLog.NewTxLogProcessor(transactionLog.ArgTxLogProcessor{Marshalizer: TestMarshalizer})
-	messenger := CreateMessengerWithNoDiscovery()
+	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(p2pRating.ArgPeersRatingHandler{Randomizer: &random.ConcurrentSafeIntRandomizer{}})
+	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 	tpn := &TestProcessorNode{
 		ShardCoordinator:        shardCoordinator,
 		Messenger:               messenger,
@@ -70,6 +73,7 @@ func NewTestProcessorNodeWithCustomNodesCoordinator(
 		ArwenChangeLocker:       &sync.RWMutex{},
 		TransactionLogProcessor: logsProcessor,
 		Bootstrapper:            mock.NewTestBootstrapperMock(),
+		PeersRatingHandler:      peersRatingHandler,
 	}
 
 	tpn.ScheduledMiniBlocksEnableEpoch = uint32(1000000)
@@ -241,7 +245,8 @@ func CreateNodeWithBLSAndTxKeys(
 	shardCoordinator, _ := sharding.NewMultiShardCoordinator(uint32(nbShards), shardId)
 
 	logsProcessor, _ := transactionLog.NewTxLogProcessor(transactionLog.ArgTxLogProcessor{Marshalizer: TestMarshalizer})
-	messenger := CreateMessengerWithNoDiscovery()
+	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(p2pRating.ArgPeersRatingHandler{Randomizer: &random.ConcurrentSafeIntRandomizer{}})
+	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 	tpn := &TestProcessorNode{
 		ShardCoordinator:        shardCoordinator,
 		Messenger:               messenger,
@@ -256,6 +261,7 @@ func CreateNodeWithBLSAndTxKeys(
 		EpochNotifier:           forking.NewGenericEpochNotifier(),
 		ArwenChangeLocker:       &sync.RWMutex{},
 		TransactionLogProcessor: logsProcessor,
+		PeersRatingHandler:      peersRatingHandler,
 	}
 
 	tpn.ScheduledMiniBlocksEnableEpoch = uint32(1000000)

--- a/integrationTests/testProcessorNodeWithStateCheckpointModulus.go
+++ b/integrationTests/testProcessorNodeWithStateCheckpointModulus.go
@@ -4,11 +4,13 @@ import (
 	"sync"
 
 	arwenConfig "github.com/ElrondNetwork/arwen-wasm-vm/v1_4/config"
+	"github.com/ElrondNetwork/elrond-go-core/core/random"
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/common/forking"
 	"github.com/ElrondNetwork/elrond-go/consensus/spos/sposFactory"
 	"github.com/ElrondNetwork/elrond-go/epochStart/notifier"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/mock"
+	p2pRating "github.com/ElrondNetwork/elrond-go/p2p/rating"
 	"github.com/ElrondNetwork/elrond-go/process/smartContract"
 	"github.com/ElrondNetwork/elrond-go/process/transactionLog"
 	"github.com/ElrondNetwork/elrond-go/sharding"
@@ -68,7 +70,9 @@ func NewTestProcessorNodeWithStateCheckpointModulus(
 	}
 
 	logsProcessor, _ := transactionLog.NewTxLogProcessor(transactionLog.ArgTxLogProcessor{Marshalizer: TestMarshalizer})
-	messenger := CreateMessengerWithNoDiscovery()
+	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(p2pRating.ArgPeersRatingHandler{Randomizer: &random.ConcurrentSafeIntRandomizer{}})
+
+	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 	tpn := &TestProcessorNode{
 		ShardCoordinator:        shardCoordinator,
 		Messenger:               messenger,
@@ -81,6 +85,7 @@ func NewTestProcessorNodeWithStateCheckpointModulus(
 		EpochNotifier:           forking.NewGenericEpochNotifier(),
 		ArwenChangeLocker:       &sync.RWMutex{},
 		TransactionLogProcessor: logsProcessor,
+		PeersRatingHandler:      peersRatingHandler,
 	}
 	tpn.NodesSetup = nodesSetup
 

--- a/integrationTests/testProcessorNodeWithStateCheckpointModulus.go
+++ b/integrationTests/testProcessorNodeWithStateCheckpointModulus.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 
 	arwenConfig "github.com/ElrondNetwork/arwen-wasm-vm/v1_4/config"
-	"github.com/ElrondNetwork/elrond-go-core/core/random"
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/common/forking"
 	"github.com/ElrondNetwork/elrond-go/consensus/spos/sposFactory"
@@ -74,7 +73,6 @@ func NewTestProcessorNodeWithStateCheckpointModulus(
 		p2pRating.ArgPeersRatingHandler{
 			TopRatedCache: testscommon.NewCacherMock(),
 			BadRatedCache: testscommon.NewCacherMock(),
-			Randomizer:    &random.ConcurrentSafeIntRandomizer{},
 		})
 
 	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)

--- a/integrationTests/testProcessorNodeWithStateCheckpointModulus.go
+++ b/integrationTests/testProcessorNodeWithStateCheckpointModulus.go
@@ -70,7 +70,12 @@ func NewTestProcessorNodeWithStateCheckpointModulus(
 	}
 
 	logsProcessor, _ := transactionLog.NewTxLogProcessor(transactionLog.ArgTxLogProcessor{Marshalizer: TestMarshalizer})
-	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(p2pRating.ArgPeersRatingHandler{Randomizer: &random.ConcurrentSafeIntRandomizer{}})
+	peersRatingHandler, _ := p2pRating.NewPeersRatingHandler(
+		p2pRating.ArgPeersRatingHandler{
+			TopRatedCache: testscommon.NewCacherMock(),
+			BadRatedCache: testscommon.NewCacherMock(),
+			Randomizer:    &random.ConcurrentSafeIntRandomizer{},
+		})
 
 	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 	tpn := &TestProcessorNode{

--- a/integrationTests/testSyncNode.go
+++ b/integrationTests/testSyncNode.go
@@ -6,6 +6,7 @@ import (
 
 	arwenConfig "github.com/ElrondNetwork/arwen-wasm-vm/v1_4/config"
 	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/random"
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/common/forking"
 	"github.com/ElrondNetwork/elrond-go/config"
@@ -14,6 +15,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/provider"
 	"github.com/ElrondNetwork/elrond-go/epochStart/notifier"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/mock"
+	"github.com/ElrondNetwork/elrond-go/p2p/rating"
 	"github.com/ElrondNetwork/elrond-go/process/block"
 	"github.com/ElrondNetwork/elrond-go/process/block/bootstrapStorage"
 	"github.com/ElrondNetwork/elrond-go/process/smartContract"
@@ -71,7 +73,9 @@ func NewTestSyncNode(
 		},
 	}
 
-	messenger := CreateMessengerWithNoDiscovery()
+	peersRatingHandler, _ := rating.NewPeersRatingHandler(rating.ArgPeersRatingHandler{Randomizer: &random.ConcurrentSafeIntRandomizer{}})
+
+	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 
 	logsProcessor, _ := transactionLog.NewTxLogProcessor(transactionLog.ArgTxLogProcessor{Marshalizer: TestMarshalizer})
 	tpn := &TestProcessorNode{
@@ -94,6 +98,7 @@ func NewTestSyncNode(
 		EpochNotifier:           forking.NewGenericEpochNotifier(),
 		ArwenChangeLocker:       &syncGo.RWMutex{},
 		TransactionLogProcessor: logsProcessor,
+		PeersRatingHandler:      peersRatingHandler,
 	}
 
 	kg := &mock.KeyGenMock{}

--- a/integrationTests/testSyncNode.go
+++ b/integrationTests/testSyncNode.go
@@ -73,7 +73,12 @@ func NewTestSyncNode(
 		},
 	}
 
-	peersRatingHandler, _ := rating.NewPeersRatingHandler(rating.ArgPeersRatingHandler{Randomizer: &random.ConcurrentSafeIntRandomizer{}})
+	peersRatingHandler, _ := rating.NewPeersRatingHandler(
+		rating.ArgPeersRatingHandler{
+			TopRatedCache: testscommon.NewCacherMock(),
+			BadRatedCache: testscommon.NewCacherMock(),
+			Randomizer:    &random.ConcurrentSafeIntRandomizer{},
+		})
 
 	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)
 

--- a/integrationTests/testSyncNode.go
+++ b/integrationTests/testSyncNode.go
@@ -6,7 +6,6 @@ import (
 
 	arwenConfig "github.com/ElrondNetwork/arwen-wasm-vm/v1_4/config"
 	"github.com/ElrondNetwork/elrond-go-core/core"
-	"github.com/ElrondNetwork/elrond-go-core/core/random"
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/common/forking"
 	"github.com/ElrondNetwork/elrond-go/config"
@@ -77,7 +76,6 @@ func NewTestSyncNode(
 		rating.ArgPeersRatingHandler{
 			TopRatedCache: testscommon.NewCacherMock(),
 			BadRatedCache: testscommon.NewCacherMock(),
-			Randomizer:    &random.ConcurrentSafeIntRandomizer{},
 		})
 
 	messenger := CreateMessengerWithNoDiscoveryAndPeersRatingHandler(peersRatingHandler)

--- a/node/mock/factory/networkComponentsMock.go
+++ b/node/mock/factory/networkComponentsMock.go
@@ -8,11 +8,12 @@ import (
 
 // NetworkComponentsMock -
 type NetworkComponentsMock struct {
-	Messenger            p2p.Messenger
-	InputAntiFlood       factory.P2PAntifloodHandler
-	OutputAntiFlood      factory.P2PAntifloodHandler
-	PeerBlackList        process.PeerBlackListCacher
-	PreferredPeersHolder factory.PreferredPeersHolderHandler
+	Messenger               p2p.Messenger
+	InputAntiFlood          factory.P2PAntifloodHandler
+	OutputAntiFlood         factory.P2PAntifloodHandler
+	PeerBlackList           process.PeerBlackListCacher
+	PreferredPeersHolder    factory.PreferredPeersHolderHandler
+	PeersRatingHandlerField p2p.PeersRatingHandler
 }
 
 // PubKeyCacher -
@@ -63,6 +64,11 @@ func (ncm *NetworkComponentsMock) PeerBlackListHandler() process.PeerBlackListCa
 // PreferredPeersHolderHandler -
 func (ncm *NetworkComponentsMock) PreferredPeersHolderHandler() factory.PreferredPeersHolderHandler {
 	return ncm.PreferredPeersHolder
+}
+
+// PeersRatingHandler -
+func (ncm *NetworkComponentsMock) PeersRatingHandler() p2p.PeersRatingHandler {
+	return ncm.PeersRatingHandlerField
 }
 
 // String -

--- a/node/nodeHelper.go
+++ b/node/nodeHelper.go
@@ -80,6 +80,7 @@ func CreateHardForkTrigger(
 		InputAntifloodHandler:     network.InputAntiFloodHandler(),
 		OutputAntifloodHandler:    network.OutputAntiFloodHandler(),
 		RoundHandler:              process.RoundHandler(),
+		PeersRatingHandler:        network.PeersRatingHandler(),
 		InterceptorDebugConfig:    config.Debug.InterceptorResolver,
 		EnableSignTxWithHashEpoch: epochConfig.EnableEpochs.TransactionSignedWithTxHashEnableEpoch,
 		MaxHardCapForMissingNodes: config.TrieSync.MaxHardCapForMissingNodes,

--- a/p2p/errors.go
+++ b/p2p/errors.go
@@ -97,12 +97,6 @@ var ErrNilSharder = errors.New("nil sharder")
 // ErrNilPeerShardResolver signals that the peer shard resolver provided is nil
 var ErrNilPeerShardResolver = errors.New("nil PeerShardResolver")
 
-// ErrNilNetworkShardingCollector signals that the network sharding collector provided is nil
-var ErrNilNetworkShardingCollector = errors.New("nil network sharding collector")
-
-// ErrNilSignerVerifier signals that the signer-verifier instance provided is nil
-var ErrNilSignerVerifier = errors.New("nil signer-verifier")
-
 // ErrNilMarshalizer signals that an operation has been attempted to or with a nil marshalizer implementation
 var ErrNilMarshalizer = errors.New("nil marshalizer")
 
@@ -158,3 +152,9 @@ var ErrWrongTypeAssertions = errors.New("wrong type assertion")
 
 // ErrNilConnectionsWatcher signals that a nil connections watcher has been provided
 var ErrNilConnectionsWatcher = errors.New("nil connections watcher")
+
+// ErrNilRandomizer signals that a nil randomizer has been provided
+var ErrNilRandomizer = errors.New("nil randomizer")
+
+// ErrNilPeersRatingHandler signals that a nil peers rating handler has been provided
+var ErrNilPeersRatingHandler = errors.New("nil peers rating handler")

--- a/p2p/errors.go
+++ b/p2p/errors.go
@@ -158,3 +158,6 @@ var ErrNilRandomizer = errors.New("nil randomizer")
 
 // ErrNilPeersRatingHandler signals that a nil peers rating handler has been provided
 var ErrNilPeersRatingHandler = errors.New("nil peers rating handler")
+
+// ErrNilCacher signals that a nil cacher has been provided
+var ErrNilCacher = errors.New("nil cacher")

--- a/p2p/errors.go
+++ b/p2p/errors.go
@@ -153,9 +153,6 @@ var ErrWrongTypeAssertions = errors.New("wrong type assertion")
 // ErrNilConnectionsWatcher signals that a nil connections watcher has been provided
 var ErrNilConnectionsWatcher = errors.New("nil connections watcher")
 
-// ErrNilRandomizer signals that a nil randomizer has been provided
-var ErrNilRandomizer = errors.New("nil randomizer")
-
 // ErrNilPeersRatingHandler signals that a nil peers rating handler has been provided
 var ErrNilPeersRatingHandler = errors.New("nil peers rating handler")
 

--- a/p2p/libp2p/connectionMonitor/libp2pConnectionMonitorSimple.go
+++ b/p2p/libp2p/connectionMonitor/libp2pConnectionMonitorSimple.go
@@ -23,7 +23,6 @@ type libp2pConnectionMonitorSimple struct {
 	thresholdMinConnectedPeers int
 	sharder                    Sharder
 	preferredPeersHolder       p2p.PreferredPeersHolderHandler
-	peersRatingHandler         p2p.PeersRatingHandler
 	cancelFunc                 context.CancelFunc
 	connectionsWatcher         p2p.ConnectionsWatcher
 }
@@ -34,7 +33,6 @@ type ArgsConnectionMonitorSimple struct {
 	ThresholdMinConnectedPeers uint32
 	Sharder                    Sharder
 	PreferredPeersHolder       p2p.PreferredPeersHolderHandler
-	PeersRatingHandler         p2p.PeersRatingHandler
 	ConnectionsWatcher         p2p.ConnectionsWatcher
 }
 
@@ -50,9 +48,6 @@ func NewLibp2pConnectionMonitorSimple(args ArgsConnectionMonitorSimple) (*libp2p
 	if check.IfNil(args.PreferredPeersHolder) {
 		return nil, p2p.ErrNilPreferredPeersHolder
 	}
-	if check.IfNil(args.PeersRatingHandler) {
-		return nil, p2p.ErrNilPeersRatingHandler
-	}
 	if check.IfNil(args.ConnectionsWatcher) {
 		return nil, p2p.ErrNilConnectionsWatcher
 	}
@@ -66,7 +61,6 @@ func NewLibp2pConnectionMonitorSimple(args ArgsConnectionMonitorSimple) (*libp2p
 		sharder:                    args.Sharder,
 		cancelFunc:                 cancelFunc,
 		preferredPeersHolder:       args.PreferredPeersHolder,
-		peersRatingHandler:         args.PeersRatingHandler,
 		connectionsWatcher:         args.ConnectionsWatcher,
 	}
 
@@ -92,9 +86,6 @@ func (lcms *libp2pConnectionMonitorSimple) doReconn() {
 // Connected is called when a connection opened
 func (lcms *libp2pConnectionMonitorSimple) Connected(netw network.Network, conn network.Conn) {
 	allPeers := netw.Peers()
-
-	newPeer := core.PeerID(conn.RemotePeer())
-	lcms.peersRatingHandler.AddPeer(newPeer)
 
 	lcms.connectionsWatcher.NewKnownConnection(core.PeerID(conn.RemotePeer()), conn.RemoteMultiaddr().String())
 	evicted := lcms.sharder.ComputeEvictionList(allPeers)

--- a/p2p/libp2p/connectionMonitor/libp2pConnectionMonitorSimple_test.go
+++ b/p2p/libp2p/connectionMonitor/libp2pConnectionMonitorSimple_test.go
@@ -24,7 +24,6 @@ func createMockArgsConnectionMonitorSimple() ArgsConnectionMonitorSimple {
 		ThresholdMinConnectedPeers: 3,
 		Sharder:                    &mock.KadSharderStub{},
 		PreferredPeersHolder:       &p2pmocks.PeersHolderStub{},
-		PeersRatingHandler:         &p2pmocks.PeersRatingHandlerStub{},
 		ConnectionsWatcher:         &mock.ConnectionsWatcherStub{},
 	}
 }
@@ -60,16 +59,6 @@ func TestNewLibp2pConnectionMonitorSimple(t *testing.T) {
 		lcms, err := NewLibp2pConnectionMonitorSimple(args)
 
 		assert.Equal(t, p2p.ErrNilPreferredPeersHolder, err)
-		assert.True(t, check.IfNil(lcms))
-	})
-	t.Run("nil peers rating handler should error", func(t *testing.T) {
-		t.Parallel()
-
-		args := createMockArgsConnectionMonitorSimple()
-		args.PeersRatingHandler = nil
-		lcms, err := NewLibp2pConnectionMonitorSimple(args)
-
-		assert.Equal(t, p2p.ErrNilPeersRatingHandler, err)
 		assert.True(t, check.IfNil(lcms))
 	})
 	t.Run("nil connections watcher should error", func(t *testing.T) {
@@ -143,12 +132,6 @@ func TestLibp2pConnectionMonitorSimple_ConnectedWithSharderShouldCallEvictAndClo
 			knownConnectionCalled = true
 		},
 	}
-	addPeerCalled := false
-	args.PeersRatingHandler = &p2pmocks.PeersRatingHandlerStub{
-		AddPeerCalled: func(pid core.PeerID) {
-			addPeerCalled = true
-		},
-	}
 	lcms, _ := NewLibp2pConnectionMonitorSimple(args)
 
 	lcms.Connected(
@@ -171,7 +154,6 @@ func TestLibp2pConnectionMonitorSimple_ConnectedWithSharderShouldCallEvictAndClo
 	assert.Equal(t, 1, numClosedWasCalled)
 	assert.Equal(t, 1, numComputeWasCalled)
 	assert.True(t, knownConnectionCalled)
-	assert.True(t, addPeerCalled)
 }
 
 func TestNewLibp2pConnectionMonitorSimple_DisconnectedShouldRemovePeerFromPreferredPeers(t *testing.T) {

--- a/p2p/libp2p/issues_test.go
+++ b/p2p/libp2p/issues_test.go
@@ -36,6 +36,7 @@ func createMessenger() p2p.Messenger {
 		SyncTimer:            &libp2p.LocalSyncTimer{},
 		PreferredPeersHolder: &p2pmocks.PeersHolderStub{},
 		NodeOperationMode:    p2p.NormalOperation,
+		PeersRatingHandler:   &p2pmocks.PeersRatingHandlerStub{},
 	}
 
 	libP2PMes, err := libp2p.NewNetworkMessenger(args)

--- a/p2p/libp2p/netMessenger.go
+++ b/p2p/libp2p/netMessenger.go
@@ -354,6 +354,7 @@ func (netMes *networkMessenger) createPubSub(messageSigning messageSigningConfig
 	}
 
 	netMes.poc, err = newPeersOnChannel(
+		netMes.peersRatingHandler,
 		netMes.pb.ListPeers,
 		refreshPeersOnTopic,
 		ttlPeersOnTopic)
@@ -465,7 +466,6 @@ func (netMes *networkMessenger) createConnectionMonitor(p2pConfig config.P2PConf
 		Sharder:                    sharder,
 		ThresholdMinConnectedPeers: p2pConfig.Node.ThresholdMinConnectedPeers,
 		PreferredPeersHolder:       netMes.preferredPeersHolder,
-		PeersRatingHandler:         netMes.peersRatingHandler,
 		ConnectionsWatcher:         netMes.connectionsWatcher,
 	}
 	var err error

--- a/p2p/libp2p/netMessenger.go
+++ b/p2p/libp2p/netMessenger.go
@@ -1226,6 +1226,10 @@ func (netMes *networkMessenger) directMessageHandler(message *pubsub.Message, fr
 		}
 
 		netMes.debugger.AddIncomingMessage(msg.Topic(), uint64(len(msg.Data())), !messageOk)
+
+		if messageOk {
+			netMes.peersRatingHandler.IncreaseRating(fromConnectedPeer)
+		}
 	}(msg)
 
 	return nil

--- a/p2p/libp2p/netMessenger.go
+++ b/p2p/libp2p/netMessenger.go
@@ -127,6 +127,7 @@ type networkMessenger struct {
 	syncTimer            p2p.SyncTimer
 	preferredPeersHolder p2p.PreferredPeersHolderHandler
 	connectionsWatcher   p2p.ConnectionsWatcher
+	peersRatingHandler   p2p.PeersRatingHandler
 }
 
 // ArgsNetworkMessenger defines the options used to create a p2p wrapper
@@ -137,6 +138,7 @@ type ArgsNetworkMessenger struct {
 	SyncTimer            p2p.SyncTimer
 	PreferredPeersHolder p2p.PreferredPeersHolderHandler
 	NodeOperationMode    p2p.NodeOperation
+	PeersRatingHandler   p2p.PeersRatingHandler
 }
 
 // NewNetworkMessenger creates a libP2P messenger by opening a port on the current machine
@@ -153,6 +155,9 @@ func newNetworkMessenger(args ArgsNetworkMessenger, messageSigning messageSignin
 	}
 	if check.IfNil(args.PreferredPeersHolder) {
 		return nil, fmt.Errorf("%w when creating a new network messenger", p2p.ErrNilPreferredPeersHolder)
+	}
+	if check.IfNil(args.PeersRatingHandler) {
+		return nil, fmt.Errorf("%w when creating a new network messenger", p2p.ErrNilPeersRatingHandler)
 	}
 
 	p2pPrivKey, err := createP2PPrivKey(args.P2pConfig.Node.Seed)
@@ -227,6 +232,7 @@ func constructNode(
 		p2pHost:            NewConnectableHost(h),
 		port:               port,
 		connectionsWatcher: connWatcher,
+		peersRatingHandler: args.PeersRatingHandler,
 	}
 
 	return p2pNode, nil
@@ -295,6 +301,7 @@ func addComponentsToNode(
 	p2pNode.syncTimer = args.SyncTimer
 	p2pNode.preferredPeersHolder = args.PreferredPeersHolder
 	p2pNode.debugger = p2pDebug.NewP2PDebugger(core.PeerID(p2pNode.p2pHost.ID()))
+	p2pNode.peersRatingHandler = args.PeersRatingHandler
 
 	err = p2pNode.createPubSub(messageSigning)
 	if err != nil {
@@ -458,6 +465,7 @@ func (netMes *networkMessenger) createConnectionMonitor(p2pConfig config.P2PConf
 		Sharder:                    sharder,
 		ThresholdMinConnectedPeers: p2pConfig.Node.ThresholdMinConnectedPeers,
 		PreferredPeersHolder:       netMes.preferredPeersHolder,
+		PeersRatingHandler:         netMes.peersRatingHandler,
 		ConnectionsWatcher:         netMes.connectionsWatcher,
 	}
 	var err error
@@ -986,6 +994,10 @@ func (netMes *networkMessenger) pubsubCallback(topicProcs *topicProcessors, topi
 			}
 		}
 		netMes.processDebugMessage(topic, fromConnectedPeer, uint64(len(message.Data)), !messageOk)
+
+		if messageOk {
+			netMes.peersRatingHandler.IncreaseRating(fromConnectedPeer)
+		}
 
 		return messageOk
 	}

--- a/p2p/libp2p/netMessenger_test.go
+++ b/p2p/libp2p/netMessenger_test.go
@@ -1379,6 +1379,7 @@ func TestNetworkMessenger_PubsubCallbackNotMessageNotValidShouldNotCallHandler(t
 		},
 		SyncTimer:            &libp2p.LocalSyncTimer{},
 		PreferredPeersHolder: &p2pmocks.PeersHolderStub{},
+		PeersRatingHandler:   &p2pmocks.PeersRatingHandlerStub{},
 	}
 
 	mes, _ := libp2p.NewNetworkMessenger(args)
@@ -1451,6 +1452,7 @@ func TestNetworkMessenger_PubsubCallbackReturnsFalseIfHandlerErrors(t *testing.T
 		},
 		SyncTimer:            &libp2p.LocalSyncTimer{},
 		PreferredPeersHolder: &p2pmocks.PeersHolderStub{},
+		PeersRatingHandler:   &p2pmocks.PeersRatingHandlerStub{},
 	}
 
 	mes, _ := libp2p.NewNetworkMessenger(args)

--- a/p2p/libp2p/netMessenger_test.go
+++ b/p2p/libp2p/netMessenger_test.go
@@ -92,6 +92,7 @@ func createMockNetworkArgs() libp2p.ArgsNetworkMessenger {
 		},
 		SyncTimer:            &libp2p.LocalSyncTimer{},
 		PreferredPeersHolder: &p2pmocks.PeersHolderStub{},
+		PeersRatingHandler:   &p2pmocks.PeersRatingHandlerStub{},
 	}
 }
 
@@ -192,6 +193,15 @@ func TestNewNetworkMessenger_NilPreferredPeersHolderShouldErr(t *testing.T) {
 
 	assert.True(t, check.IfNil(mes))
 	assert.True(t, errors.Is(err, p2p.ErrNilPreferredPeersHolder))
+}
+
+func TestNewNetworkMessenger_NilPeersRatingHandlerShouldErr(t *testing.T) {
+	arg := createMockNetworkArgs()
+	arg.PeersRatingHandler = nil
+	mes, err := libp2p.NewNetworkMessenger(arg)
+
+	assert.True(t, check.IfNil(mes))
+	assert.True(t, errors.Is(err, p2p.ErrNilPeersRatingHandler))
 }
 
 func TestNewNetworkMessenger_NilSyncTimerShouldErr(t *testing.T) {
@@ -1303,6 +1313,7 @@ func TestNetworkMessenger_PreventReprocessingShouldWork(t *testing.T) {
 		},
 		SyncTimer:            &libp2p.LocalSyncTimer{},
 		PreferredPeersHolder: &p2pmocks.PeersHolderStub{},
+		PeersRatingHandler:   &p2pmocks.PeersRatingHandlerStub{},
 	}
 
 	mes, _ := libp2p.NewNetworkMessenger(args)
@@ -1757,7 +1768,8 @@ func TestNetworkMessenger_Bootstrap(t *testing.T) {
 				Type:                    "NilListSharder",
 			},
 		},
-		SyncTimer: &mock.SyncTimerStub{},
+		SyncTimer:          &mock.SyncTimerStub{},
+		PeersRatingHandler: &p2pmocks.PeersRatingHandlerStub{},
 	}
 
 	netMes, err := libp2p.NewNetworkMessenger(args)

--- a/p2p/libp2p/netMessenger_test.go
+++ b/p2p/libp2p/netMessenger_test.go
@@ -1516,6 +1516,7 @@ func TestNetworkMessenger_UnjoinAllTopicsShouldWork(t *testing.T) {
 		},
 		SyncTimer:            &libp2p.LocalSyncTimer{},
 		PreferredPeersHolder: &p2pmocks.PeersHolderStub{},
+		PeersRatingHandler:   &p2pmocks.PeersRatingHandlerStub{},
 	}
 
 	mes, _ := libp2p.NewNetworkMessenger(args)

--- a/p2p/libp2p/peersOnChannel_test.go
+++ b/p2p/libp2p/peersOnChannel_test.go
@@ -7,14 +7,24 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go/p2p"
+	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNewPeersOnChannel_NilPeersRatingHandlerShouldErr(t *testing.T) {
+	t.Parallel()
+
+	poc, err := newPeersOnChannel(nil, nil, 1, 1)
+
+	assert.Nil(t, poc)
+	assert.Equal(t, p2p.ErrNilPeersRatingHandler, err)
+}
+
 func TestNewPeersOnChannel_NilFetchPeersHandlerShouldErr(t *testing.T) {
 	t.Parallel()
 
-	poc, err := newPeersOnChannel(nil, 1, 1)
+	poc, err := newPeersOnChannel(&p2pmocks.PeersRatingHandlerStub{}, nil, 1, 1)
 
 	assert.Nil(t, poc)
 	assert.Equal(t, p2p.ErrNilFetchPeersOnTopicHandler, err)
@@ -24,6 +34,7 @@ func TestNewPeersOnChannel_InvalidRefreshIntervalShouldErr(t *testing.T) {
 	t.Parallel()
 
 	poc, err := newPeersOnChannel(
+		&p2pmocks.PeersRatingHandlerStub{},
 		func(topic string) []peer.ID {
 			return nil
 		},
@@ -38,6 +49,7 @@ func TestNewPeersOnChannel_InvalidTTLIntervalShouldErr(t *testing.T) {
 	t.Parallel()
 
 	poc, err := newPeersOnChannel(
+		&p2pmocks.PeersRatingHandlerStub{},
 		func(topic string) []peer.ID {
 			return nil
 		},
@@ -52,6 +64,7 @@ func TestNewPeersOnChannel_OkValsShouldWork(t *testing.T) {
 	t.Parallel()
 
 	poc, err := newPeersOnChannel(
+		&p2pmocks.PeersRatingHandlerStub{},
 		func(topic string) []peer.ID {
 			return nil
 		},
@@ -71,6 +84,7 @@ func TestPeersOnChannel_ConnectedPeersOnChannelMissingTopicShouldTriggerFetchAnd
 	wasFetchCalled.Store(false)
 
 	poc, _ := newPeersOnChannel(
+		&p2pmocks.PeersRatingHandlerStub{},
 		func(topic string) []peer.ID {
 			if topic == testTopic {
 				wasFetchCalled.Store(true)
@@ -99,6 +113,7 @@ func TestPeersOnChannel_ConnectedPeersOnChannelFindTopicShouldReturn(t *testing.
 	wasFetchCalled.Store(false)
 
 	poc, _ := newPeersOnChannel(
+		&p2pmocks.PeersRatingHandlerStub{},
 		func(topic string) []peer.ID {
 			wasFetchCalled.Store(true)
 			return nil
@@ -131,6 +146,7 @@ func TestPeersOnChannel_RefreshShouldBeDone(t *testing.T) {
 	ttlInterval := time.Duration(2)
 
 	poc, _ := newPeersOnChannel(
+		&p2pmocks.PeersRatingHandlerStub{},
 		func(topic string) []peer.ID {
 			wasFetchCalled.Store(true)
 			return nil

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -331,3 +331,18 @@ type ConnectionsWatcher interface {
 	Close() error
 	IsInterfaceNil() bool
 }
+
+// PeersRatingHandler represent an entity able to handle peers ratings
+type PeersRatingHandler interface {
+	AddPeer(pid core.PeerID)
+	IncreaseRating(pid core.PeerID)
+	DecreaseRating(pid core.PeerID)
+	GetTopRatedPeersFromList(peers []core.PeerID, numOfPeers int) []core.PeerID
+	IsInterfaceNil() bool
+}
+
+// IntRandomizer interface provides functionality over generating integer numbers
+type IntRandomizer interface {
+	Intn(n int) int
+	IsInterfaceNil() bool
+}

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -337,12 +337,6 @@ type PeersRatingHandler interface {
 	AddPeer(pid core.PeerID)
 	IncreaseRating(pid core.PeerID)
 	DecreaseRating(pid core.PeerID)
-	GetTopRatedPeersFromList(peers []core.PeerID, numOfPeers int) []core.PeerID
-	IsInterfaceNil() bool
-}
-
-// IntRandomizer interface provides functionality over generating integer numbers
-type IntRandomizer interface {
-	Intn(n int) int
+	GetTopRatedPeersFromList(peers []core.PeerID, minNumOfPeersExpected int) []core.PeerID
 	IsInterfaceNil() bool
 }

--- a/p2p/rating/peersRatingHandler.go
+++ b/p2p/rating/peersRatingHandler.go
@@ -1,0 +1,214 @@
+package rating
+
+import (
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/core/random"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
+	"github.com/ElrondNetwork/elrond-go/p2p"
+)
+
+const (
+	defaultRating      = 0
+	minRating          = -100
+	maxRating          = 100
+	increaseFactor     = 2
+	decreaseFactor     = -1
+	numOfTiers         = 4
+	tierRatingTreshold = 50
+	minNumOfPeers      = 1
+)
+
+// ArgPeersRatingHandler is the DTO used to create a new peers rating handler
+type ArgPeersRatingHandler struct {
+	Randomizer p2p.IntRandomizer
+}
+
+type peersRatingHandler struct {
+	peersRatingMap map[core.PeerID]int32
+	peersTiersMap  map[uint32]map[core.PeerID]struct{}
+	randomizer     dataRetriever.IntRandomizer
+	mut            sync.Mutex
+}
+
+// NewPeersRatingHandler returns a new peers rating handler
+func NewPeersRatingHandler(args ArgPeersRatingHandler) (*peersRatingHandler, error) {
+	if check.IfNil(args.Randomizer) {
+		return nil, p2p.ErrNilRandomizer
+	}
+
+	prh := &peersRatingHandler{
+		peersRatingMap: make(map[core.PeerID]int32),
+		randomizer:     args.Randomizer,
+	}
+
+	prh.mut.Lock()
+	prh.createTiersMap()
+	prh.mut.Unlock()
+
+	return prh, nil
+}
+
+// AddPeer adds a new peer to the maps with rating 0
+// this is called when a new peer is connected, so if peer is known, its rating is reset
+func (prh *peersRatingHandler) AddPeer(pid core.PeerID) {
+	prh.mut.Lock()
+	defer prh.mut.Unlock()
+
+	oldRating := prh.peersRatingMap[pid]
+	prh.updateRating(pid, oldRating, defaultRating)
+}
+
+// IncreaseRating increases the rating of a peer with the increase factor
+func (prh *peersRatingHandler) IncreaseRating(pid core.PeerID) {
+	prh.mut.Lock()
+	defer prh.mut.Unlock()
+
+	oldRating := prh.peersRatingMap[pid]
+	newRating := oldRating + increaseFactor
+	if newRating > maxRating {
+		return
+	}
+
+	prh.updateRating(pid, oldRating, newRating)
+}
+
+// DecreaseRating decreases the rating of a peer with the decrease factor
+func (prh *peersRatingHandler) DecreaseRating(pid core.PeerID) {
+	prh.mut.Lock()
+	defer prh.mut.Unlock()
+
+	oldRating := prh.peersRatingMap[pid]
+	newRating := oldRating + decreaseFactor
+	if newRating < minRating {
+		return
+	}
+
+	prh.updateRating(pid, oldRating, newRating)
+}
+
+// this method must be called under mutex protection
+func (prh *peersRatingHandler) updateRating(pid core.PeerID, oldRating, newRating int32) {
+	prh.peersRatingMap[pid] = newRating
+
+	oldTier := computeRatingTier(oldRating)
+	newTier := computeRatingTier(newRating)
+	if newTier == oldTier {
+		// if pid is not in tier, add it
+		// this happens when a new peer is added
+		_, isInTier := prh.peersTiersMap[newTier][pid]
+		if !isInTier {
+			prh.peersTiersMap[newTier][pid] = struct{}{}
+		}
+
+		return
+	}
+
+	prh.movePeerToNewTier(oldTier, newTier, pid)
+}
+
+func computeRatingTier(peerRating int32) uint32 {
+	// [100,   51] -> tier 1
+	// [ 50,    1] -> tier 2
+	// [  0,  -49] -> tier 3
+	// [-50, -100] -> tier 4
+
+	tempPositiveRating := peerRating + 2*tierRatingTreshold
+	tempTier := (tempPositiveRating - 1) / tierRatingTreshold
+
+	return uint32(numOfTiers - tempTier)
+}
+
+// this method must be called under mutex protection
+func (prh *peersRatingHandler) movePeerToNewTier(oldTier, newTier uint32, pid core.PeerID) {
+	delete(prh.peersTiersMap[oldTier], pid)
+	prh.peersTiersMap[newTier][pid] = struct{}{}
+}
+
+// this method must be called under mutex protection
+func (prh *peersRatingHandler) createTiersMap() {
+	prh.peersTiersMap = make(map[uint32]map[core.PeerID]struct{})
+	for tier := uint32(numOfTiers); tier > 0; tier-- {
+		prh.peersTiersMap[tier] = make(map[core.PeerID]struct{})
+	}
+}
+
+// GetTopRatedPeersFromList returns a list of random peers, searching them in the order of rating tiers
+func (prh *peersRatingHandler) GetTopRatedPeersFromList(peers []core.PeerID, numOfPeers int) []core.PeerID {
+	prh.mut.Lock()
+	defer prh.mut.Unlock()
+
+	isListEmpty := len(peers) == 0
+	if numOfPeers < minNumOfPeers || isListEmpty {
+		return make([]core.PeerID, 0)
+	}
+
+	peersForExtraction := make([]core.PeerID, 0)
+	for tier := uint32(numOfTiers); tier > 0; tier-- {
+		peersInCurrentTier, found := prh.extractPeersForTier(tier, peers)
+		if !found {
+			continue
+		}
+
+		peersForExtraction = append(peersForExtraction, peersInCurrentTier...)
+
+		if len(peersForExtraction) > numOfPeers {
+			return prh.extractRandomPeers(peersForExtraction, numOfPeers)
+		}
+	}
+
+	return prh.extractRandomPeers(peersForExtraction, numOfPeers)
+}
+
+// this method must be called under mutex protection
+func (prh *peersRatingHandler) extractPeersForTier(tier uint32, peers []core.PeerID) ([]core.PeerID, bool) {
+	peersInTier := make([]core.PeerID, 0)
+	knownPeersInTier, found := prh.peersTiersMap[tier]
+	isListEmpty := len(knownPeersInTier) == 0
+	if !found || isListEmpty {
+		return peersInTier, false
+	}
+
+	for _, peer := range peers {
+		_, found = knownPeersInTier[peer]
+		if found {
+			peersInTier = append(peersInTier, peer)
+		}
+	}
+
+	return peersInTier, true
+}
+
+// this method must be called under mutex protection
+func (prh *peersRatingHandler) extractRandomPeers(peers []core.PeerID, numOfPeers int) []core.PeerID {
+	peersLen := len(peers)
+	if peersLen < numOfPeers {
+		return peers
+	}
+
+	indexes := createIndexList(peersLen)
+	shuffledIndexes := random.FisherYatesShuffle(indexes, prh.randomizer)
+
+	randomPeers := make([]core.PeerID, numOfPeers)
+	for i := 0; i < numOfPeers; i++ {
+		randomPeers[i] = peers[shuffledIndexes[i]]
+	}
+
+	return randomPeers
+}
+
+func createIndexList(listLength int) []int {
+	indexes := make([]int, listLength)
+	for i := 0; i < listLength; i++ {
+		indexes[i] = i
+	}
+
+	return indexes
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (prh *peersRatingHandler) IsInterfaceNil() bool {
+	return prh == nil
+}

--- a/p2p/rating/peersRatingHandler.go
+++ b/p2p/rating/peersRatingHandler.go
@@ -212,7 +212,7 @@ func (prh *peersRatingHandler) displayPeersRating(peers *[]core.PeerID, minNumOf
 		}
 	}
 
-	log.Info("Top rated peers", "min requested", minNumOfPeersExpected, "peers ratings", strPeersRatings)
+	log.Trace("Best peers to request from", "min requested", minNumOfPeersExpected, "peers ratings", strPeersRatings)
 }
 
 func (prh *peersRatingHandler) splitPeersByTiers(peers []core.PeerID) ([]core.PeerID, []core.PeerID) {

--- a/p2p/rating/peersRatingHandler_test.go
+++ b/p2p/rating/peersRatingHandler_test.go
@@ -1,0 +1,345 @@
+package rating
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/core/random"
+	"github.com/ElrondNetwork/elrond-go/p2p"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPeersRatingHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil randomizer should error", func(t *testing.T) {
+		t.Parallel()
+
+		prh, err := NewPeersRatingHandler(ArgPeersRatingHandler{nil})
+		assert.Equal(t, p2p.ErrNilRandomizer, err)
+		assert.True(t, check.IfNil(prh))
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		prh, err := NewPeersRatingHandler(ArgPeersRatingHandler{&random.ConcurrentSafeIntRandomizer{}})
+		assert.Nil(t, err)
+		assert.False(t, check.IfNil(prh))
+	})
+}
+
+func TestPeersRatingHandler_AddPeer(t *testing.T) {
+	t.Parallel()
+
+	prh, _ := NewPeersRatingHandler(ArgPeersRatingHandler{&random.ConcurrentSafeIntRandomizer{}})
+	assert.False(t, check.IfNil(prh))
+
+	providedPid := core.PeerID("provided pid")
+	prh.AddPeer(providedPid)
+
+	rating, found := prh.peersRatingMap[providedPid]
+	assert.True(t, found)
+	assert.Equal(t, 0, int(rating))
+
+	peerInTier, found := prh.peersTiersMap[3] // rating 0 should be in tier 3
+	assert.True(t, found)
+	assert.Equal(t, 1, len(peerInTier))
+
+	_, found = peerInTier[providedPid]
+	assert.True(t, found)
+}
+
+func TestPeersRatingHandler_IncreaseRating(t *testing.T) {
+	t.Parallel()
+
+	prh, _ := NewPeersRatingHandler(ArgPeersRatingHandler{&random.ConcurrentSafeIntRandomizer{}})
+	assert.False(t, check.IfNil(prh))
+
+	providedPid := core.PeerID("provided pid")
+	numOfCalls := 10
+	for i := 0; i < numOfCalls; i++ {
+		prh.IncreaseRating(providedPid)
+	}
+
+	rating, found := prh.peersRatingMap[providedPid]
+	assert.True(t, found)
+	assert.Equal(t, numOfCalls*increaseFactor, int(rating))
+
+	// limit exceeded
+	for i := 0; i < maxRating; i++ {
+		prh.IncreaseRating(providedPid)
+	}
+
+	rating, found = prh.peersRatingMap[providedPid]
+	assert.True(t, found)
+	assert.Equal(t, maxRating, int(rating))
+
+	// peer should be in tier 1
+	peersMap, hasPeers := prh.peersTiersMap[1]
+	assert.True(t, hasPeers)
+	assert.Equal(t, 1, len(peersMap))
+	_, found = peersMap[providedPid]
+	assert.True(t, found)
+
+	// other tiers should be empty, but providedPeer went from 3 to 1
+	for i := uint32(2); i <= numOfTiers; i++ {
+		peersMap, hasPeers = prh.peersTiersMap[i]
+		assert.True(t, hasPeers)
+		assert.Equal(t, 0, len(peersMap))
+	}
+}
+
+func TestPeersRatingHandler_DecreaseRating(t *testing.T) {
+	t.Parallel()
+
+	prh, _ := NewPeersRatingHandler(ArgPeersRatingHandler{&random.ConcurrentSafeIntRandomizer{}})
+	assert.False(t, check.IfNil(prh))
+
+	providedPid := core.PeerID("provided pid")
+	numOfCalls := 10
+	for i := 0; i < numOfCalls; i++ {
+		prh.DecreaseRating(providedPid)
+	}
+
+	rating, found := prh.peersRatingMap[providedPid]
+	assert.True(t, found)
+	assert.Equal(t, numOfCalls*decreaseFactor, int(rating))
+
+	// limit exceeded
+	for i := 0; i > minRating; i-- {
+		prh.DecreaseRating(providedPid)
+	}
+
+	rating, found = prh.peersRatingMap[providedPid]
+	assert.True(t, found)
+	assert.Equal(t, minRating, int(rating))
+
+	// peer should be in tier 4
+	peersMap, hasPeers := prh.peersTiersMap[4]
+	assert.True(t, hasPeers)
+	assert.Equal(t, 1, len(peersMap))
+	_, found = peersMap[providedPid]
+	assert.True(t, found)
+
+	// other tiers should be empty, but providedPeer went from 3 to 4
+	for i := uint32(1); i < 4; i++ {
+		peersMap, hasPeers = prh.peersTiersMap[i]
+		assert.True(t, hasPeers)
+		assert.Equal(t, 0, len(peersMap))
+	}
+}
+
+func Test_computeRatingTier(t *testing.T) {
+	t.Parallel()
+
+	tier1, tier2, tier3, tier4 := uint32(1), uint32(2), uint32(3), uint32(4)
+	assert.Equal(t, tier4, computeRatingTier(-100))
+	assert.Equal(t, tier4, computeRatingTier(-75))
+	assert.Equal(t, tier4, computeRatingTier(-50))
+	assert.Equal(t, tier3, computeRatingTier(-49))
+	assert.Equal(t, tier3, computeRatingTier(-25))
+	assert.Equal(t, tier3, computeRatingTier(0))
+	assert.Equal(t, tier2, computeRatingTier(1))
+	assert.Equal(t, tier2, computeRatingTier(25))
+	assert.Equal(t, tier2, computeRatingTier(50))
+	assert.Equal(t, tier1, computeRatingTier(51))
+	assert.Equal(t, tier1, computeRatingTier(75))
+	assert.Equal(t, tier1, computeRatingTier(100))
+}
+
+func TestPeersRatingHandler_GetTopRatedPeersFromList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("asking for 0 peers should return empty list", func(t *testing.T) {
+		t.Parallel()
+
+		prh, _ := NewPeersRatingHandler(ArgPeersRatingHandler{&random.ConcurrentSafeIntRandomizer{}})
+		assert.False(t, check.IfNil(prh))
+
+		res := prh.GetTopRatedPeersFromList([]core.PeerID{"pid"}, 0)
+		assert.Equal(t, 0, len(res))
+	})
+	t.Run("nil provided list should return empty list", func(t *testing.T) {
+		t.Parallel()
+
+		prh, _ := NewPeersRatingHandler(ArgPeersRatingHandler{&random.ConcurrentSafeIntRandomizer{}})
+		assert.False(t, check.IfNil(prh))
+
+		res := prh.GetTopRatedPeersFromList(nil, 1)
+		assert.Equal(t, 0, len(res))
+	})
+	t.Run("no peers in maps should return empty list", func(t *testing.T) {
+		t.Parallel()
+
+		prh, _ := NewPeersRatingHandler(ArgPeersRatingHandler{&random.ConcurrentSafeIntRandomizer{}})
+		assert.False(t, check.IfNil(prh))
+
+		providedListOfPeers := []core.PeerID{"pid 1", "pid 2"}
+		res := prh.GetTopRatedPeersFromList(providedListOfPeers, 5)
+		assert.Equal(t, 0, len(res))
+	})
+	t.Run("one peer in tier 1 should work", func(t *testing.T) {
+		t.Parallel()
+
+		prh, _ := NewPeersRatingHandler(ArgPeersRatingHandler{&random.ConcurrentSafeIntRandomizer{}})
+		assert.False(t, check.IfNil(prh))
+
+		providedPid := core.PeerID("provided pid")
+		for i := 0; i < maxRating; i++ {
+			prh.IncreaseRating(providedPid)
+		}
+
+		providedListOfPeers := []core.PeerID{providedPid, "another pid"}
+		res := prh.GetTopRatedPeersFromList(providedListOfPeers, 5)
+		assert.Equal(t, 1, len(res))
+		assert.Equal(t, providedPid, res[0])
+	})
+	t.Run("one peer in tier one should work", func(t *testing.T) {
+		t.Parallel()
+
+		prh, _ := NewPeersRatingHandler(ArgPeersRatingHandler{&random.ConcurrentSafeIntRandomizer{}})
+		assert.False(t, check.IfNil(prh))
+
+		providedPid := core.PeerID("provided pid")
+		for i := 0; i < maxRating; i++ {
+			prh.IncreaseRating(providedPid)
+		}
+
+		providedListOfPeers := []core.PeerID{providedPid, "another pid"}
+		res := prh.GetTopRatedPeersFromList(providedListOfPeers, 1)
+		assert.Equal(t, 1, len(res))
+		assert.Equal(t, providedPid, res[0])
+	})
+	t.Run("all peers in same tier should work", func(t *testing.T) {
+		t.Parallel()
+
+		prh, _ := NewPeersRatingHandler(ArgPeersRatingHandler{&random.ConcurrentSafeIntRandomizer{}})
+		assert.False(t, check.IfNil(prh))
+
+		providedPid1 := core.PeerID("provided pid 1")
+		providedPid2 := core.PeerID("provided pid 2")
+		providedPid3 := core.PeerID("provided pid 3")
+
+		prh.AddPeer(providedPid1)
+		prh.AddPeer(providedPid2)
+		prh.AddPeer(providedPid3)
+
+		providedListOfPeers := []core.PeerID{providedPid1, "extra pid 1", providedPid2, providedPid3, "extra pid 2"}
+		requestedNumOfPeers := 2
+		res := prh.GetTopRatedPeersFromList(providedListOfPeers, requestedNumOfPeers) // should return 2 random from provided
+		assert.Equal(t, requestedNumOfPeers, len(res))
+
+		for _, resEntry := range res {
+			println(fmt.Sprintf("got pid: %s", resEntry.Bytes()))
+		}
+	})
+	t.Run("peers from multiple tiers should work", func(t *testing.T) {
+		t.Parallel()
+
+		prh, _ := NewPeersRatingHandler(ArgPeersRatingHandler{&random.ConcurrentSafeIntRandomizer{}})
+		assert.False(t, check.IfNil(prh))
+
+		providedPid1 := core.PeerID("provided pid 1")
+		providedPid2 := core.PeerID("provided pid 2")
+		providedPid3 := core.PeerID("provided pid 3")
+		prh.AddPeer(providedPid3) // tier 3
+
+		prh.AddPeer(providedPid2)
+		prh.IncreaseRating(providedPid2) // tier 2
+
+		for i := 0; i < maxRating; i++ {
+			prh.IncreaseRating(providedPid1)
+		} // tier 1
+
+		providedListOfPeers := []core.PeerID{providedPid1, "extra pid 1", providedPid2, providedPid3, "extra pid 2"}
+		requestedNumOfPeers := 2
+		res := prh.GetTopRatedPeersFromList(providedListOfPeers, requestedNumOfPeers) // should return 2 random from provided
+		assert.Equal(t, requestedNumOfPeers, len(res))
+
+		for _, resEntry := range res {
+			println(fmt.Sprintf("got pid: %s", resEntry.Bytes()))
+		}
+	})
+}
+
+func TestPeerRatingHandler_concurrency_test(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		r := recover()
+		if r != nil {
+			assert.Fail(t, "should not panic")
+		}
+	}()
+
+	prh, _ := NewPeersRatingHandler(ArgPeersRatingHandler{&random.ConcurrentSafeIntRandomizer{}})
+	assert.False(t, check.IfNil(prh))
+
+	prh.AddPeer("pid0")
+	prh.AddPeer("pid1")
+
+	var wg sync.WaitGroup
+
+	numOps := 500
+	wg.Add(numOps)
+
+	for i := 1; i <= numOps; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			pid1 := core.PeerID(fmt.Sprintf("pid%d", i%2))
+			pid2 := core.PeerID(fmt.Sprintf("pid%d", (i+1)%2))
+
+			prh.IncreaseRating(pid1)
+			prh.DecreaseRating(pid2)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// increase factor = 2, decrease factor = 1 so both pids should be in tier 1
+	peers := prh.peersTiersMap[1]
+	assert.Equal(t, 2, len(peers))
+	_, pid0ExistsInTier := peers["pid0"]
+	assert.True(t, pid0ExistsInTier)
+	_, pid1ExistsInTier := peers["pid1"]
+	assert.True(t, pid1ExistsInTier)
+
+	ratingPid0 := prh.peersRatingMap["pid0"]
+	assert.True(t, ratingPid0 > 90)
+	ratingPid1 := prh.peersRatingMap["pid1"]
+	assert.True(t, ratingPid1 > 90)
+
+	numOps = 200
+	wg.Add(numOps)
+
+	for i := 1; i <= numOps; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			pid1 := core.PeerID(fmt.Sprintf("pid%d", i%2))
+			pid2 := core.PeerID(fmt.Sprintf("pid%d", (i+1)%2))
+
+			prh.DecreaseRating(pid1)
+			prh.DecreaseRating(pid2)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// increase factor = 2, decrease factor = 1 so both pids should be in tier 4
+	peers = prh.peersTiersMap[4]
+	assert.Equal(t, 2, len(peers))
+	_, pid0ExistsInTier = peers["pid0"]
+	assert.True(t, pid0ExistsInTier)
+	_, pid1ExistsInTier = peers["pid1"]
+	assert.True(t, pid1ExistsInTier)
+
+	ratingPid0 = prh.peersRatingMap["pid0"]
+	assert.True(t, ratingPid0 < -90)
+	ratingPid1 = prh.peersRatingMap["pid1"]
+	assert.True(t, ratingPid1 < -90)
+}

--- a/testscommon/generalConfig.go
+++ b/testscommon/generalConfig.go
@@ -422,6 +422,10 @@ func GetGeneralConfig() config.Config {
 			Capacity: 10000,
 			Name:     "VMOutputCacher",
 		},
+		PeersRatingConfig: config.PeersRatingConfig{
+			TopRatedCacheCapacity: 1000,
+			BadRatedCacheCapacity: 1000,
+		},
 	}
 }
 

--- a/testscommon/p2pmocks/peersRatingHandlerStub.go
+++ b/testscommon/p2pmocks/peersRatingHandlerStub.go
@@ -11,36 +11,36 @@ type PeersRatingHandlerStub struct {
 }
 
 // AddPeer -
-func (prhs *PeersRatingHandlerStub) AddPeer(pid core.PeerID) {
-	if prhs.AddPeerCalled != nil {
-		prhs.AddPeerCalled(pid)
+func (stub *PeersRatingHandlerStub) AddPeer(pid core.PeerID) {
+	if stub.AddPeerCalled != nil {
+		stub.AddPeerCalled(pid)
 	}
 }
 
 // IncreaseRating -
-func (prhs *PeersRatingHandlerStub) IncreaseRating(pid core.PeerID) {
-	if prhs.IncreaseRatingCalled != nil {
-		prhs.IncreaseRatingCalled(pid)
+func (stub *PeersRatingHandlerStub) IncreaseRating(pid core.PeerID) {
+	if stub.IncreaseRatingCalled != nil {
+		stub.IncreaseRatingCalled(pid)
 	}
 }
 
 // DecreaseRating -
-func (prhs *PeersRatingHandlerStub) DecreaseRating(pid core.PeerID) {
-	if prhs.DecreaseRatingCalled != nil {
-		prhs.DecreaseRatingCalled(pid)
+func (stub *PeersRatingHandlerStub) DecreaseRating(pid core.PeerID) {
+	if stub.DecreaseRatingCalled != nil {
+		stub.DecreaseRatingCalled(pid)
 	}
 }
 
 // GetTopRatedPeersFromList -
-func (prhs *PeersRatingHandlerStub) GetTopRatedPeersFromList(peers []core.PeerID, numOfPeers int) []core.PeerID {
-	if prhs.GetTopRatedPeersFromListCalled != nil {
-		return prhs.GetTopRatedPeersFromListCalled(peers, numOfPeers)
+func (stub *PeersRatingHandlerStub) GetTopRatedPeersFromList(peers []core.PeerID, numOfPeers int) []core.PeerID {
+	if stub.GetTopRatedPeersFromListCalled != nil {
+		return stub.GetTopRatedPeersFromListCalled(peers, numOfPeers)
 	}
 
 	return peers
 }
 
 // IsInterfaceNil returns true if there is no value under the interface
-func (prhs *PeersRatingHandlerStub) IsInterfaceNil() bool {
-	return prhs == nil
+func (stub *PeersRatingHandlerStub) IsInterfaceNil() bool {
+	return stub == nil
 }

--- a/testscommon/p2pmocks/peersRatingHandlerStub.go
+++ b/testscommon/p2pmocks/peersRatingHandlerStub.go
@@ -1,0 +1,46 @@
+package p2pmocks
+
+import "github.com/ElrondNetwork/elrond-go-core/core"
+
+// PeersRatingHandlerStub -
+type PeersRatingHandlerStub struct {
+	AddPeerCalled                  func(pid core.PeerID)
+	IncreaseRatingCalled           func(pid core.PeerID)
+	DecreaseRatingCalled           func(pid core.PeerID)
+	GetTopRatedPeersFromListCalled func(peers []core.PeerID, numOfPeers int) []core.PeerID
+}
+
+// AddPeer -
+func (prhs *PeersRatingHandlerStub) AddPeer(pid core.PeerID) {
+	if prhs.AddPeerCalled != nil {
+		prhs.AddPeerCalled(pid)
+	}
+}
+
+// IncreaseRating -
+func (prhs *PeersRatingHandlerStub) IncreaseRating(pid core.PeerID) {
+	if prhs.IncreaseRatingCalled != nil {
+		prhs.IncreaseRatingCalled(pid)
+	}
+}
+
+// DecreaseRating -
+func (prhs *PeersRatingHandlerStub) DecreaseRating(pid core.PeerID) {
+	if prhs.DecreaseRatingCalled != nil {
+		prhs.DecreaseRatingCalled(pid)
+	}
+}
+
+// GetTopRatedPeersFromList -
+func (prhs *PeersRatingHandlerStub) GetTopRatedPeersFromList(peers []core.PeerID, numOfPeers int) []core.PeerID {
+	if prhs.GetTopRatedPeersFromListCalled != nil {
+		return prhs.GetTopRatedPeersFromListCalled(peers, numOfPeers)
+	}
+
+	return peers
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (prhs *PeersRatingHandlerStub) IsInterfaceNil() bool {
+	return prhs == nil
+}

--- a/update/errors.go
+++ b/update/errors.go
@@ -277,3 +277,6 @@ var ErrInvalidMaxHardCapForMissingNodes = errors.New("invalid max hardcap for mi
 
 // ErrInvalidNumConcurrentTrieSyncers signals that the number of concurrent trie syncers is invalid
 var ErrInvalidNumConcurrentTrieSyncers = errors.New("invalid num concurrent trie syncers")
+
+// ErrNilPeersRatingHandler signals that a nil peers rating handler implementation has been provided
+var ErrNilPeersRatingHandler = errors.New("nil peers rating handler")

--- a/update/factory/exportHandlerFactory.go
+++ b/update/factory/exportHandlerFactory.go
@@ -62,6 +62,7 @@ type ArgsExporter struct {
 	InputAntifloodHandler     process.P2PAntifloodHandler
 	OutputAntifloodHandler    process.P2PAntifloodHandler
 	RoundHandler              process.RoundHandler
+	PeersRatingHandler        dataRetriever.PeersRatingHandler
 	InterceptorDebugConfig    config.InterceptorResolverDebugConfig
 	EnableSignTxWithHashEpoch uint32
 	MaxHardCapForMissingNodes int
@@ -98,6 +99,7 @@ type exportHandlerFactory struct {
 	inputAntifloodHandler     process.P2PAntifloodHandler
 	outputAntifloodHandler    process.P2PAntifloodHandler
 	roundHandler              process.RoundHandler
+	peersRatingHandler        dataRetriever.PeersRatingHandler
 	interceptorDebugConfig    config.InterceptorResolverDebugConfig
 	enableSignTxWithHashEpoch uint32
 	maxHardCapForMissingNodes int
@@ -200,6 +202,9 @@ func NewExportHandlerFactory(args ArgsExporter) (*exportHandlerFactory, error) {
 	if check.IfNil(args.RoundHandler) {
 		return nil, update.ErrNilRoundHandler
 	}
+	if check.IfNil(args.PeersRatingHandler) {
+		return nil, update.ErrNilPeersRatingHandler
+	}
 	if check.IfNil(args.CoreComponents.TxSignHasher()) {
 		return nil, update.ErrNilHasher
 	}
@@ -244,6 +249,7 @@ func NewExportHandlerFactory(args ArgsExporter) (*exportHandlerFactory, error) {
 		outputAntifloodHandler:    args.OutputAntifloodHandler,
 		maxTrieLevelInMemory:      args.MaxTrieLevelInMemory,
 		roundHandler:              args.RoundHandler,
+		peersRatingHandler:        args.PeersRatingHandler,
 		interceptorDebugConfig:    args.InterceptorDebugConfig,
 		enableSignTxWithHashEpoch: args.EnableSignTxWithHashEpoch,
 		maxHardCapForMissingNodes: args.MaxHardCapForMissingNodes,
@@ -333,6 +339,7 @@ func (e *exportHandlerFactory) Create() (update.ExportHandler, error) {
 		NumConcurrentResolvingJobs: 100,
 		InputAntifloodHandler:      e.inputAntifloodHandler,
 		OutputAntifloodHandler:     e.outputAntifloodHandler,
+		PeersRatingHandler:         e.peersRatingHandler,
 	}
 	resolversFactory, err := NewResolversContainerFactory(argsResolvers)
 	if err != nil {


### PR DESCRIPTION
Added mechanism to keep track of peers rating. When something is requested from a peer, its rating is decreased. Then, when some valid message is received, its rating is increased. 

Based on this info, the peers will be split into 2 tiers, good rated(>0) and bad rated. Then, the peers selection works like this:
- first choose one completely random cross peer
- based on the info from config, choose the remaining cross and intra peers based on their rating