### PR TITLE
transactions pool API endpoint

### DIFF
--- a/api/groups/transactionGroup.go
+++ b/api/groups/transactionGroup.go
@@ -539,7 +539,7 @@ func (tg *transactionGroup) computeTransactionGasLimit(c *gin.Context) {
 	)
 }
 
-// computeTransactionGasLimit returns how many gas units a transaction wil consume
+// getTransactionsPool returns the transactions hashes in the pool
 func (tg *transactionGroup) getTransactionsPool(c *gin.Context) {
 	txsHashes, err := tg.getFacade().GetTransactionsPool()
 	if err != nil {

--- a/api/groups/transactionGroup.go
+++ b/api/groups/transactionGroup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/api/errors"
 	"github.com/ElrondNetwork/elrond-go/api/middleware"
 	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/ElrondNetwork/elrond-go/common"
 	txSimData "github.com/ElrondNetwork/elrond-go/process/txsimulator/data"
 	"github.com/gin-gonic/gin"
 )
@@ -28,6 +29,7 @@ const (
 	costPath                         = "/cost"
 	sendMultiplePath                 = "/send-multiple"
 	getTransactionPath               = "/:txhash"
+	getTransactionsPool              = "/pool"
 
 	queryParamWithResults    = "withResults"
 	queryParamCheckSignature = "checkSignature"
@@ -42,6 +44,7 @@ type transactionFacadeHandler interface {
 	SendBulkTransactions([]*transaction.Transaction) (uint64, error)
 	SimulateTransactionExecution(tx *transaction.Transaction) (*txSimData.SimulationResults, error)
 	GetTransaction(hash string, withResults bool) (*transaction.ApiTransactionResult, error)
+	GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error)
 	ComputeTransactionGasLimit(tx *transaction.Transaction) (*transaction.CostResponse, error)
 	EncodeAddressPubkey(pk []byte) (string, error)
 	GetThrottlerForEndpoint(endpoint string) (core.Throttler, bool)
@@ -92,6 +95,11 @@ func NewTransactionGroup(facade transactionFacadeHandler) (*transactionGroup, er
 			Path:    costPath,
 			Method:  http.MethodPost,
 			Handler: tg.computeTransactionGasLimit,
+		},
+		{
+			Path:    getTransactionsPool,
+			Method:  http.MethodGet,
+			Handler: tg.getTransactionsPool,
 		},
 		{
 			Path:    sendMultiplePath,
@@ -525,6 +533,31 @@ func (tg *transactionGroup) computeTransactionGasLimit(c *gin.Context) {
 		http.StatusOK,
 		shared.GenericAPIResponse{
 			Data:  cost,
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// computeTransactionGasLimit returns how many gas units a transaction wil consume
+func (tg *transactionGroup) getTransactionsPool(c *gin.Context) {
+	txsHashes, err := tg.getFacade().GetTransactionsPool()
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: err.Error(),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"txPool": txsHashes},
 			Error: "",
 			Code:  shared.ReturnCodeSuccess,
 		},

--- a/api/groups/transactionGroup_test.go
+++ b/api/groups/transactionGroup_test.go
@@ -837,7 +837,7 @@ func TestSimulateTransaction(t *testing.T) {
 func TestGetTransactionsPoolShouldError(t *testing.T) {
 	t.Parallel()
 
-	expectedErr := errors.New("i am the error")
+	expectedErr := errors.New("expected error")
 	facade := mock.FacadeStub{
 		GetTransactionsPoolCalled: func() (*common.TransactionsPoolAPIResponse, error) {
 			return nil, expectedErr

--- a/api/groups/transactionGroup_test.go
+++ b/api/groups/transactionGroup_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/api/groups"
 	"github.com/ElrondNetwork/elrond-go/api/mock"
 	"github.com/ElrondNetwork/elrond-go/api/shared"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/config"
 	txSimData "github.com/ElrondNetwork/elrond-go/process/txsimulator/data"
 	"github.com/stretchr/testify/assert"
@@ -85,6 +86,16 @@ type transactionCostResponse struct {
 	Data  transactionCostResponseData `json:"data"`
 	Error string                      `json:"error"`
 	Code  string                      `json:"code"`
+}
+
+type txsPoolResponseData struct {
+	TxPool common.TransactionsPoolAPIResponse `json:"txPool"`
+}
+
+type txsPoolResponse struct {
+	Data  txsPoolResponseData `json:"data"`
+	Error string              `json:"error"`
+	Code  string              `json:"code"`
 }
 
 func TestGetTransaction_WithCorrectHashShouldReturnTransaction(t *testing.T) {
@@ -823,6 +834,63 @@ func TestSimulateTransaction(t *testing.T) {
 	assert.Equal(t, string(shared.ReturnCodeSuccess), simulateResponse.Code)
 }
 
+func TestGetTransactionsPoolShouldError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("i am the error")
+	facade := mock.FacadeStub{
+		GetTransactionsPoolCalled: func() (*common.TransactionsPoolAPIResponse, error) {
+			return nil, expectedErr
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/transaction/pool", nil)
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	txsPoolResp := generalResponse{}
+	loadResponse(resp.Body, &txsPoolResp)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(txsPoolResp.Error, expectedErr.Error()))
+}
+
+func TestGetTransactionsPoolShouldWork(t *testing.T) {
+	t.Parallel()
+
+	expectedTxPool := &common.TransactionsPoolAPIResponse{
+		RegularTransactions: []string{"tx", "tx2"},
+	}
+	facade := mock.FacadeStub{
+		GetTransactionsPoolCalled: func() (*common.TransactionsPoolAPIResponse, error) {
+			return expectedTxPool, nil
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/transaction/pool", nil)
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	txsPoolResp := txsPoolResponse{}
+	loadResponse(resp.Body, &txsPoolResp)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Empty(t, txsPoolResp.Error)
+	assert.Equal(t, *expectedTxPool, txsPoolResp.Data.TxPool)
+}
+
 func getTransactionRoutesConfig() config.ApiRoutesConfig {
 	return config.ApiRoutesConfig{
 		APIPackages: map[string]config.APIPackageConfig{
@@ -831,6 +899,7 @@ func getTransactionRoutesConfig() config.ApiRoutesConfig {
 					{Name: "/send", Open: true},
 					{Name: "/send-multiple", Open: true},
 					{Name: "/cost", Open: true},
+					{Name: "/pool", Open: true},
 					{Name: "/:txhash", Open: true},
 					{Name: "/:txhash/status", Open: true},
 					{Name: "/simulate", Open: true},

--- a/api/mock/facadeStub.go
+++ b/api/mock/facadeStub.go
@@ -70,6 +70,7 @@ type FacadeStub struct {
 	VerifyProofCalled                       func(string, string, [][]byte) (bool, error)
 	GetTokenSupplyCalled                    func(token string) (*api.ESDTSupply, error)
 	GetGenesisNodesPubKeysCalled            func() (map[uint32][]string, map[uint32][]string, error)
+	GetTransactionsPoolCalled               func() (*common.TransactionsPoolAPIResponse, error)
 }
 
 // GetTokenSupply -
@@ -429,6 +430,15 @@ func (f *FacadeStub) GetGenesisNodesPubKeys() (map[uint32][]string, map[uint32][
 		return f.GetGenesisNodesPubKeysCalled()
 	}
 	return nil, nil, nil
+}
+
+// GetTransactionsPool -
+func (f *FacadeStub) GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error) {
+	if f.GetTransactionsPoolCalled != nil {
+		return f.GetTransactionsPoolCalled()
+	}
+
+	return nil, nil
 }
 
 // Trigger -

--- a/api/shared/interface.go
+++ b/api/shared/interface.go
@@ -113,5 +113,6 @@ type FacadeHandler interface {
 	RestAPIServerDebugMode() bool
 	PprofEnabled() bool
 	GetGenesisNodesPubKeys() (map[uint32][]string, map[uint32][]string, error)
+	GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error)
 	IsInterfaceNil() bool
 }

--- a/cmd/node/config/api.toml
+++ b/cmd/node/config/api.toml
@@ -163,6 +163,9 @@
         # /transaction/cost will receive a single transaction in JSON format and will return the estimated cost of it
         { Name = "/cost", Open = true },
 
+        # /transaction/pool will return the hashes of the transactions that are currently in the pool
+        { Name = "/pool", Open = true },
+
         # /transaction/:txhash will return the transaction in JSON format based on its hash
         { Name = "/:txhash", Open = true },
     ]

--- a/common/dtos.go
+++ b/common/dtos.go
@@ -6,3 +6,10 @@ type GetProofResponse struct {
 	Value    []byte
 	RootHash string
 }
+
+// TransactionsPoolAPIResponse is a struct that holds the data to be returned when getting the transaction pool from an API call
+type TransactionsPoolAPIResponse struct {
+	RegularTransactions  []string `json:"regularTransactions"`
+	SmartContractResults []string `json:"smartContractResults"`
+	Rewards              []string `json:"rewards"`
+}

--- a/dataRetriever/interface.go
+++ b/dataRetriever/interface.go
@@ -272,6 +272,7 @@ type ShardedDataCacherNotifier interface {
 	Clear()
 	ClearShardStore(cacheId string)
 	GetCounts() counting.CountsWithSize
+	Keys() [][]byte
 	IsInterfaceNil() bool
 }
 

--- a/dataRetriever/shardedData/shardedData.go
+++ b/dataRetriever/shardedData/shardedData.go
@@ -256,6 +256,20 @@ func (sd *shardedData) RegisterOnAdded(handler func(key []byte, value interface{
 	sd.mutAddedDataHandlers.Unlock()
 }
 
+// Keys returns all the keys contained in shard caches
+func (sd *shardedData) Keys() [][]byte {
+	sd.mutShardedDataStore.RLock()
+	defer sd.mutShardedDataStore.RUnlock()
+
+	keys := make([][]byte, 0)
+	for _, shard := range sd.shardedDataStore {
+		cache := shard.cache
+		keys = append(keys, cache.Keys()...)
+	}
+
+	return keys
+}
+
 // GetCounts returns the total number of transactions in the pool
 func (sd *shardedData) GetCounts() counting.CountsWithSize {
 	sd.mutShardedDataStore.RLock()

--- a/dataRetriever/shardedData/shardedData_test.go
+++ b/dataRetriever/shardedData/shardedData_test.go
@@ -237,6 +237,18 @@ func TestShardedData_RegisterAddedDataHandlerReallyAddsAhandler(t *testing.T) {
 	assert.Equal(t, 1, len(sd.addedDataHandlers))
 }
 
+func TestShardedData_Keys(t *testing.T) {
+	sd, _ := NewShardedData("", defaultTestConfig)
+
+	txsHashes := [][]byte{[]byte("hash-w"), []byte("hash-x"), []byte("hash-y"), []byte("hash-z")}
+	sd.AddData(txsHashes[0], nil, 0, "1")
+	sd.AddData(txsHashes[1], nil, 0, "1")
+	sd.AddData(txsHashes[2], nil, 0, "2")
+	sd.AddData(txsHashes[3], nil, 0, "3")
+
+	assert.ElementsMatch(t, txsHashes, sd.Keys())
+}
+
 func TestShardedData_RegisterAddedDataHandlerNotAddedShouldNotCall(t *testing.T) {
 	t.Parallel()
 

--- a/dataRetriever/txpool/shardedTxPool.go
+++ b/dataRetriever/txpool/shardedTxPool.go
@@ -327,6 +327,20 @@ func (txPool *shardedTxPool) GetCounts() counting.CountsWithSize {
 	return counts
 }
 
+// Keys returns all the keys contained in shard caches
+func(txPool *shardedTxPool) Keys() [][]byte {
+	txPool.mutexBackingMap.RLock()
+	defer txPool.mutexBackingMap.RUnlock()
+
+	keys := make([][]byte, 0)
+	for _, shard := range txPool.backingMap {
+		cache := shard.Cache
+		keys = append(keys, cache.Keys()...)
+	}
+
+	return keys
+}
+
 // Diagnose diagnoses the internal caches
 func (txPool *shardedTxPool) Diagnose(deep bool) {
 	log.Trace("shardedTxPool.Diagnose()", "counts", txPool.GetCounts().String())

--- a/dataRetriever/txpool/shardedTxPool_test.go
+++ b/dataRetriever/txpool/shardedTxPool_test.go
@@ -333,6 +333,19 @@ func Test_GetCounts(t *testing.T) {
 	require.Equal(t, int64(0), pool.GetCounts().GetTotal())
 }
 
+func Test_Keys(t *testing.T) {
+	poolAsInterface, _ := newTxPoolToTest()
+	pool := poolAsInterface.(*shardedTxPool)
+
+	txsHashes := [][]byte{[]byte("hash-w"), []byte("hash-x"), []byte("hash-y"), []byte("hash-z")}
+	pool.AddData(txsHashes[0], createTx("alice", 42), 0, "1")
+	pool.AddData(txsHashes[1], createTx("alice", 43), 0, "1")
+	pool.AddData(txsHashes[2], createTx("bob", 15), 0, "2")
+	pool.AddData(txsHashes[3], createTx("bob", 15), 0, "3")
+
+	require.ElementsMatch(t, txsHashes, pool.Keys())
+}
+
 func Test_IsInterfaceNil(t *testing.T) {
 	poolAsInterface, _ := newTxPoolToTest()
 	require.False(t, check.IfNil(poolAsInterface))

--- a/facade/initial/initialNodeFacade.go
+++ b/facade/initial/initialNodeFacade.go
@@ -336,6 +336,11 @@ func (inf *initialNodeFacade) GetGenesisNodesPubKeys() (map[uint32][]string, map
 	return nil, nil, errNodeStarting
 }
 
+// GetTransactionsPool returns a nil structure and error
+func (inf *initialNodeFacade) GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error) {
+	return nil, errNodeStarting
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (inf *initialNodeFacade) IsInterfaceNil() bool {
 	return inf == nil

--- a/facade/initial/initialNodeFacade_test.go
+++ b/facade/initial/initialNodeFacade_test.go
@@ -186,5 +186,9 @@ func TestDisabledNodeFacade_AllMethodsShouldNotPanic(t *testing.T) {
 	assert.Nil(t, supply)
 	assert.Equal(t, errNodeStarting, err)
 
+	txPool, err := inf.GetTransactionsPool()
+	assert.Nil(t, txPool)
+	assert.Equal(t, errNodeStarting, err)
+
 	assert.False(t, check.IfNil(inf))
 }

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -108,6 +108,7 @@ type ApiResolver interface {
 	GetDirectStakedList(ctx context.Context) ([]*api.DirectStakedValue, error)
 	GetDelegatorsList(ctx context.Context) ([]*api.Delegator, error)
 	GetTransaction(hash string, withResults bool) (*transaction.ApiTransactionResult, error)
+	GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error)
 	GetBlockByHash(hash string, withTxs bool) (*api.Block, error)
 	GetBlockByNonce(nonce uint64, withTxs bool) (*api.Block, error)
 	GetBlockByRound(round uint64, withTxs bool) (*api.Block, error)

--- a/facade/mock/apiResolverStub.go
+++ b/facade/mock/apiResolverStub.go
@@ -32,6 +32,7 @@ type ApiResolverStub struct {
 	GetInternalMiniBlockCalled             func(format common.ApiOutputFormat, hash string, epoch uint32) (interface{}, error)
 	GetInternalStartOfEpochMetaBlockCalled func(format common.ApiOutputFormat, epoch uint32) (interface{}, error)
 	GetGenesisNodesPubKeysCalled           func() (map[uint32][]string, map[uint32][]string)
+	GetTransactionsPoolCalled              func() (*common.TransactionsPoolAPIResponse, error)
 }
 
 // GetTransaction -
@@ -153,6 +154,15 @@ func (ars *ApiResolverStub) GetInternalMetaBlockByNonce(format common.ApiOutputF
 	if ars.GetInternalMetaBlockByNonceCalled != nil {
 		return ars.GetInternalMetaBlockByNonceCalled(format, nonce)
 	}
+	return nil, nil
+}
+
+// GetTransactionsPool -
+func (ars *ApiResolverStub) GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error) {
+	if ars.GetTransactionsPoolCalled != nil {
+		return ars.GetTransactionsPoolCalled()
+	}
+
 	return nil, nil
 }
 

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -294,6 +294,11 @@ func (nf *nodeFacade) GetTransaction(hash string, withResults bool) (*transactio
 	return nf.apiResolver.GetTransaction(hash, withResults)
 }
 
+// GetTransactionsPool returns a slice containing the hashes of the transaction in pool
+func (nf *nodeFacade) GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error) {
+	return nf.apiResolver.GetTransactionsPool()
+}
+
 // ComputeTransactionGasLimit will estimate how many gas a transaction will consume
 func (nf *nodeFacade) ComputeTransactionGasLimit(tx *transaction.Transaction) (*transaction.CostResponse, error) {
 	return nf.apiResolver.ComputeTransactionGasLimit(tx)

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -294,7 +294,7 @@ func (nf *nodeFacade) GetTransaction(hash string, withResults bool) (*transactio
 	return nf.apiResolver.GetTransaction(hash, withResults)
 }
 
-// GetTransactionsPool returns a slice containing the hashes of the transaction in pool
+// GetTransactionsPool will return a structure containing the transactions pool that is to be returned on API calls
 func (nf *nodeFacade) GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error) {
 	return nf.apiResolver.GetTransactionsPool()
 }

--- a/facade/nodeFacade_test.go
+++ b/facade/nodeFacade_test.go
@@ -1198,3 +1198,45 @@ func TestNodeFacade_GetInternalMiniBlockByHashShouldWork(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, ret, blk)
 }
+
+func TestNodeFacade_GetTransactionsPool(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArguments()
+		expectedErr := errors.New("i am the error")
+		arg.ApiResolver = &mock.ApiResolverStub{
+			GetTransactionsPoolCalled: func() (*common.TransactionsPoolAPIResponse, error) {
+				return nil, expectedErr
+			},
+		}
+
+		nf, _ := NewNodeFacade(arg)
+		res, err := nf.GetTransactionsPool()
+		require.Nil(t, res)
+		require.Equal(t, expectedErr, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArguments()
+		expectedPool := &common.TransactionsPoolAPIResponse{
+			RegularTransactions: []string{"tx0", "tx1"},
+			SmartContractResults: []string{"tx2", "tx3"},
+			Rewards: []string{"tx4"},
+		}
+		arg.ApiResolver = &mock.ApiResolverStub{
+			GetTransactionsPoolCalled: func() (*common.TransactionsPoolAPIResponse, error) {
+				return expectedPool, nil
+			},
+		}
+
+		nf, _ := NewNodeFacade(arg)
+		res, err := nf.GetTransactionsPool()
+		require.NoError(t, err)
+		require.Equal(t, expectedPool, res)
+	})
+}

--- a/facade/nodeFacade_test.go
+++ b/facade/nodeFacade_test.go
@@ -1206,7 +1206,7 @@ func TestNodeFacade_GetTransactionsPool(t *testing.T) {
 		t.Parallel()
 
 		arg := createMockArguments()
-		expectedErr := errors.New("i am the error")
+		expectedErr := errors.New("expected error")
 		arg.ApiResolver = &mock.ApiResolverStub{
 			GetTransactionsPoolCalled: func() (*common.TransactionsPoolAPIResponse, error) {
 				return nil, expectedErr

--- a/integrationTests/interface.go
+++ b/integrationTests/interface.go
@@ -95,5 +95,6 @@ type Facade interface {
 	GetProofCurrentRootHash(address string) (*common.GetProofResponse, error)
 	VerifyProof(rootHash string, address string, proof [][]byte) (bool, error)
 	GetGenesisNodesPubKeys() (map[uint32][]string, map[uint32][]string, error)
+	GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error)
 	IsInterfaceNil() bool
 }

--- a/node/external/interface.go
+++ b/node/external/interface.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/data/api"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/process"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
@@ -57,6 +58,7 @@ type DelegatedListHandler interface {
 // APITransactionHandler defines what an API transaction handler should be able to do
 type APITransactionHandler interface {
 	GetTransaction(txHash string, withResults bool) (*transaction.ApiTransactionResult, error)
+	GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error)
 	UnmarshalTransaction(txBytes []byte, txType transaction.TxType) (*transaction.ApiTransactionResult, error)
 	UnmarshalReceipt(receiptBytes []byte) (*transaction.ApiReceipt, error)
 	IsInterfaceNil() bool

--- a/node/external/nodeApiResolver.go
+++ b/node/external/nodeApiResolver.go
@@ -137,7 +137,7 @@ func (nar *nodeApiResolver) GetTransaction(hash string, withResults bool) (*tran
 	return nar.apiTransactionHandler.GetTransaction(hash, withResults)
 }
 
-// GetTransactionsPool will return a slice with all the transactions' hashes in the pool
+// GetTransactionsPool will return a structure containing the transactions pool that is to be returned on API calls
 func (nar *nodeApiResolver) GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error) {
 	return nar.apiTransactionHandler.GetTransactionsPool()
 }

--- a/node/external/nodeApiResolver.go
+++ b/node/external/nodeApiResolver.go
@@ -137,6 +137,11 @@ func (nar *nodeApiResolver) GetTransaction(hash string, withResults bool) (*tran
 	return nar.apiTransactionHandler.GetTransaction(hash, withResults)
 }
 
+// GetTransactionsPool will return a slice with all the transactions' hashes in the pool
+func (nar *nodeApiResolver) GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error) {
+	return nar.apiTransactionHandler.GetTransactionsPool()
+}
+
 // GetBlockByHash will return the block with the given hash and optionally with transactions
 func (nar *nodeApiResolver) GetBlockByHash(hash string, withTxs bool) (*api.Block, error) {
 	decodedHash, err := hex.DecodeString(hash)

--- a/node/external/nodeApiResolver_test.go
+++ b/node/external/nodeApiResolver_test.go
@@ -346,7 +346,7 @@ func TestNodeApiResolver_GetTransactionsPool(t *testing.T) {
 	t.Run("should error", func(t *testing.T) {
 		t.Parallel()
 
-		expectedErr := errors.New("i am the error")
+		expectedErr := errors.New("expected error")
 		arg := createMockArgs()
 		arg.APITransactionHandler = &mock.TransactionAPIHandlerStub{
 			GetTransactionsPoolCalled: func() (*common.TransactionsPoolAPIResponse, error) {

--- a/node/external/nodeApiResolver_test.go
+++ b/node/external/nodeApiResolver_test.go
@@ -3,11 +3,13 @@ package external_test
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data/api"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/node/external"
 	"github.com/ElrondNetwork/elrond-go/node/mock"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -336,6 +338,48 @@ func TestNodeApiResolver_APITransactionHandler(t *testing.T) {
 
 	_, _ = nar.GetTransaction("0101", true)
 	require.True(t, wasCalled)
+}
+
+func TestNodeApiResolver_GetTransactionsPool(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should error", func(t *testing.T) {
+		t.Parallel()
+
+		expectedErr := errors.New("i am the error")
+		arg := createMockArgs()
+		arg.APITransactionHandler = &mock.TransactionAPIHandlerStub{
+			GetTransactionsPoolCalled: func() (*common.TransactionsPoolAPIResponse, error) {
+				return nil, expectedErr
+			},
+		}
+
+		nar, _ := external.NewNodeApiResolver(arg)
+		res, err := nar.GetTransactionsPool()
+		require.Nil(t, res)
+		require.Equal(t, expectedErr, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		expectedTxsPool := &common.TransactionsPoolAPIResponse{
+			RegularTransactions:  []string{"txhash1"},
+			SmartContractResults: []string{"txhash2"},
+			Rewards:              []string{"txhash3"},
+		}
+		arg := createMockArgs()
+		arg.APITransactionHandler = &mock.TransactionAPIHandlerStub{
+			GetTransactionsPoolCalled: func() (*common.TransactionsPoolAPIResponse, error) {
+				return expectedTxsPool, nil
+			},
+		}
+
+		nar, _ := external.NewNodeApiResolver(arg)
+		res, err := nar.GetTransactionsPool()
+		require.NoError(t, err)
+		require.Equal(t, expectedTxsPool, res)
+	})
 }
 
 func TestNodeApiResolver_GetGenesisNodesPubKeys(t *testing.T) {

--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/typeConverters"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/dblookupext"
 	"github.com/ElrondNetwork/elrond-go/process/txstatus"
@@ -88,6 +89,26 @@ func (atp *apiTransactionProcessor) GetTransaction(txHash string, withResults bo
 	}
 
 	return atp.getTransactionFromStorage(hash)
+}
+
+// GetTransactionsPool will return a slice with all the transactions' hashes in the pool
+func (atp *apiTransactionProcessor) GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error) {
+	txsPoolResponse := &common.TransactionsPoolAPIResponse{
+		RegularTransactions:  txsHashesBytesToString(atp.dataPool.Transactions().Keys()),
+		SmartContractResults: txsHashesBytesToString(atp.dataPool.UnsignedTransactions().Keys()),
+		Rewards:              txsHashesBytesToString(atp.dataPool.RewardTransactions().Keys()),
+	}
+
+	return txsPoolResponse, nil
+}
+
+func txsHashesBytesToString(input [][]byte) []string {
+	result := make([]string, 0, len(input))
+	for _, txHashBytes := range input {
+		result = append(result, hex.EncodeToString(txHashBytes))
+	}
+
+	return result
 }
 
 func (atp *apiTransactionProcessor) optionallyGetTransactionFromPool(hash []byte) (*transaction.ApiTransactionResult, error) {

--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -91,7 +91,7 @@ func (atp *apiTransactionProcessor) GetTransaction(txHash string, withResults bo
 	return atp.getTransactionFromStorage(hash)
 }
 
-// GetTransactionsPool will return a slice with all the transactions' hashes in the pool
+// GetTransactionsPool will return a structure containing the transactions pool that is to be returned on API calls
 func (atp *apiTransactionProcessor) GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error) {
 	txsPoolResponse := &common.TransactionsPoolAPIResponse{
 		RegularTransactions:  txsHashesBytesToString(atp.dataPool.Transactions().Keys()),

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -556,9 +556,10 @@ func TestNode_PutHistoryFieldsInTransaction(t *testing.T) {
 func TestApiTransactionProcessor_GetTransactionsPool(t *testing.T) {
 	t.Parallel()
 
-	expectedTxs := [][]byte{[]byte("txhash0"), []byte("txhash1")}
-	expectedScrs := [][]byte{[]byte("txhash2")}
-	expectedRwds := [][]byte{[]byte("txhash3")}
+	txHash0, txHash1, txHash2, txHash3 := []byte("txHash0"), []byte("txHash1"), []byte("txHash2"), []byte("txHash3")
+	expectedTxs := [][]byte{txHash0, txHash1}
+	expectedScrs := [][]byte{txHash2}
+	expectedRwds := [][]byte{txHash3}
 	args := createMockArgAPIBlockProcessor()
 	args.DataPool = &dataRetrieverMock.PoolsHolderStub{
 		TransactionsCalled: func() dataRetriever.ShardedDataCacherNotifier {
@@ -589,9 +590,9 @@ func TestApiTransactionProcessor_GetTransactionsPool(t *testing.T) {
 
 	res, err := atp.GetTransactionsPool()
 	require.NoError(t, err)
-	require.Equal(t, []string{"74786861736830", "74786861736831"}, res.RegularTransactions)
-	require.Equal(t, []string{"74786861736832"}, res.SmartContractResults)
-	require.Equal(t, []string{"74786861736833"}, res.Rewards)
+	require.Equal(t, []string{hex.EncodeToString(txHash0), hex.EncodeToString(txHash1)}, res.RegularTransactions)
+	require.Equal(t, []string{hex.EncodeToString(txHash2)}, res.SmartContractResults)
+	require.Equal(t, []string{hex.EncodeToString(txHash3)}, res.Rewards)
 }
 
 func createAPITransactionProc(t *testing.T, epoch uint32, withDbLookupExt bool) (*apiTransactionProcessor, *genericMocks.ChainStorerMock, *dataRetrieverMock.PoolsHolderMock, *dblookupextMock.HistoryRepositoryStub) {

--- a/node/mock/apiTransactionHandlerStub.go
+++ b/node/mock/apiTransactionHandlerStub.go
@@ -1,10 +1,14 @@
 package mock
 
-import "github.com/ElrondNetwork/elrond-go-core/data/transaction"
+import (
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
+	"github.com/ElrondNetwork/elrond-go/common"
+)
 
 // TransactionAPIHandlerStub -
 type TransactionAPIHandlerStub struct {
 	GetTransactionCalled       func(hash string, withResults bool) (*transaction.ApiTransactionResult, error)
+	GetTransactionsPoolCalled  func() (*common.TransactionsPoolAPIResponse, error)
 	UnmarshalTransactionCalled func(txBytes []byte, txType transaction.TxType) (*transaction.ApiTransactionResult, error)
 	UnmarshalReceiptCalled     func(receiptBytes []byte) (*transaction.ApiReceipt, error)
 }
@@ -13,6 +17,15 @@ type TransactionAPIHandlerStub struct {
 func (tas *TransactionAPIHandlerStub) GetTransaction(hash string, withResults bool) (*transaction.ApiTransactionResult, error) {
 	if tas.GetTransactionCalled != nil {
 		return tas.GetTransactionCalled(hash, withResults)
+	}
+
+	return nil, nil
+}
+
+// GetTransactionsPool -
+func (tas *TransactionAPIHandlerStub) GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error) {
+	if tas.GetTransactionsPoolCalled != nil {
+		return tas.GetTransactionsPoolCalled()
 	}
 
 	return nil, nil

--- a/testscommon/shardedDataCacheNotifierMock.go
+++ b/testscommon/shardedDataCacheNotifierMock.go
@@ -110,6 +110,19 @@ func (mock *ShardedDataCacheNotifierMock) GetCounts() counting.CountsWithSize {
 	return nil
 }
 
+// Keys -
+func (mock *ShardedDataCacheNotifierMock) Keys() [][]byte {
+	mock.mutCaches.Lock()
+	defer mock.mutCaches.Unlock()
+
+	keys := make([][]byte, 0)
+	for _, cache := range mock.caches {
+		keys = append(keys, cache.Keys()...)
+	}
+
+	return keys
+}
+
 // IsInterfaceNil -
 func (mock *ShardedDataCacheNotifierMock) IsInterfaceNil() bool {
 	return mock == nil

--- a/testscommon/shardedDataStub.go
+++ b/testscommon/shardedDataStub.go
@@ -21,6 +21,7 @@ type ShardedDataStub struct {
 	ImmunizeSetOfDataAgainstEvictionCalled func(keys [][]byte, cacheID string)
 	CreateShardStoreCalled                 func(destCacheID string)
 	GetCountsCalled                        func() counting.CountsWithSize
+	KeysCalled                             func() [][]byte
 }
 
 // NewShardedDataStub -
@@ -29,63 +30,63 @@ func NewShardedDataStub() *ShardedDataStub {
 }
 
 // RegisterOnAdded -
-func (shardedData *ShardedDataStub) RegisterOnAdded(handler func(key []byte, value interface{})) {
-	if shardedData.RegisterOnAddedCalled != nil {
-		shardedData.RegisterOnAddedCalled(handler)
+func (sd *ShardedDataStub) RegisterOnAdded(handler func(key []byte, value interface{})) {
+	if sd.RegisterOnAddedCalled != nil {
+		sd.RegisterOnAddedCalled(handler)
 	}
 }
 
 // ShardDataStore -
-func (shardedData *ShardedDataStub) ShardDataStore(cacheID string) storage.Cacher {
-	return shardedData.ShardDataStoreCalled(cacheID)
+func (sd *ShardedDataStub) ShardDataStore(cacheID string) storage.Cacher {
+	return sd.ShardDataStoreCalled(cacheID)
 }
 
 // AddData -
-func (shardedData *ShardedDataStub) AddData(key []byte, data interface{}, sizeInBytes int, cacheID string) {
-	if shardedData.AddDataCalled != nil {
-		shardedData.AddDataCalled(key, data, sizeInBytes, cacheID)
+func (sd *ShardedDataStub) AddData(key []byte, data interface{}, sizeInBytes int, cacheID string) {
+	if sd.AddDataCalled != nil {
+		sd.AddDataCalled(key, data, sizeInBytes, cacheID)
 	}
 }
 
 // SearchFirstData -
-func (shardedData *ShardedDataStub) SearchFirstData(key []byte) (value interface{}, ok bool) {
-	return shardedData.SearchFirstDataCalled(key)
+func (sd *ShardedDataStub) SearchFirstData(key []byte) (value interface{}, ok bool) {
+	return sd.SearchFirstDataCalled(key)
 }
 
 // RemoveData -
-func (shardedData *ShardedDataStub) RemoveData(key []byte, cacheID string) {
-	shardedData.RemoveDataCalled(key, cacheID)
+func (sd *ShardedDataStub) RemoveData(key []byte, cacheID string) {
+	sd.RemoveDataCalled(key, cacheID)
 }
 
 // RemoveDataFromAllShards -
-func (shardedData *ShardedDataStub) RemoveDataFromAllShards(key []byte) {
-	shardedData.RemoveDataFromAllShardsCalled(key)
+func (sd *ShardedDataStub) RemoveDataFromAllShards(key []byte) {
+	sd.RemoveDataFromAllShardsCalled(key)
 }
 
 // MergeShardStores -
-func (shardedData *ShardedDataStub) MergeShardStores(sourceCacheID, destCacheID string) {
-	shardedData.MergeShardStoresCalled(sourceCacheID, destCacheID)
+func (sd *ShardedDataStub) MergeShardStores(sourceCacheID, destCacheID string) {
+	sd.MergeShardStoresCalled(sourceCacheID, destCacheID)
 }
 
 // Clear -
-func (shardedData *ShardedDataStub) Clear() {
-	shardedData.ClearCalled()
+func (sd *ShardedDataStub) Clear() {
+	sd.ClearCalled()
 }
 
 // ClearShardStore -
-func (shardedData *ShardedDataStub) ClearShardStore(cacheID string) {
-	shardedData.ClearShardStoreCalled(cacheID)
+func (sd *ShardedDataStub) ClearShardStore(cacheID string) {
+	sd.ClearShardStoreCalled(cacheID)
 }
 
 // RemoveSetOfDataFromPool -
-func (shardedData *ShardedDataStub) RemoveSetOfDataFromPool(keys [][]byte, cacheID string) {
-	shardedData.RemoveSetOfDataFromPoolCalled(keys, cacheID)
+func (sd *ShardedDataStub) RemoveSetOfDataFromPool(keys [][]byte, cacheID string) {
+	sd.RemoveSetOfDataFromPoolCalled(keys, cacheID)
 }
 
 // ImmunizeSetOfDataAgainstEviction -
-func (shardedData *ShardedDataStub) ImmunizeSetOfDataAgainstEviction(keys [][]byte, cacheID string) {
-	if shardedData.ImmunizeSetOfDataAgainstEvictionCalled != nil {
-		shardedData.ImmunizeSetOfDataAgainstEvictionCalled(keys, cacheID)
+func (sd *ShardedDataStub) ImmunizeSetOfDataAgainstEviction(keys [][]byte, cacheID string) {
+	if sd.ImmunizeSetOfDataAgainstEvictionCalled != nil {
+		sd.ImmunizeSetOfDataAgainstEvictionCalled(keys, cacheID)
 	}
 }
 
@@ -98,7 +99,16 @@ func (sd *ShardedDataStub) GetCounts() counting.CountsWithSize {
 	return &counting.NullCounts{}
 }
 
+// Keys -
+func (sd *ShardedDataStub) Keys() [][]byte {
+	if sd.KeysCalled != nil {
+		return sd.KeysCalled()
+	}
+
+	return nil
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
-func (shardedData *ShardedDataStub) IsInterfaceNil() bool {
-	return shardedData == nil
+func (sd *ShardedDataStub) IsInterfaceNil() bool {
+	return sd == nil
 }


### PR DESCRIPTION
added a new API endpoint GET `/transaction/pool` that returns the txs hashes for regular transactions, smart contract results or rewards txs