### PR TITLE
Remove lastSnapshotStarted if the snapshot finished successfully

### DIFF
--- a/state/accountsDB_test.go
+++ b/state/accountsDB_test.go
@@ -2383,6 +2383,9 @@ func TestAccountsDB_NewAccountsDbStartsSnapshotAfterRestart(t *testing.T) {
 				TakeSnapshotCalled: func(_ []byte, _ []byte, _ chan core.KeyValueHolder, _ chan error, _ common.SnapshotStatisticsHandler, _ uint32) {
 					takeSnapshotCalled.SetValue(true)
 				},
+				GetLatestStorageEpochCalled: func() (uint32, error) {
+					return 1, nil
+				},
 			}
 		},
 	}

--- a/state/peerAccountsDB_test.go
+++ b/state/peerAccountsDB_test.go
@@ -213,6 +213,9 @@ func TestPeerAccountsDB_NewAccountsDbStartsSnapshotAfterRestart(t *testing.T) {
 					takeSnapshotCalled = true
 					mutex.Unlock()
 				},
+				GetLatestStorageEpochCalled: func() (uint32, error) {
+					return 1, nil
+				},
 			}
 		},
 	}


### PR DESCRIPTION
If a snapshot finished successfully, remove lastSnapshotStarted from storage in order to prevent a new snapshot for the same rootHash if the node restarts.