### PR TITLE
Generate bls key flag

### DIFF
--- a/cmd/node/CLI.md
+++ b/cmd/node/CLI.md
@@ -51,7 +51,7 @@ GLOBAL OPTIONS:
    --num-epochs-to-keep value             This flag represents the number of epochs which will kept in the databases. It is relevant only if the full archive flag is not set. (default: 2)
    --num-active-persisters value          This flag represents the number of databases (1 database = 1 epoch) which are kept open at a moment. It is relevant even if the node is full archive or not. (default: 2)
    --start-in-epoch                       Boolean option for enabling a node the fast bootstrap mechanism from the network.Should be enabled if data is not available in local disk.
-   --generate-key                         Boolean flag for enabling the node to generate a signing key when it starts (if the validatorKey.pem file is present, this flag is not required)
+   --generate-key                         Boolean flag for enabling the node to generate a signing key when it starts (if the validatorKey.pem file is present, setting this flag to true will overwrite the BLS key used by the node)
    --help, -h                             show help
    --version, -v                          print the version
    

--- a/cmd/node/CLI.md
+++ b/cmd/node/CLI.md
@@ -51,7 +51,7 @@ GLOBAL OPTIONS:
    --num-epochs-to-keep value             This flag represents the number of epochs which will kept in the databases. It is relevant only if the full archive flag is not set. (default: 2)
    --num-active-persisters value          This flag represents the number of databases (1 database = 1 epoch) which are kept open at a moment. It is relevant even if the node is full archive or not. (default: 2)
    --start-in-epoch                       Boolean option for enabling a node the fast bootstrap mechanism from the network.Should be enabled if data is not available in local disk.
-   --autogenerate-key                     Boolean flag for enabling the node to generate a signing key when it starts (if is set a BLS key file will be no longer required)   
+   --generate-key                          Boolean flag for enabling the node to generate a signing key when it starts (if is set a BLS key file will be no longer required)   
    --help, -h                             show help
    --version, -v                          print the version
    

--- a/cmd/node/CLI.md
+++ b/cmd/node/CLI.md
@@ -51,7 +51,7 @@ GLOBAL OPTIONS:
    --num-epochs-to-keep value             This flag represents the number of epochs which will kept in the databases. It is relevant only if the full archive flag is not set. (default: 2)
    --num-active-persisters value          This flag represents the number of databases (1 database = 1 epoch) which are kept open at a moment. It is relevant even if the node is full archive or not. (default: 2)
    --start-in-epoch                       Boolean option for enabling a node the fast bootstrap mechanism from the network.Should be enabled if data is not available in local disk.
-   --generate-key                          Boolean flag for enabling the node to generate a signing key when it starts (if is set a BLS key file will be no longer required)   
+   --generate-key                         Boolean flag for enabling the node to generate a signing key when it starts (if is set a BLS key file will be no longer required)   
    --help, -h                             show help
    --version, -v                          print the version
    

--- a/cmd/node/CLI.md
+++ b/cmd/node/CLI.md
@@ -51,6 +51,7 @@ GLOBAL OPTIONS:
    --num-epochs-to-keep value             This flag represents the number of epochs which will kept in the databases. It is relevant only if the full archive flag is not set. (default: 2)
    --num-active-persisters value          This flag represents the number of databases (1 database = 1 epoch) which are kept open at a moment. It is relevant even if the node is full archive or not. (default: 2)
    --start-in-epoch                       Boolean option for enabling a node the fast bootstrap mechanism from the network.Should be enabled if data is not available in local disk.
+   --auto-generate-signing-key            Boolean flag for enabling the node to generate a signing key when it starts (if is set a BLS key file will be no longer required)   
    --help, -h                             show help
    --version, -v                          print the version
    

--- a/cmd/node/CLI.md
+++ b/cmd/node/CLI.md
@@ -51,7 +51,7 @@ GLOBAL OPTIONS:
    --num-epochs-to-keep value             This flag represents the number of epochs which will kept in the databases. It is relevant only if the full archive flag is not set. (default: 2)
    --num-active-persisters value          This flag represents the number of databases (1 database = 1 epoch) which are kept open at a moment. It is relevant even if the node is full archive or not. (default: 2)
    --start-in-epoch                       Boolean option for enabling a node the fast bootstrap mechanism from the network.Should be enabled if data is not available in local disk.
