### PR TITLE
Last nonce in pool for sender endpoint

### DIFF
--- a/api/mock/facadeStub.go
+++ b/api/mock/facadeStub.go
@@ -72,6 +72,7 @@ type FacadeStub struct {
 	GetGenesisNodesPubKeysCalled            func() (map[uint32][]string, map[uint32][]string, error)
 	GetTransactionsPoolCalled               func() (*common.TransactionsPoolAPIResponse, error)
 	GetTransactionsPoolForSenderCalled      func(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
+	GetLastPoolNonceForSenderCalled         func(sender string) (uint64, error)
 }
 
 // GetTokenSupply -
@@ -449,6 +450,15 @@ func (f *FacadeStub) GetTransactionsPoolForSender(sender string) (*common.Transa
 	}
 
 	return nil, nil
+}
+
+// GetLastPoolNonceForSender -
+func (f *FacadeStub) GetLastPoolNonceForSender(sender string) (uint64, error) {
+	if f.GetLastPoolNonceForSenderCalled != nil {
+		return f.GetLastPoolNonceForSenderCalled(sender)
+	}
+
+	return 0, nil
 }
 
 // Trigger -

--- a/api/shared/interface.go
+++ b/api/shared/interface.go
@@ -115,5 +115,6 @@ type FacadeHandler interface {
 	GetGenesisNodesPubKeys() (map[uint32][]string, map[uint32][]string, error)
 	GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error)
 	GetTransactionsPoolForSender(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
+	GetLastPoolNonceForSender(sender string) (uint64, error)
 	IsInterfaceNil() bool
 }

--- a/cmd/node/config/api.toml
+++ b/cmd/node/config/api.toml
@@ -171,6 +171,9 @@
 
         # /transaction/pool/by-sender/:sender will return the transactions in JSON format for the sender
         { Name = "/pool/by-sender/:sender", Open = true },
+
+        # /transaction/pool/by-sender/last-nonce/:sender will return the last pool nonce in JSON format for the sender
+        { Name = "/pool/by-sender/last-nonce/:sender", Open = true },
     ]
 
 [APIPackages.block]

--- a/dataRetriever/txpool/interface.go
+++ b/dataRetriever/txpool/interface.go
@@ -16,4 +16,5 @@ type txCache interface {
 	NumBytes() int
 	Diagnose(deep bool)
 	GetTransactionsPoolForSender(sender string) [][]byte
+	GetLastPoolNonceForSender(sender string) (uint64, bool)
 }

--- a/facade/initial/initialNodeFacade.go
+++ b/facade/initial/initialNodeFacade.go
@@ -266,8 +266,8 @@ func (inf *initialNodeFacade) GetInternalMetaBlockByRound(_ common.ApiOutputForm
 	return nil, errNodeStarting
 }
 
