### PR TITLE
Optimistic signature aggregation by leader

### DIFF
--- a/consensus/spos/bls/export_test.go
+++ b/consensus/spos/bls/export_test.go
@@ -293,6 +293,10 @@ func (sr *subroundEndRound) IsOutOfTime() bool {
 	return sr.isOutOfTime()
 }
 
+func (sr *subroundEndRound) VerifyNodesOnAggSigVerificationFail(multiSigner crypto.MultiSigner) error {
+	return sr.verifyNodesOnAggSigVerificationFail(multiSigner)
+}
+
 // GetStringValue gets the name of the message type
 func GetStringValue(messageType consensus.MessageType) string {
 	return getStringValue(messageType)

--- a/consensus/spos/bls/export_test.go
+++ b/consensus/spos/bls/export_test.go
@@ -297,6 +297,12 @@ func (sr *subroundEndRound) VerifyNodesOnAggSigVerificationFail(multiSigner cryp
 	return sr.verifyNodesOnAggSigVerificationFail(multiSigner)
 }
 
+func (sr *subroundEndRound) ComputeAggSigOnValidNodes(
+	multiSigner crypto.MultiSigner,
+) ([]byte, []byte, error) {
+	return sr.computeAggSigOnValidNodes(multiSigner)
+}
+
 // GetStringValue gets the name of the message type
 func GetStringValue(messageType consensus.MessageType) string {
 	return getStringValue(messageType)

--- a/consensus/spos/bls/export_test.go
+++ b/consensus/spos/bls/export_test.go
@@ -293,7 +293,7 @@ func (sr *subroundEndRound) IsOutOfTime() bool {
 	return sr.isOutOfTime()
 }
 
-func (sr *subroundEndRound) VerifyNodesOnAggSigVerificationFail(multiSigner crypto.MultiSigner) error {
+func (sr *subroundEndRound) VerifyNodesOnAggSigVerificationFail(multiSigner crypto.MultiSigner) ([]byte, []byte, error) {
 	return sr.verifyNodesOnAggSigVerificationFail(multiSigner)
 }
 

--- a/consensus/spos/bls/export_test.go
+++ b/consensus/spos/bls/export_test.go
@@ -293,7 +293,7 @@ func (sr *subroundEndRound) IsOutOfTime() bool {
 	return sr.isOutOfTime()
 }
 
-func (sr *subroundEndRound) VerifyNodesOnAggSigVerificationFail(multiSigner crypto.MultiSigner) ([]byte, []byte, error) {
+func (sr *subroundEndRound) VerifyNodesOnAggSigVerificationFail(multiSigner crypto.MultiSigner) error {
 	return sr.verifyNodesOnAggSigVerificationFail(multiSigner)
 }
 

--- a/consensus/spos/bls/export_test.go
+++ b/consensus/spos/bls/export_test.go
@@ -269,6 +269,10 @@ func (sr *subroundEndRound) DoEndRoundJobByParticipant(cnsDta *consensus.Message
 	return sr.doEndRoundJobByParticipant(cnsDta)
 }
 
+func (sr *subroundEndRound) DoEndRoundJobByLeader() bool {
+	return sr.doEndRoundJobByLeader()
+}
+
 func (sr *subroundEndRound) HaveConsensusHeaderWithFullInfo(cnsDta *consensus.Message) (bool, data.HeaderHandler) {
 	return sr.haveConsensusHeaderWithFullInfo(cnsDta)
 }

--- a/consensus/spos/bls/export_test.go
+++ b/consensus/spos/bls/export_test.go
@@ -297,14 +297,12 @@ func (sr *subroundEndRound) IsOutOfTime() bool {
 	return sr.isOutOfTime()
 }
 
-func (sr *subroundEndRound) VerifyNodesOnAggSigVerificationFail(multiSigner crypto.MultiSigner) error {
-	return sr.verifyNodesOnAggSigVerificationFail(multiSigner)
+func (sr *subroundEndRound) VerifyNodesOnAggSigVerificationFail() error {
+	return sr.verifyNodesOnAggSigVerificationFail()
 }
 
-func (sr *subroundEndRound) ComputeAggSigOnValidNodes(
-	multiSigner crypto.MultiSigner,
-) ([]byte, []byte, error) {
-	return sr.computeAggSigOnValidNodes(multiSigner)
+func (sr *subroundEndRound) ComputeAggSigOnValidNodes() ([]byte, []byte, error) {
+	return sr.computeAggSigOnValidNodes()
 }
 
 // GetStringValue gets the name of the message type

--- a/consensus/spos/bls/subroundEndRound.go
+++ b/consensus/spos/bls/subroundEndRound.go
@@ -222,8 +222,6 @@ func (sr *subroundEndRound) doEndRoundJobByLeader() bool {
 		}
 	}
 
-	log.Debug("doEndRoundJobByLeader.Verify: TRIGERRED")
-
 	err = sr.Header.SetPubKeysBitmap(bitmap)
 	if err != nil {
 		log.Debug("doEndRoundJobByLeader.SetPubKeysBitmap", "error", err.Error())
@@ -313,10 +311,6 @@ func (sr *subroundEndRound) verifyNodesOnAggSigVerificationFail(
 ) error {
 	pubKeys := sr.ConsensusGroup()
 
-	invalidSigSharesNodes := make([]int, 0)
-
-	// TODO: analize better error handling and logs
-
 	for i, pk := range pubKeys {
 		isJobDone, err := sr.JobDone(pk, SrSignature)
 		if err != nil || !isJobDone {
@@ -333,7 +327,6 @@ func (sr *subroundEndRound) verifyNodesOnAggSigVerificationFail(
 		if err != nil {
 			isSuccessfull = false
 
-			invalidSigSharesNodes = append(invalidSigSharesNodes, i)
 			err = sr.SetJobDone(pk, SrSignature, false)
 			if err != nil {
 				return err
@@ -341,13 +334,6 @@ func (sr *subroundEndRound) verifyNodesOnAggSigVerificationFail(
 		}
 
 		log.Trace("verifyNodesOnAggSigVerificationFail: verifying signature share", "public key", pk, "is successfull", isSuccessfull)
-	}
-
-	// TODO: handle slashing on invalid sig share nodes
-	if len(invalidSigSharesNodes) == 0 {
-		log.Debug("verifyNodesOnAggSigVerificationFail.VerifySignatureShare: no invalid signature share")
-	} else {
-		log.Debug("verifyNodesOnAggSigVerificationFail.VerifySignatureShare: num invalid signature shares", "numInvalidSigShares", len(invalidSigSharesNodes))
 	}
 
 	return nil

--- a/consensus/spos/bls/subroundEndRound.go
+++ b/consensus/spos/bls/subroundEndRound.go
@@ -332,6 +332,12 @@ func (sr *subroundEndRound) verifyNodesOnAggSigVerificationFail() error {
 			if err != nil {
 				return err
 			}
+
+			sr.PeerHonestyHandler().ChangeScore(
+				pk,
+				spos.GetConsensusTopicID(sr.ShardCoordinator()),
+				spos.ValidatorPeerHonestyDecreaseFactor,
+			)
 		}
 
 		log.Trace("verifyNodesOnAggSigVerificationFail: verifying signature share", "public key", pk, "is successfull", isSuccessfull)

--- a/consensus/spos/bls/subroundEndRound.go
+++ b/consensus/spos/bls/subroundEndRound.go
@@ -306,6 +306,9 @@ func (sr *subroundEndRound) doEndRoundJobByLeader() bool {
 	return true
 }
 
+// TODO:
+//	- slashing for invalid sig shares
+//	- handle sig share verifications concurrently
 func (sr *subroundEndRound) verifyNodesOnAggSigVerificationFail(
 	multiSigner crypto.MultiSigner,
 ) error {

--- a/consensus/spos/bls/subroundEndRound.go
+++ b/consensus/spos/bls/subroundEndRound.go
@@ -333,8 +333,8 @@ func (sr *subroundEndRound) verifyNodesOnAggSigVerificationFail() error {
 				return err
 			}
 
-			// include also increase factor since it was added optimistically, and it was wrong
-			decreaseFactor := spos.ValidatorPeerHonestyDecreaseFactor - spos.ValidatorPeerHonestyIncreaseFactor
+			// use increase factor since it was added optimistically, and it proved to be wrong
+			decreaseFactor := -spos.ValidatorPeerHonestyIncreaseFactor
 			sr.PeerHonestyHandler().ChangeScore(
 				pk,
 				spos.GetConsensusTopicID(sr.ShardCoordinator()),

--- a/consensus/spos/bls/subroundEndRound.go
+++ b/consensus/spos/bls/subroundEndRound.go
@@ -204,7 +204,7 @@ func (sr *subroundEndRound) doEndRoundJobByLeader() bool {
 		return false
 	}
 
-	err = sr.MultiSigner().Verify(sr.GetData(), bitmap)
+	err = currentMultiSigner.Verify(sr.GetData(), bitmap)
 	if err != nil {
 		log.Debug("doEndRoundJobByLeader.Verify", "error", err.Error())
 		return false

--- a/consensus/spos/bls/subroundEndRound.go
+++ b/consensus/spos/bls/subroundEndRound.go
@@ -331,7 +331,11 @@ func (sr *subroundEndRound) verifyNodesOnAggSigVerificationFail(
 			log.Debug("verifyNodesOnAggSigVerificationFail.VerifySignatureShare", "error", err.Error())
 
 			invalidSigSharesNodes = append(invalidSigSharesNodes, i)
-			sr.setIndexInBitmap(uint16(i), bitmap)
+			err = sr.setIndexInBitmap(uint16(i), bitmap)
+			if err != nil {
+				return err
+			}
+
 			continue
 		}
 
@@ -340,6 +344,9 @@ func (sr *subroundEndRound) verifyNodesOnAggSigVerificationFail(
 	}
 
 	// TODO: handle slashing on invalid sig share nodes
+	if len(invalidSigSharesNodes) == 0 {
+		log.Debug("verifyNodesOnAggSigVerificationFail.VerifySignatureShare: no invalid signature share")
+	}
 
 	if len(validSigSharesNodes) >= threshold {
 		err := multiSigner.Verify(sr.GetData(), bitmap)
@@ -351,6 +358,7 @@ func (sr *subroundEndRound) verifyNodesOnAggSigVerificationFail(
 	return nil
 }
 
+// TODO: handle this separately, maybe in another component
 func (sr *subroundEndRound) isIndexInBitmap(index uint16, bitmap []byte) error {
 	indexOutOfBounds := index >= uint16(len(sr.ConsensusGroup()))
 	if indexOutOfBounds {

--- a/consensus/spos/bls/subroundEndRound.go
+++ b/consensus/spos/bls/subroundEndRound.go
@@ -333,10 +333,12 @@ func (sr *subroundEndRound) verifyNodesOnAggSigVerificationFail() error {
 				return err
 			}
 
+			// include also increase factor since it was added optimistically, and it was wrong
+			decreaseFactor := spos.ValidatorPeerHonestyDecreaseFactor - spos.ValidatorPeerHonestyIncreaseFactor
 			sr.PeerHonestyHandler().ChangeScore(
 				pk,
 				spos.GetConsensusTopicID(sr.ShardCoordinator()),
-				spos.ValidatorPeerHonestyDecreaseFactor,
+				decreaseFactor,
 			)
 		}
 

--- a/consensus/spos/bls/subroundEndRound.go
+++ b/consensus/spos/bls/subroundEndRound.go
@@ -337,16 +337,6 @@ func (sr *subroundEndRound) verifyNodesOnAggSigVerificationFail(
 			continue
 		}
 
-		nodeIndex, err := sr.ConsensusGroupIndex(pk)
-
-		err = multiSigner.StoreSignatureShare(uint16(nodeIndex), sigShare)
-		if err != nil {
-			log.Debug("receivedSignature.StoreSignatureShare",
-				"node", pk,
-				"index", nodeIndex,
-				"error", err.Error())
-			return nil, nil, err
-		}
 		log.Debug("verifyNodesOnAggSigVerificationFail.VerifySignatureShare checked SUCCESSFULLY", "public key", pk)
 	}
 

--- a/consensus/spos/bls/subroundEndRound.go
+++ b/consensus/spos/bls/subroundEndRound.go
@@ -197,6 +197,20 @@ func (sr *subroundEndRound) doEndRoundJobByLeader() bool {
 		return false
 	}
 
+	currentMultiSigner := sr.MultiSigner()
+	err = currentMultiSigner.SetAggregatedSig(sig)
+	if err != nil {
+		log.Debug("doEndRoundJobByLeader.SetAggregatedSig", "error", err.Error())
+		return false
+	}
+
+	err = sr.MultiSigner().Verify(sr.GetData(), bitmap)
+	if err != nil {
+		log.Debug("doEndRoundJobByLeader.Verify", "error", err.Error())
+		return false
+	}
+	log.Debug("doEndRoundJobByLeader.Verify: TRIGERRED")
+
 	err = sr.Header.SetPubKeysBitmap(bitmap)
 	if err != nil {
 		log.Debug("doEndRoundJobByLeader.SetPubKeysBitmap", "error", err.Error())

--- a/consensus/spos/bls/subroundEndRound_test.go
+++ b/consensus/spos/bls/subroundEndRound_test.go
@@ -955,7 +955,7 @@ func TestVerifyNodesOnAggSigVerificationFail(t *testing.T) {
 
 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 
-		err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
+		_, _, err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
 		require.Equal(t, expectedErr, err)
 	})
 
@@ -976,7 +976,7 @@ func TestVerifyNodesOnAggSigVerificationFail(t *testing.T) {
 
 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 
-		err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
+		_, _, err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
 		require.Nil(t, err)
 
 		isJobDone, err := sr.JobDone(sr.ConsensusGroup()[0], bls.SrSignature)
@@ -1004,7 +1004,7 @@ func TestVerifyNodesOnAggSigVerificationFail(t *testing.T) {
 
 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 
-		err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
+		_, _, err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
 		require.Equal(t, expectedErr, err)
 	})
 
@@ -1027,7 +1027,7 @@ func TestVerifyNodesOnAggSigVerificationFail(t *testing.T) {
 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 		_ = sr.SetJobDone(sr.ConsensusGroup()[1], bls.SrSignature, true)
 
-		err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
+		_, _, err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
 		require.Nil(t, err)
 	})
 }

--- a/consensus/spos/bls/subroundEndRound_test.go
+++ b/consensus/spos/bls/subroundEndRound_test.go
@@ -1008,88 +1008,88 @@ func TestVerifyNodesOnAggSigVerificationFail(t *testing.T) {
 	})
 }
 
-// func TestComputeAddSigOnValidNodes(t *testing.T) {
-// 	t.Parallel()
+func TestComputeAddSigOnValidNodes(t *testing.T) {
+	t.Parallel()
 
-// 	t.Run("invalid number of valid sig shares", func(t *testing.T) {
-// 		t.Parallel()
+	t.Run("invalid number of valid sig shares", func(t *testing.T) {
+		t.Parallel()
 
-// 		container := mock.InitConsensusCore()
-// 		sr := *initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
-// 		sr.SetThreshold(bls.SrEndRound, 2)
-// 		multiSignerMock := mock.InitMultiSignerMock()
+		container := mock.InitConsensusCore()
+		sr := *initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
+		sr.SetThreshold(bls.SrEndRound, 2)
+		multiSignerMock := mock.InitMultiSignerMock()
 
-// 		_, _, err := sr.ComputeAggSigOnValidNodes(multiSignerMock)
-// 		require.True(t, errors.Is(err, spos.ErrInvalidNumSigShares))
-// 	})
+		_, _, err := sr.ComputeAggSigOnValidNodes(multiSignerMock)
+		require.True(t, errors.Is(err, spos.ErrInvalidNumSigShares))
+	})
 
-// 	t.Run("fail to created aggregated sig", func(t *testing.T) {
-// 		t.Parallel()
+	t.Run("fail to created aggregated sig", func(t *testing.T) {
+		t.Parallel()
 
-// 		container := mock.InitConsensusCore()
-// 		sr := *initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
-// 		multiSignerMock := mock.InitMultiSignerMock()
+		container := mock.InitConsensusCore()
+		sr := *initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
+		multiSignerMock := mock.InitMultiSignerMock()
 
-// 		expectedErr := errors.New("exptected error")
-// 		multiSignerMock.AggregateSigsCalled = func(bitmap []byte) ([]byte, error) {
-// 			return nil, expectedErr
-// 		}
+		expectedErr := errors.New("exptected error")
+		multiSignerMock.AggregateSigsCalled = func(bitmap []byte) ([]byte, error) {
+			return nil, expectedErr
+		}
 
-// 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
+		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 
-// 		_, _, err := sr.ComputeAggSigOnValidNodes(multiSignerMock)
-// 		require.Equal(t, expectedErr, err)
-// 	})
+		_, _, err := sr.ComputeAggSigOnValidNodes(multiSignerMock)
+		require.Equal(t, expectedErr, err)
+	})
 
-// 	t.Run("fail to set aggregated sig", func(t *testing.T) {
-// 		t.Parallel()
+	t.Run("fail to set aggregated sig", func(t *testing.T) {
+		t.Parallel()
 
-// 		container := mock.InitConsensusCore()
-// 		sr := *initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
-// 		multiSignerMock := mock.InitMultiSignerMock()
+		container := mock.InitConsensusCore()
+		sr := *initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
+		multiSignerMock := mock.InitMultiSignerMock()
 
-// 		expectedErr := errors.New("exptected error")
-// 		multiSignerMock.SetAggregatedSigCalled = func(aggSig []byte) error {
-// 			return expectedErr
-// 		}
-// 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
+		expectedErr := errors.New("exptected error")
+		multiSignerMock.SetAggregatedSigCalled = func(aggSig []byte) error {
+			return expectedErr
+		}
+		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 
-// 		_, _, err := sr.ComputeAggSigOnValidNodes(multiSignerMock)
-// 		require.Equal(t, expectedErr, err)
-// 	})
+		_, _, err := sr.ComputeAggSigOnValidNodes(multiSignerMock)
+		require.Equal(t, expectedErr, err)
+	})
 
-// 	t.Run("fail to verify aggregated sig share", func(t *testing.T) {
-// 		t.Parallel()
+	t.Run("fail to verify aggregated sig share", func(t *testing.T) {
+		t.Parallel()
 
-// 		container := mock.InitConsensusCore()
-// 		sr := *initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
-// 		multiSignerMock := mock.InitMultiSignerMock()
+		container := mock.InitConsensusCore()
+		sr := *initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
+		multiSignerMock := mock.InitMultiSignerMock()
 
-// 		expectedErr := errors.New("exptected error")
-// 		multiSignerMock.VerifyCalled = func(msg, bitmap []byte) error {
-// 			return expectedErr
-// 		}
+		expectedErr := errors.New("exptected error")
+		multiSignerMock.VerifyCalled = func(msg, bitmap []byte) error {
+			return expectedErr
+		}
 
-// 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
+		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 
-// 		_, _, err := sr.ComputeAggSigOnValidNodes(multiSignerMock)
-// 		require.Equal(t, expectedErr, err)
-// 	})
+		_, _, err := sr.ComputeAggSigOnValidNodes(multiSignerMock)
+		require.Equal(t, expectedErr, err)
+	})
 
-// 	t.Run("should work", func(t *testing.T) {
-// 		t.Parallel()
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
 
-// 		container := mock.InitConsensusCore()
-// 		sr := *initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
-// 		multiSignerMock := mock.InitMultiSignerMock()
-// 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
+		container := mock.InitConsensusCore()
+		sr := *initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
+		multiSignerMock := mock.InitMultiSignerMock()
+		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 
-// 		bitmap, sig, err := sr.ComputeAggSigOnValidNodes(multiSignerMock)
-// 		require.NotNil(t, bitmap)
-// 		require.NotNil(t, sig)
-// 		require.Nil(t, err)
-// 	})
-// }
+		bitmap, sig, err := sr.ComputeAggSigOnValidNodes(multiSignerMock)
+		require.NotNil(t, bitmap)
+		require.NotNil(t, sig)
+		require.Nil(t, err)
+	})
+}
 
 func TestSubroundEndRound_DoEndRoundJobByLeaderVerificationFail(t *testing.T) {
 	t.Parallel()

--- a/consensus/spos/bls/subroundEndRound_test.go
+++ b/consensus/spos/bls/subroundEndRound_test.go
@@ -1104,13 +1104,14 @@ func TestSubroundEndRound_DoEndRoundJobByLeaderVerificationFail(t *testing.T) {
 			return nil, nil
 		}
 
-		verifySigShareFirstCall := true
+		verifySigShareNumCalls := 0
 		multiSignerMock.VerifySignatureShareCalled = func(index uint16, sig, msg, bitmap []byte) error {
-			if verifySigShareFirstCall {
-				verifySigShareFirstCall = false
+			if verifySigShareNumCalls == 0 {
+				verifySigShareNumCalls++
 				return errors.New("expected error")
 			}
 
+			verifySigShareNumCalls++
 			return nil
 		}
 
@@ -1137,7 +1138,7 @@ func TestSubroundEndRound_DoEndRoundJobByLeaderVerificationFail(t *testing.T) {
 		require.False(t, r)
 
 		assert.False(t, verifyFirstCall)
-		assert.False(t, verifySigShareFirstCall)
+		assert.Equal(t, 2, verifySigShareNumCalls)
 	})
 
 	t.Run("should work", func(t *testing.T) {
@@ -1150,13 +1151,14 @@ func TestSubroundEndRound_DoEndRoundJobByLeaderVerificationFail(t *testing.T) {
 			return nil, nil
 		}
 
-		verifySigShareFirstCall := true
+		verifySigShareNumCalls := 0
 		multiSignerMock.VerifySignatureShareCalled = func(index uint16, sig, msg, bitmap []byte) error {
-			if verifySigShareFirstCall {
-				verifySigShareFirstCall = false
+			if verifySigShareNumCalls == 0 {
+				verifySigShareNumCalls++
 				return errors.New("expected error")
 			}
 
+			verifySigShareNumCalls++
 			return nil
 		}
 
@@ -1184,6 +1186,6 @@ func TestSubroundEndRound_DoEndRoundJobByLeaderVerificationFail(t *testing.T) {
 		require.True(t, r)
 
 		assert.False(t, verifyFirstCall)
-		assert.False(t, verifySigShareFirstCall)
+		assert.Equal(t, 3, verifySigShareNumCalls)
 	})
 }

--- a/consensus/spos/bls/subroundEndRound_test.go
+++ b/consensus/spos/bls/subroundEndRound_test.go
@@ -953,9 +953,11 @@ func TestVerifyNodesOnAggSigVerificationFail(t *testing.T) {
 			return nil, expectedErr
 		}
 
+		container.SetMultiSigner(multiSignerMock)
+
 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 
-		err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
+		err := sr.VerifyNodesOnAggSigVerificationFail()
 		require.Equal(t, expectedErr, err)
 	})
 
@@ -975,8 +977,9 @@ func TestVerifyNodesOnAggSigVerificationFail(t *testing.T) {
 		}
 
 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
+		container.SetMultiSigner(multiSignerMock)
 
-		err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
+		err := sr.VerifyNodesOnAggSigVerificationFail()
 		require.Nil(t, err)
 
 		isJobDone, err := sr.JobDone(sr.ConsensusGroup()[0], bls.SrSignature)
@@ -999,11 +1002,12 @@ func TestVerifyNodesOnAggSigVerificationFail(t *testing.T) {
 		multiSignerMock.VerifyCalled = func(msg, bitmap []byte) error {
 			return nil
 		}
+		container.SetMultiSigner(multiSignerMock)
 
 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 		_ = sr.SetJobDone(sr.ConsensusGroup()[1], bls.SrSignature, true)
 
-		err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
+		err := sr.VerifyNodesOnAggSigVerificationFail()
 		require.Nil(t, err)
 	})
 }
@@ -1017,9 +1021,8 @@ func TestComputeAddSigOnValidNodes(t *testing.T) {
 		container := mock.InitConsensusCore()
 		sr := *initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
 		sr.SetThreshold(bls.SrEndRound, 2)
-		multiSignerMock := mock.InitMultiSignerMock()
 
-		_, _, err := sr.ComputeAggSigOnValidNodes(multiSignerMock)
+		_, _, err := sr.ComputeAggSigOnValidNodes()
 		require.True(t, errors.Is(err, spos.ErrInvalidNumSigShares))
 	})
 
@@ -1034,10 +1037,11 @@ func TestComputeAddSigOnValidNodes(t *testing.T) {
 		multiSignerMock.AggregateSigsCalled = func(bitmap []byte) ([]byte, error) {
 			return nil, expectedErr
 		}
+		container.SetMultiSigner(multiSignerMock)
 
 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 
-		_, _, err := sr.ComputeAggSigOnValidNodes(multiSignerMock)
+		_, _, err := sr.ComputeAggSigOnValidNodes()
 		require.Equal(t, expectedErr, err)
 	})
 
@@ -1052,27 +1056,10 @@ func TestComputeAddSigOnValidNodes(t *testing.T) {
 		multiSignerMock.SetAggregatedSigCalled = func(aggSig []byte) error {
 			return expectedErr
 		}
+		container.SetMultiSigner(multiSignerMock)
 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 
-		_, _, err := sr.ComputeAggSigOnValidNodes(multiSignerMock)
-		require.Equal(t, expectedErr, err)
-	})
-
-	t.Run("fail to verify aggregated sig share", func(t *testing.T) {
-		t.Parallel()
-
-		container := mock.InitConsensusCore()
-		sr := *initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
-		multiSignerMock := mock.InitMultiSignerMock()
-
-		expectedErr := errors.New("exptected error")
-		multiSignerMock.VerifyCalled = func(msg, bitmap []byte) error {
-			return expectedErr
-		}
-
-		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
-
-		_, _, err := sr.ComputeAggSigOnValidNodes(multiSignerMock)
+		_, _, err := sr.ComputeAggSigOnValidNodes()
 		require.Equal(t, expectedErr, err)
 	})
 
@@ -1081,10 +1068,9 @@ func TestComputeAddSigOnValidNodes(t *testing.T) {
 
 		container := mock.InitConsensusCore()
 		sr := *initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
-		multiSignerMock := mock.InitMultiSignerMock()
 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 
-		bitmap, sig, err := sr.ComputeAggSigOnValidNodes(multiSignerMock)
+		bitmap, sig, err := sr.ComputeAggSigOnValidNodes()
 		require.NotNil(t, bitmap)
 		require.NotNil(t, sig)
 		require.Nil(t, err)

--- a/consensus/spos/bls/subroundEndRound_test.go
+++ b/consensus/spos/bls/subroundEndRound_test.go
@@ -955,7 +955,7 @@ func TestVerifyNodesOnAggSigVerificationFail(t *testing.T) {
 
 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 
-		_, _, err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
+		err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
 		require.Equal(t, expectedErr, err)
 	})
 
@@ -976,7 +976,7 @@ func TestVerifyNodesOnAggSigVerificationFail(t *testing.T) {
 
 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 
-		_, _, err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
+		err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
 		require.Nil(t, err)
 
 		isJobDone, err := sr.JobDone(sr.ConsensusGroup()[0], bls.SrSignature)
@@ -984,29 +984,29 @@ func TestVerifyNodesOnAggSigVerificationFail(t *testing.T) {
 		require.False(t, isJobDone)
 	})
 
-	t.Run("fail to verify aggregated sig share", func(t *testing.T) {
-		t.Parallel()
+	// t.Run("fail to verify aggregated sig share", func(t *testing.T) {
+	// 	t.Parallel()
 
-		container := mock.InitConsensusCore()
-		sr := *initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
-		multiSignerMock := mock.InitMultiSignerMock()
+	// 	container := mock.InitConsensusCore()
+	// 	sr := *initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
+	// 	multiSignerMock := mock.InitMultiSignerMock()
 
-		expectedErr := errors.New("exptected error")
-		multiSignerMock.SignatureShareCalled = func(index uint16) ([]byte, error) {
-			return nil, nil
-		}
-		multiSignerMock.VerifySignatureShareCalled = func(index uint16, sig, msg, bitmap []byte) error {
-			return nil
-		}
-		multiSignerMock.VerifyCalled = func(msg, bitmap []byte) error {
-			return expectedErr
-		}
+	// 	expectedErr := errors.New("exptected error")
+	// 	multiSignerMock.SignatureShareCalled = func(index uint16) ([]byte, error) {
+	// 		return nil, nil
+	// 	}
+	// 	multiSignerMock.VerifySignatureShareCalled = func(index uint16, sig, msg, bitmap []byte) error {
+	// 		return nil
+	// 	}
+	// 	multiSignerMock.VerifyCalled = func(msg, bitmap []byte) error {
+	// 		return expectedErr
+	// 	}
 
-		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
+	// 	_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 
-		_, _, err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
-		require.Equal(t, expectedErr, err)
-	})
+	// 	err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
+	// 	require.Equal(t, expectedErr, err)
+	// })
 
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -1027,7 +1027,7 @@ func TestVerifyNodesOnAggSigVerificationFail(t *testing.T) {
 		_ = sr.SetJobDone(sr.ConsensusGroup()[0], bls.SrSignature, true)
 		_ = sr.SetJobDone(sr.ConsensusGroup()[1], bls.SrSignature, true)
 
-		_, _, err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
+		err := sr.VerifyNodesOnAggSigVerificationFail(multiSignerMock)
 		require.Nil(t, err)
 	})
 }

--- a/consensus/spos/bls/subroundSignature.go
+++ b/consensus/spos/bls/subroundSignature.go
@@ -161,14 +161,6 @@ func (sr *subroundSignature) receivedSignature(_ context.Context, cnsDta *consen
 	}
 
 	currentMultiSigner := sr.MultiSigner()
-	err = currentMultiSigner.VerifySignatureShare(uint16(index), cnsDta.SignatureShare, sr.GetData(), nil)
-	if err != nil {
-		log.Debug("receivedSignature.VerifySignatureShare",
-			"node", pkForLogs,
-			"index", index,
-			"error", err.Error())
-		return false
-	}
 
 	err = currentMultiSigner.StoreSignatureShare(uint16(index), cnsDta.SignatureShare)
 	if err != nil {

--- a/consensus/spos/bls/subroundSignature.go
+++ b/consensus/spos/bls/subroundSignature.go
@@ -161,7 +161,6 @@ func (sr *subroundSignature) receivedSignature(_ context.Context, cnsDta *consen
 	}
 
 	currentMultiSigner := sr.MultiSigner()
-
 	err = currentMultiSigner.StoreSignatureShare(uint16(index), cnsDta.SignatureShare)
 	if err != nil {
 		log.Debug("receivedSignature.StoreSignatureShare",

--- a/consensus/spos/bls/subroundSignature_test.go
+++ b/consensus/spos/bls/subroundSignature_test.go
@@ -359,85 +359,11 @@ func TestSubroundSignature_ReceivedSignature(t *testing.T) {
 	assert.True(t, r)
 }
 
-func TestSubroundSignature_ReceivedSignatureVerifyShareFailed(t *testing.T) {
-	t.Parallel()
-
-	errVerify := errors.New("signature share verification failed")
-	multiSigner := cryptoMocks.NewMultiSigner(21)
-	multiSigner.VerifySignatureShareCalled = func(index uint16, sig []byte, msg []byte, bitmap []byte) error {
-		return errVerify
-	}
-	storeSigShareCalled := false
-	multiSigner.StoreSignatureShareCalled = func(index uint16, sig []byte) error {
-		storeSigShareCalled = true
-		return nil
-	}
-
-	container := mock.InitConsensusCoreWithMultiSigner(multiSigner)
-	sr := *initSubroundSignatureWithContainer(container)
-
-	signature := []byte("signature")
-	cnsMsg := consensus.NewConsensusMessage(
-		sr.Data,
-		signature,
-		nil,
-		nil,
-		[]byte(sr.ConsensusGroup()[1]),
-		[]byte("sig"),
-		int(bls.MtSignature),
-		0,
-		chainID,
-		nil,
-		nil,
-		nil,
-		currentPid,
-	)
-
-	sr.Data = nil
-	r := sr.ReceivedSignature(cnsMsg)
-	assert.False(t, r)
-
-	sr.Data = []byte("Y")
-	r = sr.ReceivedSignature(cnsMsg)
-	assert.False(t, r)
-
-	sr.Data = []byte("X")
-	r = sr.ReceivedSignature(cnsMsg)
-	assert.False(t, r)
-
-	sr.SetSelfPubKey(sr.ConsensusGroup()[0])
-
-	cnsMsg.PubKey = []byte("X")
-	r = sr.ReceivedSignature(cnsMsg)
-	assert.False(t, r)
-
-	cnsMsg.PubKey = []byte(sr.ConsensusGroup()[1])
-	maxCount := len(sr.ConsensusGroup()) * 2 / 3
-	count := 0
-	for i := 0; i < len(sr.ConsensusGroup()); i++ {
-		if sr.ConsensusGroup()[i] != string(cnsMsg.PubKey) {
-			_ = sr.SetJobDone(sr.ConsensusGroup()[i], bls.SrSignature, true)
-			count++
-			if count == maxCount {
-				break
-			}
-		}
-	}
-	r = sr.ReceivedSignature(cnsMsg)
-	assert.False(t, r)
-	assert.False(t, storeSigShareCalled)
-}
-
 func TestSubroundSignature_ReceivedSignatureStoreShareFailed(t *testing.T) {
 	t.Parallel()
 
 	errStore := errors.New("signature share store failed")
 	multiSigner := cryptoMocks.NewMultiSigner(21)
-	verifySigShareCalled := false
-	multiSigner.VerifySignatureShareCalled = func(index uint16, sig []byte, msg []byte, bitmap []byte) error {
-		verifySigShareCalled = true
-		return nil
-	}
 	storeSigShareCalled := false
 	multiSigner.StoreSignatureShareCalled = func(index uint16, sig []byte) error {
 		storeSigShareCalled = true
@@ -497,7 +423,6 @@ func TestSubroundSignature_ReceivedSignatureStoreShareFailed(t *testing.T) {
 	r = sr.ReceivedSignature(cnsMsg)
 	assert.False(t, r)
 	assert.True(t, storeSigShareCalled)
-	assert.True(t, verifySigShareCalled)
 }
 
 func TestSubroundSignature_SignaturesCollected(t *testing.T) {

--- a/consensus/spos/errors.go
+++ b/consensus/spos/errors.go
@@ -219,3 +219,6 @@ var ErrNilNodeRedundancyHandler = errors.New("nil node redundancy handler")
 
 // ErrNilScheduledProcessor signals that the provided scheduled processor is nil
 var ErrNilScheduledProcessor = errors.New("nil scheduled processor")
+
+// ErrInvalidNumSigShares signals that an invalid number of signature shares has been provided
+var ErrInvalidNumSigShares = errors.New("invalid number of sig shares")

--- a/testscommon/cryptoMocks/multisignerMock.go
+++ b/testscommon/cryptoMocks/multisignerMock.go
@@ -1,7 +1,7 @@
 package cryptoMocks
 
 import (
-	"github.com/ElrondNetwork/elrond-go-crypto"
+	crypto "github.com/ElrondNetwork/elrond-go-crypto"
 )
 
 const signatureSize = 48
@@ -20,6 +20,7 @@ type MultisignerMock struct {
 	AggregateSigsCalled                    func(bitmap []byte) ([]byte, error)
 	SignatureShareCalled                   func(index uint16) ([]byte, error)
 	CreateCalled                           func(pubKeys []string, index uint16) (crypto.MultiSigner, error)
+	SetAggregatedSigCalled                 func(sig []byte) error
 	ResetCalled                            func(pubKeys []string, index uint16) error
 	CreateAndAddSignatureShareForKeyCalled func(message []byte, privateKey crypto.PrivateKey, pubKeyBytes []byte) ([]byte, error)
 	StoreSignatureShareCalled              func(index uint16, sig []byte) error
@@ -74,6 +75,10 @@ func (mm *MultisignerMock) Reset(pubKeys []string, index uint16) error {
 
 // SetAggregatedSig -
 func (mm *MultisignerMock) SetAggregatedSig(aggSig []byte) error {
+	if mm.SetAggregatedSigCalled != nil {
+		return mm.SetAggregatedSigCalled(aggSig)
+	}
+
 	mm.aggSig = aggSig
 
 	return nil


### PR DESCRIPTION
Optimistic signature aggregation on consensus:
- the consensus nodes will not verify signature share anymore, since the leader will verify the aggregated signature anyway
- if the agg sig verifcation fail, the leader will check every signature share for each node, and if the number of valid signature shares will be higher than the threshold, it will send the partial agg signature
- unit tests