-   --auto-generate-signing-key            Boolean flag for enabling the node to generate a signing key when it starts (if is set a BLS key file will be no longer required)   
+   --autogenerate-key                     Boolean flag for enabling the node to generate a signing key when it starts (if is set a BLS key file will be no longer required)   
    --help, -h                             show help
    --version, -v                          print the version
    

--- a/cmd/node/CLI.md
+++ b/cmd/node/CLI.md
@@ -51,7 +51,7 @@ GLOBAL OPTIONS:
    --num-epochs-to-keep value             This flag represents the number of epochs which will kept in the databases. It is relevant only if the full archive flag is not set. (default: 2)
    --num-active-persisters value          This flag represents the number of databases (1 database = 1 epoch) which are kept open at a moment. It is relevant even if the node is full archive or not. (default: 2)
    --start-in-epoch                       Boolean option for enabling a node the fast bootstrap mechanism from the network.Should be enabled if data is not available in local disk.
-   --generate-key                         Boolean flag for enabling the node to generate a signing key when it starts (if is set a BLS key file will be no longer required)   
+   --generate-key                         Boolean flag for enabling the node to generate a signing key when it starts (if the validatorKey.pem file is present, this flag is not required)
    --help, -h                             show help
    --version, -v                          print the version
    

--- a/cmd/node/CLI.md
+++ b/cmd/node/CLI.md
@@ -51,7 +51,7 @@ GLOBAL OPTIONS:
    --num-epochs-to-keep value             This flag represents the number of epochs which will kept in the databases. It is relevant only if the full archive flag is not set. (default: 2)
    --num-active-persisters value          This flag represents the number of databases (1 database = 1 epoch) which are kept open at a moment. It is relevant even if the node is full archive or not. (default: 2)
    --start-in-epoch                       Boolean option for enabling a node the fast bootstrap mechanism from the network.Should be enabled if data is not available in local disk.
-   --generate-key                         Boolean flag for enabling the node to generate a signing key when it starts (if the validatorKey.pem file is present, setting this flag to true will overwrite the BLS key used by the node)
+   --no-key                               Boolean flag for enabling the node to generate a signing key when it starts (if the validatorKey.pem file is present, setting this flag to true will overwrite the BLS key used by the node)
    --help, -h                             show help
    --version, -v                          print the version
    

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -323,9 +323,9 @@ var (
 			"should not be higher than 20-25% of the machine's available RAM",
 	}
 
-	// autoGenerateSigningKey defines a flag that, if set, will generate every time when node starts a new signing key
-	autoGenerateSigningKey = cli.BoolFlag{
-		Name:  "auto-generate-signing-key",
+	// autoGenerateKey defines a flag that, if set, will generate every time when node starts a new signing key
+	autoGenerateKey = cli.BoolFlag{
+		Name:  "autogenerate-key",
 		Usage: "Boolean flag for enabling the node to generate a signing key when it starts (if is set a BLS key file will be no longer required)",
 	}
 )
@@ -377,7 +377,7 @@ func getFlags() []cli.Flag {
 		fullArchive,
 		memBallast,
 		memoryUsageToCreateProfiles,
-		autoGenerateSigningKey,
+		autoGenerateKey,
 	}
 }
 
@@ -400,7 +400,7 @@ func getFlagsConfig(ctx *cli.Context, log logger.Logger) *config.ContextFlagsCon
 	flagsConfig.EnablePprof = ctx.GlobalBool(profileMode.Name)
 	flagsConfig.UseLogView = ctx.GlobalBool(useLogView.Name)
 	flagsConfig.ValidatorKeyIndex = ctx.GlobalInt(validatorKeyIndex.Name)
-	flagsConfig.AutoGenerateSigningKey = ctx.GlobalBool(autoGenerateSigningKey.Name)
+	flagsConfig.AutoGenerateSigningKey = ctx.GlobalBool(autoGenerateKey.Name)
 
 	return flagsConfig
 }

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -326,7 +326,7 @@ var (
 	// generateKey defines a flag that, if set, will generate every time when node starts a new signing key
 	generateKey = cli.BoolFlag{
 		Name:  "generate-key",
-		Usage: "Boolean flag for enabling the node to generate a signing key when it starts (if is set a BLS key file will be no longer required)",
+		Usage: "Boolean flag for enabling the node to generate a signing key when it starts (if the validatorKey.pem file is present, this flag is not required)",
 	}
 )
 

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -322,6 +322,12 @@ var (
 			"and by advanced users, as a too high memory ballast could lead to Out Of Memory panics. The memory ballast " +
 			"should not be higher than 20-25% of the machine's available RAM",
 	}
