### PR TITLE
added backwardsCompatibility for partialExecution on epochStartData

### DIFF
--- a/epochStart/metachain/epochStartData.go
+++ b/epochStart/metachain/epochStartData.go
@@ -19,28 +19,30 @@ import (
 var _ process.EpochStartDataCreator = (*epochStartData)(nil)
 
 type epochStartData struct {
-	marshalizer       marshal.Marshalizer
-	hasher            hashing.Hasher
-	store             dataRetriever.StorageService
-	dataPool          dataRetriever.PoolsHolder
-	blockTracker      process.BlockTracker
-	shardCoordinator  sharding.Coordinator
-	epochStartTrigger process.EpochStartTriggerHandler
-	requestHandler    epochStart.RequestHandler
-	genesisEpoch      uint32
+	marshalizer                          marshal.Marshalizer
+	hasher                               hashing.Hasher
+	store                                dataRetriever.StorageService
+	dataPool                             dataRetriever.PoolsHolder
+	blockTracker                         process.BlockTracker
+	shardCoordinator                     sharding.Coordinator
+	epochStartTrigger                    process.EpochStartTriggerHandler
+	requestHandler                       epochStart.RequestHandler
+	genesisEpoch                         uint32
+	miniBlockPartialExecutionEnableEpoch uint32
 }
 
 // ArgsNewEpochStartData defines the input parameters for epoch start data creator
 type ArgsNewEpochStartData struct {
-	Marshalizer       marshal.Marshalizer
-	Hasher            hashing.Hasher
-	Store             dataRetriever.StorageService
-	DataPool          dataRetriever.PoolsHolder
-	BlockTracker      process.BlockTracker
-	ShardCoordinator  sharding.Coordinator
-	EpochStartTrigger process.EpochStartTriggerHandler
-	RequestHandler    epochStart.RequestHandler
-	GenesisEpoch      uint32
+	Marshalizer                          marshal.Marshalizer
+	Hasher                               hashing.Hasher
+	Store                                dataRetriever.StorageService
+	DataPool                             dataRetriever.PoolsHolder
+	BlockTracker                         process.BlockTracker
+	ShardCoordinator                     sharding.Coordinator
+	EpochStartTrigger                    process.EpochStartTriggerHandler
+	RequestHandler                       epochStart.RequestHandler
+	GenesisEpoch                         uint32
+	MiniBlockPartialExecutionEnableEpoch uint32
 }
 
 // NewEpochStartData creates a new epoch start creator
@@ -68,15 +70,16 @@ func NewEpochStartData(args ArgsNewEpochStartData) (*epochStartData, error) {
 	}
 
 	e := &epochStartData{
-		marshalizer:       args.Marshalizer,
-		hasher:            args.Hasher,
-		store:             args.Store,
-		dataPool:          args.DataPool,
-		blockTracker:      args.BlockTracker,
-		shardCoordinator:  args.ShardCoordinator,
-		epochStartTrigger: args.EpochStartTrigger,
-		requestHandler:    args.RequestHandler,
-		genesisEpoch:      args.GenesisEpoch,
+		marshalizer:                          args.Marshalizer,
+		hasher:                               args.Hasher,
+		store:                                args.Store,
+		dataPool:                             args.DataPool,
+		blockTracker:                         args.BlockTracker,
+		shardCoordinator:                     args.ShardCoordinator,
+		epochStartTrigger:                    args.EpochStartTrigger,
+		requestHandler:                       args.RequestHandler,
+		genesisEpoch:                         args.GenesisEpoch,
+		miniBlockPartialExecutionEnableEpoch: args.MiniBlockPartialExecutionEnableEpoch,
 	}
 
 	return e, nil
@@ -374,10 +377,10 @@ func (e *epochStartData) computeStillPending(
 	miniBlockHeaders map[string]block.MiniBlockHeader,
 ) []block.MiniBlockHeader {
 
-	initIndexesOfProcessedTxs(miniBlockHeaders, shardID)
+	e.initIndexesOfProcessedTxs(miniBlockHeaders, shardID)
 
 	for _, shardHdr := range shardHdrs {
-		computeStillPendingInShardHeader(shardHdr, miniBlockHeaders, shardID)
+		e.computeStillPendingInShardHeader(shardHdr, miniBlockHeaders, shardID)
 	}
 
 	pendingMiniBlocks := make([]block.MiniBlockHeader, 0)
@@ -393,7 +396,7 @@ func (e *epochStartData) computeStillPending(
 	return pendingMiniBlocks
 }
 
-func initIndexesOfProcessedTxs(miniBlockHeaders map[string]block.MiniBlockHeader, shardID uint32) {
+func (e *epochStartData) initIndexesOfProcessedTxs(miniBlockHeaders map[string]block.MiniBlockHeader, shardID uint32) {
 	for mbHash, mbHeader := range miniBlockHeaders {
 		log.Debug("epochStartData.initIndexesOfProcessedTxs",
 			"mb hash", mbHash,
@@ -405,12 +408,12 @@ func initIndexesOfProcessedTxs(miniBlockHeaders map[string]block.MiniBlockHeader
 			continue
 		}
 
-		setIndexOfFirstAndLastTxProcessed(&mbHeader, -1, -1)
+		e.setIndexOfFirstAndLastTxProcessed(&mbHeader, -1, -1)
 		miniBlockHeaders[mbHash] = mbHeader
 	}
 }
 
-func computeStillPendingInShardHeader(
+func (e *epochStartData) computeStillPendingInShardHeader(
 	shardHdr data.HeaderHandler,
 	miniBlockHeaders map[string]block.MiniBlockHeader,
 	shardID uint32,
@@ -431,11 +434,11 @@ func computeStillPendingInShardHeader(
 			continue
 		}
 
-		updateIndexesOfProcessedTxs(mbHeader, shardMiniBlockHeader, shardMiniBlockHash, shardID, miniBlockHeaders)
+		e.updateIndexesOfProcessedTxs(mbHeader, shardMiniBlockHeader, shardMiniBlockHash, shardID, miniBlockHeaders)
 	}
 }
 
-func updateIndexesOfProcessedTxs(
+func (e *epochStartData) updateIndexesOfProcessedTxs(
 	mbHeader block.MiniBlockHeader,
 	shardMiniBlockHeader data.MiniBlockHeaderHandler,
 	shardMiniBlockHash string,
@@ -460,7 +463,7 @@ func updateIndexesOfProcessedTxs(
 			"new index of last tx processed", newIndexOfLastTxProcessed,
 			"new construction state", newConstructionState,
 		)
-		setIndexOfFirstAndLastTxProcessed(&mbHeader, newIndexOfFirstTxProcessed, newIndexOfLastTxProcessed)
+		e.setIndexOfFirstAndLastTxProcessed(&mbHeader, newIndexOfFirstTxProcessed, newIndexOfLastTxProcessed)
 
 		// this set is not particular needed but this will trigger the marshaller to save in the reserved field a
 		// non-empty slice so the rest of the code will run as designed
@@ -472,7 +475,10 @@ func updateIndexesOfProcessedTxs(
 	}
 }
 
-func setIndexOfFirstAndLastTxProcessed(mbHeader *block.MiniBlockHeader, indexOfFirstTxProcessed int32, indexOfLastTxProcessed int32) {
+func (e *epochStartData) setIndexOfFirstAndLastTxProcessed(mbHeader *block.MiniBlockHeader, indexOfFirstTxProcessed int32, indexOfLastTxProcessed int32) {
+	if e.epochStartTrigger.Epoch() < e.miniBlockPartialExecutionEnableEpoch {
+		return
+	}
 	err := mbHeader.SetIndexOfFirstTxProcessed(indexOfFirstTxProcessed)
 	if err != nil {
 		log.Warn("setIndexOfFirstAndLastTxProcessed: SetIndexOfFirstTxProcessed", "error", err.Error())

--- a/epochStart/metachain/epochStartData_test.go
+++ b/epochStart/metachain/epochStartData_test.go
@@ -67,14 +67,15 @@ func createMockEpochStartCreatorArguments() ArgsNewEpochStartData {
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
 	startHeaders := createGenesisBlocks(shardCoordinator)
 	argsNewEpochStartData := ArgsNewEpochStartData{
-		Marshalizer:       &mock.MarshalizerMock{},
-		Hasher:            &mock.HasherStub{},
-		Store:             createMetaStore(),
-		DataPool:          dataRetrieverMock.NewPoolsHolderStub(),
-		BlockTracker:      mock.NewBlockTrackerMock(shardCoordinator, startHeaders),
-		ShardCoordinator:  shardCoordinator,
-		EpochStartTrigger: &mock.EpochStartTriggerStub{},
-		RequestHandler:    &testscommon.RequestHandlerStub{},
+		Marshalizer:                          &mock.MarshalizerMock{},
+		Hasher:                               &mock.HasherStub{},
+		Store:                                createMetaStore(),
+		DataPool:                             dataRetrieverMock.NewPoolsHolderStub(),
+		BlockTracker:                         mock.NewBlockTrackerMock(shardCoordinator, startHeaders),
+		ShardCoordinator:                     shardCoordinator,
+		EpochStartTrigger:                    &mock.EpochStartTriggerStub{},
+		RequestHandler:                       &testscommon.RequestHandlerStub{},
+		MiniBlockPartialExecutionEnableEpoch: 0,
 	}
 	return argsNewEpochStartData
 }
@@ -569,7 +570,9 @@ func Test_initIndexesOfProcessedTxs(t *testing.T) {
 	miniBlockHeaders["mbHash1"] = mbh1
 	miniBlockHeaders["mbHash2"] = mbh2
 
-	initIndexesOfProcessedTxs(miniBlockHeaders, 0)
+	arguments := createMockEpochStartCreatorArguments()
+	epoch, _ := NewEpochStartData(arguments)
+	epoch.initIndexesOfProcessedTxs(miniBlockHeaders, 0)
 
 	mbh := miniBlockHeaders["mbHash1"]
 	assert.Equal(t, int32(1), mbh.GetIndexOfFirstTxProcessed())
@@ -622,7 +625,10 @@ func Test_computeStillPendingInShardHeader(t *testing.T) {
 	miniBlockHeaders[string(mbHash3)] = mbh3
 
 	assert.Equal(t, 2, len(miniBlockHeaders))
-	computeStillPendingInShardHeader(shardHdr, miniBlockHeaders, 0)
+
+	arguments := createMockEpochStartCreatorArguments()
+	epoch, _ := NewEpochStartData(arguments)
+	epoch.computeStillPendingInShardHeader(shardHdr, miniBlockHeaders, 0)
 	assert.Equal(t, 1, len(miniBlockHeaders))
 
 	_, ok := miniBlockHeaders[string(mbHash2)]
@@ -671,7 +677,9 @@ func Test_updateIndexesOfProcessedTxsEdgeCaseWithIndex0(t *testing.T) {
 		Reserved:        reservedBytes,
 	}
 
-	updateIndexesOfProcessedTxs(mbHeader, shardMiniblockHeader, mbHash, 2, miniblockHeaders)
+	arguments := createMockEpochStartCreatorArguments()
+	epoch, _ := NewEpochStartData(arguments)
+	epoch.updateIndexesOfProcessedTxs(mbHeader, shardMiniblockHeader, mbHash, 2, miniblockHeaders)
 
 	require.Equal(t, 1, len(miniblockHeaders))
 	processedMbHeader, found := miniblockHeaders[mbHash]
@@ -679,4 +687,52 @@ func Test_updateIndexesOfProcessedTxsEdgeCaseWithIndex0(t *testing.T) {
 	assert.True(t, len(processedMbHeader.Reserved) > 0)
 	assert.Equal(t, int32(0), processedMbHeader.GetIndexOfFirstTxProcessed())
 	assert.Equal(t, int32(0), processedMbHeader.GetIndexOfLastTxProcessed())
+}
+
+func Test_setIndexOfFirstAndLastTxProcessedShouldNotSetReserved(t *testing.T) {
+	t.Parallel()
+
+	partialExecutionEnableEpoch := uint32(5)
+
+	arguments := createMockEpochStartCreatorArguments()
+	arguments.MiniBlockPartialExecutionEnableEpoch = partialExecutionEnableEpoch
+	arguments.EpochStartTrigger = &mock.EpochStartTriggerStub{
+		IsEpochStartCalled: func() bool {
+			return true
+		},
+		EpochCalled: func() uint32 {
+			return partialExecutionEnableEpoch - 1
+		},
+	}
+
+	mbHeader := &block.MiniBlockHeader{}
+
+	epoch, _ := NewEpochStartData(arguments)
+	epoch.setIndexOfFirstAndLastTxProcessed(mbHeader, 1, 2)
+
+	require.Nil(t, mbHeader.GetReserved())
+}
+
+func Test_setIndexOfFirstAndLastTxProcessedShouldSetReserved(t *testing.T) {
+	t.Parallel()
+
+	partialExecutionEnableEpoch := uint32(5)
+
+	arguments := createMockEpochStartCreatorArguments()
+	arguments.MiniBlockPartialExecutionEnableEpoch = partialExecutionEnableEpoch
+	arguments.EpochStartTrigger = &mock.EpochStartTriggerStub{
+		IsEpochStartCalled: func() bool {
+			return true
+		},
+		EpochCalled: func() uint32 {
+			return partialExecutionEnableEpoch
+		},
+	}
+
+	mbHeader := &block.MiniBlockHeader{}
+
+	epoch, _ := NewEpochStartData(arguments)
+	epoch.setIndexOfFirstAndLastTxProcessed(mbHeader, 1, 2)
+
+	require.NotNil(t, mbHeader.GetReserved())
 }

--- a/factory/blockProcessorCreator.go
+++ b/factory/blockProcessorCreator.go
@@ -711,15 +711,16 @@ func (pcf *processComponentsFactory) newMetaBlockProcessor(
 
 	genesisHdr := pcf.data.Blockchain().GetGenesisHeader()
 	argsEpochStartData := metachainEpochStart.ArgsNewEpochStartData{
-		Marshalizer:       pcf.coreData.InternalMarshalizer(),
-		Hasher:            pcf.coreData.Hasher(),
-		Store:             pcf.data.StorageService(),
-		DataPool:          pcf.data.Datapool(),
-		BlockTracker:      blockTracker,
-		ShardCoordinator:  pcf.bootstrapComponents.ShardCoordinator(),
-		EpochStartTrigger: epochStartTrigger,
-		RequestHandler:    requestHandler,
-		GenesisEpoch:      genesisHdr.GetEpoch(),
+		Marshalizer:                          pcf.coreData.InternalMarshalizer(),
+		Hasher:                               pcf.coreData.Hasher(),
+		Store:                                pcf.data.StorageService(),
+		DataPool:                             pcf.data.Datapool(),
+		BlockTracker:                         blockTracker,
+		ShardCoordinator:                     pcf.bootstrapComponents.ShardCoordinator(),
+		EpochStartTrigger:                    epochStartTrigger,
+		RequestHandler:                       requestHandler,
+		GenesisEpoch:                         genesisHdr.GetEpoch(),
+		MiniBlockPartialExecutionEnableEpoch: pcf.epochConfig.EnableEpochs.MiniBlockPartialExecutionEnableEpoch,
 	}
 	epochStartDataCreator, err := metachainEpochStart.NewEpochStartData(argsEpochStartData)
 	if err != nil {

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -647,6 +647,7 @@ func (bp *baseProcessor) setMiniBlockHeaderReservedField(
 		return nil
 	}
 
+	// TODO: check if partialExecutionEnableEpoch is not needed
 	err := bp.setIndexOfFirstTxProcessed(miniBlockHeaderHandler)
 	if err != nil {
 		return err

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -647,7 +647,6 @@ func (bp *baseProcessor) setMiniBlockHeaderReservedField(
 		return nil
 	}
 
-	// TODO: check if partialExecutionEnableEpoch is not needed
 	err := bp.setIndexOfFirstTxProcessed(miniBlockHeaderHandler)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- backwards compatibility for the partialExecution on the meta epochStartData

  
## Proposed Changes
- added MiniBlockPartialExecutionEnableEpoch to epochStartData to take partialExecution enableEpooch into consideration


## Testing procedure
- import-db should work now
