### PR TITLE
Fixed integration tests

### DIFF
--- a/integrationTests/vm/arwen/arwenvm/arwenVM_test.go
+++ b/integrationTests/vm/arwen/arwenvm/arwenVM_test.go
@@ -182,7 +182,7 @@ func TestSCMoveBalanceBeforeSCDeploy(t *testing.T) {
 	_, err = testContext.TxProcessor.ProcessTransaction(tx)
 
 	require.Equal(t, process.ErrFailedTransaction, err)
-	require.Equal(t, process.ErrAccountNotPayable, testContext.GetLatestError())
+	require.Equal(t, fmt.Errorf("%s: %s", process.ErrAccountNotPayable.Error(), "sending value to non payable contract"), testContext.GetCompositeTestError())
 	vm.TestAccount(
 		t,
 		testContext.Accounts,

--- a/integrationTests/vm/arwen/badcontracts/badcontracts_test.go
+++ b/integrationTests/vm/arwen/badcontracts/badcontracts_test.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 package badcontracts

--- a/integrationTests/vm/arwen/utils.go
+++ b/integrationTests/vm/arwen/utils.go
@@ -496,7 +496,7 @@ func (context *TestContext) DeploySC(wasmPath string, parametersString string) e
 		return err
 	}
 
-	err = context.GetLatestError()
+	err = context.GetCompositeTestError()
 	if err != nil {
 		return err
 	}
@@ -550,7 +550,7 @@ func (context *TestContext) UpgradeSC(wasmPath string, parametersString string) 
 		return err
 	}
 
-	err = context.GetLatestError()
+	err = context.GetCompositeTestError()
 	if err != nil {
 		return err
 	}
@@ -626,7 +626,7 @@ func (context *TestContext) ExecuteSCWithValue(sender *testParticipant, txData s
 		return err
 	}
 
-	err = context.GetLatestError()
+	err = context.GetCompositeTestError()
 	if err != nil {
 		return err
 	}
@@ -698,9 +698,9 @@ func (context *TestContext) GoToEpoch(epoch int) {
 	context.BlockchainHook.SetCurrentHeader(header)
 }
 
-// GetLatestError -
-func (context *TestContext) GetLatestError() error {
-	return context.ScProcessor.GetLatestTestError()
+// GetCompositeTestError -
+func (context *TestContext) GetCompositeTestError() error {
+	return context.ScProcessor.GetCompositeTestError()
 }
 
 // FormatHexNumber -

--- a/integrationTests/vm/testInitializer.go
+++ b/integrationTests/vm/testInitializer.go
@@ -130,9 +130,9 @@ func (vmTestContext *VMTestContext) Close() {
 	_ = vmTestContext.VMContainer.Close()
 }
 
-// GetLatestError -
-func (vmTestContext *VMTestContext) GetLatestError() error {
-	return vmTestContext.ScProcessor.GetLatestTestError()
+// GetCompositeTestError -
+func (vmTestContext *VMTestContext) GetCompositeTestError() error {
+	return vmTestContext.ScProcessor.GetCompositeTestError()
 }
 
 // CreateBlockStarted -

--- a/integrationTests/vm/txsFee/multiESDTTransfer_test.go
+++ b/integrationTests/vm/txsFee/multiESDTTransfer_test.go
@@ -39,7 +39,7 @@ func TestMultiESDTTransferShouldWork(t *testing.T) {
 	retCode, err := testContext.TxProcessor.ProcessTransaction(tx)
 	require.Equal(t, vmcommon.Ok, retCode)
 	require.Nil(t, err)
-	require.Nil(t, testContext.GetLatestError())
+	require.Nil(t, testContext.GetCompositeTestError())
 
 	_, err = testContext.Accounts.Commit()
 	require.Nil(t, err)
@@ -68,8 +68,8 @@ func TestMultiESDTTransferShouldWork(t *testing.T) {
 	testIndexer.SaveTransaction(tx, block.TxBlock, intermediateTxs)
 
 	indexerTx := testIndexer.GetIndexerPreparedTransaction(t)
-	require.Equal(t, uint64(4000), indexerTx.GasUsed)
-	require.Equal(t, "40000", indexerTx.Fee)
+	require.Equal(t, uint64(133), indexerTx.GasUsed)
+	require.Equal(t, "1330", indexerTx.Fee)
 
 	allLogs := testContext.TxsLogsProcessor.GetAllCurrentLogs()
 	require.NotNil(t, allLogs)

--- a/integrationTests/vm/txsFee/multiShard/moveBalance_test.go
+++ b/integrationTests/vm/txsFee/multiShard/moveBalance_test.go
@@ -84,7 +84,7 @@ func TestMoveBalanceContractAddressDataFieldNilShouldConsumeGas(t *testing.T) {
 	retCode, err := testContext.TxProcessor.ProcessTransaction(tx)
 	require.Equal(t, vmcommon.UserError, retCode)
 	require.Nil(t, err)
-	require.Equal(t, errors.New("sending value to non payable contract"), testContext.GetLatestError())
+	require.Equal(t, errors.New("sending value to non payable contract: sending value to non payable contract"), testContext.GetCompositeTestError())
 
 	_, err = testContext.Accounts.Commit()
 	require.Nil(t, err)
@@ -133,7 +133,7 @@ func TestMoveBalanceContractAddressDataFieldNotNilShouldConsumeGas(t *testing.T)
 	retCode, err := testContext.TxProcessor.ProcessTransaction(tx)
 	require.Equal(t, vmcommon.UserError, retCode)
 	require.Nil(t, err)
-	require.Equal(t, errors.New("invalid contract code (not found)"), testContext.GetLatestError())
+	require.Equal(t, errors.New("invalid contract code (not found): contract not found"), testContext.GetCompositeTestError())
 
 	_, err = testContext.Accounts.Commit()
 	require.Nil(t, err)

--- a/integrationTests/vm/txsFee/scDeploy_test.go
+++ b/integrationTests/vm/txsFee/scDeploy_test.go
@@ -36,7 +36,7 @@ func TestScDeployShouldWork(t *testing.T) {
 
 	_, err = testContext.TxProcessor.ProcessTransaction(tx)
 	require.Nil(t, err)
-	require.Nil(t, testContext.GetLatestError())
+	require.Nil(t, testContext.GetCompositeTestError())
 
 	_, err = testContext.Accounts.Commit()
 	require.Nil(t, err)
@@ -118,7 +118,7 @@ func TestScDeployInsufficientGasLimitShouldNotConsumeGas(t *testing.T) {
 
 	_, err = testContext.TxProcessor.ProcessTransaction(tx)
 	require.Equal(t, process.ErrInsufficientGasLimitInTx, err)
-	require.Nil(t, testContext.GetLatestError())
+	require.Nil(t, testContext.GetCompositeTestError())
 
 	_, err = testContext.Accounts.Commit()
 	require.Nil(t, err)


### PR DESCRIPTION
- fixed integration tests by calling `tsp.txLogsProcessor.Clean()` in testScProcessor
- changed the testScProcessor`s GetLatestTestError function to return all errors it finds