### PR TITLE
Fix indexer warn logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ElrondNetwork/arwen-wasm-vm/v1_4 v1.4.57
 	github.com/ElrondNetwork/concurrent-map v0.1.3
 	github.com/ElrondNetwork/covalent-indexer-go v1.0.6
-	github.com/ElrondNetwork/elastic-indexer-go v1.2.36
+	github.com/ElrondNetwork/elastic-indexer-go v1.2.37-0.20220718113231-d9d8ce7ec3eb
 	github.com/ElrondNetwork/elrond-go-core v1.1.16-0.20220708085217-ccc0c5ac9076
 	github.com/ElrondNetwork/elrond-go-crypto v1.0.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ElrondNetwork/arwen-wasm-vm/v1_4 v1.4.57
 	github.com/ElrondNetwork/concurrent-map v0.1.3
 	github.com/ElrondNetwork/covalent-indexer-go v1.0.6
-	github.com/ElrondNetwork/elastic-indexer-go v1.2.37-0.20220718113231-d9d8ce7ec3eb
+	github.com/ElrondNetwork/elastic-indexer-go v1.2.37
 	github.com/ElrondNetwork/elrond-go-core v1.1.16-0.20220708085217-ccc0c5ac9076
 	github.com/ElrondNetwork/elrond-go-crypto v1.0.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/ElrondNetwork/concurrent-map v0.1.3 h1:j2LtPrNJuerannC1cQDE79STvi/P04
 github.com/ElrondNetwork/concurrent-map v0.1.3/go.mod h1:3XwSwn4JHI0lrKxWLZvtp53Emr8BXYTmNQGwcukHJEE=
 github.com/ElrondNetwork/covalent-indexer-go v1.0.6 h1:+LNKItUc+Pb7WuTbil3VuiLMmdQ1AY7lBJM476PtVNE=
 github.com/ElrondNetwork/covalent-indexer-go v1.0.6/go.mod h1:j3h2g96vqhJAuj3aEX2PWhomae2/o7YfXGEfweNXEeQ=
-github.com/ElrondNetwork/elastic-indexer-go v1.2.37-0.20220718113231-d9d8ce7ec3eb h1:+dJwKtKA8wXvxXqRH9v4w9+twuUvMdzuTjy9BDehD6o=
-github.com/ElrondNetwork/elastic-indexer-go v1.2.37-0.20220718113231-d9d8ce7ec3eb/go.mod h1:w+J48ssy1kxOawG2lwiOUR4JYPA092g8Zjk88kRVDNA=
+github.com/ElrondNetwork/elastic-indexer-go v1.2.37 h1:Z1TBPjFro13lbIUigpdD3RBmddqv2CKKLVX7qN7bv9g=
+github.com/ElrondNetwork/elastic-indexer-go v1.2.37/go.mod h1:w+J48ssy1kxOawG2lwiOUR4JYPA092g8Zjk88kRVDNA=
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-core v1.1.13/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/ElrondNetwork/concurrent-map v0.1.3 h1:j2LtPrNJuerannC1cQDE79STvi/P04
 github.com/ElrondNetwork/concurrent-map v0.1.3/go.mod h1:3XwSwn4JHI0lrKxWLZvtp53Emr8BXYTmNQGwcukHJEE=
 github.com/ElrondNetwork/covalent-indexer-go v1.0.6 h1:+LNKItUc+Pb7WuTbil3VuiLMmdQ1AY7lBJM476PtVNE=
 github.com/ElrondNetwork/covalent-indexer-go v1.0.6/go.mod h1:j3h2g96vqhJAuj3aEX2PWhomae2/o7YfXGEfweNXEeQ=
-github.com/ElrondNetwork/elastic-indexer-go v1.2.36 h1:vUZSa79625HmOYd+HihNKKdQwqHBBROxZR3fIZnY46E=
-github.com/ElrondNetwork/elastic-indexer-go v1.2.36/go.mod h1:w+J48ssy1kxOawG2lwiOUR4JYPA092g8Zjk88kRVDNA=
+github.com/ElrondNetwork/elastic-indexer-go v1.2.37-0.20220718113231-d9d8ce7ec3eb h1:+dJwKtKA8wXvxXqRH9v4w9+twuUvMdzuTjy9BDehD6o=
+github.com/ElrondNetwork/elastic-indexer-go v1.2.37-0.20220718113231-d9d8ce7ec3eb/go.mod h1:w+J48ssy1kxOawG2lwiOUR4JYPA092g8Zjk88kRVDNA=
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-core v1.1.13/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=


### PR DESCRIPTION
- Fixed unnecessary `log.Warn` (elastic indexer) 