### PR TITLE
return empty list if sender is not found in pool for sender

### DIFF
--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -192,7 +192,9 @@ func (atp *apiTransactionProcessor) GetTransactionsPoolForSender(sender, fields 
 	fields = strings.ToLower(fields)
 	wrappedTxs := atp.fetchTxsForSender(string(senderAddr), senderShard)
 	if len(wrappedTxs) == 0 {
-		return nil, fmt.Errorf("%w, no transaction in pool for sender", ErrCannotRetrieveTransactions)
+		return &common.TransactionsPoolForSenderApiResponse{
+			Transactions: []common.Transaction{},
+		}, nil
 	}
 
 	requestedFieldsHandler := newFieldsHandler(fields)
@@ -398,7 +400,7 @@ func (atp *apiTransactionProcessor) fetchLastNonceForSender(sender string, sende
 func (atp *apiTransactionProcessor) extractNonceGaps(sender string, senderShard uint32) ([]common.NonceGapApiResponse, error) {
 	wrappedTxs := atp.fetchTxsForSender(sender, senderShard)
 	if len(wrappedTxs) == 0 {
-		return nil, fmt.Errorf("%w, no transaction in pool for sender", ErrCannotRetrieveTransactions)
+		return []common.NonceGapApiResponse{}, nil
 	}
 
 	nonceGaps := make([]common.NonceGapApiResponse, 0)

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -795,7 +795,7 @@ func TestApiTransactionProcessor_GetTransactionsPoolForSender(t *testing.T) {
 		require.Equal(t, sender, tx.TxFields["sender"])
 	}
 
-	// if no tx if found in pool for a sender, it isn't an error, but return empty slice
+	// if no tx is found in pool for a sender, it isn't an error, but return empty slice
 	newSender := "new-sender"
 	res, err  = atp.GetTransactionsPoolForSender(newSender, "")
 	require.NoError(t, err)
@@ -960,7 +960,7 @@ func TestApiTransactionProcessor_GetTransactionsPoolNonceGapsForSender(t *testin
 	require.NoError(t, err)
 	require.Equal(t, expectedResponse, res)
 
-	// if no tx if found in pool for a sender, it isn't an error, but return empty slice
+	// if no tx is found in pool for a sender, it isn't an error, but return empty slice
 	newSender := "new-sender"
 	res, err  = atp.GetTransactionsPoolNonceGapsForSender(newSender)
 	require.NoError(t, err)

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -794,6 +794,14 @@ func TestApiTransactionProcessor_GetTransactionsPoolForSender(t *testing.T) {
 		require.Equal(t, expectedHashes[i], tx.TxFields[hashField])
 		require.Equal(t, sender, tx.TxFields["sender"])
 	}
+
+	// if no tx if found in pool for a sender, it isn't an error, but return empty slice
+	newSender := "new-sender"
+	res, err  = atp.GetTransactionsPoolForSender(newSender, "")
+	require.NoError(t, err)
+	require.Equal(t, &common.TransactionsPoolForSenderApiResponse{
+		Transactions: []common.Transaction{},
+	}, res)
 }
 
 func TestApiTransactionProcessor_GetLastPoolNonceForSender(t *testing.T) {
@@ -951,6 +959,15 @@ func TestApiTransactionProcessor_GetTransactionsPoolNonceGapsForSender(t *testin
 	res, err := atp.GetTransactionsPoolNonceGapsForSender(sender)
 	require.NoError(t, err)
 	require.Equal(t, expectedResponse, res)
+
+	// if no tx if found in pool for a sender, it isn't an error, but return empty slice
+	newSender := "new-sender"
+	res, err  = atp.GetTransactionsPoolNonceGapsForSender(newSender)
+	require.NoError(t, err)
+	require.Equal(t, &common.TransactionsPoolNonceGapsForSenderApiResponse{
+		Sender: newSender,
+		Gaps: []common.NonceGapApiResponse{},
+	}, res)
 }
 
 func createAPITransactionProc(t *testing.T, epoch uint32, withDbLookupExt bool) (*apiTransactionProcessor, *genericMocks.ChainStorerMock, *dataRetrieverMock.PoolsHolderMock, *dblookupextMock.HistoryRepositoryStub) {


### PR DESCRIPTION
in case no tx is found in the pool for a sender, return an empty slice instead of an error.
not applicable for `last nonce` because `0` would be confusing (`0` vs `null`)