### PR TITLE
Nonce gaps endpoint

### DIFF
--- a/api/groups/transactionGroup_test.go
+++ b/api/groups/transactionGroup_test.go
@@ -1071,8 +1071,8 @@ func TestGetTransactionsPoolNonceGapsForSenderShouldWork(t *testing.T) {
 		Sender: expectedSender,
 		Gaps: []common.NonceGapApiResponse{
 			{
-				From: "33",
-				To:   "60",
+				From: 33,
+				To:   60,
 			},
 		},
 	}
@@ -1087,7 +1087,7 @@ func TestGetTransactionsPoolNonceGapsForSenderShouldWork(t *testing.T) {
 
 	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
 
-	req, _ := http.NewRequest("GET", "/transaction/pool/by-sender/nonce-gaps/:sender"+expectedSender, nil)
+	req, _ := http.NewRequest("GET", "/transaction/pool/by-sender/nonce-gaps/"+expectedSender, nil)
 
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)

--- a/api/groups/transactionGroup_test.go
+++ b/api/groups/transactionGroup_test.go
@@ -1097,7 +1097,7 @@ func TestGetTransactionsPoolNonceGapsForSenderShouldWork(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.Code)
 	assert.Empty(t, nonceGapsResp.Error)
-	assert.Equal(t, expectedNonceGaps, nonceGapsResp.Data.NonceGaps)
+	assert.Equal(t, *expectedNonceGaps, nonceGapsResp.Data.NonceGaps)
 }
 
 func getTransactionRoutesConfig() config.ApiRoutesConfig {

--- a/api/groups/transactionGroup_test.go
+++ b/api/groups/transactionGroup_test.go
@@ -118,6 +118,16 @@ type lastPoolNonceForSenderResponse struct {
 	Code  string                             `json:"code"`
 }
 
+type txPoolNonceGapsForSenderResponseData struct {
+	NonceGaps common.TransactionsPoolNonceGapsForSenderApiResponse `json:"nonceGaps"`
+}
+
+type txPoolNonceGapsForSenderResponse struct {
+	Data  txPoolNonceGapsForSenderResponseData `json:"data"`
+	Error string                               `json:"error"`
+	Code  string                               `json:"code"`
+}
+
 func TestGetTransaction_WithCorrectHashShouldReturnTransaction(t *testing.T) {
 	sender := "sender"
 	receiver := "receiver"
@@ -1026,6 +1036,70 @@ func TestGetLastPoolNonceForSenderShouldWork(t *testing.T) {
 	assert.Equal(t, expectedNonce, lastPoolNonceResp.Data.Nonce)
 }
 
+func TestGetTransactionsPoolNonceGapsForSenderShouldError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("expected error")
+	facade := mock.FacadeStub{
+		GetTransactionsPoolNonceGapsForSenderCalled: func(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error) {
+			return nil, expectedErr
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/transaction/pool/by-sender/nonce-gaps/:sender", nil)
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	nonceGapsResp := txPoolNonceGapsForSenderResponse{}
+	loadResponse(resp.Body, &nonceGapsResp)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, strings.Contains(nonceGapsResp.Error, expectedErr.Error()))
+}
+
+func TestGetTransactionsPoolNonceGapsForSenderShouldWork(t *testing.T) {
+	t.Parallel()
+
+	expectedSender := "sender"
+	expectedNonceGaps := &common.TransactionsPoolNonceGapsForSenderApiResponse{
+		Sender: expectedSender,
+		Gaps: []common.NonceGapApiResponse{
+			{
+				From: "33",
+				To:   "60",
+			},
+		},
+	}
+	facade := mock.FacadeStub{
+		GetTransactionsPoolNonceGapsForSenderCalled: func(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error) {
+			return expectedNonceGaps, nil
+		},
+	}
+
+	transactionGroup, err := groups.NewTransactionGroup(&facade)
+	require.NoError(t, err)
+
+	ws := startWebServer(transactionGroup, "transaction", getTransactionRoutesConfig())
+
+	req, _ := http.NewRequest("GET", "/transaction/pool/by-sender/nonce-gaps/:sender"+expectedSender, nil)
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	nonceGapsResp := txPoolNonceGapsForSenderResponse{}
+	loadResponse(resp.Body, &nonceGapsResp)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Empty(t, nonceGapsResp.Error)
+	assert.Equal(t, expectedNonceGaps, nonceGapsResp.Data.NonceGaps)
+}
+
 func getTransactionRoutesConfig() config.ApiRoutesConfig {
 	return config.ApiRoutesConfig{
 		APIPackages: map[string]config.APIPackageConfig{
@@ -1040,6 +1114,7 @@ func getTransactionRoutesConfig() config.ApiRoutesConfig {
 					{Name: "/simulate", Open: true},
 					{Name: "/pool/by-sender/:sender", Open: true},
 					{Name: "/pool/by-sender/last-nonce/:sender", Open: true},
+					{Name: "/pool/by-sender/nonce-gaps/:sender", Open: true},
 				},
 			},
 		},

--- a/api/mock/facadeStub.go
+++ b/api/mock/facadeStub.go
@@ -29,50 +29,51 @@ type FacadeStub struct {
 	GetTransactionHandler      func(hash string, withResults bool) (*transaction.ApiTransactionResult, error)
 	CreateTransactionHandler   func(nonce uint64, value string, receiver string, receiverUsername []byte, sender string, senderUsername []byte, gasPrice uint64,
 		gasLimit uint64, data []byte, signatureHex string, chainID string, version uint32, options uint32) (*transaction.Transaction, []byte, error)
-	ValidateTransactionHandler              func(tx *transaction.Transaction) error
-	ValidateTransactionForSimulationHandler func(tx *transaction.Transaction, bypassSignature bool) error
-	SendBulkTransactionsHandler             func(txs []*transaction.Transaction) (uint64, error)
-	ExecuteSCQueryHandler                   func(query *process.SCQuery) (*vm.VMOutputApi, error)
-	StatusMetricsHandler                    func() external.StatusMetricsHandler
-	ValidatorStatisticsHandler              func() (map[string]*state.ValidatorApiResponse, error)
-	ComputeTransactionGasLimitHandler       func(tx *transaction.Transaction) (*transaction.CostResponse, error)
-	NodeConfigCalled                        func() map[string]interface{}
-	GetQueryHandlerCalled                   func(name string) (debug.QueryHandler, error)
-	GetValueForKeyCalled                    func(address string, key string) (string, error)
-	GetPeerInfoCalled                       func(pid string) ([]core.QueryP2PPeerInfo, error)
-	GetThrottlerForEndpointCalled           func(endpoint string) (core.Throttler, bool)
-	GetUsernameCalled                       func(address string) (string, error)
-	GetKeyValuePairsCalled                  func(address string) (map[string]string, error)
-	SimulateTransactionExecutionHandler     func(tx *transaction.Transaction) (*txSimData.SimulationResults, error)
-	GetESDTDataCalled                       func(address string, key string, nonce uint64) (*esdt.ESDigitalToken, error)
-	GetAllESDTTokensCalled                  func(address string) (map[string]*esdt.ESDigitalToken, error)
-	GetESDTsWithRoleCalled                  func(address string, role string) ([]string, error)
-	GetESDTsRolesCalled                     func(address string) (map[string][]string, error)
-	GetNFTTokenIDsRegisteredByAddressCalled func(address string) ([]string, error)
-	GetBlockByHashCalled                    func(hash string, withTxs bool) (*api.Block, error)
-	GetBlockByNonceCalled                   func(nonce uint64, withTxs bool) (*api.Block, error)
-	GetBlockByRoundCalled                   func(round uint64, withTxs bool) (*api.Block, error)
-	GetInternalShardBlockByNonceCalled      func(format common.ApiOutputFormat, nonce uint64) (interface{}, error)
-	GetInternalShardBlockByHashCalled       func(format common.ApiOutputFormat, hash string) (interface{}, error)
-	GetInternalShardBlockByRoundCalled      func(format common.ApiOutputFormat, round uint64) (interface{}, error)
-	GetInternalMetaBlockByNonceCalled       func(format common.ApiOutputFormat, nonce uint64) (interface{}, error)
-	GetInternalMetaBlockByHashCalled        func(format common.ApiOutputFormat, hash string) (interface{}, error)
-	GetInternalMetaBlockByRoundCalled       func(format common.ApiOutputFormat, round uint64) (interface{}, error)
-	GetInternalStartOfEpochMetaBlockCalled  func(format common.ApiOutputFormat, epoch uint32) (interface{}, error)
-	GetInternalMiniBlockByHashCalled        func(format common.ApiOutputFormat, txHash string, epoch uint32) (interface{}, error)
-	GetTotalStakedValueHandler              func() (*api.StakeValues, error)
-	GetAllIssuedESDTsCalled                 func(tokenType string) ([]string, error)
-	GetDirectStakedListHandler              func() ([]*api.DirectStakedValue, error)
-	GetDelegatorsListHandler                func() ([]*api.Delegator, error)
-	GetProofCalled                          func(string, string) (*common.GetProofResponse, error)
-	GetProofCurrentRootHashCalled           func(string) (*common.GetProofResponse, error)
-	GetProofDataTrieCalled                  func(string, string, string) (*common.GetProofResponse, *common.GetProofResponse, error)
-	VerifyProofCalled                       func(string, string, [][]byte) (bool, error)
-	GetTokenSupplyCalled                    func(token string) (*api.ESDTSupply, error)
-	GetGenesisNodesPubKeysCalled            func() (map[uint32][]string, map[uint32][]string, error)
-	GetTransactionsPoolCalled               func() (*common.TransactionsPoolAPIResponse, error)
-	GetTransactionsPoolForSenderCalled      func(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
-	GetLastPoolNonceForSenderCalled         func(sender string) (uint64, error)
+	ValidateTransactionHandler                  func(tx *transaction.Transaction) error
+	ValidateTransactionForSimulationHandler     func(tx *transaction.Transaction, bypassSignature bool) error
+	SendBulkTransactionsHandler                 func(txs []*transaction.Transaction) (uint64, error)
+	ExecuteSCQueryHandler                       func(query *process.SCQuery) (*vm.VMOutputApi, error)
+	StatusMetricsHandler                        func() external.StatusMetricsHandler
+	ValidatorStatisticsHandler                  func() (map[string]*state.ValidatorApiResponse, error)
+	ComputeTransactionGasLimitHandler           func(tx *transaction.Transaction) (*transaction.CostResponse, error)
+	NodeConfigCalled                            func() map[string]interface{}
+	GetQueryHandlerCalled                       func(name string) (debug.QueryHandler, error)
+	GetValueForKeyCalled                        func(address string, key string) (string, error)
+	GetPeerInfoCalled                           func(pid string) ([]core.QueryP2PPeerInfo, error)
+	GetThrottlerForEndpointCalled               func(endpoint string) (core.Throttler, bool)
+	GetUsernameCalled                           func(address string) (string, error)
+	GetKeyValuePairsCalled                      func(address string) (map[string]string, error)
+	SimulateTransactionExecutionHandler         func(tx *transaction.Transaction) (*txSimData.SimulationResults, error)
+	GetESDTDataCalled                           func(address string, key string, nonce uint64) (*esdt.ESDigitalToken, error)
+	GetAllESDTTokensCalled                      func(address string) (map[string]*esdt.ESDigitalToken, error)
+	GetESDTsWithRoleCalled                      func(address string, role string) ([]string, error)
+	GetESDTsRolesCalled                         func(address string) (map[string][]string, error)
+	GetNFTTokenIDsRegisteredByAddressCalled     func(address string) ([]string, error)
+	GetBlockByHashCalled                        func(hash string, withTxs bool) (*api.Block, error)
+	GetBlockByNonceCalled                       func(nonce uint64, withTxs bool) (*api.Block, error)
+	GetBlockByRoundCalled                       func(round uint64, withTxs bool) (*api.Block, error)
+	GetInternalShardBlockByNonceCalled          func(format common.ApiOutputFormat, nonce uint64) (interface{}, error)
+	GetInternalShardBlockByHashCalled           func(format common.ApiOutputFormat, hash string) (interface{}, error)
+	GetInternalShardBlockByRoundCalled          func(format common.ApiOutputFormat, round uint64) (interface{}, error)
+	GetInternalMetaBlockByNonceCalled           func(format common.ApiOutputFormat, nonce uint64) (interface{}, error)
+	GetInternalMetaBlockByHashCalled            func(format common.ApiOutputFormat, hash string) (interface{}, error)
+	GetInternalMetaBlockByRoundCalled           func(format common.ApiOutputFormat, round uint64) (interface{}, error)
+	GetInternalStartOfEpochMetaBlockCalled      func(format common.ApiOutputFormat, epoch uint32) (interface{}, error)
+	GetInternalMiniBlockByHashCalled            func(format common.ApiOutputFormat, txHash string, epoch uint32) (interface{}, error)
+	GetTotalStakedValueHandler                  func() (*api.StakeValues, error)
+	GetAllIssuedESDTsCalled                     func(tokenType string) ([]string, error)
+	GetDirectStakedListHandler                  func() ([]*api.DirectStakedValue, error)
+	GetDelegatorsListHandler                    func() ([]*api.Delegator, error)
+	GetProofCalled                              func(string, string) (*common.GetProofResponse, error)
+	GetProofCurrentRootHashCalled               func(string) (*common.GetProofResponse, error)
+	GetProofDataTrieCalled                      func(string, string, string) (*common.GetProofResponse, *common.GetProofResponse, error)
+	VerifyProofCalled                           func(string, string, [][]byte) (bool, error)
+	GetTokenSupplyCalled                        func(token string) (*api.ESDTSupply, error)
+	GetGenesisNodesPubKeysCalled                func() (map[uint32][]string, map[uint32][]string, error)
+	GetTransactionsPoolCalled                   func() (*common.TransactionsPoolAPIResponse, error)
+	GetTransactionsPoolForSenderCalled          func(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
+	GetLastPoolNonceForSenderCalled             func(sender string) (uint64, error)
+	GetTransactionsPoolNonceGapsForSenderCalled func(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error)
 }
 
 // GetTokenSupply -
@@ -459,6 +460,15 @@ func (f *FacadeStub) GetLastPoolNonceForSender(sender string) (uint64, error) {
 	}
 
 	return 0, nil
+}
+
+// GetTransactionsPoolNonceGapsForSender -
+func (f *FacadeStub) GetTransactionsPoolNonceGapsForSender(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error) {
+	if f.GetTransactionsPoolNonceGapsForSenderCalled != nil {
+		return f.GetTransactionsPoolNonceGapsForSenderCalled(sender)
+	}
+
+	return nil, nil
 }
 
 // Trigger -

--- a/api/shared/interface.go
+++ b/api/shared/interface.go
@@ -116,5 +116,6 @@ type FacadeHandler interface {
 	GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error)
 	GetTransactionsPoolForSender(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
 	GetLastPoolNonceForSender(sender string) (uint64, error)
+	GetTransactionsPoolNonceGapsForSender(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error)
 	IsInterfaceNil() bool
 }

--- a/cmd/node/config/api.toml
+++ b/cmd/node/config/api.toml
@@ -174,6 +174,9 @@
 
         # /transaction/pool/by-sender/last-nonce/:sender will return the last pool nonce in JSON format for the sender
         { Name = "/pool/by-sender/last-nonce/:sender", Open = true },
+
+        # /transaction/pool/by-sender/nonce-gaps/:sender will return the nonce gaps from pool in JSON format for the sender
+        { Name = "/pool/by-sender/nonce-gaps/:sender", Open = true },
     ]
 
 [APIPackages.block]

--- a/common/dtos.go
+++ b/common/dtos.go
@@ -19,3 +19,17 @@ type TransactionsPoolForSenderApiResponse struct {
 	Sender       string   `json:"sender"`
 	Transactions []string `json:"transactions"`
 }
+
+// NonceGapApiResponse is a struct that holds a nonce gap from transactions pool
+// From - last known nonce
+// To   - next known nonce
+type NonceGapApiResponse struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// TransactionsPoolNonceGapsForSenderApiResponse is a struct that holds the data to be returned when getting the nonce gaps from transactions pool for a sender from an API call
+type TransactionsPoolNonceGapsForSenderApiResponse struct {
+	Sender string                `json:"sender"`
+	Gaps   []NonceGapApiResponse `json:"gaps"`
+}

--- a/common/dtos.go
+++ b/common/dtos.go
@@ -24,8 +24,8 @@ type TransactionsPoolForSenderApiResponse struct {
 // From - last known nonce
 // To   - next known nonce
 type NonceGapApiResponse struct {
-	From string `json:"from"`
-	To   string `json:"to"`
+	From uint64 `json:"from"`
+	To   uint64 `json:"to"`
 }
 
 // TransactionsPoolNonceGapsForSenderApiResponse is a struct that holds the data to be returned when getting the nonce gaps from transactions pool for a sender from an API call

--- a/dataRetriever/txpool/interface.go
+++ b/dataRetriever/txpool/interface.go
@@ -15,6 +15,5 @@ type txCache interface {
 	ForEachTransaction(function txcache.ForEachTransaction)
 	NumBytes() int
 	Diagnose(deep bool)
-	GetTransactionsPoolForSender(sender string) [][]byte
-	GetLastPoolNonceForSender(sender string) (uint64, bool)
+	GetTransactionsPoolForSender(sender string) []*txcache.WrappedTransaction
 }

--- a/facade/initial/initialNodeFacade.go
+++ b/facade/initial/initialNodeFacade.go
@@ -346,6 +346,11 @@ func (inf *initialNodeFacade) GetLastPoolNonceForSender(_ string) (uint64, error
 	return 0, errNodeStarting
 }
 
+// GetTransactionsPoolNonceGapsForSender returns a nil structure and error
+func (inf *initialNodeFacade) GetTransactionsPoolNonceGapsForSender(_ string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error) {
+	return nil, errNodeStarting
+}
+
 // GetTransactionsPoolForSender returns a nil structure and error
 func (inf *initialNodeFacade) GetTransactionsPoolForSender(_ string) (*common.TransactionsPoolForSenderApiResponse, error) {
 	return nil, errNodeStarting

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -111,6 +111,7 @@ type ApiResolver interface {
 	GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error)
 	GetTransactionsPoolForSender(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
 	GetLastPoolNonceForSender(sender string) (uint64, error)
+	GetTransactionsPoolNonceGapsForSender(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error)
 	GetBlockByHash(hash string, withTxs bool) (*api.Block, error)
 	GetBlockByNonce(nonce uint64, withTxs bool) (*api.Block, error)
 	GetBlockByRound(round uint64, withTxs bool) (*api.Block, error)

--- a/facade/mock/apiResolverStub.go
+++ b/facade/mock/apiResolverStub.go
@@ -13,28 +13,29 @@ import (
 
 // ApiResolverStub -
 type ApiResolverStub struct {
-	ExecuteSCQueryHandler                  func(query *process.SCQuery) (*vmcommon.VMOutput, error)
-	StatusMetricsHandler                   func() external.StatusMetricsHandler
-	ComputeTransactionGasLimitHandler      func(tx *transaction.Transaction) (*transaction.CostResponse, error)
-	GetTotalStakedValueHandler             func(ctx context.Context) (*api.StakeValues, error)
-	GetDirectStakedListHandler             func(ctx context.Context) ([]*api.DirectStakedValue, error)
-	GetDelegatorsListHandler               func(ctx context.Context) ([]*api.Delegator, error)
-	GetBlockByHashCalled                   func(hash string, withTxs bool) (*api.Block, error)
-	GetBlockByNonceCalled                  func(nonce uint64, withTxs bool) (*api.Block, error)
-	GetBlockByRoundCalled                  func(round uint64, withTxs bool) (*api.Block, error)
-	GetTransactionHandler                  func(hash string, withEvents bool) (*transaction.ApiTransactionResult, error)
-	GetInternalShardBlockByNonceCalled     func(format common.ApiOutputFormat, nonce uint64) (interface{}, error)
-	GetInternalShardBlockByHashCalled      func(format common.ApiOutputFormat, hash string) (interface{}, error)
-	GetInternalShardBlockByRoundCalled     func(format common.ApiOutputFormat, round uint64) (interface{}, error)
-	GetInternalMetaBlockByNonceCalled      func(format common.ApiOutputFormat, nonce uint64) (interface{}, error)
-	GetInternalMetaBlockByHashCalled       func(format common.ApiOutputFormat, hash string) (interface{}, error)
-	GetInternalMetaBlockByRoundCalled      func(format common.ApiOutputFormat, round uint64) (interface{}, error)
-	GetInternalMiniBlockCalled             func(format common.ApiOutputFormat, hash string, epoch uint32) (interface{}, error)
-	GetInternalStartOfEpochMetaBlockCalled func(format common.ApiOutputFormat, epoch uint32) (interface{}, error)
-	GetGenesisNodesPubKeysCalled           func() (map[uint32][]string, map[uint32][]string)
-	GetTransactionsPoolCalled              func() (*common.TransactionsPoolAPIResponse, error)
-	GetTransactionsPoolForSenderCalled     func(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
-	GetLastPoolNonceForSenderCalled        func(sender string) (uint64, error)
+	ExecuteSCQueryHandler                       func(query *process.SCQuery) (*vmcommon.VMOutput, error)
+	StatusMetricsHandler                        func() external.StatusMetricsHandler
+	ComputeTransactionGasLimitHandler           func(tx *transaction.Transaction) (*transaction.CostResponse, error)
+	GetTotalStakedValueHandler                  func(ctx context.Context) (*api.StakeValues, error)
+	GetDirectStakedListHandler                  func(ctx context.Context) ([]*api.DirectStakedValue, error)
+	GetDelegatorsListHandler                    func(ctx context.Context) ([]*api.Delegator, error)
+	GetBlockByHashCalled                        func(hash string, withTxs bool) (*api.Block, error)
+	GetBlockByNonceCalled                       func(nonce uint64, withTxs bool) (*api.Block, error)
+	GetBlockByRoundCalled                       func(round uint64, withTxs bool) (*api.Block, error)
+	GetTransactionHandler                       func(hash string, withEvents bool) (*transaction.ApiTransactionResult, error)
+	GetInternalShardBlockByNonceCalled          func(format common.ApiOutputFormat, nonce uint64) (interface{}, error)
+	GetInternalShardBlockByHashCalled           func(format common.ApiOutputFormat, hash string) (interface{}, error)
+	GetInternalShardBlockByRoundCalled          func(format common.ApiOutputFormat, round uint64) (interface{}, error)
+	GetInternalMetaBlockByNonceCalled           func(format common.ApiOutputFormat, nonce uint64) (interface{}, error)
+	GetInternalMetaBlockByHashCalled            func(format common.ApiOutputFormat, hash string) (interface{}, error)
+	GetInternalMetaBlockByRoundCalled           func(format common.ApiOutputFormat, round uint64) (interface{}, error)
+	GetInternalMiniBlockCalled                  func(format common.ApiOutputFormat, hash string, epoch uint32) (interface{}, error)
+	GetInternalStartOfEpochMetaBlockCalled      func(format common.ApiOutputFormat, epoch uint32) (interface{}, error)
+	GetGenesisNodesPubKeysCalled                func() (map[uint32][]string, map[uint32][]string)
+	GetTransactionsPoolCalled                   func() (*common.TransactionsPoolAPIResponse, error)
+	GetTransactionsPoolForSenderCalled          func(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
+	GetLastPoolNonceForSenderCalled             func(sender string) (uint64, error)
+	GetTransactionsPoolNonceGapsForSenderCalled func(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error)
 }
 
 // GetTransaction -
@@ -184,6 +185,15 @@ func (ars *ApiResolverStub) GetLastPoolNonceForSender(sender string) (uint64, er
 	}
 
 	return 0, nil
+}
+
+// GetTransactionsPoolNonceGapsForSender -
+func (ars *ApiResolverStub) GetTransactionsPoolNonceGapsForSender(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error) {
+	if ars.GetTransactionsPoolNonceGapsForSenderCalled != nil {
+		return ars.GetTransactionsPoolNonceGapsForSenderCalled(sender)
+	}
+
+	return nil, nil
 }
 
 // GetInternalMetaBlockByHash -

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -309,6 +309,11 @@ func (nf *nodeFacade) GetLastPoolNonceForSender(sender string) (uint64, error) {
 	return nf.apiResolver.GetLastPoolNonceForSender(sender)
 }
 
+// GetTransactionsPoolNonceGapsForSender will return the nonce gaps from pool for sender, if exists, that is to be returned on API calls
+func (nf *nodeFacade) GetTransactionsPoolNonceGapsForSender(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error) {
+	return nf.apiResolver.GetTransactionsPoolNonceGapsForSender(sender)
+}
+
 // ComputeTransactionGasLimit will estimate how many gas a transaction will consume
 func (nf *nodeFacade) ComputeTransactionGasLimit(tx *transaction.Transaction) (*transaction.CostResponse, error) {
 	return nf.apiResolver.ComputeTransactionGasLimit(tx)

--- a/facade/nodeFacade_test.go
+++ b/facade/nodeFacade_test.go
@@ -1394,3 +1394,50 @@ func TestNodeFacade_GetLastPoolNonceForSender(t *testing.T) {
 		require.Equal(t, expectedNonce, res)
 	})
 }
+
+func TestNodeFacade_GetTransactionsPoolNonceGapsForSender(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArguments()
+		expectedErr := errors.New("expected error")
+		arg.ApiResolver = &mock.ApiResolverStub{
+			GetTransactionsPoolNonceGapsForSenderCalled: func(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error) {
+				return nil, expectedErr
+			},
+		}
+
+		nf, _ := NewNodeFacade(arg)
+		res, err := nf.GetTransactionsPoolNonceGapsForSender("")
+		require.Nil(t, res)
+		require.Equal(t, expectedErr, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArguments()
+		expectedSender := "alice"
+		expectedNonceGaps := &common.TransactionsPoolNonceGapsForSenderApiResponse{
+			Sender: expectedSender,
+			Gaps: []common.NonceGapApiResponse{
+				{
+					From: "33",
+					To:   "60",
+				},
+			},
+		}
+		arg.ApiResolver = &mock.ApiResolverStub{
+			GetTransactionsPoolNonceGapsForSenderCalled: func(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error) {
+				return expectedNonceGaps, nil
+			},
+		}
+
+		nf, _ := NewNodeFacade(arg)
+		res, err := nf.GetTransactionsPoolNonceGapsForSender(expectedSender)
+		require.NoError(t, err)
+		require.Equal(t, expectedNonceGaps, res)
+	})
+}

--- a/facade/nodeFacade_test.go
+++ b/facade/nodeFacade_test.go
@@ -1424,8 +1424,8 @@ func TestNodeFacade_GetTransactionsPoolNonceGapsForSender(t *testing.T) {
 			Sender: expectedSender,
 			Gaps: []common.NonceGapApiResponse{
 				{
-					From: "33",
-					To:   "60",
+					From: 33,
+					To:   60,
 				},
 			},
 		}

--- a/integrationTests/interface.go
+++ b/integrationTests/interface.go
@@ -101,5 +101,6 @@ type Facade interface {
 	GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error)
 	GetTransactionsPoolForSender(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
 	GetLastPoolNonceForSender(sender string) (uint64, error)
+	GetTransactionsPoolNonceGapsForSender(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error)
 	IsInterfaceNil() bool
 }

--- a/integrationTests/testProcessorNodeWithTestWebServer.go
+++ b/integrationTests/testProcessorNodeWithTestWebServer.go
@@ -107,7 +107,7 @@ func createTestApiConfig() config.ApiRoutesConfig {
 		"log":         {"/log"},
 		"validator":   {"/statistics"},
 		"vm-values":   {"/hex", "/string", "/int", "/query"},
-		"transaction": {"/send", "/simulate", "/send-multiple", "/cost", "/:txhash", "/pool/by-sender/:sender", "/pool/by-sender/last-nonce/:sender"},
+		"transaction": {"/send", "/simulate", "/send-multiple", "/cost", "/:txhash", "/pool/by-sender/:sender", "/pool/by-sender/last-nonce/:sender", "/pool/by-sender/nonce-gaps/:sender"},
 		"block":       {"/by-nonce/:nonce", "/by-hash/:hash", "/by-round/:round"},
 	}
 

--- a/node/external/interface.go
+++ b/node/external/interface.go
@@ -61,6 +61,7 @@ type APITransactionHandler interface {
 	GetTransactionsPool() (*common.TransactionsPoolAPIResponse, error)
 	GetTransactionsPoolForSender(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
 	GetLastPoolNonceForSender(sender string) (uint64, error)
+	GetTransactionsPoolNonceGapsForSender(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error)
 	UnmarshalTransaction(txBytes []byte, txType transaction.TxType) (*transaction.ApiTransactionResult, error)
 	UnmarshalReceipt(receiptBytes []byte) (*transaction.ApiReceipt, error)
 	IsInterfaceNil() bool

--- a/node/external/nodeApiResolver.go
+++ b/node/external/nodeApiResolver.go
@@ -152,6 +152,11 @@ func (nar *nodeApiResolver) GetLastPoolNonceForSender(sender string) (uint64, er
 	return nar.apiTransactionHandler.GetLastPoolNonceForSender(sender)
 }
 
+// GetTransactionsPoolNonceGapsForSender will return the nonce gaps from pool for sender, if exists, that is to be returned on API calls
+func (nar *nodeApiResolver) GetTransactionsPoolNonceGapsForSender(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error) {
+	return nar.apiTransactionHandler.GetTransactionsPoolNonceGapsForSender(sender)
+}
+
 // GetBlockByHash will return the block with the given hash and optionally with transactions
 func (nar *nodeApiResolver) GetBlockByHash(hash string, withTxs bool) (*api.Block, error) {
 	decodedHash, err := hex.DecodeString(hash)

--- a/node/external/nodeApiResolver_test.go
+++ b/node/external/nodeApiResolver_test.go
@@ -464,6 +464,53 @@ func TestNodeApiResolver_GetLastPoolNonceForSender(t *testing.T) {
 	})
 }
 
+func TestNodeApiResolver_GetTransactionsPoolNonceGapsForSender(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should error", func(t *testing.T) {
+		t.Parallel()
+
+		expectedErr := errors.New("expected error")
+		arg := createMockArgs()
+		arg.APITransactionHandler = &mock.TransactionAPIHandlerStub{
+			GetTransactionsPoolNonceGapsForSenderCalled: func(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error) {
+				return nil, expectedErr
+			},
+		}
+
+		nar, _ := external.NewNodeApiResolver(arg)
+		res, err := nar.GetTransactionsPoolNonceGapsForSender("sender")
+		require.Nil(t, res)
+		require.Equal(t, expectedErr, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		expectedSender := "alice"
+		expectedNonceGaps := &common.TransactionsPoolNonceGapsForSenderApiResponse{
+			Sender: expectedSender,
+			Gaps: []common.NonceGapApiResponse{
+				{
+					From: "33",
+					To:   "60",
+				},
+			},
+		}
+		arg := createMockArgs()
+		arg.APITransactionHandler = &mock.TransactionAPIHandlerStub{
+			GetTransactionsPoolNonceGapsForSenderCalled: func(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error) {
+				return expectedNonceGaps, nil
+			},
+		}
+
+		nar, _ := external.NewNodeApiResolver(arg)
+		res, err := nar.GetTransactionsPoolNonceGapsForSender(expectedSender)
+		require.NoError(t, err)
+		require.Equal(t, expectedNonceGaps, res)
+	})
+}
+
 func TestNodeApiResolver_GetGenesisNodesPubKeys(t *testing.T) {
 	t.Parallel()
 

--- a/node/external/nodeApiResolver_test.go
+++ b/node/external/nodeApiResolver_test.go
@@ -492,8 +492,8 @@ func TestNodeApiResolver_GetTransactionsPoolNonceGapsForSender(t *testing.T) {
 			Sender: expectedSender,
 			Gaps: []common.NonceGapApiResponse{
 				{
-					From: "33",
-					To:   "60",
+					From: 33,
+					To:   60,
 				},
 			},
 		}

--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -234,8 +234,8 @@ func (atp *apiTransactionProcessor) extractNonceGaps(sender string, senderShard 
 		nonceDiff := nextNonce - currentNonce
 		if nonceDiff > 1 {
 			nonceGap := common.NonceGapApiResponse{
-				From: fmt.Sprintf("%d", currentNonce),
-				To:   fmt.Sprintf("%d", nextNonce),
+				From: currentNonce,
+				To:   nextNonce,
 			}
 			nonceGaps = append(nonceGaps, nonceGap)
 		}

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -806,11 +806,11 @@ func TestApiTransactionProcessor_GetTransactionsPoolNonceGapsForSender(t *testin
 
 	// final sorted nonces 1, 2, 5, 6, 15
 	gap1FirstNonce := uint64(2)
-	gap1LasttNonce := uint64(5)
+	gap1LastNonce := uint64(5)
 	gap2FirstNonce := uint64(6)
 	gap2LastNonce := uint64(15)
 	txCacheIntraShard.AddTx(createTx(txHash0, sender, 1))
-	txCacheIntraShard.AddTx(createTx(txHash1, sender, gap1LasttNonce))
+	txCacheIntraShard.AddTx(createTx(txHash1, sender, gap1LastNonce))
 	txCacheIntraShard.AddTx(createTx(txHash2, sender, gap2FirstNonce))
 	txCacheIntraShard.AddTx(createTx(txHash3, sender, gap1FirstNonce))
 	txCacheIntraShard.AddTx(createTx(txHash4, sender, gap2LastNonce))
@@ -851,7 +851,7 @@ func TestApiTransactionProcessor_GetTransactionsPoolNonceGapsForSender(t *testin
 		Gaps: []common.NonceGapApiResponse{
 			{
 				From: gap1FirstNonce,
-				To:   gap1LasttNonce,
+				To:   gap1LastNonce,
 			},
 			{
 				From: gap2FirstNonce,

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -808,12 +808,12 @@ func TestApiTransactionProcessor_GetTransactionsPoolNonceGapsForSender(t *testin
 	gap1FirstNonce := uint64(2)
 	gap1LasttNonce := uint64(5)
 	gap2FirstNonce := uint64(6)
-	gap2LasttNonce := uint64(15)
+	gap2LastNonce := uint64(15)
 	txCacheIntraShard.AddTx(createTx(txHash0, sender, 1))
 	txCacheIntraShard.AddTx(createTx(txHash1, sender, gap1LasttNonce))
 	txCacheIntraShard.AddTx(createTx(txHash2, sender, gap2FirstNonce))
 	txCacheIntraShard.AddTx(createTx(txHash3, sender, gap1FirstNonce))
-	txCacheIntraShard.AddTx(createTx(txHash4, sender, gap2LasttNonce))
+	txCacheIntraShard.AddTx(createTx(txHash4, sender, gap2LastNonce))
 
 	args := createMockArgAPIBlockProcessor()
 	args.DataPool = &dataRetrieverMock.PoolsHolderStub{
@@ -850,12 +850,12 @@ func TestApiTransactionProcessor_GetTransactionsPoolNonceGapsForSender(t *testin
 		Sender: sender,
 		Gaps: []common.NonceGapApiResponse{
 			{
-				From: fmt.Sprintf("%d", gap1FirstNonce),
-				To:   fmt.Sprintf("%d", gap1LasttNonce),
+				From: gap1FirstNonce,
+				To:   gap1LasttNonce,
 			},
 			{
-				From: fmt.Sprintf("%d", gap2FirstNonce),
-				To:   fmt.Sprintf("%d", gap2LasttNonce),
+				From: gap2FirstNonce,
+				To:   gap2LastNonce,
 			},
 		},
 	}

--- a/node/mock/apiTransactionHandlerStub.go
+++ b/node/mock/apiTransactionHandlerStub.go
@@ -7,12 +7,13 @@ import (
 
 // TransactionAPIHandlerStub -
 type TransactionAPIHandlerStub struct {
-	GetTransactionCalled               func(hash string, withResults bool) (*transaction.ApiTransactionResult, error)
-	GetTransactionsPoolCalled          func() (*common.TransactionsPoolAPIResponse, error)
-	UnmarshalTransactionCalled         func(txBytes []byte, txType transaction.TxType) (*transaction.ApiTransactionResult, error)
-	GetTransactionsPoolForSenderCalled func(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
-	GetLastPoolNonceForSenderCalled    func(sender string) (uint64, error)
-	UnmarshalReceiptCalled             func(receiptBytes []byte) (*transaction.ApiReceipt, error)
+	GetTransactionCalled                        func(hash string, withResults bool) (*transaction.ApiTransactionResult, error)
+	GetTransactionsPoolCalled                   func() (*common.TransactionsPoolAPIResponse, error)
+	UnmarshalTransactionCalled                  func(txBytes []byte, txType transaction.TxType) (*transaction.ApiTransactionResult, error)
+	GetTransactionsPoolForSenderCalled          func(sender string) (*common.TransactionsPoolForSenderApiResponse, error)
+	GetLastPoolNonceForSenderCalled             func(sender string) (uint64, error)
+	GetTransactionsPoolNonceGapsForSenderCalled func(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error)
+	UnmarshalReceiptCalled                      func(receiptBytes []byte) (*transaction.ApiReceipt, error)
 }
 
 // GetTransaction -
@@ -49,6 +50,15 @@ func (tas *TransactionAPIHandlerStub) GetLastPoolNonceForSender(sender string) (
 	}
 
 	return 0, nil
+}
+
+// GetTransactionsPoolNonceGapsForSender -
+func (tas *TransactionAPIHandlerStub) GetTransactionsPoolNonceGapsForSender(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error) {
+	if tas.GetTransactionsPoolNonceGapsForSenderCalled != nil {
+		return tas.GetTransactionsPoolNonceGapsForSenderCalled(sender)
+	}
+
+	return nil, nil
 }
 
 // UnmarshalTransaction -

--- a/storage/txcache/crossTxCache.go
+++ b/storage/txcache/crossTxCache.go
@@ -108,18 +108,11 @@ func (cache *CrossTxCache) ForEachTransaction(function ForEachTransaction) {
 	})
 }
 
-// GetTransactionsPoolForSender returns an empty slice, only to respect the intrface
+// GetTransactionsPoolForSender returns an empty slice, only to respect the interface
 // CrossTxCache does not support transaction selection (not applicable, since transactions are already half-executed),
 // thus does not handle nonces, nonce gaps etc.
-func (cache *CrossTxCache) GetTransactionsPoolForSender(_ string) [][]byte {
-	return make([][]byte, 0)
-}
-
-// GetLastPoolNonceForSender returns 0 and false, only to respect the intrface
-// CrossTxCache does not support transaction selection (not applicable, since transactions are already half-executed),
-// thus does not handle nonces, nonce gaps etc.
-func (cache *CrossTxCache) GetLastPoolNonceForSender(_ string) (uint64, bool) {
-	return 0, false
+func (cache *CrossTxCache) GetTransactionsPoolForSender(_ string) []*WrappedTransaction {
+	return make([]*WrappedTransaction, 0)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/storage/txcache/crossTxCache_test.go
+++ b/storage/txcache/crossTxCache_test.go
@@ -54,7 +54,7 @@ func TestCrossTxCache_Get(t *testing.T) {
 	require.False(t, ok)
 	require.Nil(t, xTx)
 
-	require.Equal(t, make([][]byte, 0), cache.GetTransactionsPoolForSender(""))
+	require.Equal(t, make([]*WrappedTransaction, 0), cache.GetTransactionsPoolForSender(""))
 }
 
 func newCrossTxCacheToTest(numChunks uint32, maxNumItems uint32, numMaxBytes uint32) *CrossTxCache {

--- a/storage/txcache/crossTxCache_test.go
+++ b/storage/txcache/crossTxCache_test.go
@@ -55,9 +55,6 @@ func TestCrossTxCache_Get(t *testing.T) {
 	require.Nil(t, xTx)
 
 	require.Equal(t, make([][]byte, 0), cache.GetTransactionsPoolForSender(""))
-	lastNonce, ok := cache.GetLastPoolNonceForSender("")
-	require.False(t, ok)
-	require.Equal(t, uint64(0), lastNonce)
 }
 
 func newCrossTxCacheToTest(numChunks uint32, maxNumItems uint32, numMaxBytes uint32) *CrossTxCache {

--- a/storage/txcache/disabledCache.go
+++ b/storage/txcache/disabledCache.go
@@ -118,13 +118,8 @@ func (cache *DisabledCache) Diagnose(_ bool) {
 }
 
 // GetTransactionsPoolForSender returns an empty slice
-func (cache *DisabledCache) GetTransactionsPoolForSender(_ string) [][]byte {
-	return make([][]byte, 0)
-}
-
-// GetLastPoolNonceForSender returns 0 and false
-func (cache *DisabledCache) GetLastPoolNonceForSender(_ string) (uint64, bool) {
-	return 0, false
+func (cache *DisabledCache) GetTransactionsPoolForSender(_ string) []*WrappedTransaction {
+	return make([]*WrappedTransaction, 0)
 }
 
 // Close does nothing

--- a/storage/txcache/disabledCache_test.go
+++ b/storage/txcache/disabledCache_test.go
@@ -63,6 +63,8 @@ func TestDisabledCache_DoesNothing(t *testing.T) {
 	require.NotPanics(t, func() { cache.RegisterHandler(func(_ []byte, _ interface{}) {}, "") })
 	require.False(t, cache.IsInterfaceNil())
 
+	require.Equal(t, make([][]byte, 0), cache.GetTransactionsPoolForSender(""))
+
 	err := cache.Close()
 	require.Nil(t, err)
 }

--- a/storage/txcache/disabledCache_test.go
+++ b/storage/txcache/disabledCache_test.go
@@ -30,7 +30,7 @@ func TestDisabledCache_DoesNothing(t *testing.T) {
 	require.NotPanics(t, func() { cache.ForEachTransaction(func(_ []byte, _ *WrappedTransaction) {}) })
 
 	txs := cache.GetTransactionsPoolForSender("")
-	require.Equal(t, make([][]byte, 0), txs)
+	require.Equal(t, make([]*WrappedTransaction, 0), txs)
 
 	cache.Clear()
 
@@ -62,8 +62,6 @@ func TestDisabledCache_DoesNothing(t *testing.T) {
 
 	require.NotPanics(t, func() { cache.RegisterHandler(func(_ []byte, _ interface{}) {}, "") })
 	require.False(t, cache.IsInterfaceNil())
-
-	require.Equal(t, make([][]byte, 0), cache.GetTransactionsPoolForSender(""))
 
 	err := cache.Close()
 	require.Nil(t, err)

--- a/storage/txcache/txCache.go
+++ b/storage/txcache/txCache.go
@@ -219,35 +219,19 @@ func (cache *TxCache) ForEachTransaction(function ForEachTransaction) {
 }
 
 // GetTransactionsPoolForSender returns the list of transaction hashes for the sender
-func (cache *TxCache) GetTransactionsPoolForSender(sender string) [][]byte {
+func (cache *TxCache) GetTransactionsPoolForSender(sender string) []*WrappedTransaction {
 	listForSender, ok := cache.txListBySender.getListForSender(sender)
 	if !ok {
 		return nil
 	}
 
-	txsHashes := make([][]byte, listForSender.items.Len())
+	wrappedTxs := make([]*WrappedTransaction, listForSender.items.Len())
 	for element, i := listForSender.items.Front(), 0; element != nil; element, i = element.Next(), i+1 {
 		tx := element.Value.(*WrappedTransaction)
-		txsHashes[i] = tx.TxHash
+		wrappedTxs[i] = tx
 	}
 
-	return txsHashes
-}
-
-// GetLastPoolNonceForSender returns the last nonce from pool for the sender
-func (cache *TxCache) GetLastPoolNonceForSender(sender string) (uint64, bool) {
-	listForSender, ok := cache.txListBySender.getListForSender(sender)
-	if !ok {
-		return 0, ok
-	}
-
-	lastTxElement := listForSender.items.Back()
-	lastTx, ok := lastTxElement.Value.(*WrappedTransaction)
-	if !ok {
-		return 0, ok
-	}
-
-	return lastTx.Tx.GetNonce(), ok
+	return wrappedTxs
 }
 
 // Clear clears the cache


### PR DESCRIPTION
##### Changes
- added new endpoint for nonce gaps by sender `"/pool/by-sender/nonce-gaps/:sender"`
- small refactor to remove code duplicate + for further improvements. Now `txCache` returns a slice of entire wrapped transactions which have all the info needed(hashes, nonces, etc)
- now received wrapped txs from all txCaches are merged and sorted on `apiTransactionProcessor`
---
In order to test the changes, the following steps are needed:
1. start a local testnet with this branch
2. clone `elrond-txgen-go` and update the following:
   - in `cmd/txgen/config/config.toml`, leave `Scenarios = ["badNonce"]`, update `ProxyServerURL` with the port that your local proxy uses, optional update `MintingValue` to a smaller one
   - copy from the newly generated `node/config/walletKey.pem`(local testnet) one of the private keys and paste it into `cmd/txgen/config/walletKey.Pem`
   - alter `badNonceSecnario.go` file, `HandleTransaction` method in order to always send bad nonces with gaps(eg. on line 62 you can use `b.sendersMap[tx.Sender] = nonceToUse + 3`)
4. `cd /cmd/txgen`, `go build` and start txgen `./txgen --new-account --num-accounts 10`
5. run ./scripts/badNonce.sh
6. make a Get request to the node: `http://127.0.0.1:node-port/transaction/pool` to get tx pool
7. copy one hash and get the tx details via `http://127.0.0.1:node-port/transaction/your-hash`
8. copy the tx sender and get nonce gaps from this new endpoint: `http://127.0.0.1:node-port/transaction/pool/by-sender/nonce-gaps/your-sender`(if the provided alter example is used, one who tests should see many gaps of 3 nonces)