### PR TITLE
Fix github workflow for create release

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -116,6 +116,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           hub release create --draft --message="Release draft from Github Actions" vNext
+          sleep 10
           for i in $(find ./assets -name '*.tgz' -type f); do
             hub release edit --attach=${i} --message="" vNext
           done


### PR DESCRIPTION
On github workflow for create release, sleep 10 seconds between creating the tag and uploading the artifacts.