### PR TITLE
Fix token type log for register and set all roles

### DIFF
--- a/vm/systemSmartContracts/esdt.go
+++ b/vm/systemSmartContracts/esdt.go
@@ -531,7 +531,7 @@ func (e *esdt) registerAndSetRoles(args *vmcommon.ContractCallInput) vmcommon.Re
 	logEntry := &vmcommon.LogEntry{
 		Identifier: []byte(args.Function),
 		Address:    args.CallerAddr,
-		Topics:     [][]byte{tokenIdentifier, args.Arguments[0], args.Arguments[1], []byte(metaESDT)},
+		Topics:     [][]byte{tokenIdentifier, args.Arguments[0], args.Arguments[1], tokenType},
 	}
 	e.eei.Finish(tokenIdentifier)
 	e.eei.AddLogEntry(logEntry)
@@ -553,6 +553,7 @@ func getAllRolesForTokenType(tokenType string) ([][]byte, error) {
 }
 
 func getTokenType(compressed []byte) (bool, []byte, error) {
+	// TODO: might extract the compressed constants to core, alongside metaESDT
 	switch string(compressed) {
 	case "NFT":
 		return false, []byte(core.NonFungibleESDT), nil

--- a/vm/systemSmartContracts/esdt_test.go
+++ b/vm/systemSmartContracts/esdt_test.go
@@ -4592,9 +4592,16 @@ func TestEsdt_ExecuteRegisterAndSetSemiFungible(t *testing.T) {
 	assert.Equal(t, token.TokenType, []byte(core.SemiFungibleESDT))
 }
 
-func TestEsdt_ExecuteRegisterAndSetMetaESDT(t *testing.T) {
+func TestEsdt_ExecuteRegisterAndSetMetaESDTShouldSetType(t *testing.T) {
 	t.Parallel()
 
+	registerAndSetAllRolesWithTypeCheck(t, []byte("NFT"), []byte(core.NonFungibleESDT))
+	registerAndSetAllRolesWithTypeCheck(t, []byte("SFT"), []byte(core.SemiFungibleESDT))
+	registerAndSetAllRolesWithTypeCheck(t, []byte("META"), []byte(metaESDT))
+	registerAndSetAllRolesWithTypeCheck(t, []byte("FNG"), []byte(core.FungibleESDT))
+}
+
+func registerAndSetAllRolesWithTypeCheck(t *testing.T, typeArgument []byte, expectedType []byte) {
 	args := createMockArgumentsForESDT()
 	eei, _ := NewVMContext(
 		&mock.BlockChainHookStub{},
@@ -4608,7 +4615,7 @@ func TestEsdt_ExecuteRegisterAndSetMetaESDT(t *testing.T) {
 	vmInput := getDefaultVmInputForFunc("registerAndSetAllRoles", nil)
 	vmInput.CallValue = big.NewInt(0).Set(e.baseIssuingCost)
 
-	vmInput.Arguments = [][]byte{[]byte("tokenName"), []byte("TICKER"), []byte("META"), big.NewInt(10).Bytes()}
+	vmInput.Arguments = [][]byte{[]byte("tokenName"), []byte("TICKER"), typeArgument, big.NewInt(10).Bytes()}
 	eei.gasRemaining = 9999
 	eei.returnMessage = ""
 	output := e.Execute(vmInput)
@@ -4617,5 +4624,5 @@ func TestEsdt_ExecuteRegisterAndSetMetaESDT(t *testing.T) {
 	assert.True(t, strings.Contains(string(eei.output[0]), "TICKER-"))
 
 	token, _ := e.getExistingToken(eei.output[0])
-	assert.Equal(t, token.TokenType, []byte(metaESDT))
+	assert.Equal(t, expectedType, token.TokenType)
 }


### PR DESCRIPTION
This PR fixes the log that resembles the token's type when calling the registerAndSetAllRoles function