### PR TITLE
Do not start state sync if the node is closing

### DIFF
--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"context"
-	"strings"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
@@ -173,8 +172,7 @@ func (boot *MetaBootstrap) setLastEpochStartRound() {
 // in the blockchain, and all this mechanism will be reiterated for the next block.
 func (boot *MetaBootstrap) SyncBlock(ctx context.Context) error {
 	err := boot.syncBlock()
-	isErrGetNodeFromDB := err != nil && strings.Contains(err.Error(), common.GetNodeFromDBErrorString)
-	if isErrGetNodeFromDB {
+	if isErrGetNodeFromDB(err) {
 		errSync := boot.syncAccountsDBs()
 		shouldOutputLog := errSync != nil && !common.IsContextDone(ctx)
 		if shouldOutputLog {


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- When the node is closing, the sync block will fail because it can not get from storage, so it starts a state sync process. 
  
## Proposed Changes
- If the node is closing, do not start the state sync process

## Testing procedure
- We should not have any `base sync: started syncUserAccountsState` WARNs