### PR TITLE
Fix flag in import-db

### DIFF
--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -513,7 +513,6 @@ func processConfigImportDBMode(log logger.Logger, configs *config.Configs) error
 
 	generalConfigs.StoragePruning.NumActivePersisters = generalConfigs.StoragePruning.NumEpochsToKeep
 	generalConfigs.StateTriesConfig.CheckpointsEnabled = false
-	generalConfigs.StateTriesConfig.SnapshotsEnabled = false
 	generalConfigs.StateTriesConfig.CheckpointRoundsModulus = 100000000
 	p2pConfigs.Node.ThresholdMinConnectedPeers = 0
 	p2pConfigs.KadDhtPeerDiscovery.Enabled = false
@@ -523,7 +522,6 @@ func processConfigImportDBMode(log logger.Logger, configs *config.Configs) error
 	log.Warn("the node is in import mode! Will auto-set some config values, including storage config values",
 		"GeneralSettings.StartInEpochEnabled", generalConfigs.GeneralSettings.StartInEpochEnabled,
 		"StateTriesConfig.CheckpointsEnabled", generalConfigs.StateTriesConfig.CheckpointsEnabled,
-		"StateTriesConfig.SnapshotsEnabled", generalConfigs.StateTriesConfig.SnapshotsEnabled,
 		"StateTriesConfig.CheckpointRoundsModulus", generalConfigs.StateTriesConfig.CheckpointRoundsModulus,
 		"StoragePruning.NumActivePersisters", generalConfigs.StoragePruning.NumEpochsToKeep,
 		"p2p.ThresholdMinConnectedPeers", p2pConfigs.Node.ThresholdMinConnectedPeers,


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- there was a bug when the node ran in import-db that automatically reset the flag `SnapshotsEnabled` causing the node to not start due to the fact it didn't found the main trie data
  
## Proposed Changes
- remove the auto-reset operation in import-db mode

## Testing procedure
- import-db process should work when starting on a non-zero epoch and regular system test should pass