+
+	// autoGenerateSigningKey defines a flag that, if set, will generate every time when node starts a new signing key
+	autoGenerateSigningKey = cli.BoolFlag{
+		Name:  "auto-generate-signing-key",
+		Usage: "Boolean flag for enabling the node to generate a signing key when it starts (if is set a BLS key file will be no longer required)",
+	}
 )
 
 func getFlags() []cli.Flag {
@@ -371,6 +377,7 @@ func getFlags() []cli.Flag {
 		fullArchive,
 		memBallast,
 		memoryUsageToCreateProfiles,
+		autoGenerateSigningKey,
 	}
 }
 
@@ -393,6 +400,8 @@ func getFlagsConfig(ctx *cli.Context, log logger.Logger) *config.ContextFlagsCon
 	flagsConfig.EnablePprof = ctx.GlobalBool(profileMode.Name)
 	flagsConfig.UseLogView = ctx.GlobalBool(useLogView.Name)
 	flagsConfig.ValidatorKeyIndex = ctx.GlobalInt(validatorKeyIndex.Name)
+	flagsConfig.AutoGenerateSigningKey = ctx.GlobalBool(autoGenerateSigningKey.Name)
+
 	return flagsConfig
 }
 

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -325,8 +325,9 @@ var (
 
 	// generateKey defines a flag that, if set, will generate every time when node starts a new signing key
 	generateKey = cli.BoolFlag{
-		Name:  "generate-key",
-		Usage: "Boolean flag for enabling the node to generate a signing key when it starts (if the validatorKey.pem file is present, this flag is not required)",
+		Name: "generate-key",
+		Usage: "Boolean flag for enabling the node to generate a signing key when it starts (if the validatorKey.pem" +
+			" file is present, setting this flag to true will overwrite the BLS key used by the node)",
 	}
 )
 

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -323,9 +323,9 @@ var (
 			"should not be higher than 20-25% of the machine's available RAM",
 	}
 
-	// generateKey defines a flag that, if set, will generate every time when node starts a new signing key
-	generateKey = cli.BoolFlag{
-		Name: "generate-key",
+	// noKey defines a flag that, if set, will generate every time when node starts a new signing key
+	noKey = cli.BoolFlag{
+		Name: "no-key",
 		Usage: "Boolean flag for enabling the node to generate a signing key when it starts (if the validatorKey.pem" +
 			" file is present, setting this flag to true will overwrite the BLS key used by the node)",
 	}
@@ -378,7 +378,7 @@ func getFlags() []cli.Flag {
 		fullArchive,
 		memBallast,
 		memoryUsageToCreateProfiles,
-		generateKey,
+		noKey,
 	}
 }
 
@@ -401,7 +401,7 @@ func getFlagsConfig(ctx *cli.Context, log logger.Logger) *config.ContextFlagsCon
 	flagsConfig.EnablePprof = ctx.GlobalBool(profileMode.Name)
 	flagsConfig.UseLogView = ctx.GlobalBool(useLogView.Name)
 	flagsConfig.ValidatorKeyIndex = ctx.GlobalInt(validatorKeyIndex.Name)
-	flagsConfig.GenerateSigningKey = ctx.GlobalBool(generateKey.Name)
+	flagsConfig.NoKeyProvided = ctx.GlobalBool(noKey.Name)
 
 	return flagsConfig
 }

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -323,9 +323,9 @@ var (
 			"should not be higher than 20-25% of the machine's available RAM",
 	}
 
-	// autoGenerateKey defines a flag that, if set, will generate every time when node starts a new signing key
-	autoGenerateKey = cli.BoolFlag{
-		Name:  "autogenerate-key",
+	// generateKey defines a flag that, if set, will generate every time when node starts a new signing key
+	generateKey = cli.BoolFlag{
+		Name:  "generate-key",
 		Usage: "Boolean flag for enabling the node to generate a signing key when it starts (if is set a BLS key file will be no longer required)",
 	}
 )
@@ -377,7 +377,7 @@ func getFlags() []cli.Flag {
 		fullArchive,
 		memBallast,
 		memoryUsageToCreateProfiles,
-		autoGenerateKey,
+		generateKey,
 	}
 }
 
@@ -400,7 +400,7 @@ func getFlagsConfig(ctx *cli.Context, log logger.Logger) *config.ContextFlagsCon
 	flagsConfig.EnablePprof = ctx.GlobalBool(profileMode.Name)
 	flagsConfig.UseLogView = ctx.GlobalBool(useLogView.Name)
 	flagsConfig.ValidatorKeyIndex = ctx.GlobalInt(validatorKeyIndex.Name)
