### PR TITLE
Vm query different config for meta

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -699,9 +699,10 @@
         ]
 
     [VirtualMachine.GasConfig]
-        # MaxGasPerVmQuery defines the maximum amount of gas to be allocated for VM Queries coming from API
+        # The following values define the maximum amount of gas to be allocated for VM Queries coming from API
         # If set to 0, then MaxUInt64 will be used
-        MaxGasPerVmQuery = 1500000000  #1.5b
+        ShardMaxGasPerVmQuery = 1500000000  #1.5b
+        MetaMaxGasPerVmQuery = 0  #unlimited
 
 [Hardfork]
     EnableTrigger = true

--- a/config/config.go
+++ b/config/config.go
@@ -384,7 +384,8 @@ type QueryVirtualMachineConfig struct {
 
 // VirtualMachineGasConfig holds the configuration for the virtual machine(s) gas operations
 type VirtualMachineGasConfig struct {
-	MaxGasPerVmQuery uint64
+	ShardMaxGasPerVmQuery uint64
+	MetaMaxGasPerVmQuery  uint64
 }
 
 // HardforkConfig holds the configuration for the hardfork trigger

--- a/config/tomlConfig_test.go
+++ b/config/tomlConfig_test.go
@@ -107,7 +107,8 @@ func TestTomlParser(t *testing.T) {
 				VirtualMachineConfig: VirtualMachineConfig{ArwenVersions: arwenVersions},
 			},
 			GasConfig: VirtualMachineGasConfig{
-				MaxGasPerVmQuery: 1_500_000_000,
+				ShardMaxGasPerVmQuery: 1_500_000_000,
+				MetaMaxGasPerVmQuery:  0,
 			},
 		},
 		Debug: DebugConfig{
@@ -196,7 +197,8 @@ func TestTomlParser(t *testing.T) {
         ]
 
 	[VirtualMachine.GasConfig]
-		MaxGasPerVmQuery = 1500000000
+		ShardMaxGasPerVmQuery = 1500000000
+		MetaMaxGasPerVmQuery = 0
 
 [Debug]
     [Debug.InterceptorResolver]

--- a/factory/apiResolverFactory.go
+++ b/factory/apiResolverFactory.go
@@ -382,6 +382,8 @@ func createScQueryElement(
 		}
 	}
 
+	log.Debug("maximum gas per VM Query", "value", maxGasForVmQueries)
+
 	vmContainer, err := vmFactory.Create()
 	if err != nil {
 		return nil, err

--- a/factory/apiResolverFactory.go
+++ b/factory/apiResolverFactory.go
@@ -319,7 +319,10 @@ func createScQueryElement(
 		NilCompiledSCStore:    true,
 	}
 
+	maxGasForVmQueries := args.generalConfig.VirtualMachine.GasConfig.ShardMaxGasPerVmQuery
 	if args.processComponents.ShardCoordinator().SelfId() == core.MetachainShardId {
+		maxGasForVmQueries = args.generalConfig.VirtualMachine.GasConfig.MetaMaxGasPerVmQuery
+
 		blockChainHookImpl, errBlockChainHook := hooks.NewBlockChainHookImpl(argsHook)
 		if errBlockChainHook != nil {
 			return nil, errBlockChainHook
@@ -397,7 +400,7 @@ func createScQueryElement(
 		ArwenChangeLocker:        args.coreComponents.ArwenChangeLocker(),
 		Bootstrapper:             args.bootstrapper,
 		AllowExternalQueriesChan: args.allowVMQueriesChan,
-		MaxGasLimitPerQuery:      args.generalConfig.VirtualMachine.GasConfig.MaxGasPerVmQuery,
+		MaxGasLimitPerQuery:      maxGasForVmQueries,
 	}
 
 	return smartContract.NewSCQueryService(argsNewSCQueryService)

--- a/factory/stateComponents_test.go
+++ b/factory/stateComponents_test.go
@@ -218,6 +218,10 @@ func getGeneralConfig() config.Config {
 					{StartEpoch: 0, Version: "v0.3"},
 				},
 			},
+			GasConfig: config.VirtualMachineGasConfig{
+				ShardMaxGasPerVmQuery: 1_500_000_000,
+				MetaMaxGasPerVmQuery:  0,
+			},
 		},
 		SmartContractsStorageForSCQuery: config.StorageConfig{
 			Cache: config.CacheConfig{


### PR DESCRIPTION
separate the configurations for shards and meta for the maximum gas to be used for VM Queries. 

**How to test**
There are 2 ways of validating this PR:
1. when running a shard/meta node, a vm query that consumes more than what is set in config will return error
2. search in the logs for `maximum gas per VM Query`. for shard it should be 1.5b and for meta it should be 0