### PR TITLE
extracted max gas limit for vm query to config

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -588,9 +588,6 @@
         SameSourceRequests = 10000
         # SameSourceResetIntervalInSec time frame between counter reset, in seconds
         SameSourceResetIntervalInSec = 1
-        # MaxGasPerVmQuery defines the maximum amount of gas to be allocated for VM Queries comming from API
-        # If set to 0, then MaxUInt64 will be used
-        MaxGasPerVmQuery = 1500000000  #1.5b
         # EndpointsThrottlers represents a map for maximum simultaneous go routines for an endpoint
         EndpointsThrottlers = [{ Endpoint = "/transaction/:hash", MaxNumGoRoutines = 10 },
                                { Endpoint = "/transaction/send", MaxNumGoRoutines = 2 },
@@ -721,6 +718,11 @@
             { StartEpoch = 0, Version = "v1.3" },
             { StartEpoch = 1, Version = "v1.4" },
         ]
+
+    [VirtualMachine.GasConfig]
+        # MaxGasPerVmQuery defines the maximum amount of gas to be allocated for VM Queries comming from API
+        # If set to 0, then MaxUInt64 will be used
+        MaxGasPerVmQuery = 1500000000  #1.5b
 
 [Hardfork]
     EnableTrigger = true

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -588,6 +588,9 @@
         SameSourceRequests = 10000
         # SameSourceResetIntervalInSec time frame between counter reset, in seconds
         SameSourceResetIntervalInSec = 1
+        # MaxGasPerVmQuery defines the maximum amount of gas to be allocated for VM Queries comming from API
+        # If set to 0, then MaxUInt64 will be used
+        MaxGasPerVmQuery = 1500000000  #1.5b
         # EndpointsThrottlers represents a map for maximum simultaneous go routines for an endpoint
         EndpointsThrottlers = [{ Endpoint = "/transaction/:hash", MaxNumGoRoutines = 10 },
                                { Endpoint = "/transaction/send", MaxNumGoRoutines = 2 },

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -720,7 +720,7 @@
         ]
 
     [VirtualMachine.GasConfig]
-        # MaxGasPerVmQuery defines the maximum amount of gas to be allocated for VM Queries comming from API
+        # MaxGasPerVmQuery defines the maximum amount of gas to be allocated for VM Queries coming from API
         # If set to 0, then MaxUInt64 will be used
         MaxGasPerVmQuery = 1500000000  #1.5b
 