-	flagsConfig.AutoGenerateSigningKey = ctx.GlobalBool(autoGenerateKey.Name)
+	flagsConfig.GenerateSigningKey = ctx.GlobalBool(generateKey.Name)
 
 	return flagsConfig
 }

--- a/config/contextFlagsConfig.go
+++ b/config/contextFlagsConfig.go
@@ -20,7 +20,7 @@ type ContextFlagsConfig struct {
 	ValidatorKeyIndex            int
 	EnableRestAPIServerDebugMode bool
 	Version                      string
-	GenerateSigningKey           bool
+	NoKeyProvided                bool
 }
 
 // ImportDbConfig will hold the import-db parameters

--- a/config/contextFlagsConfig.go
+++ b/config/contextFlagsConfig.go
@@ -20,6 +20,7 @@ type ContextFlagsConfig struct {
 	ValidatorKeyIndex            int
 	EnableRestAPIServerDebugMode bool
 	Version                      string
+	AutoGenerateSigningKey       bool
 }
 
 // ImportDbConfig will hold the import-db parameters

--- a/config/contextFlagsConfig.go
+++ b/config/contextFlagsConfig.go
@@ -20,7 +20,7 @@ type ContextFlagsConfig struct {
 	ValidatorKeyIndex            int
 	EnableRestAPIServerDebugMode bool
 	Version                      string
-	AutoGenerateSigningKey       bool
+	GenerateSigningKey           bool
 }
 
 // ImportDbConfig will hold the import-db parameters