-// GetInternalStartOfEpochMetaBlockByEpoch returns nil and error
-func (inf *initialNodeFacade) GetInternalStartOfEpochMetaBlock(format common.ApiOutputFormat, epoch uint32) (interface{}, error) {
+// GetInternalStartOfEpochMetaBlock returns nil and error
+func (inf *initialNodeFacade) GetInternalStartOfEpochMetaBlock(_ common.ApiOutputFormat, _ uint32) (interface{}, error) {
 	return nil, errNodeStarting
 }
 
@@ -339,6 +339,11 @@ func (inf *initialNodeFacade) GetGenesisNodesPubKeys() (map[uint32][]string, map
 // GetTransactionsPool returns a nil structure and error
 func (inf *initialNodeFacade) GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error) {
 	return nil, errNodeStarting
+}
+
+// GetLastPoolNonceForSender returns nonce 0 and error
+func (inf *initialNodeFacade) GetLastPoolNonceForSender(_ string) (uint64, error) {
+	return 0, errNodeStarting
 }
 
 // GetTransactionsPoolForSender returns a nil structure and error

--- a/facade/initial/initialNodeFacade_test.go
+++ b/facade/initial/initialNodeFacade_test.go
@@ -194,5 +194,9 @@ func TestDisabledNodeFacade_AllMethodsShouldNotPanic(t *testing.T) {
 	assert.Nil(t, txs)
 	assert.Equal(t, errNodeStarting, err)
 
+	nonce, err := inf.GetLastPoolNonceForSender("")
+	assert.Equal(t, uint64(0), nonce)
+	assert.Equal(t, errNodeStarting, err)
+
 	assert.False(t, check.IfNil(inf))
 }

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -110,6 +110,7 @@ type ApiResolver interface {
 	GetTransaction(hash string, withResults bool) (*transaction.ApiTransactionResult, error)
 	GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error)
 	GetTransactionsPoolForSender(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
+	GetLastPoolNonceForSender(sender string) (uint64, error)
 	GetBlockByHash(hash string, withTxs bool) (*api.Block, error)
 	GetBlockByNonce(nonce uint64, withTxs bool) (*api.Block, error)
 	GetBlockByRound(round uint64, withTxs bool) (*api.Block, error)

--- a/facade/mock/apiResolverStub.go
+++ b/facade/mock/apiResolverStub.go
@@ -34,6 +34,7 @@ type ApiResolverStub struct {
 	GetGenesisNodesPubKeysCalled           func() (map[uint32][]string, map[uint32][]string)
 	GetTransactionsPoolCalled              func() (*common.TransactionsPoolAPIResponse, error)
 	GetTransactionsPoolForSenderCalled     func(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
+	GetLastPoolNonceForSenderCalled        func(sender string) (uint64, error)
 }
 
 // GetTransaction -
@@ -174,6 +175,15 @@ func (ars *ApiResolverStub) GetTransactionsPoolForSender(sender string) (*common
 	}
 
 	return nil, nil
+}
+
+// GetLastPoolNonceForSender -
+func (ars *ApiResolverStub) GetLastPoolNonceForSender(sender string) (uint64, error) {
+	if ars.GetLastPoolNonceForSenderCalled != nil {
+		return ars.GetLastPoolNonceForSenderCalled(sender)
+	}
+
+	return 0, nil
 }
 
 // GetInternalMetaBlockByHash -

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -304,6 +304,11 @@ func (nf *nodeFacade) GetTransactionsPoolForSender(sender string) (*common.Trans
 	return nf.apiResolver.GetTransactionsPoolForSender(sender)
 }
 
+// GetLastPoolNonceForSender will return the last nonce from pool for sender that is to be returned on API calls
+func (nf *nodeFacade) GetLastPoolNonceForSender(sender string) (uint64, error) {
+	return nf.apiResolver.GetLastPoolNonceForSender(sender)
+}
+
 // ComputeTransactionGasLimit will estimate how many gas a transaction will consume
 func (nf *nodeFacade) ComputeTransactionGasLimit(tx *transaction.Transaction) (*transaction.CostResponse, error) {
 	return nf.apiResolver.ComputeTransactionGasLimit(tx)

--- a/facade/nodeFacade_test.go
+++ b/facade/nodeFacade_test.go
@@ -1355,3 +1355,42 @@ func TestNodeFacade_GetTransactionsPoolForSender(t *testing.T) {
 		require.Equal(t, expectedResponse, res)
 	})
 }
+
+func TestNodeFacade_GetLastPoolNonceForSender(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArguments()
+		expectedErr := errors.New("expected error")
+		arg.ApiResolver = &mock.ApiResolverStub{
+			GetLastPoolNonceForSenderCalled: func(sender string) (uint64, error) {
+				return 0, expectedErr
+			},
+		}
+
+		nf, _ := NewNodeFacade(arg)
+		res, err := nf.GetLastPoolNonceForSender("")
+		require.Equal(t, uint64(0), res)
+		require.Equal(t, expectedErr, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArguments()
+		expectedSender := "alice"
+		expectedNonce := uint64(33)
+		arg.ApiResolver = &mock.ApiResolverStub{
+			GetLastPoolNonceForSenderCalled: func(sender string) (uint64, error) {
+				return expectedNonce, nil
+			},
+		}
+
+		nf, _ := NewNodeFacade(arg)
+		res, err := nf.GetLastPoolNonceForSender(expectedSender)
+		require.NoError(t, err)
+		require.Equal(t, expectedNonce, res)
+	})
+}

--- a/integrationTests/interface.go
+++ b/integrationTests/interface.go
@@ -100,5 +100,6 @@ type Facade interface {
 	GetGenesisNodesPubKeys() (map[uint32][]string, map[uint32][]string, error)
 	GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error)
 	GetTransactionsPoolForSender(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
+	GetLastPoolNonceForSender(sender string) (uint64, error)
 	IsInterfaceNil() bool
 }

