### PR TITLE
[FIX]Added a disabled peer authentication resolver in import-db mode

### DIFF
--- a/dataRetriever/factory/storageResolversContainer/baseResolversContainerFactory.go
+++ b/dataRetriever/factory/storageResolversContainer/baseResolversContainerFactory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/common/disabled"
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
+	disabledResolvers "github.com/ElrondNetwork/elrond-go/dataRetriever/resolvers/disabled"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/storageResolvers"
 	"github.com/ElrondNetwork/elrond-go/process/factory"
 	"github.com/ElrondNetwork/elrond-go/sharding"
@@ -224,4 +225,11 @@ func (brcf *baseResolversContainerFactory) newImportDBTrieStorage(
 		IdleProvider:       disabled.NewProcessStatusHandler(),
 	}
 	return trieFactoryInstance.Create(args)
+}
+
+func (brcf *baseResolversContainerFactory) generatePeerAuthenticationResolver() error {
+	identifierPeerAuth := common.PeerAuthenticationTopic
+	peerAuthResolver := disabledResolvers.NewDisabledPeerAuthenticatorResolver()
+
+	return brcf.container.Add(identifierPeerAuth, peerAuthResolver)
 }

--- a/dataRetriever/factory/storageResolversContainer/metaResolversContainerFactory.go
+++ b/dataRetriever/factory/storageResolversContainer/metaResolversContainerFactory.go
@@ -94,10 +94,15 @@ func (mrcf *metaResolversContainerFactory) Create() (dataRetriever.ResolversCont
 		return nil, err
 	}
 
+	err = mrcf.generatePeerAuthenticationResolver()
+	if err != nil {
+		return nil, err
+	}
+
 	return mrcf.container, nil
 }
 