--- a/factory/cryptoComponents.go
+++ b/factory/cryptoComponents.go
@@ -43,7 +43,7 @@ type CryptoComponentsFactoryArgs struct {
 	ActivateBLSPubKeyMessageVerification bool
 	IsInImportMode                       bool
 	ImportModeNoSigCheck                 bool
-	GenerateSigningKey                   bool
+	NoKeyProvided                        bool
 }
 
 type cryptoComponentsFactory struct {
@@ -56,7 +56,7 @@ type cryptoComponentsFactory struct {
 	keyLoader                            KeyLoaderHandler
 	isInImportMode                       bool
 	importModeNoSigCheck                 bool
-	generateSigningKey                   bool
+	noKeyProvided                        bool
 }
 
 // cryptoParams holds the node public/private key data
@@ -102,7 +102,7 @@ func NewCryptoComponentsFactory(args CryptoComponentsFactoryArgs) (*cryptoCompon
 		keyLoader:                            args.KeyLoader,
 		isInImportMode:                       args.IsInImportMode,
 		importModeNoSigCheck:                 args.ImportModeNoSigCheck,
-		generateSigningKey:                   args.GenerateSigningKey,
+		noKeyProvided:                        args.NoKeyProvided,
 	}
 
 	return ccf, nil
@@ -255,7 +255,7 @@ func (ccf *cryptoComponentsFactory) createCryptoParams(
 	keygen crypto.KeyGenerator,
 ) (*cryptoParams, error) {
 
-	shouldGenerateCryptoParams := ccf.isInImportMode || ccf.generateSigningKey
+	shouldGenerateCryptoParams := ccf.isInImportMode || ccf.noKeyProvided
 	if shouldGenerateCryptoParams {
 		return ccf.generateCryptoParams(keygen)
 	}
@@ -295,8 +295,8 @@ func (ccf *cryptoComponentsFactory) readCryptoParams(keygen crypto.KeyGenerator)
 
 func (ccf *cryptoComponentsFactory) generateCryptoParams(keygen crypto.KeyGenerator) (*cryptoParams, error) {
 	var message string
-	if ccf.generateSigningKey {
-		message = "with generate-key flag enabled"
+	if ccf.noKeyProvided {
+		message = "with no-key flag enabled"
 	} else {
 		message = "in import mode"
 	}

--- a/factory/cryptoComponents.go
+++ b/factory/cryptoComponents.go
@@ -43,7 +43,7 @@ type CryptoComponentsFactoryArgs struct {
 	ActivateBLSPubKeyMessageVerification bool
 	IsInImportMode                       bool
 	ImportModeNoSigCheck                 bool
-	AutoGenerateKey                      bool
+	GenerateSigningKey                   bool
 }
 
 type cryptoComponentsFactory struct {
@@ -56,7 +56,7 @@ type cryptoComponentsFactory struct {
 	keyLoader                            KeyLoaderHandler
 	isInImportMode                       bool
 	importModeNoSigCheck                 bool
-	autoGenerateKey                      bool
+	generateSigningKey                   bool
 }
 
 // cryptoParams holds the node public/private key data
@@ -102,7 +102,7 @@ func NewCryptoComponentsFactory(args CryptoComponentsFactoryArgs) (*cryptoCompon
 		keyLoader:                            args.KeyLoader,
 		isInImportMode:                       args.IsInImportMode,
 		importModeNoSigCheck:                 args.ImportModeNoSigCheck,
-		autoGenerateKey:                      args.AutoGenerateKey,
+		generateSigningKey:                   args.GenerateSigningKey,
 	}
 
 	return ccf, nil
@@ -255,7 +255,7 @@ func (ccf *cryptoComponentsFactory) createCryptoParams(
 	keygen crypto.KeyGenerator,
 ) (*cryptoParams, error) {
 
-	shouldGenerateCryptoParams := ccf.isInImportMode || ccf.autoGenerateKey
+	shouldGenerateCryptoParams := ccf.isInImportMode || ccf.generateSigningKey
 	if shouldGenerateCryptoParams {
 		return ccf.generateCryptoParams(keygen)
 	}
@@ -295,8 +295,8 @@ func (ccf *cryptoComponentsFactory) readCryptoParams(keygen crypto.KeyGenerator)
 
 func (ccf *cryptoComponentsFactory) generateCryptoParams(keygen crypto.KeyGenerator) (*cryptoParams, error) {
 	var message string
-	if ccf.autoGenerateKey {
-		message = "with autogenerate-key flag enabled"
+	if ccf.generateSigningKey {
+		message = "with generate-key flag enabled"
 	} else {
 		message = "in import mode"
 	}

--- a/factory/cryptoComponents.go
+++ b/factory/cryptoComponents.go
@@ -39,10 +39,11 @@ type CryptoComponentsFactoryArgs struct {
 	SkIndex                              int
 	Config                               config.Config
 	CoreComponentsHolder                 CoreComponentsHolder
-	ActivateBLSPubKeyMessageVerification bool
 	KeyLoader                            KeyLoaderHandler
+	ActivateBLSPubKeyMessageVerification bool
 	IsInImportMode                       bool
 	ImportModeNoSigCheck                 bool
+	AutoGenerateKey                      bool
 }
 
 type cryptoComponentsFactory struct {
@@ -55,6 +56,7 @@ type cryptoComponentsFactory struct {
 	keyLoader                            KeyLoaderHandler
 	isInImportMode                       bool
 	importModeNoSigCheck                 bool
+	autoGenerateKey                      bool
 }
 
 // cryptoParams holds the node public/private key data
@@ -100,6 +102,7 @@ func NewCryptoComponentsFactory(args CryptoComponentsFactoryArgs) (*cryptoCompon
 		keyLoader:                            args.KeyLoader,
 		isInImportMode:                       args.IsInImportMode,
 		importModeNoSigCheck:                 args.ImportModeNoSigCheck,
+		autoGenerateKey:                      args.AutoGenerateKey,
 	}
 
 	return ccf, nil
@@ -252,7 +255,8 @@ func (ccf *cryptoComponentsFactory) createCryptoParams(
 	keygen crypto.KeyGenerator,
 ) (*cryptoParams, error) {
 
-	if ccf.isInImportMode {
+	shouldGenerateCryptoParams := ccf.isInImportMode || ccf.autoGenerateKey
+	if shouldGenerateCryptoParams {
 		return ccf.generateCryptoParams(keygen)
 	}
 
@@ -290,7 +294,14 @@ func (ccf *cryptoComponentsFactory) readCryptoParams(keygen crypto.KeyGenerator)
 }
 
 func (ccf *cryptoComponentsFactory) generateCryptoParams(keygen crypto.KeyGenerator) (*cryptoParams, error) {
-	log.Warn("the node is in import mode! Will generate a fresh new BLS key")
+	var message string
+	if ccf.autoGenerateKey {
+		message = "with auto-generate-signing-key flag enabled"
+	} else {
+		message = "in import mode"
+	}
+
+	log.Warn(fmt.Sprintf("the node is %s! Will generate a fresh new BLS key", message))
 	cp := &cryptoParams{}
 	cp.privateKey, cp.publicKey = keygen.GeneratePair()
 

--- a/factory/cryptoComponents.go
+++ b/factory/cryptoComponents.go
@@ -296,7 +296,7 @@ func (ccf *cryptoComponentsFactory) readCryptoParams(keygen crypto.KeyGenerator)
 func (ccf *cryptoComponentsFactory) generateCryptoParams(keygen crypto.KeyGenerator) (*cryptoParams, error) {
 	var message string
 	if ccf.autoGenerateKey {
-		message = "with auto-generate-signing-key flag enabled"
+		message = "with autogenerate-key flag enabled"
 	} else {
 		message = "in import mode"
 	}

--- a/factory/cryptoComponents_test.go
+++ b/factory/cryptoComponents_test.go
@@ -184,7 +184,7 @@ func TestCryptoComponentsFactory_CreateWithAutoGenerateKey(t *testing.T) {
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
-	args.GenerateSigningKey = true
+	args.NoKeyProvided = true
 	ccf, _ := factory.NewCryptoComponentsFactory(args)
 
 	cc, err := ccf.Create()

--- a/factory/cryptoComponents_test.go
+++ b/factory/cryptoComponents_test.go
@@ -184,7 +184,7 @@ func TestCryptoComponentsFactory_CreateWithAutoGenerateKey(t *testing.T) {
 
 	coreComponents := getCoreComponents()
 	args := getCryptoArgs(coreComponents)
-	args.AutoGenerateKey = true
+	args.GenerateSigningKey = true
 	ccf, _ := factory.NewCryptoComponentsFactory(args)
 
 	cc, err := ccf.Create()

--- a/factory/cryptoComponents_test.go
+++ b/factory/cryptoComponents_test.go
@@ -176,6 +176,22 @@ func TestCryptoComponentsFactory_CreateWithDisabledSig(t *testing.T) {
 	require.NotNil(t, cc)
 }
 
+func TestCryptoComponentsFactory_CreateWithAutoGenerateKey(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	coreComponents := getCoreComponents()
+	args := getCryptoArgs(coreComponents)
+	args.AutoGenerateKey = true
+	ccf, _ := factory.NewCryptoComponentsFactory(args)
+
+	cc, err := ccf.Create()
+	require.NoError(t, err)
+	require.NotNil(t, cc)
+}
+
 func TestCryptoComponentsFactory_CreateSingleSignerInvalidConsensusTypeShouldErr(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -1301,6 +1301,7 @@ func (nr *nodeRunner) CreateManagedCryptoComponents(
 		KeyLoader:                            &core.KeyLoader{},
 		ImportModeNoSigCheck:                 configs.ImportDbConfig.ImportDbNoSigCheckFlag,
 		IsInImportMode:                       configs.ImportDbConfig.IsImportDBMode,
+		AutoGenerateKey:                      configs.FlagsConfig.AutoGenerateSigningKey,
 	}
 
 	cryptoComponentsFactory, err := mainFactory.NewCryptoComponentsFactory(cryptoComponentsHandlerArgs)

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -1301,7 +1301,7 @@ func (nr *nodeRunner) CreateManagedCryptoComponents(
 		KeyLoader:                            &core.KeyLoader{},
 		ImportModeNoSigCheck:                 configs.ImportDbConfig.ImportDbNoSigCheckFlag,
 		IsInImportMode:                       configs.ImportDbConfig.IsImportDBMode,
-		AutoGenerateKey:                      configs.FlagsConfig.AutoGenerateSigningKey,
+		GenerateSigningKey:                   configs.FlagsConfig.GenerateSigningKey,
 	}
 
 	cryptoComponentsFactory, err := mainFactory.NewCryptoComponentsFactory(cryptoComponentsHandlerArgs)

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -1301,7 +1301,7 @@ func (nr *nodeRunner) CreateManagedCryptoComponents(
 		KeyLoader:                            &core.KeyLoader{},
 		ImportModeNoSigCheck:                 configs.ImportDbConfig.ImportDbNoSigCheckFlag,
 		IsInImportMode:                       configs.ImportDbConfig.IsImportDBMode,
-		GenerateSigningKey:                   configs.FlagsConfig.GenerateSigningKey,
+		NoKeyProvided:                        configs.FlagsConfig.NoKeyProvided,
 	}
 
 	cryptoComponentsFactory, err := mainFactory.NewCryptoComponentsFactory(cryptoComponentsHandlerArgs)


### PR DESCRIPTION
- Added an extra flag `no-key` and if set, the node will generate at the start a new BLS key
- With this flag enabled a file with a BLS key will be no longer required 