### PR TITLE
Enable snapshot even if pruning is disabled

### DIFF
--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -1258,9 +1258,6 @@ func (sp *shardProcessor) updateState(headers []data.HeaderHandler, currentHeade
 
 func (sp *shardProcessor) snapShotEpochStartFromMeta(header data.ShardHeaderHandler) {
 	accounts := sp.accountsDB[state.UserAccountsState]
-	if !accounts.IsPruningEnabled() {
-		return
-	}
 
 	sp.hdrsForCurrBlock.mutHdrsForBlock.RLock()
 	defer sp.hdrsForCurrBlock.mutHdrsForBlock.RUnlock()


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- If pruning was disabled, the snapshotting process was automatically disabled. Snapshotting is needed to copy from an older db to a new one (because db pruning is enabled even if trie pruning is disabled)
  
## Proposed Changes
- Snapshot the state even if trie pruning is disabled

## Testing procedure
- Test with `AccountsStatePruningEnabled = false` and with `AccountsStatePruningEnabled = true` and both scenarios should work