### PR TITLE
[FIX]Heartbeat v2 integration with the hardfork trigger

### DIFF
--- a/heartbeat/sender/routineHandler.go
+++ b/heartbeat/sender/routineHandler.go
@@ -52,10 +52,20 @@ func (handler *routineHandler) processLoop(ctx context.Context) {
 			handler.heartbeatSender.Execute()
 		case <-handler.hardforkSender.ShouldTriggerHardfork():
 			handler.hardforkSender.Execute()
-			time.Sleep(handler.delayAfterHardforkMessageBroadcast)
+			handler.waitAfterHarforkBroadcast(ctx)
 		case <-ctx.Done():
 			return
 		}
+	}
+}
+
+func (handler *routineHandler) waitAfterHarforkBroadcast(ctx context.Context) {
+	timer := time.NewTimer(handler.delayAfterHardforkMessageBroadcast)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
 	}
 }
 

--- a/heartbeat/sender/routineHandler_test.go
+++ b/heartbeat/sender/routineHandler_test.go
@@ -48,7 +48,8 @@ func TestRoutineHandler_ShouldWork(t *testing.T) {
 			},
 		}
 
-		_ = newRoutineHandler(handler1, handler2, handler3)
+		handler := newRoutineHandler(handler1, handler2, handler3)
+		handler.delayAfterHardforkMessageBroadcast = time.Second
 		time.Sleep(time.Second) // wait for the go routine start
 
 		assert.Equal(t, uint32(1), atomic.LoadUint32(&numExecuteCalled1)) // initial call
@@ -67,7 +68,7 @@ func TestRoutineHandler_ShouldWork(t *testing.T) {
 			ch3 <- struct{}{}
 		}()
 
-		time.Sleep(time.Second) // wait for the iteration
+		time.Sleep(time.Second * 3) // wait for the iteration
 
 		assert.Equal(t, uint32(2), atomic.LoadUint32(&numExecuteCalled1))
 		assert.Equal(t, uint32(2), atomic.LoadUint32(&numExecuteCalled2))


### PR DESCRIPTION
Fixed the heartbeat v2 integration with the hardfork trigger by adding an extra blocking time.sleep when the trigger is activated. This will prevent the continuous re-entry on the `Execute` function which will raise havoc at the p2p level (high amount of messages sent)