### PR TITLE
Fixed import-db

### DIFF
--- a/epochStart/metachain/epochStartData.go
+++ b/epochStart/metachain/epochStartData.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/epochStart"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/sharding"
+	"github.com/davecgh/go-spew/spew"
 )
 
 var _ process.EpochStartDataCreator = (*epochStartData)(nil)
@@ -106,11 +107,8 @@ func (e *epochStartData) VerifyEpochStartDataForMetablock(metaBlock *block.MetaB
 	}
 
 	if !bytes.Equal(receivedEpochStartHash, createdEpochStartHash) {
-		log.Warn("RECEIVED epoch start data")
-		displayEpochStartData(&metaBlock.EpochStart)
-
-		log.Warn("CREATED epoch start data")
-		displayEpochStartData(startData)
+		displayEpochStartData("received", receivedEpochStartHash, &metaBlock.EpochStart)
+		displayEpochStartData("created", createdEpochStartHash, startData)
 
 		return process.ErrEpochStartDataDoesNotMatch
 	}
@@ -118,9 +116,12 @@ func (e *epochStartData) VerifyEpochStartDataForMetablock(metaBlock *block.MetaB
 	return nil
 }
 
-func displayEpochStartData(startData *block.EpochStart) {
+func displayEpochStartData(mode string, hash []byte, startData *block.EpochStart) {
+	log.Warn(mode+" epoch start data",
+		"hash", hash, "startData", spew.Sdump(startData))
+
 	for _, shardData := range startData.LastFinalizedHeaders {
-		log.Debug("epoch start shard data",
+		log.Warn("epoch start shard data",
 			"shardID", shardData.ShardID,
 			"num pending miniblocks", len(shardData.PendingMiniBlockHeaders),
 			"first pending meta", shardData.FirstPendingMetaBlock,

--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -163,7 +163,8 @@ func startSnapshotAfterRestart(adb AccountsAdapter, args ArgsAccountsDB) {
 		log.Error("could not get latest storage epoch")
 	}
 	putActiveDBMarker := epoch == 0 && err == nil
-	putActiveDBMarker = putActiveDBMarker || args.ProcessingMode == common.ImportDb
+	isInImportDBMode := args.ProcessingMode == common.ImportDb
+	putActiveDBMarker = putActiveDBMarker || isInImportDBMode
 	if putActiveDBMarker {
 		log.Debug("marking activeDB", "epoch", epoch, "error", err, "processing mode", args.ProcessingMode)
 		err = tsm.Put([]byte(common.ActiveDBKey), []byte(common.ActiveDBVal))

--- a/state/peerAccountsDB.go
+++ b/state/peerAccountsDB.go
@@ -42,7 +42,7 @@ func NewPeerAccountsDB(args ArgsAccountsDB) (*PeerAccountsDB, error) {
 	trieStorageManager := adb.mainTrie.GetStorageManager()
 	val, err := trieStorageManager.GetFromCurrentEpoch([]byte(common.ActiveDBKey))
 	if err != nil || !bytes.Equal(val, []byte(common.ActiveDBVal)) {
-		startSnapshotAfterRestart(adb, trieStorageManager)
+		startSnapshotAfterRestart(adb, args)
 	}
 
 	return adb, nil

--- a/state/peerAccountsDB_test.go
+++ b/state/peerAccountsDB_test.go
@@ -321,6 +321,104 @@ func TestPeerAccountsDB_MarkSnapshotDone(t *testing.T) {
 
 }
 
+func TestPeerAccountsDB_NewAccountsDbShouldSetActiveDB(t *testing.T) {
+	t.Parallel()
+
+	rootHash := []byte("rootHash")
+	expectedErr := errors.New("expected error")
+	t.Run("epoch 0", func(t *testing.T) {
+		putCalled := false
+		trieStub := &trieMock.TrieStub{
+			RootCalled: func() ([]byte, error) {
+				return rootHash, nil
+			},
+			GetStorageManagerCalled: func() common.StorageManager {
+				return &testscommon.StorageManagerStub{
+					ShouldTakeSnapshotCalled: func() bool {
+						return true
+					},
+					GetLatestStorageEpochCalled: func() (uint32, error) {
+						return 0, nil
+					},
+					PutCalled: func(key []byte, val []byte) error {
+						assert.Equal(t, []byte(common.ActiveDBKey), key)
+						assert.Equal(t, []byte(common.ActiveDBVal), val)
+
+						putCalled = true
+
+						return nil
+					},
+				}
+			},
+		}
+
+		args := createMockAccountsDBArgs()
+		args.Trie = trieStub
+		_, _ = state.NewPeerAccountsDB(args)
+
+		assert.True(t, putCalled)
+	})
+	t.Run("epoch 0, GetLatestStorageEpoch errors should not put", func(t *testing.T) {
+		trieStub := &trieMock.TrieStub{
+			RootCalled: func() ([]byte, error) {
+				return rootHash, nil
+			},
+			GetStorageManagerCalled: func() common.StorageManager {
+				return &testscommon.StorageManagerStub{
+					ShouldTakeSnapshotCalled: func() bool {
+						return true
+					},
+					GetLatestStorageEpochCalled: func() (uint32, error) {
+						return 0, expectedErr
+					},
+					PutCalled: func(key []byte, val []byte) error {
+						assert.Fail(t, "should have not called put")
+
+						return nil
+					},
+				}
+			},
+		}
+
+		args := createMockAccountsDBArgs()
+		args.Trie = trieStub
+		_, _ = state.NewPeerAccountsDB(args)
+	})
+	t.Run("in import DB mode", func(t *testing.T) {
+		putCalled := false
+		trieStub := &trieMock.TrieStub{
+			RootCalled: func() ([]byte, error) {
+				return rootHash, nil
+			},
+			GetStorageManagerCalled: func() common.StorageManager {
+				return &testscommon.StorageManagerStub{
+					ShouldTakeSnapshotCalled: func() bool {
+						return true
+					},
+					GetLatestStorageEpochCalled: func() (uint32, error) {
+						return 1, nil
+					},
+					PutCalled: func(key []byte, val []byte) error {
+						assert.Equal(t, []byte(common.ActiveDBKey), key)
+						assert.Equal(t, []byte(common.ActiveDBVal), val)
+
+						putCalled = true
+
+						return nil
+					},
+				}
+			},
+		}
+
+		args := createMockAccountsDBArgs()
+		args.ProcessingMode = common.ImportDb
+		args.Trie = trieStub
+		_, _ = state.NewPeerAccountsDB(args)
+
+		assert.True(t, putCalled)
+	})
+}
+
 func TestPeerAccountsDB_SnapshotStateOnAClosedStorageManagerShouldNotMarkActiveDB(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- there was a bug in the import-db process if we have used the old version of DBs that did not contain the `ActiveDB` marker. The versions <=1.3.36 did not care about it as it would have re-written anyway that marker and the snapshotting process worked as expected. With the rc/2022-july branch, a new condition appeared as to write the marker only on epoch 0;
- some prints regarding the wrong epoch data were not in line with the rest of the project, refactored the prints for better debugging experience.
  
## Proposed Changes
- add a composed condition in which, we take for granted in `import-db` process that the DB is correctly constructed as to reuse the old trie databases.

## Testing procedure
- `import-db` process should work as expected, without ERRORs or WARNs;
- internal testing scenarios should work.