-//------- Shard header resolvers
+// ------- Shard header resolvers
 
 func (mrcf *metaResolversContainerFactory) generateShardHeaderResolvers() error {
 	shardC := mrcf.shardCoordinator
@@ -105,7 +110,7 @@ func (mrcf *metaResolversContainerFactory) generateShardHeaderResolvers() error 
 	keys := make([]string, noOfShards)
 	resolversSlice := make([]dataRetriever.Resolver, noOfShards)
 
-	//wire up to topics: shardBlocks_0_META, shardBlocks_1_META ...
+	// wire up to topics: shardBlocks_0_META, shardBlocks_1_META ...
 	for idx := uint32(0); idx < noOfShards; idx++ {
 		identifierHeader := factory.ShardBlocksTopic + shardC.CommunicationIdentifier(idx)
 		resolver, err := mrcf.createShardHeaderResolver(identifierHeader, idx)
@@ -126,7 +131,7 @@ func (mrcf *metaResolversContainerFactory) createShardHeaderResolver(
 ) (dataRetriever.Resolver, error) {
 	hdrStorer := mrcf.store.GetStorer(dataRetriever.BlockHeaderUnit)
 
-	//TODO change this data unit creation method through a factory or func
+	// TODO change this data unit creation method through a factory or func
 	hdrNonceHashDataUnit := dataRetriever.ShardHdrNonceHashDataUnit + dataRetriever.UnitType(shardID)
 	hdrNonceStore := mrcf.store.GetStorer(hdrNonceHashDataUnit)
 	arg := storageResolvers.ArgHeaderResolver{
@@ -147,7 +152,7 @@ func (mrcf *metaResolversContainerFactory) createShardHeaderResolver(
 	return resolver, nil
 }
 
-//------- Meta header resolvers
+// ------- Meta header resolvers
 
 func (mrcf *metaResolversContainerFactory) generateMetaChainHeaderResolvers() error {
 	identifierHeader := factory.MetachainBlocksTopic
@@ -252,7 +257,7 @@ func (mrcf *metaResolversContainerFactory) generateRewardsResolvers(
 	keys := make([]string, noOfShards)
 	resolverSlice := make([]dataRetriever.Resolver, noOfShards)
 
-	//wire up to topics: shardBlocks_0_META, shardBlocks_1_META ...
+	// wire up to topics: shardBlocks_0_META, shardBlocks_1_META ...
 	for idx := uint32(0); idx < noOfShards; idx++ {
 		identifierTx := topic + shardC.CommunicationIdentifier(idx)
 		resolver, err := mrcf.createTxResolver(identifierTx, unit)

--- a/dataRetriever/factory/storageResolversContainer/metaResolversContainerFactory_test.go
+++ b/dataRetriever/factory/storageResolversContainer/metaResolversContainerFactory_test.go
@@ -54,7 +54,7 @@ func createStoreForMeta() dataRetriever.StorageService {
 	}
 }
 
-//------- NewResolversContainerFactory
+// ------- NewResolversContainerFactory
 
 func TestNewMetaResolversContainerFactory_NilShardCoordinatorShouldErr(t *testing.T) {
 	t.Parallel()
@@ -132,7 +132,7 @@ func TestNewMetaResolversContainerFactory_ShouldWork(t *testing.T) {
 	assert.False(t, check.IfNil(rcf))
 }
 
-//------- Create
+// ------- Create
 
 func TestMetaResolversContainerFactory_CreateShouldWork(t *testing.T) {
 	t.Parallel()
@@ -169,8 +169,9 @@ func TestMetaResolversContainerFactory_With4ShardsShouldWork(t *testing.T) {
 	numResolversRewards := noOfShards
 	numResolversTxs := noOfShards + 1
 	numResolversTrieNodes := 2
+	numPeerAuthentication := 1
 	totalResolvers := numResolversShardHeadersForMetachain + numResolverMetablocks + numResolversMiniBlocks +
-		numResolversUnsigned + numResolversTxs + numResolversTrieNodes + numResolversRewards
+		numResolversUnsigned + numResolversTxs + numResolversTrieNodes + numResolversRewards + numPeerAuthentication
 
 	assert.Equal(t, totalResolvers, container.Len())
 	assert.Equal(t, totalResolvers, container.Len())

--- a/dataRetriever/factory/storageResolversContainer/shardResolversContainerFactory.go
+++ b/dataRetriever/factory/storageResolversContainer/shardResolversContainerFactory.go
@@ -94,15 +94,20 @@ func (srcf *shardResolversContainerFactory) Create() (dataRetriever.ResolversCon
 		return nil, err
 	}
 
+	err = srcf.generatePeerAuthenticationResolver()
+	if err != nil {
+		return nil, err
+	}
+
 	return srcf.container, nil
 }
 
-//------- Hdr resolver
+// ------- Hdr resolver
 
 func (srcf *shardResolversContainerFactory) generateHeaderResolvers() error {
 	shardC := srcf.shardCoordinator
 
-	//only one shard header topic, for example: shardBlocks_0_META
+	// only one shard header topic, for example: shardBlocks_0_META
 	identifierHdr := factory.ShardBlocksTopic + shardC.CommunicationIdentifier(core.MetachainShardId)
 
 	hdrStorer := srcf.store.GetStorer(dataRetriever.BlockHeaderUnit)
@@ -127,11 +132,11 @@ func (srcf *shardResolversContainerFactory) generateHeaderResolvers() error {
 	return srcf.container.Add(identifierHdr, resolver)
 }
 
-//------- MetaBlockHeaderResolvers
+// ------- MetaBlockHeaderResolvers
 
 func (srcf *shardResolversContainerFactory) generateMetablockHeaderResolvers() error {
-	//only one metachain header block topic
-	//this is: metachainBlocks
+	// only one metachain header block topic
+	// this is: metachainBlocks
 	identifierHdr := factory.MetachainBlocksTopic
 	hdrStorer := srcf.store.GetStorer(dataRetriever.MetaBlockUnit)
 

--- a/dataRetriever/factory/storageResolversContainer/shardResolversContainerFactory_test.go
+++ b/dataRetriever/factory/storageResolversContainer/shardResolversContainerFactory_test.go
@@ -58,7 +58,7 @@ func createStoreForShard() dataRetriever.StorageService {
 	}
 }
 
-//------- NewResolversContainerFactory
+// ------- NewResolversContainerFactory
 
 func TestNewShardResolversContainerFactory_NilShardCoordinatorShouldErr(t *testing.T) {
 	t.Parallel()
@@ -137,7 +137,7 @@ func TestNewShardResolversContainerFactory_ShouldWork(t *testing.T) {
 	require.False(t, rcf.IsInterfaceNil())
 }
 
-//------- Create
+// ------- Create
 
 func TestShardResolversContainerFactory_CreateShouldWork(t *testing.T) {
 	t.Parallel()
@@ -173,8 +173,9 @@ func TestShardResolversContainerFactory_With4ShardsShouldWork(t *testing.T) {
 	numResolverMiniBlocks := noOfShards + 2
 	numResolverMetaBlockHeaders := 1
 	numResolverTrieNodes := 1
+	numPeerAuthentication := 1
 	totalResolvers := numResolverTxs + numResolverHeaders + numResolverMiniBlocks +
-		numResolverMetaBlockHeaders + numResolverSCRs + numResolverRewardTxs + numResolverTrieNodes
+		numResolverMetaBlockHeaders + numResolverSCRs + numResolverRewardTxs + numResolverTrieNodes + numPeerAuthentication
 
 	assert.Equal(t, totalResolvers, container.Len())
 }

--- a/dataRetriever/resolvers/disabled/peerAuthenticationResolver.go
+++ b/dataRetriever/resolvers/disabled/peerAuthenticationResolver.go
@@ -1,0 +1,59 @@
+package disabled
+
+import (
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
+	"github.com/ElrondNetwork/elrond-go/p2p"
+)
+
+type peerAuthenticatorResolver struct {
+}
+
+// NewDisabledPeerAuthenticatorResolver creates a new disabled peer authentication resolver instance
+func NewDisabledPeerAuthenticatorResolver() *peerAuthenticatorResolver {
+	return &peerAuthenticatorResolver{}
+}
+
+// RequestDataFromHash does nothing and returns nil
+func (res *peerAuthenticatorResolver) RequestDataFromHash(_ []byte, _ uint32) error {
+	return nil
+}
+
+// RequestDataFromChunk does nothing and returns nil
+func (res *peerAuthenticatorResolver) RequestDataFromChunk(_ uint32, _ uint32) error {
+	return nil
+}
+
+// RequestDataFromHashArray does nothing and returns nil
+func (res *peerAuthenticatorResolver) RequestDataFromHashArray(_ [][]byte, _ uint32) error {
+	return nil
+}
+
+// ProcessReceivedMessage does nothing and returns nil
+func (res *peerAuthenticatorResolver) ProcessReceivedMessage(_ p2p.MessageP2P, _ core.PeerID) error {
+	return nil
+}
+
+// SetResolverDebugHandler does nothing and returns nil
+func (res *peerAuthenticatorResolver) SetResolverDebugHandler(_ dataRetriever.ResolverDebugHandler) error {
+	return nil
+}
+
+// SetNumPeersToQuery does nothing
+func (res *peerAuthenticatorResolver) SetNumPeersToQuery(_ int, _ int) {
+}
+
+// NumPeersToQuery returns 0 and 0
+func (res *peerAuthenticatorResolver) NumPeersToQuery() (int, int) {
+	return 0, 0
+}
+
+// Close does nothing and returns nil
+func (res *peerAuthenticatorResolver) Close() error {
+	return nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (res *peerAuthenticatorResolver) IsInterfaceNil() bool {
+	return res == nil
+}

--- a/dataRetriever/resolvers/disabled/peerAuthenticatorResolver_test.go
+++ b/dataRetriever/resolvers/disabled/peerAuthenticatorResolver_test.go
@@ -1,0 +1,53 @@
+package disabled
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDisabledPeerAuthenticatorResolver(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewDisabledPeerAuthenticatorResolver()
+	assert.False(t, check.IfNil(resolver))
+}
+
+func TestPeerAuthenticatorResolver_MethodsShouldNotPanicAndReturnNil(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		r := recover()
+		if r != nil {
+			assert.Fail(t, fmt.Sprintf("should have not failed %v", r))
+		}
+	}()
+
+	resolver := NewDisabledPeerAuthenticatorResolver()
+
+	err := resolver.RequestDataFromChunk(0, 0)
+	assert.Nil(t, err)
+
+	err = resolver.ProcessReceivedMessage(nil, "")
+	assert.Nil(t, err)
+
+	err = resolver.RequestDataFromHash(nil, 0)
+	assert.Nil(t, err)
+
+	err = resolver.RequestDataFromHashArray(nil, 0)
+	assert.Nil(t, err)
+
+	err = resolver.SetResolverDebugHandler(nil)
+	assert.Nil(t, err)
+
+	value1, value2 := resolver.NumPeersToQuery()
+	assert.Zero(t, value1)
+	assert.Zero(t, value2)
+
+	err = resolver.Close()
+	assert.Nil(t, err)
+
+	resolver.SetNumPeersToQuery(100, 100)
+}


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- added a disabled peer authentication resolver when the node is running in import-db mode to avoid the benign error messages like:
```
ERROR[2022-07-26 13:51:57.318]   RequestPeerAuthenticationsChunk.MetaChainResolver error = element does not exist in container in resolvers container for key peerAuthentication topic = peerAuthentication shard = 0 chunk = 13 epoch = 301
```
  
## Proposed Changes
- added a new disabled resolver in order to avoid the error signaled by the requestHandler component 

## Testing procedure
- standard internal testnet procedure and re-run the import-db process and validate that the aforementioned error does not appear
