### PR TITLE
On API, populate field "miniblock.isFromReceiptsStorage".

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ElrondNetwork/concurrent-map v0.1.3
 	github.com/ElrondNetwork/covalent-indexer-go v1.0.6
 	github.com/ElrondNetwork/elastic-indexer-go v1.2.30-rc1
-	github.com/ElrondNetwork/elrond-go-core v1.1.16-0.20220622092812-cc07c736c3b8
+	github.com/ElrondNetwork/elrond-go-core v1.1.16-0.20220628194555-427cd3a134a4
 	github.com/ElrondNetwork/elrond-go-crypto v1.0.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7
 	github.com/ElrondNetwork/elrond-vm-common v1.3.6

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6y
 github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-core v1.1.13/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-core v1.1.14/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
-github.com/ElrondNetwork/elrond-go-core v1.1.16-0.20220622092812-cc07c736c3b8 h1:UlTNy10bAge+b1p12Lq0LeJh/3S8TALZ0DQ8a/bBUBI=
-github.com/ElrondNetwork/elrond-go-core v1.1.16-0.20220622092812-cc07c736c3b8/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
+github.com/ElrondNetwork/elrond-go-core v1.1.16-0.20220628194555-427cd3a134a4 h1:wYjquP13aT+EWw9M4GnTRW74G1eu3d+S+YVmLNT4xwQ=
+github.com/ElrondNetwork/elrond-go-core v1.1.16-0.20220628194555-427cd3a134a4/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.0/go.mod h1:DGiR7/j1xv729Xg8SsjYaUzWXL5svMd44REXjWS/gAc=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.1 h1:xJUUshIZQ7h+rG7Art/9QHVyaPRV1wEjrxXYBdpmRlM=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.1/go.mod h1:uunsvweBrrhVojL8uiQSaTPsl3YIQ9iBqtYGM6xs4s0=

--- a/node/external/blockAPI/baseBlock_test.go
+++ b/node/external/blockAPI/baseBlock_test.go
@@ -93,7 +93,7 @@ func TestBaseBlockGetIntraMiniblocksSCRS(t *testing.T) {
 		},
 	}
 
-	intraMbs, err := baseAPIBlockProc.getIntraMiniblocks(receiptsHash, 0, api.BlockQueryOptions{WithTransactions: true})
+	intraMbs, err := baseAPIBlockProc.getIntrashardMiniblocksFromReceiptsStorage(receiptsHash, 0, api.BlockQueryOptions{WithTransactions: true})
 	require.Nil(t, err)
 	require.Equal(t, &api.MiniBlock{
 		Hash: "7630a217810d1ad3ea67e32dbff0e8f3ea6d970191f03d3c71761b3b60e57b91",
@@ -109,7 +109,8 @@ func TestBaseBlockGetIntraMiniblocksSCRS(t *testing.T) {
 				MiniBlockHash: "7630a217810d1ad3ea67e32dbff0e8f3ea6d970191f03d3c71761b3b60e57b91",
 			},
 		},
-		ProcessingType: block.Normal.String(),
+		ProcessingType:        block.Normal.String(),
+		IsFromReceiptsStorage: true,
 	}, intraMbs[0])
 }
 
@@ -169,7 +170,7 @@ func TestBaseBlockGetIntraMiniblocksReceipts(t *testing.T) {
 		},
 	}
 
-	intraMbs, err := baseAPIBlockProc.getIntraMiniblocks(receiptsHash, 0, api.BlockQueryOptions{WithTransactions: true})
+	intraMbs, err := baseAPIBlockProc.getIntrashardMiniblocksFromReceiptsStorage(receiptsHash, 0, api.BlockQueryOptions{WithTransactions: true})
 	require.Nil(t, err)
 	require.Equal(t, &api.MiniBlock{
 		Hash: "262b3023ca9ba61e90a60932b4db7f8b0d1dec7c2a00261cf0c5d43785f17f6f",
@@ -182,7 +183,8 @@ func TestBaseBlockGetIntraMiniblocksReceipts(t *testing.T) {
 				Value:   big.NewInt(1000),
 			},
 		},
-		ProcessingType: block.Normal.String(),
+		ProcessingType:        block.Normal.String(),
+		IsFromReceiptsStorage: true,
 	}, intraMbs[0])
 }
 

--- a/node/external/blockAPI/metaBlock.go
+++ b/node/external/blockAPI/metaBlock.go
@@ -114,7 +114,7 @@ func (mbp *metaAPIBlockProcessor) convertMetaBlockBytesToAPIBlock(hash []byte, b
 		miniblocks = append(miniblocks, miniblockAPI)
 	}
 
-	intraMb, err := mbp.getIntraMiniblocks(blockHeader.GetReceiptsHash(), headerEpoch, options)
+	intraMb, err := mbp.getIntrashardMiniblocksFromReceiptsStorage(blockHeader.GetReceiptsHash(), headerEpoch, options)
 	if err != nil {
 		return nil, err
 	}

--- a/node/external/blockAPI/shardBlock.go
+++ b/node/external/blockAPI/shardBlock.go
@@ -118,12 +118,14 @@ func (sbp *shardAPIBlockProcessor) convertShardBlockBytesToAPIBlock(hash []byte,
 		miniblocks = append(miniblocks, miniblockAPI)
 	}
 
-	intraMb, err := sbp.getIntraMiniblocks(blockHeader.GetReceiptsHash(), headerEpoch, options)
+	intraMb, err := sbp.getIntrashardMiniblocksFromReceiptsStorage(blockHeader.GetReceiptsHash(), headerEpoch, options)
 	if err != nil {
 		return nil, err
 	}
 
 	miniblocks = append(miniblocks, intraMb...)
+	// QUESTION FOR REVIEW: perhaps do not do any deduplication here, and let clients do it?
+	// (that is, return both the miniblock from header, and the miniblock from receipts storage)
 	miniblocks = filterOutDuplicatedMiniblocks(miniblocks)
 
 	statusFilters := filters.NewStatusFilters(sbp.selfShardID)


### PR DESCRIPTION
On API, inform clients when the miniblock was loaded from the receipts storage (as opposed to being loaded from the block body).