### PR TITLE
Fix logs order

### DIFF
--- a/process/smartContract/process.go
+++ b/process/smartContract/process.go
@@ -1055,7 +1055,8 @@ func mergeVMOutputLogs(newVMOutput *vmcommon.VMOutput, vmOutput *vmcommon.VMOutp
 	if newVMOutput.Logs == nil {
 		newVMOutput.Logs = make([]*vmcommon.LogEntry, 0, len(vmOutput.Logs))
 	}
-	newVMOutput.Logs = append(newVMOutput.Logs, vmOutput.Logs...)
+
+	newVMOutput.Logs = append(vmOutput.Logs, newVMOutput.Logs...)
 }
 
 func (sc *scProcessor) processSCRForSenderAfterBuiltIn(

--- a/process/smartContract/process_test.go
+++ b/process/smartContract/process_test.go
@@ -4243,6 +4243,27 @@ func TestMergeVmOutputLogs(t *testing.T) {
 
 	mergeVMOutputLogs(vmOutput1, vmOutput2)
 	require.Len(t, vmOutput1.Logs, 2)
+
+	vmOutput1 = &vmcommon.VMOutput{
+		Logs: []*vmcommon.LogEntry{
+			{
+				Identifier: []byte("identifier2"),
+			},
+		},
+	}
+
+	vmOutput2 = &vmcommon.VMOutput{
+		Logs: []*vmcommon.LogEntry{
+			{
+				Identifier: []byte("identifier1"),
+			},
+		},
+	}
+
+	mergeVMOutputLogs(vmOutput1, vmOutput2)
+	require.Len(t, vmOutput1.Logs, 2)
+	require.Equal(t, []byte("identifier1"), vmOutput1.Logs[0].Identifier)
+	require.Equal(t, []byte("identifier2"), vmOutput1.Logs[1].Identifier)
 }
 
 func TestScProcessor_TooMuchGasProvidedMessage(t *testing.T) {


### PR DESCRIPTION
- Fix the order in how the logs are generated. 
- The logs generated by a built-in function with a smart contract call were put last instead of first.