### PR TITLE
Fixed `factory` unit tests

### DIFF
--- a/factory/apiResolverFactory_test.go
+++ b/factory/apiResolverFactory_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestCreateApiResolver(t *testing.T) {
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(1)
 	coreComponents := getCoreComponents()
 	coreComponents.StatusHandlerUtils().Metrics()

--- a/factory/blockProcessorCreator_test.go
+++ b/factory/blockProcessorCreator_test.go
@@ -26,6 +26,9 @@ import (
 
 func Test_newBlockProcessorCreatorForShard(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	pcf, _ := factory.NewProcessComponentsFactory(getProcessComponentsArgs(shardCoordinator))
@@ -57,6 +60,9 @@ func Test_newBlockProcessorCreatorForShard(t *testing.T) {
 
 func Test_newBlockProcessorCreatorForMeta(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardC := mock.NewMultiShardsCoordinatorMock(1)

--- a/factory/bootstrapComponentsHandler_test.go
+++ b/factory/bootstrapComponentsHandler_test.go
@@ -12,6 +12,9 @@ import (
 // ------------ Test ManagedBootstrapComponents --------------------
 func TestNewManagedBootstrapComponents(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getBootStrapArgs()
 	bcf, _ := factory.NewBootstrapComponentsFactory(args)
@@ -23,6 +26,9 @@ func TestNewManagedBootstrapComponents(t *testing.T) {
 
 func TestNewBootstrapComponentsFactory_NilFactory(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	mbc, err := factory.NewManagedBootstrapComponents(nil)
 
@@ -30,8 +36,11 @@ func TestNewBootstrapComponentsFactory_NilFactory(t *testing.T) {
 	require.Equal(t, errorsErd.ErrNilBootstrapComponentsFactory, err)
 }
 
-func TestManagedBootstrapComponents_CheckSubcomponents_NoCreate(t *testing.T) {
+func TestManagedBootstrapComponents_CheckSubcomponentsNoCreate(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getBootStrapArgs()
 	bcf, _ := factory.NewBootstrapComponentsFactory(args)
@@ -43,6 +52,9 @@ func TestManagedBootstrapComponents_CheckSubcomponents_NoCreate(t *testing.T) {
 
 func TestManagedBootstrapComponents_Create(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getBootStrapArgs()
 	bcf, _ := factory.NewBootstrapComponentsFactory(args)
@@ -55,8 +67,11 @@ func TestManagedBootstrapComponents_Create(t *testing.T) {
 	require.Nil(t, err)
 }
 
-func TestManagedBootstrapComponents_Create_NilInternalMarshalizer(t *testing.T) {
+func TestManagedBootstrapComponents_CreateNilInternalMarshalizer(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getBootStrapArgs()
 	coreComponents := getDefaultCoreComponents()
@@ -71,6 +86,10 @@ func TestManagedBootstrapComponents_Create_NilInternalMarshalizer(t *testing.T) 
 
 func TestManagedBootstrapComponents_Close(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
 	args := getBootStrapArgs()
 
 	bcf, _ := factory.NewBootstrapComponentsFactory(args)

--- a/factory/bootstrapComponents_test.go
+++ b/factory/bootstrapComponents_test.go
@@ -19,6 +19,9 @@ import (
 // ------------ Test BootstrapComponentsFactory --------------------
 func TestNewBootstrapComponentsFactory_OkValuesShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getBootStrapArgs()
 
@@ -30,6 +33,9 @@ func TestNewBootstrapComponentsFactory_OkValuesShouldWork(t *testing.T) {
 
 func TestNewBootstrapComponentsFactory_NilCoreComponents(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getBootStrapArgs()
 	args.CoreComponents = nil
@@ -42,6 +48,9 @@ func TestNewBootstrapComponentsFactory_NilCoreComponents(t *testing.T) {
 
 func TestNewBootstrapComponentsFactory_NilCryptoComponents(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getBootStrapArgs()
 	args.CryptoComponents = nil
@@ -54,6 +63,9 @@ func TestNewBootstrapComponentsFactory_NilCryptoComponents(t *testing.T) {
 
 func TestNewBootstrapComponentsFactory_NilNetworkComponents(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getBootStrapArgs()
 	args.NetworkComponents = nil
@@ -66,6 +78,9 @@ func TestNewBootstrapComponentsFactory_NilNetworkComponents(t *testing.T) {
 
 func TestNewBootstrapComponentsFactory_NilWorkingDir(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getBootStrapArgs()
 	args.WorkingDir = ""
@@ -76,8 +91,11 @@ func TestNewBootstrapComponentsFactory_NilWorkingDir(t *testing.T) {
 	require.Equal(t, errorsErd.ErrInvalidWorkingDir, err)
 }
 
-func TestBootstrapComponentsFactory_Create_ShouldWork(t *testing.T) {
+func TestBootstrapComponentsFactory_CreateShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getBootStrapArgs()
 
@@ -89,8 +107,11 @@ func TestBootstrapComponentsFactory_Create_ShouldWork(t *testing.T) {
 	require.NotNil(t, bc)
 }
 
-func TestBootstrapComponentsFactory_Create_BootstrapDataProviderCreationFail(t *testing.T) {
+func TestBootstrapComponentsFactory_CreateBootstrapDataProviderCreationFail(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getBootStrapArgs()
 	coreComponents := getDefaultCoreComponents()
@@ -105,8 +126,11 @@ func TestBootstrapComponentsFactory_Create_BootstrapDataProviderCreationFail(t *
 	require.True(t, errors.Is(err, errorsErd.ErrNewBootstrapDataProvider))
 }
 
-func TestBootstrapComponentsFactory_Create_EpochStartBootstrapCreationFail(t *testing.T) {
+func TestBootstrapComponentsFactory_CreateEpochStartBootstrapCreationFail(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getBootStrapArgs()
 	coreComponents := getDefaultCoreComponents()

--- a/factory/consensusComponentsHandler_test.go
+++ b/factory/consensusComponentsHandler_test.go
@@ -9,8 +9,11 @@ import (
 )
 
 // ------------ Test ManagedConsensusComponentsFactory --------------------
-func TestManagedConsensusComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) {
+func TestManagedConsensusComponents_CreateWithInvalidArgsShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getConsensusArgs(shardCoordinator)
@@ -26,8 +29,11 @@ func TestManagedConsensusComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T
 	require.NotNil(t, managedConsensusComponents.CheckSubcomponents())
 }
 
-func TestManagedConsensusComponents_Create_ShouldWork(t *testing.T) {
+func TestManagedConsensusComponents_CreateShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getConsensusArgs(shardCoordinator)
@@ -51,6 +57,9 @@ func TestManagedConsensusComponents_Create_ShouldWork(t *testing.T) {
 
 func TestManagedConsensusComponents_Close(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	consensusArgs := getConsensusArgs(shardCoordinator)

--- a/factory/consensusComponents_test.go
+++ b/factory/consensusComponents_test.go
@@ -30,6 +30,9 @@ import (
 // ------------ Test ConsensusComponentsFactory --------------------
 func TestNewConsensusComponentsFactory_OkValuesShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getConsensusArgs(shardCoordinator)
@@ -42,6 +45,9 @@ func TestNewConsensusComponentsFactory_OkValuesShouldWork(t *testing.T) {
 
 func TestNewConsensusComponentsFactory_NilCoreComponents(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getConsensusArgs(shardCoordinator)
@@ -55,6 +61,9 @@ func TestNewConsensusComponentsFactory_NilCoreComponents(t *testing.T) {
 
 func TestNewConsensusComponentsFactory_NilDataComponents(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getConsensusArgs(shardCoordinator)
@@ -68,6 +77,9 @@ func TestNewConsensusComponentsFactory_NilDataComponents(t *testing.T) {
 
 func TestNewConsensusComponentsFactory_NilCryptoComponents(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getConsensusArgs(shardCoordinator)
@@ -81,6 +93,9 @@ func TestNewConsensusComponentsFactory_NilCryptoComponents(t *testing.T) {
 
 func TestNewConsensusComponentsFactory_NilNetworkComponents(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getConsensusArgs(shardCoordinator)
@@ -94,6 +109,9 @@ func TestNewConsensusComponentsFactory_NilNetworkComponents(t *testing.T) {
 
 func TestNewConsensusComponentsFactory_NilProcessComponents(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getConsensusArgs(shardCoordinator)
@@ -107,6 +125,9 @@ func TestNewConsensusComponentsFactory_NilProcessComponents(t *testing.T) {
 
 func TestNewConsensusComponentsFactory_NilStateComponents(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getConsensusArgs(shardCoordinator)
@@ -119,8 +140,11 @@ func TestNewConsensusComponentsFactory_NilStateComponents(t *testing.T) {
 }
 
 // ------------ Test Old Use Cases --------------------
-func TestConsensusComponentsFactory_Create_GenesisBlockNotInitializedShouldErr(t *testing.T) {
+func TestConsensusComponentsFactory_CreateGenesisBlockNotInitializedShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	consensusArgs := getConsensusArgs(shardCoordinator)
@@ -145,6 +169,9 @@ func TestConsensusComponentsFactory_Create_GenesisBlockNotInitializedShouldErr(t
 
 func TestConsensusComponentsFactory_CreateForShard(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getConsensusArgs(shardCoordinator)
@@ -171,6 +198,9 @@ func (wp *wrappedProcessComponents) ShardCoordinator() sharding.Coordinator {
 
 func TestConsensusComponentsFactory_CreateForMeta(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getConsensusArgs(shardCoordinator)
@@ -186,8 +216,11 @@ func TestConsensusComponentsFactory_CreateForMeta(t *testing.T) {
 	require.NotNil(t, cc)
 }
 
-func TestConsensusComponentsFactory_Create_NilShardCoordinator(t *testing.T) {
+func TestConsensusComponentsFactory_CreateNilShardCoordinator(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	consensusArgs := getConsensusArgs(shardCoordinator)
@@ -201,8 +234,11 @@ func TestConsensusComponentsFactory_Create_NilShardCoordinator(t *testing.T) {
 	require.Equal(t, errorsErd.ErrNilShardCoordinator, err)
 }
 
-func TestConsensusComponentsFactory_Create_ConsensusTopicCreateTopicError(t *testing.T) {
+func TestConsensusComponentsFactory_CreateConsensusTopicCreateTopicError(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	localError := errors.New("error")
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
@@ -228,8 +264,11 @@ func TestConsensusComponentsFactory_Create_ConsensusTopicCreateTopicError(t *tes
 	require.Equal(t, localError, err)
 }
 
-func TestConsensusComponentsFactory_Create_ConsensusTopicNilMessageProcessor(t *testing.T) {
+func TestConsensusComponentsFactory_CreateConsensusTopicNilMessageProcessor(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getConsensusArgs(shardCoordinator)
@@ -244,8 +283,11 @@ func TestConsensusComponentsFactory_Create_ConsensusTopicNilMessageProcessor(t *
 	require.Equal(t, errorsErd.ErrNilMessenger, err)
 }
 
-func TestConsensusComponentsFactory_Create_NilSyncTimer(t *testing.T) {
+func TestConsensusComponentsFactory_CreateNilSyncTimer(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getConsensusArgs(shardCoordinator)
@@ -261,6 +303,9 @@ func TestConsensusComponentsFactory_Create_NilSyncTimer(t *testing.T) {
 
 func TestStartConsensus_ShardBootstrapperNilAccounts(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getConsensusArgs(shardCoordinator)
@@ -276,6 +321,10 @@ func TestStartConsensus_ShardBootstrapperNilAccounts(t *testing.T) {
 
 func TestStartConsensus_ShardBootstrapperNilPoolHolder(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(1)
 	shardCoordinator.CurrentShard = 0
 	args := getConsensusArgs(shardCoordinator)
@@ -293,6 +342,9 @@ func TestStartConsensus_ShardBootstrapperNilPoolHolder(t *testing.T) {
 
 func TestStartConsensus_MetaBootstrapperNilPoolHolder(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(1)
 	shardCoordinator.CurrentShard = core.MetachainShardId
@@ -319,6 +371,9 @@ func TestStartConsensus_MetaBootstrapperNilPoolHolder(t *testing.T) {
 
 func TestStartConsensus_MetaBootstrapperWrongNumberShards(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(1)
 	args := getConsensusArgs(shardCoordinator)
@@ -335,6 +390,9 @@ func TestStartConsensus_MetaBootstrapperWrongNumberShards(t *testing.T) {
 
 func TestStartConsensus_ShardBootstrapperPubKeyToByteArrayError(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	localErr := errors.New("err")
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
@@ -354,6 +412,9 @@ func TestStartConsensus_ShardBootstrapperPubKeyToByteArrayError(t *testing.T) {
 
 func TestStartConsensus_ShardBootstrapperInvalidConsensusType(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getConsensusArgs(shardCoordinator)

--- a/factory/coreComponentsHandler_test.go
+++ b/factory/coreComponentsHandler_test.go
@@ -9,8 +9,11 @@ import (
 )
 
 // ------------ Test ManagedCoreComponents --------------------
-func TestManagedCoreComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) {
+func TestManagedCoreComponents_CreateWithInvalidArgsShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreArgs := getCoreArgs()
 	coreArgs.Config.Marshalizer = config.MarshalizerConfig{
@@ -27,6 +30,9 @@ func TestManagedCoreComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) {
 
 func TestManagedCoreComponents_CreateShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreArgs := getCoreArgs()
 	coreComponentsFactory, _ := factory.NewCoreComponentsFactory(coreArgs)
@@ -67,6 +73,9 @@ func TestManagedCoreComponents_CreateShouldWork(t *testing.T) {
 
 func TestManagedCoreComponents_Close(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreArgs := getCoreArgs()
 	coreComponentsFactory, _ := factory.NewCoreComponentsFactory(coreArgs)

--- a/factory/coreComponents_test.go
+++ b/factory/coreComponents_test.go
@@ -20,6 +20,9 @@ const consecutiveMissedBlocksPenalty = 1.1
 
 func TestNewCoreComponentsFactory_OkValuesShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getCoreArgs()
 	ccf, _ := factory.NewCoreComponentsFactory(args)
@@ -27,8 +30,11 @@ func TestNewCoreComponentsFactory_OkValuesShouldWork(t *testing.T) {
 	require.NotNil(t, ccf)
 }
 
-func TestCoreComponentsFactory_CreateCoreComponents_NoHasherConfigShouldErr(t *testing.T) {
+func TestCoreComponentsFactory_CreateCoreComponentsNoHasherConfigShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getCoreArgs()
 	args.Config = config.Config{
@@ -44,8 +50,11 @@ func TestCoreComponentsFactory_CreateCoreComponents_NoHasherConfigShouldErr(t *t
 	require.True(t, errors.Is(err, errorsErd.ErrHasherCreation))
 }
 
-func TestCoreComponentsFactory_CreateCoreComponents_InvalidHasherConfigShouldErr(t *testing.T) {
+func TestCoreComponentsFactory_CreateCoreComponentsInvalidHasherConfigShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getCoreArgs()
 	args.Config = config.Config{
@@ -64,8 +73,11 @@ func TestCoreComponentsFactory_CreateCoreComponents_InvalidHasherConfigShouldErr
 	require.True(t, errors.Is(err, errorsErd.ErrHasherCreation))
 }
 
-func TestCoreComponentsFactory_CreateCoreComponents_NoInternalMarshalizerConfigShouldErr(t *testing.T) {
+func TestCoreComponentsFactory_CreateCoreComponentsNoInternalMarshallerConfigShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getCoreArgs()
 	args.Config = config.Config{
@@ -80,8 +92,11 @@ func TestCoreComponentsFactory_CreateCoreComponents_NoInternalMarshalizerConfigS
 	require.True(t, errors.Is(err, errorsErd.ErrMarshalizerCreation))
 }
 
-func TestCoreComponentsFactory_CreateCoreComponents_InvalidInternalMarshalizerConfigShouldErr(t *testing.T) {
+func TestCoreComponentsFactory_CreateCoreComponentsInvalidInternalMarshallerConfigShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getCoreArgs()
 	args.Config = config.Config{
@@ -100,8 +115,11 @@ func TestCoreComponentsFactory_CreateCoreComponents_InvalidInternalMarshalizerCo
 	require.True(t, errors.Is(err, errorsErd.ErrMarshalizerCreation))
 }
 
-func TestCoreComponentsFactory_CreateCoreComponents_NoVmMarshalizerConfigShouldErr(t *testing.T) {
+func TestCoreComponentsFactory_CreateCoreComponentsNoVmMarshallerConfigShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getCoreArgs()
 	args.Config = config.Config{
@@ -120,8 +138,11 @@ func TestCoreComponentsFactory_CreateCoreComponents_NoVmMarshalizerConfigShouldE
 	require.True(t, errors.Is(err, errorsErd.ErrMarshalizerCreation))
 }
 
-func TestCoreComponentsFactory_CreateCoreComponents_InvalidVmMarshalizerConfigShouldErr(t *testing.T) {
+func TestCoreComponentsFactory_CreateCoreComponentsInvalidVmMarshallerConfigShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getCoreArgs()
 	args.Config = config.Config{
@@ -143,8 +164,11 @@ func TestCoreComponentsFactory_CreateCoreComponents_InvalidVmMarshalizerConfigSh
 	require.True(t, errors.Is(err, errorsErd.ErrMarshalizerCreation))
 }
 
-func TestCoreComponentsFactory_CreateCoreComponents_NoTxSignMarshalizerConfigShouldErr(t *testing.T) {
+func TestCoreComponentsFactory_CreateCoreComponentsNoTxSignMarshallerConfigShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getCoreArgs()
 	args.Config = config.Config{
@@ -166,8 +190,11 @@ func TestCoreComponentsFactory_CreateCoreComponents_NoTxSignMarshalizerConfigSho
 	require.True(t, errors.Is(err, errorsErd.ErrMarshalizerCreation))
 }
 
-func TestCoreComponentsFactory_CreateCoreComponents_InvalidTxSignMarshalizerConfigShouldErr(t *testing.T) {
+func TestCoreComponentsFactory_CreateCoreComponentsInvalidTxSignMarshallerConfigShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getCoreArgs()
 	args.Config = config.Config{
@@ -194,6 +221,9 @@ func TestCoreComponentsFactory_CreateCoreComponents_InvalidTxSignMarshalizerConf
 
 func TestCoreComponentsFactory_CreateCoreComponentsInvalidValPubKeyConverterShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getCoreArgs()
 	args.Config.ValidatorPubkeyConverter.Type = "invalid"
@@ -206,6 +236,9 @@ func TestCoreComponentsFactory_CreateCoreComponentsInvalidValPubKeyConverterShou
 
 func TestCoreComponentsFactory_CreateCoreComponentsInvalidAddrPubKeyConverterShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getCoreArgs()
 	args.Config.AddressPubkeyConverter.Type = "invalid"
@@ -216,8 +249,11 @@ func TestCoreComponentsFactory_CreateCoreComponentsInvalidAddrPubKeyConverterSho
 	require.True(t, errors.Is(err, state.ErrInvalidPubkeyConverterType))
 }
 
-func TestCoreComponentsFactory_CreateCoreComponents_ShouldWork(t *testing.T) {
+func TestCoreComponentsFactory_CreateCoreComponentsShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getCoreArgs()
 	ccf, _ := factory.NewCoreComponentsFactory(args)
@@ -228,8 +264,11 @@ func TestCoreComponentsFactory_CreateCoreComponents_ShouldWork(t *testing.T) {
 }
 
 // ------------ Test CoreComponents --------------------
-func TestCoreComponents_Close_ShouldWork(t *testing.T) {
+func TestCoreComponents_CloseShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getCoreArgs()
 	ccf, _ := factory.NewCoreComponentsFactory(args)

--- a/factory/cryptoComponentsHandler_test.go
+++ b/factory/cryptoComponentsHandler_test.go
@@ -9,8 +9,11 @@ import (
 )
 
 // ------------ Test ManagedCryptoComponents --------------------
-func TestManagedCryptoComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) {
+func TestManagedCryptoComponents_CreateWithInvalidArgsShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -23,8 +26,11 @@ func TestManagedCryptoComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) {
 	require.Nil(t, managedCryptoComponents.BlockSignKeyGen())
 }
 
-func TestManagedCryptoComponents_Create_ShouldWork(t *testing.T) {
+func TestManagedCryptoComponents_CreateShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -50,6 +56,9 @@ func TestManagedCryptoComponents_Create_ShouldWork(t *testing.T) {
 
 func TestManagedCryptoComponents_CheckSubcomponents(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	managedCryptoComponents := getManagedCryptoComponents(t)
 
@@ -59,6 +68,9 @@ func TestManagedCryptoComponents_CheckSubcomponents(t *testing.T) {
 
 func TestManagedCryptoComponents_SetMultiSigner(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	managedCryptoComponents := getManagedCryptoComponents(t)
 
@@ -71,6 +83,9 @@ func TestManagedCryptoComponents_SetMultiSigner(t *testing.T) {
 
 func TestManagedCryptoComponents_Close(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	managedCryptoComponents := getManagedCryptoComponents(t)
 
@@ -94,6 +109,9 @@ func getManagedCryptoComponents(t *testing.T) factory.CryptoComponentsHandler {
 
 func TestManagedCryptoComponents_Clone(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)

--- a/factory/cryptoComponents_test.go
+++ b/factory/cryptoComponents_test.go
@@ -23,6 +23,9 @@ type LoadKeysFunc func(string, int) ([]byte, string, error)
 
 func TestNewCryptoComponentsFactory_NiCoreComponentsHandlerShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getCryptoArgs(nil)
 	ccf, err := factory.NewCryptoComponentsFactory(args)
@@ -32,6 +35,9 @@ func TestNewCryptoComponentsFactory_NiCoreComponentsHandlerShouldErr(t *testing.
 
 func TestNewCryptoComponentsFactory_NilPemFileShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -43,6 +49,9 @@ func TestNewCryptoComponentsFactory_NilPemFileShouldErr(t *testing.T) {
 
 func TestCryptoComponentsFactory_CreateCryptoParamsNilKeyLoaderShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -55,6 +64,9 @@ func TestCryptoComponentsFactory_CreateCryptoParamsNilKeyLoaderShouldErr(t *test
 
 func TestNewCryptoComponentsFactory_OkValsShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -65,6 +77,9 @@ func TestNewCryptoComponentsFactory_OkValsShouldWork(t *testing.T) {
 
 func TestNewCryptoComponentsFactory_DisabledSigShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -76,6 +91,9 @@ func TestNewCryptoComponentsFactory_DisabledSigShouldWork(t *testing.T) {
 
 func TestNewCryptoComponentsFactory_CreateInvalidConsensusTypeShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -89,6 +107,9 @@ func TestNewCryptoComponentsFactory_CreateInvalidConsensusTypeShouldErr(t *testi
 
 func TestCryptoComponentsFactory_CreateShouldErrDueToMissingConfig(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -109,6 +130,9 @@ func TestCryptoComponentsFactory_CreateShouldErrDueToMissingConfig(t *testing.T)
 
 func TestCryptoComponentsFactory_CreateInvalidMultiSigHasherShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -123,6 +147,9 @@ func TestCryptoComponentsFactory_CreateInvalidMultiSigHasherShouldErr(t *testing
 
 func TestCryptoComponentsFactory_CreateOK(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -135,6 +162,9 @@ func TestCryptoComponentsFactory_CreateOK(t *testing.T) {
 
 func TestCryptoComponentsFactory_CreateWithDisabledSig(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -148,6 +178,9 @@ func TestCryptoComponentsFactory_CreateWithDisabledSig(t *testing.T) {
 
 func TestCryptoComponentsFactory_CreateSingleSignerInvalidConsensusTypeShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -163,6 +196,9 @@ func TestCryptoComponentsFactory_CreateSingleSignerInvalidConsensusTypeShouldErr
 
 func TestCryptoComponentsFactory_CreateSingleSignerOK(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -177,6 +213,9 @@ func TestCryptoComponentsFactory_CreateSingleSignerOK(t *testing.T) {
 
 func TestCryptoComponentsFactory_GetMultiSigHasherFromConfigInvalidHasherShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -191,8 +230,11 @@ func TestCryptoComponentsFactory_GetMultiSigHasherFromConfigInvalidHasherShouldE
 	require.Equal(t, errErd.ErrMissingMultiHasherConfig, err)
 }
 
-func TestCryptoComponentsFactory_GetMultiSigHasherFromConfigMissmatchConsensusTypeMultiSigHasher(t *testing.T) {
+func TestCryptoComponentsFactory_GetMultiSigHasherFromConfigMismatchConsensusTypeMultiSigHasher(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -208,6 +250,9 @@ func TestCryptoComponentsFactory_GetMultiSigHasherFromConfigMissmatchConsensusTy
 
 func TestCryptoComponentsFactory_GetMultiSigHasherFromConfigOK(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -224,6 +269,9 @@ func TestCryptoComponentsFactory_GetMultiSigHasherFromConfigOK(t *testing.T) {
 
 func TestCryptoComponentsFactory_CreateMultiSignerInvalidConsensusTypeShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -240,6 +288,9 @@ func TestCryptoComponentsFactory_CreateMultiSignerInvalidConsensusTypeShouldErr(
 
 func TestCryptoComponentsFactory_CreateMultiSignerOK(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -259,6 +310,9 @@ func TestCryptoComponentsFactory_CreateMultiSignerOK(t *testing.T) {
 
 func TestCryptoComponentsFactory_GetSuiteInvalidConsensusTypeShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -274,6 +328,9 @@ func TestCryptoComponentsFactory_GetSuiteInvalidConsensusTypeShouldErr(t *testin
 
 func TestCryptoComponentsFactory_GetSuiteOK(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -289,6 +346,9 @@ func TestCryptoComponentsFactory_GetSuiteOK(t *testing.T) {
 
 func TestCryptoComponentsFactory_CreateCryptoParamsInvalidPrivateKeyByteArrayShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -305,6 +365,10 @@ func TestCryptoComponentsFactory_CreateCryptoParamsInvalidPrivateKeyByteArraySho
 
 func TestCryptoComponentsFactory_CreateCryptoParamsLoadKeysFailShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
 	expectedError := errors.New("expected error")
 
 	coreComponents := getCoreComponents()
@@ -322,6 +386,9 @@ func TestCryptoComponentsFactory_CreateCryptoParamsLoadKeysFailShouldErr(t *test
 
 func TestCryptoComponentsFactory_CreateCryptoParamsOK(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
@@ -337,6 +404,9 @@ func TestCryptoComponentsFactory_CreateCryptoParamsOK(t *testing.T) {
 
 func TestCryptoComponentsFactory_GetSkPkInvalidSkBytesShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	setSk := []byte("zxwY")
 	setPk := []byte(dummyPk)
@@ -353,6 +423,10 @@ func TestCryptoComponentsFactory_GetSkPkInvalidSkBytesShouldErr(t *testing.T) {
 
 func TestCryptoComponentsFactory_GetSkPkInvalidPkBytesShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
 	setSk := []byte(dummySk)
 	setPk := "0"
 
@@ -369,6 +443,9 @@ func TestCryptoComponentsFactory_GetSkPkInvalidPkBytesShouldErr(t *testing.T) {
 
 func TestCryptoComponentsFactory_GetSkPkOK(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)

--- a/factory/dataComponentsHandler_test.go
+++ b/factory/dataComponentsHandler_test.go
@@ -10,8 +10,11 @@ import (
 )
 
 // ------------ Test ManagedDataComponents --------------------
-func TestManagedDataComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) {
+func TestManagedDataComponents_CreateWithInvalidArgsShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
@@ -25,8 +28,11 @@ func TestManagedDataComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) {
 	require.Nil(t, managedDataComponents.Blockchain())
 }
 
-func TestManagedDataComponents_Create_ShouldWork(t *testing.T) {
+func TestManagedDataComponents_CreateShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
@@ -47,6 +53,9 @@ func TestManagedDataComponents_Create_ShouldWork(t *testing.T) {
 
 func TestManagedDataComponents_Close(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
@@ -63,6 +72,9 @@ func TestManagedDataComponents_Close(t *testing.T) {
 
 func TestManagedDataComponents_Clone(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)

--- a/factory/dataComponents_test.go
+++ b/factory/dataComponents_test.go
@@ -15,6 +15,9 @@ import (
 
 func TestNewDataComponentsFactory_NilShardCoordinatorShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	coreComponents := getCoreComponents()
@@ -28,6 +31,9 @@ func TestNewDataComponentsFactory_NilShardCoordinatorShouldErr(t *testing.T) {
 
 func TestNewDataComponentsFactory_NilCoreComponentsShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args := getDataArgs(nil, shardCoordinator)
@@ -40,6 +46,9 @@ func TestNewDataComponentsFactory_NilCoreComponentsShouldErr(t *testing.T) {
 
 func TestNewDataComponentsFactory_NilEpochStartNotifierShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	coreComponents := getCoreComponents()
@@ -53,6 +62,9 @@ func TestNewDataComponentsFactory_NilEpochStartNotifierShouldErr(t *testing.T) {
 
 func TestNewDataComponentsFactory_OkValsShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	coreComponents := getCoreComponents()
@@ -64,6 +76,9 @@ func TestNewDataComponentsFactory_OkValsShouldWork(t *testing.T) {
 
 func TestDataComponentsFactory_CreateShouldErrDueBadConfig(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	coreComponents := getCoreComponents()
@@ -79,6 +94,9 @@ func TestDataComponentsFactory_CreateShouldErrDueBadConfig(t *testing.T) {
 
 func TestDataComponentsFactory_CreateForShardShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
@@ -93,6 +111,9 @@ func TestDataComponentsFactory_CreateForShardShouldWork(t *testing.T) {
 
 func TestDataComponentsFactory_CreateForMetaShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
@@ -107,8 +128,11 @@ func TestDataComponentsFactory_CreateForMetaShouldWork(t *testing.T) {
 }
 
 // ------------ Test DataComponents --------------------
-func TestManagedDataComponents_Close_ShouldWork(t *testing.T) {
+func TestManagedDataComponents_CloseShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)

--- a/factory/heartbeatComponentsHandler_test.go
+++ b/factory/heartbeatComponentsHandler_test.go
@@ -9,8 +9,11 @@ import (
 )
 
 // ------------ Test ManagedHeartbeatComponents --------------------
-func TestManagedHeartbeatComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) {
+func TestManagedHeartbeatComponents_CreateWithInvalidArgsShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	heartbeatArgs := getDefaultHeartbeatComponents(shardCoordinator)
@@ -23,8 +26,11 @@ func TestManagedHeartbeatComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T
 	require.Nil(t, managedHeartbeatComponents.Monitor())
 }
 
-func TestManagedHeartbeatComponents_Create_ShouldWork(t *testing.T) {
+func TestManagedHeartbeatComponents_CreateShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	heartbeatArgs := getDefaultHeartbeatComponents(shardCoordinator)
@@ -46,6 +52,9 @@ func TestManagedHeartbeatComponents_Create_ShouldWork(t *testing.T) {
 
 func TestManagedHeartbeatComponents_Close(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	heartbeatArgs := getDefaultHeartbeatComponents(shardCoordinator)

--- a/factory/heartbeatComponents_test.go
+++ b/factory/heartbeatComponents_test.go
@@ -13,8 +13,11 @@ import (
 )
 
 // ------------ Test HeartbeatComponents --------------------
-func TestHeartbeatComponents_Close_ShouldWork(t *testing.T) {
+func TestHeartbeatComponents_CloseShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	heartbeatArgs := getDefaultHeartbeatComponents(shardCoordinator)

--- a/factory/networkComponentsHandler_test.go
+++ b/factory/networkComponentsHandler_test.go
@@ -9,8 +9,11 @@ import (
 )
 
 // ------------ Test ManagedNetworkComponents --------------------
-func TestManagedNetworkComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) {
+func TestManagedNetworkComponents_CreateWithInvalidArgsShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	networkArgs := getNetworkArgs()
 	networkArgs.P2pConfig.Node.Port = "invalid"
@@ -22,8 +25,11 @@ func TestManagedNetworkComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) 
 	require.Nil(t, managedNetworkComponents.NetworkMessenger())
 }
 
-func TestManagedNetworkComponents_Create_ShouldWork(t *testing.T) {
+func TestManagedNetworkComponents_CreateShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	networkArgs := getNetworkArgs()
 	networkComponentsFactory, _ := factory.NewNetworkComponentsFactory(networkArgs)
@@ -51,6 +57,9 @@ func TestManagedNetworkComponents_Create_ShouldWork(t *testing.T) {
 
 func TestManagedNetworkComponents_CheckSubcomponents(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	networkArgs := getNetworkArgs()
 	networkComponentsFactory, _ := factory.NewNetworkComponentsFactory(networkArgs)
@@ -66,6 +75,9 @@ func TestManagedNetworkComponents_CheckSubcomponents(t *testing.T) {
 
 func TestManagedNetworkComponents_Close(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	networkArgs := getNetworkArgs()
 	networkComponentsFactory, _ := factory.NewNetworkComponentsFactory(networkArgs)

--- a/factory/networkComponents_test.go
+++ b/factory/networkComponents_test.go
@@ -16,6 +16,9 @@ import (
 
 func TestNewNetworkComponentsFactory_NilStatusHandlerShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getNetworkArgs()
 	args.StatusHandler = nil
@@ -26,6 +29,9 @@ func TestNewNetworkComponentsFactory_NilStatusHandlerShouldErr(t *testing.T) {
 
 func TestNewNetworkComponentsFactory_NilMarshalizerShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	args := getNetworkArgs()
 	args.Marshalizer = nil
@@ -36,13 +42,22 @@ func TestNewNetworkComponentsFactory_NilMarshalizerShouldErr(t *testing.T) {
 
 func TestNewNetworkComponentsFactory_OkValsShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
 	args := getNetworkArgs()
 	ncf, err := factory.NewNetworkComponentsFactory(args)
 	require.NoError(t, err)
 	require.NotNil(t, ncf)
 }
 
-func TestNetworkComponentsFactory_Create_ShouldErrDueToBadConfig(t *testing.T) {
+func TestNetworkComponentsFactory_CreateShouldErrDueToBadConfig(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
 	args := getNetworkArgs()
 	args.MainConfig = config.Config{}
 	args.P2pConfig = config.P2PConfig{}
@@ -54,7 +69,12 @@ func TestNetworkComponentsFactory_Create_ShouldErrDueToBadConfig(t *testing.T) {
 	require.Nil(t, nc)
 }
 
-func TestNetworkComponentsFactory_Create_ShouldWork(t *testing.T) {
+func TestNetworkComponentsFactory_CreateShouldWork(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
 	args := getNetworkArgs()
 	ncf, _ := factory.NewNetworkComponentsFactory(args)
 	ncf.SetListenAddress(libp2p.ListenLocalhostAddrWithIp4AndTcp)
@@ -65,7 +85,12 @@ func TestNetworkComponentsFactory_Create_ShouldWork(t *testing.T) {
 }
 
 // ------------ Test NetworkComponents --------------------
-func TestNetworkComponents_Close_ShouldWork(t *testing.T) {
+func TestNetworkComponents_CloseShouldWork(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
 	args := getNetworkArgs()
 	ncf, _ := factory.NewNetworkComponentsFactory(args)
 

--- a/factory/processComponentsHandler_test.go
+++ b/factory/processComponentsHandler_test.go
@@ -11,8 +11,11 @@ import (
 )
 
 // ------------ Test TestManagedProcessComponents --------------------
-func TestManagedProcessComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) {
+func TestManagedProcessComponents_CreateWithInvalidArgsShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	processArgs := getProcessComponentsArgs(shardCoordinator)
@@ -25,8 +28,11 @@ func TestManagedProcessComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) 
 	require.Nil(t, managedProcessComponents.NodesCoordinator())
 }
 
-func TestManagedProcessComponents_Create_ShouldWork(t *testing.T) {
+func TestManagedProcessComponents_CreateShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(1)
@@ -136,6 +142,9 @@ func TestManagedProcessComponents_Create_ShouldWork(t *testing.T) {
 
 func TestManagedProcessComponents_Close(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	processArgs := getProcessComponentsArgs(shardCoordinator)

--- a/factory/processComponents_test.go
+++ b/factory/processComponents_test.go
@@ -29,8 +29,11 @@ import (
 )
 
 // ------------ Test TestProcessComponents --------------------
-func TestProcessComponents_Close_ShouldWork(t *testing.T) {
+func TestProcessComponents_CloseShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	processArgs := getProcessComponentsArgs(shardCoordinator)
@@ -46,6 +49,9 @@ func TestProcessComponents_Close_ShouldWork(t *testing.T) {
 
 func TestProcessComponentsFactory_CreateWithInvalidTxAccumulatorTimeExpectError(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	processArgs := getProcessComponentsArgs(shardCoordinator)
@@ -269,6 +275,9 @@ func FillGasMapMetaChainSystemSCsCosts(value uint64) map[string]uint64 {
 
 func TestProcessComponents_IndexGenesisBlocks(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(1)
 	processArgs := getProcessComponentsArgs(shardCoordinator)

--- a/factory/stateComponentsHandler_test.go
+++ b/factory/stateComponentsHandler_test.go
@@ -11,8 +11,11 @@ import (
 )
 
 // ------------ Test ManagedStateComponents --------------------
-func TestManagedStateComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) {
+func TestManagedStateComponents_CreateWithInvalidArgsShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
@@ -26,8 +29,11 @@ func TestManagedStateComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) {
 	require.Nil(t, managedStateComponents.AccountsAdapter())
 }
 
-func TestManagedStateComponents_Create_ShouldWork(t *testing.T) {
+func TestManagedStateComponents_CreateShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
@@ -50,6 +56,9 @@ func TestManagedStateComponents_Create_ShouldWork(t *testing.T) {
 
 func TestManagedStateComponents_Close(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
@@ -66,6 +75,9 @@ func TestManagedStateComponents_Close(t *testing.T) {
 
 func TestManagedStateComponents_CheckSubcomponents(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
@@ -81,6 +93,9 @@ func TestManagedStateComponents_CheckSubcomponents(t *testing.T) {
 
 func TestManagedStateComponents_Setters(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)

--- a/factory/stateComponents_test.go
+++ b/factory/stateComponents_test.go
@@ -20,6 +20,9 @@ import (
 
 func TestNewStateComponentsFactory_NilShardCoordinatorShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
@@ -33,6 +36,9 @@ func TestNewStateComponentsFactory_NilShardCoordinatorShouldErr(t *testing.T) {
 
 func TestNewStateComponentsFactory_NilCoreComponents(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
@@ -46,6 +52,9 @@ func TestNewStateComponentsFactory_NilCoreComponents(t *testing.T) {
 
 func TestNewStateComponentsFactory_ShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
@@ -56,8 +65,11 @@ func TestNewStateComponentsFactory_ShouldWork(t *testing.T) {
 	require.NotNil(t, scf)
 }
 
-func TestStateComponentsFactory_Create_ShouldWork(t *testing.T) {
+func TestStateComponentsFactory_CreateShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
@@ -71,8 +83,11 @@ func TestStateComponentsFactory_Create_ShouldWork(t *testing.T) {
 }
 
 // ------------ Test StateComponents --------------------
-func TestStateComponents_Close_ShouldWork(t *testing.T) {
+func TestStateComponents_CloseShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	coreComponents := getCoreComponents()
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)

--- a/factory/statusComponentsHandler_test.go
+++ b/factory/statusComponentsHandler_test.go
@@ -9,8 +9,11 @@ import (
 )
 
 // ------------ Test ManagedStatusComponents --------------------
-func TestManagedStatusComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) {
+func TestManagedStatusComponents_CreateWithInvalidArgsShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	statusArgs, _ := getStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator)
@@ -26,8 +29,11 @@ func TestManagedStatusComponents_CreateWithInvalidArgs_ShouldErr(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestManagedStatusComponents_Create_ShouldWork(t *testing.T) {
+func TestManagedStatusComponents_CreateShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	statusArgs, _ := getStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator)
@@ -45,6 +51,9 @@ func TestManagedStatusComponents_Create_ShouldWork(t *testing.T) {
 
 func TestManagedStatusComponents_Close(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	statusArgs, _ := getStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator)
@@ -59,6 +68,9 @@ func TestManagedStatusComponents_Close(t *testing.T) {
 
 func TestManagedStatusComponents_CheckSubcomponents(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	statusArgs, _ := getStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator)

--- a/factory/statusComponents_test.go
+++ b/factory/statusComponents_test.go
@@ -21,6 +21,9 @@ var log = logger.GetOrCreate("factory/factory_test")
 
 func TestNewStatusComponentsFactory_NilCoreComponentsShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args, _ := getStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator)
@@ -32,6 +35,9 @@ func TestNewStatusComponentsFactory_NilCoreComponentsShouldErr(t *testing.T) {
 
 func TestNewStatusComponentsFactory_NilNodesCoordinatorShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args, _ := getStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator)
@@ -43,6 +49,9 @@ func TestNewStatusComponentsFactory_NilNodesCoordinatorShouldErr(t *testing.T) {
 
 func TestNewStatusComponentsFactory_NilEpochStartNotifierShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args, _ := getStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator)
@@ -54,6 +63,9 @@ func TestNewStatusComponentsFactory_NilEpochStartNotifierShouldErr(t *testing.T)
 
 func TestNewStatusComponentsFactory_NilNetworkComponentsShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args, _ := getStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator)
@@ -65,6 +77,9 @@ func TestNewStatusComponentsFactory_NilNetworkComponentsShouldErr(t *testing.T) 
 
 func TestNewStatusComponentsFactory_NilShardCoordinatorShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args, _ := getStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator)
@@ -76,6 +91,9 @@ func TestNewStatusComponentsFactory_NilShardCoordinatorShouldErr(t *testing.T) {
 
 func TestNewStatusComponents_InvalidRoundDurationShouldErr(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	coreArgs := getCoreArgs()
@@ -114,6 +132,9 @@ func TestNewStatusComponents_InvalidRoundDurationShouldErr(t *testing.T) {
 
 func TestNewStatusComponentsFactory_ShouldWork(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args, _ := getStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator)
@@ -124,6 +145,9 @@ func TestNewStatusComponentsFactory_ShouldWork(t *testing.T) {
 
 func TestStatusComponentsFactory_Create(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	args, _ := getStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator)
@@ -136,7 +160,12 @@ func TestStatusComponentsFactory_Create(t *testing.T) {
 }
 
 // ------------ Test StatusComponents --------------------
-func TestStatusComponents_Close_ShouldWork(t *testing.T) {
+func TestStatusComponents_CloseShouldWork(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	statusArgs, _ := getStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator)
 	scf, _ := factory.NewStatusComponentsFactory(statusArgs)


### PR DESCRIPTION
- fixed `factory` package unit tests by skipping them when ran with `-race -short` flags