### PR TITLE
Increased HardforkTimeBetweenSendsInSec to 1 minute

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -924,7 +924,7 @@
     MaxMissingKeysInRequest                          = 1000
     MaxDurationPeerUnresponsiveInSec                 = 900  # 15min
     HideInactiveValidatorIntervalInSec               = 3600 # 1h
-    HardforkTimeBetweenSendsInSec                    = 10   # 10sec
+    HardforkTimeBetweenSendsInSec                    = 60   # 1min
     [HeartbeatV2.PeerAuthenticationPool]
         DefaultSpanInSec = 3600 # 1h
         CacheExpiryInSec = 3600 # 1h

--- a/heartbeat/sender/baseSender.go
+++ b/heartbeat/sender/baseSender.go
@@ -46,7 +46,7 @@ func createBaseSender(args argBaseSender) baseSender {
 		thresholdBetweenSends:     args.thresholdBetweenSends,
 	}
 	bs.timerHandler = &timerWrapper{
-		timer: time.NewTimer(bs.computeRandomDuration()),
+		timer: time.NewTimer(bs.computeRandomDuration(bs.timeBetweenSends)),
 	}
 
 	return bs
@@ -76,8 +76,8 @@ func checkBaseSenderArgs(args argBaseSender) error {
 	return nil
 }
 
-func (bs *baseSender) computeRandomDuration() time.Duration {
-	timeBetweenSendsInNano := bs.timeBetweenSends.Nanoseconds()
+func (bs *baseSender) computeRandomDuration(baseDuration time.Duration) time.Duration {
+	timeBetweenSendsInNano := baseDuration.Nanoseconds()
 	maxThreshold := float64(timeBetweenSendsInNano) * bs.thresholdBetweenSends
 	randThreshold := randomizer.Intn(int(maxThreshold))
 

--- a/heartbeat/sender/baseSender_test.go
+++ b/heartbeat/sender/baseSender_test.go
@@ -28,9 +28,9 @@ func TestBaseSender_computeRandomDuration(t *testing.T) {
 
 	var d1, d2, d3 time.Duration
 	for i := 0; i < 100; i++ {
-		d1 = bs.computeRandomDuration()
-		d2 = bs.computeRandomDuration()
-		d3 = bs.computeRandomDuration()
+		d1 = bs.computeRandomDuration(bs.timeBetweenSends)
+		d2 = bs.computeRandomDuration(bs.timeBetweenSends)
+		d3 = bs.computeRandomDuration(bs.timeBetweenSends)
 		if d1 != d2 && d2 != d3 && d1 != d3 {
 			break
 		}

--- a/heartbeat/sender/heartbeatSender.go
+++ b/heartbeat/sender/heartbeatSender.go
@@ -64,7 +64,7 @@ func checkHeartbeatSenderArgs(args argHeartbeatSender) error {
 
 // Execute will handle the execution of a cycle in which the heartbeat message will be sent
 func (sender *heartbeatSender) Execute() {
-	duration := sender.computeRandomDuration()
+	duration := sender.computeRandomDuration(sender.timeBetweenSends)
 	err := sender.execute()
 	if err != nil {
 		duration = sender.timeBetweenSendsWhenError

--- a/heartbeat/sender/peerAuthenticationSender.go
+++ b/heartbeat/sender/peerAuthenticationSender.go
@@ -109,7 +109,7 @@ func (sender *peerAuthenticationSender) Execute() {
 		return
 	}
 
-	duration = sender.computeRandomDuration()
+	duration = sender.computeRandomDuration(sender.timeBetweenSends)
 	err, isHardforkTriggered := sender.execute()
 	if err != nil {
 		duration = sender.timeBetweenSendsWhenError
@@ -118,7 +118,7 @@ func (sender *peerAuthenticationSender) Execute() {
 	}
 
 	if isHardforkTriggered {
-		duration = sender.hardforkTimeBetweenSends
+		duration = sender.computeRandomDuration(sender.hardforkTimeBetweenSends)
 	}
 
 	log.Debug("peer authentication message sent", "is hardfork triggered", isHardforkTriggered, "next send will be in", duration)


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- time between hardfork messages is too low at 10 seconds
  
## Proposed Changes
- increase the time to 1 min and use a random component to avoid always having exactly 1 min

## Testing procedure
- system test
