### PR TITLE
FIX: Linter errors

### DIFF
--- a/integrationTests/vm/delegation/liquidStaking_test.go
+++ b/integrationTests/vm/delegation/liquidStaking_test.go
@@ -89,7 +89,7 @@ func TestDelegationSystemSCWithLiquidStaking(t *testing.T) {
 	}
 	time.Sleep(time.Second)
 	finalWait := 20
-	nonce, round = integrationTests.WaitOperationToBeDone(t, nodes, finalWait, nonce, round, idxProposers)
+	_, _ = integrationTests.WaitOperationToBeDone(t, nodes, finalWait, nonce, round, idxProposers)
 	time.Sleep(time.Second)
 
 	for _, node := range nodes {

--- a/state/validatorsInfoMap_test.go
+++ b/state/validatorsInfoMap_test.go
@@ -223,6 +223,7 @@ func TestShardValidatorsInfoMap_GettersShouldReturnCopiesOfInternalData(t *testi
 
 	require.Equal(t, []ValidatorInfoHandler{v0}, vi.GetShardValidatorsInfoMap()[0])
 	require.Equal(t, []ValidatorInfoHandler{v1}, vi.GetShardValidatorsInfoMap()[1])
+	require.NotEqual(t, vi.GetAllValidatorsInfo(), validators)
 }
 
 func TestShardValidatorsInfoMap_Concurrency(t *testing.T) {

--- a/vm/mock/systemEIStub.go
+++ b/vm/mock/systemEIStub.go
@@ -196,7 +196,6 @@ func (s *SystemEIStub) Transfer(destination []byte, sender []byte, value *big.In
 	if s.TransferCalled != nil {
 		s.TransferCalled(destination, sender, value, input, gasLimit)
 	}
-	return
 }
 
 // GetBalance -

--- a/vm/systemSmartContracts/liquidStaking.go
+++ b/vm/systemSmartContracts/liquidStaking.go
@@ -24,7 +24,6 @@ const attributesNoncePrefix = "a"
 
 type liquidStaking struct {
 	eei                      vm.SystemEI
-	sigVerifier              vm.MessageSignVerifier
 	liquidStakingSCAddress   []byte
 	gasCost                  vm.GasCost
 	marshalizer              marshal.Marshalizer


### PR DESCRIPTION
Fixed linter errors on `feat/liquid-staking`:
- ineffectual assignment to `nonce`, `round` in `liquidStaking_test.go`
- ineffectual assignment to `validators` in `validatorsInfoMap_test.go`
- redundant `return` in `systemEIStub.go`
- unused `sigVerifier` in `liquidStaking.go`