--- a/config/config.go
+++ b/config/config.go
@@ -283,6 +283,7 @@ type EndpointsThrottlersConfig struct {
 
 // WebServerAntifloodConfig will hold the anti-flooding parameters for the web server
 type WebServerAntifloodConfig struct {
+	MaxGasPerVmQuery             uint64
 	SimultaneousRequests         uint32
 	SameSourceRequests           uint32
 	SameSourceResetIntervalInSec uint32

--- a/config/config.go
+++ b/config/config.go
@@ -283,7 +283,6 @@ type EndpointsThrottlersConfig struct {
 
 // WebServerAntifloodConfig will hold the anti-flooding parameters for the web server
 type WebServerAntifloodConfig struct {
-	MaxGasPerVmQuery             uint64
 	SimultaneousRequests         uint32
 	SameSourceRequests           uint32
 	SameSourceResetIntervalInSec uint32
@@ -356,6 +355,7 @@ type IncreaseFactorConfig struct {
 type VirtualMachineServicesConfig struct {
 	Execution VirtualMachineConfig
 	Querying  QueryVirtualMachineConfig
+	GasConfig VirtualMachineGasConfig
 }
 
 // VirtualMachineConfig holds configuration for a Virtual Machine service
@@ -373,6 +373,11 @@ type ArwenVersionByEpoch struct {
 type QueryVirtualMachineConfig struct {
 	VirtualMachineConfig
 	NumConcurrentVMs int
+}
+
+// VirtualMachineGasConfig holds the configuration for the virtual machine(s) gas operations
+type VirtualMachineGasConfig struct {
+	MaxGasPerVmQuery uint64
 }
 
 // HardforkConfig holds the configuration for the hardfork trigger

--- a/config/tomlConfig_test.go
+++ b/config/tomlConfig_test.go
@@ -126,6 +126,11 @@ func TestTomlParser(t *testing.T) {
 				DoProfileOnShuffleOut:   true,
 			},
 		},
+		Antiflood: AntifloodConfig{
+			WebServer: WebServerAntifloodConfig{
+				MaxGasPerVmQuery: 1_500_000_000,
+			},
+		},
 	}
 	testString := `
 [MiniBlocksStorage]
@@ -173,6 +178,10 @@ func TestTomlParser(t *testing.T) {
 
 [Consensus]
 	Type = "` + consensusType + `"
+
+[Antiflood]
+    [Antiflood.WebServer]
+        MaxGasPerVmQuery = 1500000000  #1.5b
 
 [VirtualMachine]
     [VirtualMachine.Execution]

--- a/config/tomlConfig_test.go
+++ b/config/tomlConfig_test.go
@@ -104,6 +104,9 @@ func TestTomlParser(t *testing.T) {
 				NumConcurrentVMs:     16,
 				VirtualMachineConfig: vmConfig,
 			},
+			GasConfig: VirtualMachineGasConfig{
+				MaxGasPerVmQuery: 1_500_000_000,
+			},
 		},
 		Debug: DebugConfig{
 			InterceptorResolver: InterceptorResolverDebugConfig{
@@ -124,11 +127,6 @@ func TestTomlParser(t *testing.T) {
 				CallGCWhenShuffleOut:    true,
 				ExtraPrintsOnShuffleOut: true,
 				DoProfileOnShuffleOut:   true,
-			},
-		},
-		Antiflood: AntifloodConfig{
-			WebServer: WebServerAntifloodConfig{
-				MaxGasPerVmQuery: 1_500_000_000,
 			},
 		},
 	}
@@ -179,10 +177,6 @@ func TestTomlParser(t *testing.T) {
 [Consensus]
 	Type = "` + consensusType + `"
 
-[Antiflood]
-    [Antiflood.WebServer]
-        MaxGasPerVmQuery = 1500000000  #1.5b
-
 [VirtualMachine]
     [VirtualMachine.Execution]
         ArwenVersions = [
@@ -196,6 +190,9 @@ func TestTomlParser(t *testing.T) {
             { StartEpoch = 12, Version = "v0.3" },
             { StartEpoch = 88, Version = "v1.2" },
         ]
+
+	[VirtualMachine.GasConfig]
+		MaxGasPerVmQuery = 1500000000
 
 [Debug]
     [Debug.InterceptorResolver]

--- a/factory/apiResolverFactory.go
+++ b/factory/apiResolverFactory.go
@@ -346,7 +346,7 @@ func createScQueryElement(
 		ArwenChangeLocker:        args.coreComponents.ArwenChangeLocker(),
 		Bootstrapper:             args.bootstrapper,
 		AllowExternalQueriesChan: args.allowVMQueriesChan,
-		MaxGasLimitPerQuery:      args.generalConfig.Antiflood.WebServer.MaxGasPerVmQuery,
+		MaxGasLimitPerQuery:      args.generalConfig.VirtualMachine.GasConfig.MaxGasPerVmQuery,
 	}
 
 	return smartContract.NewSCQueryService(argsNewSCQueryService)

--- a/factory/apiResolverFactory.go
+++ b/factory/apiResolverFactory.go
@@ -346,6 +346,7 @@ func createScQueryElement(
 		ArwenChangeLocker:        args.coreComponents.ArwenChangeLocker(),
 		Bootstrapper:             args.bootstrapper,
 		AllowExternalQueriesChan: args.allowVMQueriesChan,
+		MaxGasLimitPerQuery:      args.generalConfig.Antiflood.WebServer.MaxGasPerVmQuery,
 	}
 
 	return smartContract.NewSCQueryService(argsNewSCQueryService)

--- a/process/smartContract/scQueryService.go
+++ b/process/smartContract/scQueryService.go
@@ -42,6 +42,7 @@ type ArgsNewSCQueryService struct {
 	ArwenChangeLocker        common.Locker
 	Bootstrapper             process.Bootstrapper
 	AllowExternalQueriesChan chan struct{}
+	MaxGasLimitPerQuery      uint64
 }
 
 // NewSCQueryService returns a new instance of SCQueryService
@@ -70,6 +71,10 @@ func NewSCQueryService(
 		return nil, process.ErrNilAllowExternalQueriesChan
 	}
 
+	gasForQuery := uint64(math.MaxUint64)
+	if args.MaxGasLimitPerQuery > 0 {
+		gasForQuery = args.MaxGasLimitPerQuery
+	}
 	return &SCQueryService{
 		vmContainer:              args.VmContainer,
 		economicsFee:             args.EconomicsFee,
@@ -77,7 +82,7 @@ func NewSCQueryService(
 		blockChainHook:           args.BlockChainHook,
 		arwenChangeLocker:        args.ArwenChangeLocker,
 		bootstrapper:             args.Bootstrapper,
-		gasForQuery:              math.MaxUint64,
+		gasForQuery:              gasForQuery,
 		allowExternalQueriesChan: args.AllowExternalQueriesChan,
 	}, nil
 }

--- a/process/smartContract/scQueryService_test.go
+++ b/process/smartContract/scQueryService_test.go
@@ -308,6 +308,85 @@ func TestExecuteQuery_ReturnsCorrectly(t *testing.T) {
 	assert.Equal(t, d[1], vmOutput.ReturnData[1])
 }
 
+func TestExecuteQuery_GasProvidedShouldBeApplied(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no gas defined, should use max uint64", func(t *testing.T) {
+		t.Parallel()
+
+		runSCWasCalled := false
+		mockVM := &mock.VMExecutionHandlerStub{
+			RunSmartContractCallCalled: func(input *vmcommon.ContractCallInput) (output *vmcommon.VMOutput, e error) {
+				require.Equal(t, uint64(math.MaxUint64), input.GasProvided)
+				runSCWasCalled = true
+				return &vmcommon.VMOutput{}, nil
+			},
+		}
+		argsNewSCQuery := createMockArgumentsForSCQuery()
+		argsNewSCQuery.VmContainer = &mock.VMContainerMock{
+			GetCalled: func(key []byte) (handler vmcommon.VMExecutionHandler, e error) {
+				return mockVM, nil
+			},
+		}
+		argsNewSCQuery.EconomicsFee = &mock.FeeHandlerStub{
+			MaxGasLimitPerBlockCalled: func() uint64 {
+				return uint64(math.MaxUint64)
+			},
+		}
+
+		target, _ := NewSCQueryService(argsNewSCQuery)
+
+		query := process.SCQuery{
+			ScAddress: []byte(DummyScAddress),
+			FuncName:  "function",
+			Arguments: [][]byte{},
+		}
+
+		_, err := target.ExecuteQuery(&query)
+		require.Nil(t, err)
+		require.True(t, runSCWasCalled)
+	})
+
+	t.Run("custom gas defined, should use max uint64", func(t *testing.T) {
+		t.Parallel()
+
+		maxGasLimit := uint64(1_500_000_000)
+		runSCWasCalled := false
+		mockVM := &mock.VMExecutionHandlerStub{
+			RunSmartContractCallCalled: func(input *vmcommon.ContractCallInput) (output *vmcommon.VMOutput, e error) {
+				require.Equal(t, maxGasLimit, input.GasProvided)
+				runSCWasCalled = true
+				return &vmcommon.VMOutput{}, nil
+			},
+		}
+		argsNewSCQuery := createMockArgumentsForSCQuery()
+		argsNewSCQuery.VmContainer = &mock.VMContainerMock{
+			GetCalled: func(key []byte) (handler vmcommon.VMExecutionHandler, e error) {
+				return mockVM, nil
+			},
+		}
+		argsNewSCQuery.EconomicsFee = &mock.FeeHandlerStub{
+			MaxGasLimitPerBlockCalled: func() uint64 {
+				return uint64(math.MaxUint64)
+			},
+		}
+
+		argsNewSCQuery.MaxGasLimitPerQuery = maxGasLimit
+
+		target, _ := NewSCQueryService(argsNewSCQuery)
+
+		query := process.SCQuery{
+			ScAddress: []byte(DummyScAddress),
+			FuncName:  "function",
+			Arguments: [][]byte{},
+		}
+
+		_, err := target.ExecuteQuery(&query)
+		require.Nil(t, err)
+		require.True(t, runSCWasCalled)
+	})
+}
+
 func TestExecuteQuery_WhenNotOkCodeShouldNotErr(t *testing.T) {
 	t.Parallel()
 

--- a/process/smartContract/scQueryService_test.go
+++ b/process/smartContract/scQueryService_test.go
@@ -347,7 +347,7 @@ func TestExecuteQuery_GasProvidedShouldBeApplied(t *testing.T) {
 		require.True(t, runSCWasCalled)
 	})
 
-	t.Run("custom gas defined, should use max uint64", func(t *testing.T) {
+	t.Run("custom gas defined, should use it", func(t *testing.T) {
 		t.Parallel()
 
 		maxGasLimit := uint64(1_500_000_000)


### PR DESCRIPTION
extracted the maximum gas limit to be used for vm queries inside config.toml