--- a/integrationTests/testProcessorNodeWithTestWebServer.go
+++ b/integrationTests/testProcessorNodeWithTestWebServer.go
@@ -107,7 +107,7 @@ func createTestApiConfig() config.ApiRoutesConfig {
 		"log":         {"/log"},
 		"validator":   {"/statistics"},
 		"vm-values":   {"/hex", "/string", "/int", "/query"},
-		"transaction": {"/send", "/simulate", "/send-multiple", "/cost", "/:txhash", "/pool/by-sender/:sender"},
+		"transaction": {"/send", "/simulate", "/send-multiple", "/cost", "/:txhash", "/pool/by-sender/:sender", "/pool/by-sender/last-nonce/:sender"},
 		"block":       {"/by-nonce/:nonce", "/by-hash/:hash", "/by-round/:round"},
 	}
 

--- a/node/external/interface.go
+++ b/node/external/interface.go
@@ -60,6 +60,7 @@ type APITransactionHandler interface {
 	GetTransaction(txHash string, withResults bool) (*transaction.ApiTransactionResult, error)
 	GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error)
 	GetTransactionsPoolForSender(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
+	GetLastPoolNonceForSender(sender string) (uint64, error)
 	UnmarshalTransaction(txBytes []byte, txType transaction.TxType) (*transaction.ApiTransactionResult, error)
 	UnmarshalReceipt(receiptBytes []byte) (*transaction.ApiReceipt, error)
 	IsInterfaceNil() bool

--- a/node/external/nodeApiResolver.go
+++ b/node/external/nodeApiResolver.go
@@ -147,6 +147,11 @@ func (nar *nodeApiResolver) GetTransactionsPoolForSender(sender string) (*common
 	return nar.apiTransactionHandler.GetTransactionsPoolForSender(sender)
 }
 
+// GetLastPoolNonceForSender will return the last nonce from pool for sender that is to be returned on API calls
+func (nar *nodeApiResolver) GetLastPoolNonceForSender(sender string) (uint64, error) {
+	return nar.apiTransactionHandler.GetLastPoolNonceForSender(sender)
+}
+
 // GetBlockByHash will return the block with the given hash and optionally with transactions
 func (nar *nodeApiResolver) GetBlockByHash(hash string, withTxs bool) (*api.Block, error) {
 	decodedHash, err := hex.DecodeString(hash)

--- a/node/external/nodeApiResolver_test.go
+++ b/node/external/nodeApiResolver_test.go
@@ -425,6 +425,45 @@ func TestNodeApiResolver_GetTransactionsPoolForSender(t *testing.T) {
 	})
 }
 
