### PR TITLE
Update self to self intermediate mini block after scheduled execution

### DIFF
--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -1752,6 +1752,8 @@ func (bp *baseProcessor) ProcessScheduledBlock(headerHandler data.HeaderHandler,
 		return err
 	}
 
+	_ = bp.txCoordinator.CreatePostProcessMiniBlocks()
+
 	finalProcessingGasAndFees := bp.getGasAndFeesWithScheduled()
 
 	scheduledProcessingGasAndFees := gasAndFeesDelta(normalProcessingGasAndFees, finalProcessingGasAndFees)


### PR DESCRIPTION
* Updated self to self intermediate mini block after scheduled execution. Needed to be saved into storage to resolve some requests only by some APIs, not needed by the protocol which always recreates it by the time of block execution. (these mini blocks are also deleted from body as they are self to self receipts or scrs)