### PR TITLE
change label name to ignore-for-release-notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,7 +1,7 @@
 changelog:
   exclude:
     labels:
-      - ignore-for-release
+      - ignore-for-release-notes
   categories:
     - title: Breaking Changes
       labels:


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- previously named `ignore-for-release` label was changed to `ignore-for-release-notes` to remove any confusion with regards to the scope of the PR
  
## Proposed Changes
- change the name of the label

## Testing procedure
- automatically generate a release note and check if PR's are  distributed to proper chapter.