+func TestNodeApiResolver_GetLastPoolNonceForSender(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should error", func(t *testing.T) {
+		t.Parallel()
+
+		expectedErr := errors.New("expected error")
+		arg := createMockArgs()
+		arg.APITransactionHandler = &mock.TransactionAPIHandlerStub{
+			GetLastPoolNonceForSenderCalled: func(sender string) (uint64, error) {
+				return 0, expectedErr
+			},
+		}
+
+		nar, _ := external.NewNodeApiResolver(arg)
+		res, err := nar.GetLastPoolNonceForSender("sender")
+		require.Equal(t, uint64(0), res)
+		require.Equal(t, expectedErr, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		expectedSender := "alice"
+		expectedNonce := uint64(33)
+		arg := createMockArgs()
+		arg.APITransactionHandler = &mock.TransactionAPIHandlerStub{
+			GetLastPoolNonceForSenderCalled: func(sender string) (uint64, error) {
+				return expectedNonce, nil
+			},
+		}
+
+		nar, _ := external.NewNodeApiResolver(arg)
+		res, err := nar.GetLastPoolNonceForSender(expectedSender)
+		require.NoError(t, err)
+		require.Equal(t, expectedNonce, res)
+	})
+}
+
 func TestNodeApiResolver_GetGenesisNodesPubKeys(t *testing.T) {
 	t.Parallel()
 

--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -116,7 +116,7 @@ func (atp *apiTransactionProcessor) GetTransactionsPoolForSender(sender string) 
 	senderShard := atp.shardCoordinator.ComputeId(senderAddr)
 	txsForSender := atp.fetchTxsForSender(string(senderAddr), senderShard)
 	if len(txsForSender) == 0 {
-		return nil, ErrCannotRetrieveTransactions
+		return nil, fmt.Errorf("%w, no transaction in pool for sender", ErrCannotRetrieveTransactions)
 	}
 
 	return &common.TransactionsPoolForSenderApiResponse{
@@ -135,7 +135,7 @@ func (atp *apiTransactionProcessor) GetLastPoolNonceForSender(sender string) (ui
 	senderShard := atp.shardCoordinator.ComputeId(senderAddr)
 	lastNonce, found := atp.fetchLastNonceForSender(string(senderAddr), senderShard)
 	if !found {
-		return 0, ErrCannotRetrieveNonce
+		return 0, fmt.Errorf("%w, no transaction in pool for sender", ErrCannotRetrieveNonce)
 	}
 
 	return lastNonce, nil

--- a/node/external/transactionAPI/errors.go
+++ b/node/external/transactionAPI/errors.go
@@ -22,3 +22,6 @@ var ErrCannotRetrieveTransactions = errors.New("transactions cannot be retrieved
 
 // ErrInvalidAddress signals that the address is invalid
 var ErrInvalidAddress = errors.New("invalid address")
+
+// ErrCannotRetrieveNonce signals that nonce cannot be retrieved
+var ErrCannotRetrieveNonce = errors.New("nonce cannot be retrieved")

--- a/node/mock/apiTransactionHandlerStub.go
+++ b/node/mock/apiTransactionHandlerStub.go
@@ -11,6 +11,7 @@ type TransactionAPIHandlerStub struct {
 	GetTransactionsPoolCalled          func() (*common.TransactionsPoolAPIResponse, error)
 	UnmarshalTransactionCalled         func(txBytes []byte, txType transaction.TxType) (*transaction.ApiTransactionResult, error)
 	GetTransactionsPoolForSenderCalled func(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
+	GetLastPoolNonceForSenderCalled    func(sender string) (uint64, error)
 	UnmarshalReceiptCalled             func(receiptBytes []byte) (*transaction.ApiReceipt, error)
 }
 
@@ -39,6 +40,15 @@ func (tas *TransactionAPIHandlerStub) GetTransactionsPoolForSender(sender string
 	}
 
 	return nil, nil
+}
+
+// GetLastPoolNonceForSender -
+func (tas *TransactionAPIHandlerStub) GetLastPoolNonceForSender(sender string) (uint64, error) {
+	if tas.GetLastPoolNonceForSenderCalled != nil {
+		return tas.GetLastPoolNonceForSenderCalled(sender)
+	}
+
+	return 0, nil
 }
 
 // UnmarshalTransaction -

--- a/storage/txcache/crossTxCache.go
+++ b/storage/txcache/crossTxCache.go
@@ -108,12 +108,16 @@ func (cache *CrossTxCache) ForEachTransaction(function ForEachTransaction) {
 	})
 }
 
-// GetTransactionsPoolForSender returns an empty slice
+// GetTransactionsPoolForSender returns an empty slice, only to respect the intrface
+// CrossTxCache does not support transaction selection (not applicable, since transactions are already half-executed),
+// thus does not handle nonces, nonce gaps etc.
 func (cache *CrossTxCache) GetTransactionsPoolForSender(_ string) [][]byte {
 	return make([][]byte, 0)
 }
 
-// GetLastPoolNonceForSender returns 0 and false
+// GetLastPoolNonceForSender returns 0 and false, only to respect the intrface
+// CrossTxCache does not support transaction selection (not applicable, since transactions are already half-executed),
+// thus does not handle nonces, nonce gaps etc.
 func (cache *CrossTxCache) GetLastPoolNonceForSender(_ string) (uint64, bool) {
 	return 0, false
 }

--- a/storage/txcache/crossTxCache.go
+++ b/storage/txcache/crossTxCache.go
@@ -113,6 +113,11 @@ func (cache *CrossTxCache) GetTransactionsPoolForSender(_ string) [][]byte {
 	return make([][]byte, 0)
 }
 
+// GetLastPoolNonceForSender returns 0 and false
+func (cache *CrossTxCache) GetLastPoolNonceForSender(_ string) (uint64, bool) {
+	return 0, false
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (cache *CrossTxCache) IsInterfaceNil() bool {
 	return cache == nil

--- a/storage/txcache/crossTxCache_test.go
+++ b/storage/txcache/crossTxCache_test.go
@@ -55,6 +55,9 @@ func TestCrossTxCache_Get(t *testing.T) {
 	require.Nil(t, xTx)
 
 	require.Equal(t, make([][]byte, 0), cache.GetTransactionsPoolForSender(""))
+	lastNonce, ok := cache.GetLastPoolNonceForSender("")
+	require.False(t, ok)
+	require.Equal(t, uint64(0), lastNonce)
 }
 
 func newCrossTxCacheToTest(numChunks uint32, maxNumItems uint32, numMaxBytes uint32) *CrossTxCache {

--- a/storage/txcache/disabledCache.go
+++ b/storage/txcache/disabledCache.go
@@ -122,6 +122,11 @@ func (cache *DisabledCache) GetTransactionsPoolForSender(_ string) [][]byte {
 	return make([][]byte, 0)
 }
 
+// GetLastPoolNonceForSender returns 0 and false
+func (cache *DisabledCache) GetLastPoolNonceForSender(_ string) (uint64, bool) {
+	return 0, false
+}
+
 // Close does nothing
 func (cache *DisabledCache) Close() error {
 	return nil

--- a/storage/txcache/txCache.go
+++ b/storage/txcache/txCache.go
@@ -234,6 +234,22 @@ func (cache *TxCache) GetTransactionsPoolForSender(sender string) [][]byte {
 	return txsHashes
 }
 
+// GetLastPoolNonceForSender returns the last nonce from pool for the sender
+func (cache *TxCache) GetLastPoolNonceForSender(sender string) (uint64, bool) {
+	listForSender, ok := cache.txListBySender.getListForSender(sender)
+	if !ok {
+		return 0, ok
+	}
+
+	lastTxElement := listForSender.items.Back()
+	lastTx, ok := lastTxElement.Value.(*WrappedTransaction)
+	if !ok {
+		return 0, ok
+	}
+
+	return lastTx.Tx.GetNonce(), ok
+}
+
 // Clear clears the cache
 func (cache *TxCache) Clear() {
 	cache.mutTxOperation.Lock()

--- a/storage/txcache/txCache_test.go
+++ b/storage/txcache/txCache_test.go
@@ -282,6 +282,31 @@ func Test_GetTransactionsPoolForSender(t *testing.T) {
 	require.Equal(t, expectedHashes, txs)
 }
 
+func Test_GetLastPoolNonceForSender(t *testing.T) {
+	cache := newUnconstrainedCacheToTest()
+
+	txSender := "alice"
+
+	nonce, ok := cache.GetLastPoolNonceForSender(txSender)
+	assert.False(t, ok)
+	require.Equal(t, uint64(0), nonce)
+
+	txHashes := [][]byte{[]byte("hash-1"), []byte("hash-2"), []byte("hash-3")}
+	lastNonce := uint64(33)
+	cache.AddTx(createTx(txHashes[1], txSender, lastNonce))
+	cache.AddTx(createTx(txHashes[0], txSender, 1))
+	cache.AddTx(createTx(txHashes[2], txSender, 3))
+
+	nonce, ok = cache.GetLastPoolNonceForSender(txSender)
+	assert.True(t, ok)
+	require.Equal(t, lastNonce, nonce)
+
+	cache.RemoveTxByHash(txHashes[1])
+	nonce, ok = cache.GetLastPoolNonceForSender(txSender)
+	assert.True(t, ok)
+	require.Equal(t, uint64(3), nonce)
+}
+
 func Test_SelectTransactions_Dummy(t *testing.T) {
 	cache := newUnconstrainedCacheToTest()
 


### PR DESCRIPTION
#### Changes
- added new endpoint `/pool/by-sender/last-nonce/:sender` for the last nonce in tx pool for sender
- small refactor on recently added logic on `apiTransactionProcessor.go` in order to reduce duplicate code
---
In order to test the changes, the following steps are needed:
1. start a local testnet with this branch
2. clone `elrond-txgen-go` and update the following:
   - in `cmd/txgen/config/config.toml`, leave `Scenarios = ["badNonce"]`, update `ProxyServerURL` with the port that your local proxy uses, optional update `MintingValue` to a smaller one
   - copy from the newly generated `node/config/walletKey.pem`(local testnet) one of the private keys and paste it into `cmd/txgen/config`
4. start txgen `./txgen --new-account --num-accounts 10`
5. run ./scripts/badNonce.sh
6. make a Get request to the node: `http://127.0.0.1:node-port/transaction/pool` to get tx pool
7. copy one hash and get the tx details via `http://127.0.0.1:node-port/transaction/your-hash`
8. copy the tx sender and get last nonce from this new endpoint: `http://127.0.0.1:node-port/transaction/pool/by-sender/last-nonce/your-sender`