### PR TITLE
Always keep a minimum of 2 active dbs open

### DIFF
--- a/storage/pruning/triePruningStorer.go
+++ b/storage/pruning/triePruningStorer.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	lastEpochIndex             = 1
-	currentEpochIndex          = 0
-	minNumOfActiveDBsNecessary = 1
+	lastEpochIndex    = 1
+	currentEpochIndex = 0
+	// leave this at 2, because in order to have a complete state at a certain moment, 2 dbs need to be opened
+	minNumOfActiveDBsNecessary = 2
 )
 
 type triePruningStorer struct {

--- a/storage/pruning/triePruningStorer_test.go
+++ b/storage/pruning/triePruningStorer_test.go
@@ -280,6 +280,8 @@ func TestTriePruningStorer_KeepMoreDbsOpenIfNecessary(t *testing.T) {
 	t.Parallel()
 
 	args := getDefaultArgs()
+	args.NumOfActivePersisters = 3
+	args.NumOfEpochsToKeep = 3
 	tps, _ := pruning.NewTriePruningStorer(args)
 
 	assert.Equal(t, 1, tps.GetNumActivePersisters())
@@ -291,18 +293,23 @@ func TestTriePruningStorer_KeepMoreDbsOpenIfNecessary(t *testing.T) {
 
 	assert.Equal(t, 2, tps.GetNumActivePersisters())
 	_ = tps.ChangeEpochSimple(2)
-	assert.Equal(t, 2, tps.GetNumActivePersisters())
-	_ = tps.ChangeEpochSimple(3)
 	assert.Equal(t, 3, tps.GetNumActivePersisters())
-	_ = tps.ChangeEpochSimple(4)
+	_ = tps.ChangeEpochSimple(3)
 	assert.Equal(t, 4, tps.GetNumActivePersisters())
+	_ = tps.ChangeEpochSimple(4)
+	assert.Equal(t, 5, tps.GetNumActivePersisters())
 
 	tps.SetEpochForPutOperation(4)
 	err = tps.Put([]byte(common.ActiveDBKey), []byte(common.ActiveDBVal))
 	assert.Nil(t, err)
 
 	_ = tps.ChangeEpochSimple(5)
-	assert.Equal(t, 2, tps.GetNumActivePersisters())
+	tps.SetEpochForPutOperation(5)
+	err = tps.Put([]byte(common.ActiveDBKey), []byte(common.ActiveDBVal))
+	assert.Nil(t, err)
+
+	_ = tps.ChangeEpochSimple(6)
+	assert.Equal(t, 3, tps.GetNumActivePersisters())
 
 	err = tps.Close()
 	assert.Nil(t, err)


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)

- The pruning storer will keep only 3 db's open. When a snapshot takes longer than an epoch, it will close a db that is needed. To fix this case, always keep a minimum of 2 db's that are marked as active, opened.

  
## Proposed Changes

-  Modify `minNumOfActiveDBsNecessary` from 1 to 2


## Testing procedure

- Add a time.Sleep() on Snapshot(), so that it will take more than 1 epoch, and check that the storer life was extended. After the snapshot is completed, verify that the correct db's are closed - (already tested this case)

