### PR TITLE
Disabled validator info resolver on storage resolvers factory

### DIFF
--- a/dataRetriever/factory/storageResolversContainer/baseResolversContainerFactory.go
+++ b/dataRetriever/factory/storageResolversContainer/baseResolversContainerFactory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/common/disabled"
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
+	disabledResolvers "github.com/ElrondNetwork/elrond-go/dataRetriever/resolvers/disabled"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/storageResolvers"
 	"github.com/ElrondNetwork/elrond-go/process/factory"
 	"github.com/ElrondNetwork/elrond-go/sharding"
@@ -224,4 +225,11 @@ func (brcf *baseResolversContainerFactory) newImportDBTrieStorage(
 		IdleProvider:       disabled.NewProcessStatusHandler(),
 	}
 	return trieFactoryInstance.Create(args)
+}
+
+func (brcf *baseResolversContainerFactory) generateValidatorInfoResolver() error {
+	identifierValidatorInfo := common.ValidatorInfoTopic
+	validatorInfoResolver := disabledResolvers.NewDisabledValidatorInfoResolver()
+
+	return brcf.container.Add(identifierValidatorInfo, validatorInfoResolver)
 }

--- a/dataRetriever/factory/storageResolversContainer/metaResolversContainerFactory.go
+++ b/dataRetriever/factory/storageResolversContainer/metaResolversContainerFactory.go
@@ -94,6 +94,11 @@ func (mrcf *metaResolversContainerFactory) Create() (dataRetriever.ResolversCont
 		return nil, err
 	}
 
+	err = mrcf.generateValidatorInfoResolver()
+	if err != nil {
+		return nil, err
+	}
+
 	return mrcf.container, nil
 }
 

--- a/dataRetriever/factory/storageResolversContainer/metaResolversContainerFactory_test.go
+++ b/dataRetriever/factory/storageResolversContainer/metaResolversContainerFactory_test.go
@@ -169,8 +169,9 @@ func TestMetaResolversContainerFactory_With4ShardsShouldWork(t *testing.T) {
 	numResolversRewards := noOfShards
 	numResolversTxs := noOfShards + 1
 	numResolversTrieNodes := 2
+	numValidatorInfo := 1
 	totalResolvers := numResolversShardHeadersForMetachain + numResolverMetablocks + numResolversMiniBlocks +
-		numResolversUnsigned + numResolversTxs + numResolversTrieNodes + numResolversRewards
+		numResolversUnsigned + numResolversTxs + numResolversTrieNodes + numResolversRewards + numValidatorInfo
 
 	assert.Equal(t, totalResolvers, container.Len())
 	assert.Equal(t, totalResolvers, container.Len())

--- a/dataRetriever/factory/storageResolversContainer/shardResolversContainerFactory.go
+++ b/dataRetriever/factory/storageResolversContainer/shardResolversContainerFactory.go
@@ -94,6 +94,11 @@ func (srcf *shardResolversContainerFactory) Create() (dataRetriever.ResolversCon
 		return nil, err
 	}
 
+	err = srcf.generateValidatorInfoResolver()
+	if err != nil {
+		return nil, err
+	}
+
 	return srcf.container, nil
 }
 

--- a/dataRetriever/factory/storageResolversContainer/shardResolversContainerFactory_test.go
+++ b/dataRetriever/factory/storageResolversContainer/shardResolversContainerFactory_test.go
@@ -173,8 +173,10 @@ func TestShardResolversContainerFactory_With4ShardsShouldWork(t *testing.T) {
 	numResolverMiniBlocks := noOfShards + 2
 	numResolverMetaBlockHeaders := 1
 	numResolverTrieNodes := 1
+	numValidatorInfo := 1
 	totalResolvers := numResolverTxs + numResolverHeaders + numResolverMiniBlocks +
-		numResolverMetaBlockHeaders + numResolverSCRs + numResolverRewardTxs + numResolverTrieNodes
+		numResolverMetaBlockHeaders + numResolverSCRs + numResolverRewardTxs +
+		numResolverTrieNodes + numValidatorInfo
 
 	assert.Equal(t, totalResolvers, container.Len())
 }

--- a/dataRetriever/resolvers/disabled/validatorInfoResolver.go
+++ b/dataRetriever/resolvers/disabled/validatorInfoResolver.go
@@ -1,0 +1,54 @@
+package disabled
+
+import (
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
+	"github.com/ElrondNetwork/elrond-go/p2p"
+)
+
+type validatorInfoResolver struct {
+}
+
+// NewDisabledValidatorInfoResolver creates a new disabled validator info resolver instance
+func NewDisabledValidatorInfoResolver() *validatorInfoResolver {
+	return &validatorInfoResolver{}
+}
+
+// RequestDataFromHash does nothing and returns nil
+func (res *validatorInfoResolver) RequestDataFromHash(_ []byte, _ uint32) error {
+	return nil
+}
+
+// RequestDataFromHashArray does nothing and returns nil
+func (res *validatorInfoResolver) RequestDataFromHashArray(_ [][]byte, _ uint32) error {
+	return nil
+}
+
+// ProcessReceivedMessage does nothing and returns nil
+func (res *validatorInfoResolver) ProcessReceivedMessage(_ p2p.MessageP2P, _ core.PeerID) error {
+	return nil
+}
+
+// SetResolverDebugHandler does nothing and returns nil
+func (res *validatorInfoResolver) SetResolverDebugHandler(_ dataRetriever.ResolverDebugHandler) error {
+	return nil
+}
+
+// SetNumPeersToQuery does nothing
+func (res *validatorInfoResolver) SetNumPeersToQuery(_ int, _ int) {
+}
+
+// NumPeersToQuery returns 0 and 0
+func (res *validatorInfoResolver) NumPeersToQuery() (int, int) {
+	return 0, 0
+}
+
+// Close does nothing and returns nil
+func (res *validatorInfoResolver) Close() error {
+	return nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (res *validatorInfoResolver) IsInterfaceNil() bool {
+	return res == nil
+}

--- a/dataRetriever/resolvers/disabled/validatorInfoResolver_test.go
+++ b/dataRetriever/resolvers/disabled/validatorInfoResolver_test.go
@@ -1,0 +1,47 @@
+package disabled
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDisabledValidatorInfoResolver(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewDisabledValidatorInfoResolver()
+	assert.False(t, check.IfNil(resolver))
+}
+
+func Test_validatorInfoResolver_SetResolverDebugHandler(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		r := recover()
+		if r != nil {
+			assert.Fail(t, fmt.Sprintf("should have not failed %v", r))
+		}
+	}()
+
+	resolver := NewDisabledValidatorInfoResolver()
+
+	err := resolver.RequestDataFromHash(nil, 0)
+	assert.Nil(t, err)
+
+	err = resolver.RequestDataFromHashArray(nil, 0)
+	assert.Nil(t, err)
+
+	err = resolver.SetResolverDebugHandler(nil)
+	assert.Nil(t, err)
+
+	value1, value2 := resolver.NumPeersToQuery()
+	assert.Zero(t, value1)
+	assert.Zero(t, value2)
+
+	err = resolver.Close()
+	assert.Nil(t, err)
+
+	resolver.SetNumPeersToQuery(100, 100)
+}


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- missing resolver creation on storage resolvers factory causing resolver not found on import-db
  
## Proposed Changes
- added disabled validator info resolver to avoid error on requestHandler

## Testing procedure
- standard internal testnet procedure and run the import-db process
