### PR TITLE
Prints fixes for rc/2022-july

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -803,10 +803,10 @@
         ProcessDataTrieOnCommitEpoch = true
 
 [Health]
-    IntervalVerifyMemoryInSeconds = 5
+    IntervalVerifyMemoryInSeconds = 30
     IntervalDiagnoseComponentsInSeconds = 30
     IntervalDiagnoseComponentsDeeplyInSeconds = 120
-    MemoryUsageToCreateProfiles = 2415919104 # 2.25GB
+    MemoryUsageToCreateProfiles = 3221225472 # 3 GB
     NumMemoryUsageRecordsToKeep = 100
     FolderPath = "health-records"
 

--- a/epochStart/shardchain/trigger.go
+++ b/epochStart/shardchain/trigger.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/epochStart"
+	"github.com/ElrondNetwork/elrond-go/errors"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/storage"
 )
@@ -589,13 +590,13 @@ func (t *trigger) isMetaBlockValid(hash string, metaHdr data.HeaderHandler) bool
 	for i := metaHdr.GetNonce() - 1; i >= metaHdr.GetNonce()-t.validity; i-- {
 		neededHdr, err := t.getHeaderWithNonceAndHash(i, currHdr.GetPrevHash())
 		if err != nil {
-			log.Debug("isMetaBlockValid.getHeaderWithNonceAndHash",  "hash", hash, "error", err.Error())
+			log.Debug("isMetaBlockValid.getHeaderWithNonceAndHash", "hash", hash, "error", err.Error())
 			return false
 		}
 
 		err = t.headerValidator.IsHeaderConstructionValid(currHdr, neededHdr)
 		if err != nil {
-			log.Debug("isMetaBlockValid.IsHeaderConstructionValid",  "hash", hash, "error", err.Error())
+			log.Debug("isMetaBlockValid.IsHeaderConstructionValid", "hash", hash, "error", err.Error())
 			return false
 		}
 
@@ -869,7 +870,11 @@ func (t *trigger) SetProcessed(header data.HeaderHandler, _ data.BodyHandler) {
 	epochStartIdentifier := core.EpochStartIdentifier(shardHdr.GetEpoch())
 	errNotCritical = t.shardHdrStorage.Put([]byte(epochStartIdentifier), shardHdrBuff)
 	if errNotCritical != nil {
-		log.Warn("SetProcessed put to shard header storage error", "error", errNotCritical)
+		logLevel := logger.LogWarning
+		if errors.IsClosingError(errNotCritical) {
+			logLevel = logger.LogDebug
+		}
+		log.Log(logLevel, "SetProcessed put to shard header storage error", "error", errNotCritical)
 	}
 
 	// save finished start of epoch meta hdrs to current storage

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/consensus"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/dblookupext"
+	"github.com/ElrondNetwork/elrond-go/errors"
 	"github.com/ElrondNetwork/elrond-go/outport"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/block/bootstrapStorage"
@@ -1672,7 +1673,11 @@ func (bp *baseProcessor) recordBlockInHistory(blockHeaderHash []byte, blockHeade
 
 	err := bp.historyRepo.RecordBlock(blockHeaderHash, blockHeader, blockBody, scrResultsFromPool, receiptsFromPool, intraMiniBlocks, logs)
 	if err != nil {
-		log.Error("historyRepo.RecordBlock()", "blockHeaderHash", blockHeaderHash, "error", err.Error())
+		logLevel := logger.LogError
+		if errors.IsClosingError(err) {
+			logLevel = logger.LogDebug
+		}
+		log.Log(logLevel, "historyRepo.RecordBlock()", "blockHeaderHash", blockHeaderHash, "error", err.Error())
 	}
 }
 

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -686,6 +686,13 @@ func (boot *baseBootstrap) syncBlock() error {
 	return nil
 }
 
+func (boot *baseBootstrap) handleTrieSyncError(err error, ctx context.Context) {
+	shouldOutputLog := err != nil && !common.IsContextDone(ctx)
+	if shouldOutputLog {
+		log.Debug("SyncBlock syncTrie", "error", err)
+	}
+}
+
 func (boot *baseBootstrap) syncUserAccountsState() error {
 	rootHash, err := boot.accounts.RootHash()
 	if err != nil {

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
-	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/state"
@@ -174,10 +173,7 @@ func (boot *MetaBootstrap) SyncBlock(ctx context.Context) error {
 	err := boot.syncBlock()
 	if isErrGetNodeFromDB(err) {
 		errSync := boot.syncAccountsDBs()
-		shouldOutputLog := errSync != nil && !common.IsContextDone(ctx)
-		if shouldOutputLog {
-			log.Debug("SyncBlock syncTrie", "error", errSync)
-		}
+		boot.handleTrieSyncError(errSync, ctx)
 	}
 
 	return err

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -140,10 +140,7 @@ func (boot *ShardBootstrap) SyncBlock(ctx context.Context) error {
 	err := boot.syncBlock()
 	if isErrGetNodeFromDB(err) {
 		errSync := boot.syncUserAccountsState()
-		shouldOutputLog := errSync != nil && !common.IsContextDone(ctx)
-		if shouldOutputLog {
-			log.Debug("SyncBlock syncTrie", "error", errSync)
-		}
+		boot.handleTrieSyncError(errSync, ctx)
 	}
 
 	return err

--- a/sharding/nodesCoordinator/indexHashedNodesCoordinator.go
+++ b/sharding/nodesCoordinator/indexHashedNodesCoordinator.go
@@ -257,13 +257,13 @@ func (ihnc *indexHashedNodesCoordinator) setNodesPerShards(
 	}
 
 	var err error
-	var currentNodeIsValidator bool
+	var isCurrentNodeValidator bool
 	// nbShards holds number of shards without meta
 	nodesConfig.nbShards = uint32(len(eligible) - 1)
 	nodesConfig.eligibleMap = eligible
 	nodesConfig.waitingMap = waiting
 	nodesConfig.leavingMap = leaving
-	nodesConfig.shardID, currentNodeIsValidator = ihnc.computeShardForSelfPublicKey(nodesConfig)
+	nodesConfig.shardID, isCurrentNodeValidator = ihnc.computeShardForSelfPublicKey(nodesConfig)
 	nodesConfig.selectors, err = ihnc.createSelectors(nodesConfig)
 	if err != nil {
 		return err
@@ -271,9 +271,9 @@ func (ihnc *indexHashedNodesCoordinator) setNodesPerShards(
 
 	ihnc.nodesConfig[epoch] = nodesConfig
 	ihnc.numTotalEligible = numTotalEligible
-	ihnc.setNodeType(currentNodeIsValidator)
+	ihnc.setNodeType(isCurrentNodeValidator)
 
-	if ihnc.isFullArchive && currentNodeIsValidator {
+	if ihnc.isFullArchive && isCurrentNodeValidator {
 		ihnc.chanStopNode <- endProcess.ArgEndProcess{
 			Reason:      common.WrongConfiguration,
 			Description: ErrValidatorCannotBeFullArchive.Error(),

--- a/sharding/nodesCoordinator/indexHashedNodesCoordinator.go
+++ b/sharding/nodesCoordinator/indexHashedNodesCoordinator.go
@@ -257,13 +257,13 @@ func (ihnc *indexHashedNodesCoordinator) setNodesPerShards(
 	}
 
 	var err error
-	var isValidator bool
+	var currentNodeIsValidator bool
 	// nbShards holds number of shards without meta
 	nodesConfig.nbShards = uint32(len(eligible) - 1)
 	nodesConfig.eligibleMap = eligible
 	nodesConfig.waitingMap = waiting
 	nodesConfig.leavingMap = leaving
-	nodesConfig.shardID, isValidator = ihnc.computeShardForSelfPublicKey(nodesConfig)
+	nodesConfig.shardID, currentNodeIsValidator = ihnc.computeShardForSelfPublicKey(nodesConfig)
 	nodesConfig.selectors, err = ihnc.createSelectors(nodesConfig)
 	if err != nil {
 		return err
@@ -271,9 +271,9 @@ func (ihnc *indexHashedNodesCoordinator) setNodesPerShards(
 
 	ihnc.nodesConfig[epoch] = nodesConfig
 	ihnc.numTotalEligible = numTotalEligible
-	ihnc.setNodeType(isValidator)
+	ihnc.setNodeType(currentNodeIsValidator)
 
-	if ihnc.isFullArchive && isValidator {
+	if ihnc.isFullArchive && currentNodeIsValidator {
 		ihnc.chanStopNode <- endProcess.ArgEndProcess{
 			Reason:      common.WrongConfiguration,
 			Description: ErrValidatorCannotBeFullArchive.Error(),
@@ -634,13 +634,7 @@ func (ihnc *indexHashedNodesCoordinator) EpochStartPrepare(metaHdr data.HeaderHa
 
 	ihnc.fillPublicKeyToValidatorMap()
 	err = ihnc.saveState(randomness)
-	if err != nil {
-		logLevel := logger.LogError
-		if errors.IsClosingError(err) {
-			logLevel = logger.LogDebug
-		}
-		log.Log(logLevel, "saving nodes coordinator config failed", "error", err.Error())
-	}
+	ihnc.handleErrorLog(err, "saving nodes coordinator config failed")
 
 	displayNodesConfiguration(
 		resUpdateNodes.Eligible,
@@ -802,6 +796,19 @@ func (ihnc *indexHashedNodesCoordinator) addValidatorToPreviousMap(
 	}
 }
 
+func (ihnc *indexHashedNodesCoordinator) handleErrorLog(err error, message string) {
+	if err == nil {
+		return
+	}
+
+	logLevel := logger.LogError
+	if errors.IsClosingError(err) {
+		logLevel = logger.LogDebug
+	}
+
+	log.Log(logLevel, message, "error", err.Error())
+}
+
 // EpochStartAction is called upon a start of epoch event.
 // NodeCoordinator has to get the nodes assignment to shards using the shuffler.
 func (ihnc *indexHashedNodesCoordinator) EpochStartAction(hdr data.HeaderHandler) {
@@ -811,13 +818,7 @@ func (ihnc *indexHashedNodesCoordinator) EpochStartAction(hdr data.HeaderHandler
 	ihnc.currentEpoch = newEpoch
 
 	err := ihnc.saveState(ihnc.savedStateKey)
-	if err != nil {
-		logLevel := logger.LogError
-		if errors.IsClosingError(err) {
-			logLevel = logger.LogDebug
-		}
-		log.Log(logLevel, "saving nodes coordinator config failed", "error", err.Error())
-	}
+	ihnc.handleErrorLog(err, "saving nodes coordinator config failed")
 
 	ihnc.mutNodesConfig.Lock()
 	if needToRemove {

--- a/sharding/nodesCoordinator/indexHashedNodesCoordinator.go
+++ b/sharding/nodesCoordinator/indexHashedNodesCoordinator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/common"
+	"github.com/ElrondNetwork/elrond-go/errors"
 	"github.com/ElrondNetwork/elrond-go/state"
 	"github.com/ElrondNetwork/elrond-go/storage"
 )
@@ -634,7 +635,11 @@ func (ihnc *indexHashedNodesCoordinator) EpochStartPrepare(metaHdr data.HeaderHa
 	ihnc.fillPublicKeyToValidatorMap()
 	err = ihnc.saveState(randomness)
 	if err != nil {
-		log.Error("saving nodes coordinator config failed", "error", err.Error())
+		logLevel := logger.LogError
+		if errors.IsClosingError(err) {
+			logLevel = logger.LogDebug
+		}
+		log.Log(logLevel, "saving nodes coordinator config failed", "error", err.Error())
 	}
 
 	displayNodesConfiguration(
@@ -807,7 +812,11 @@ func (ihnc *indexHashedNodesCoordinator) EpochStartAction(hdr data.HeaderHandler
 
 	err := ihnc.saveState(ihnc.savedStateKey)
 	if err != nil {
-		log.Error("saving nodes coordinator config failed", "error", err.Error())
+		logLevel := logger.LogError
+		if errors.IsClosingError(err) {
+			logLevel = logger.LogDebug
+		}
+		log.Log(logLevel, "saving nodes coordinator config failed", "error", err.Error())
 	}
 
 	ihnc.mutNodesConfig.Lock()

--- a/storage/leveldb/leveldb.go
+++ b/storage/leveldb/leveldb.go
@@ -21,6 +21,8 @@ var _ storage.Persister = (*DB)(nil)
 
 // read + write + execute for owner only
 const rwxOwner = 0700
+const mkdirAllFunction = "MkdirAll"
+const openLevelDBFunction = "openLevelDB"
 
 var log = logger.GetOrCreate("storage/leveldb")
 
@@ -38,15 +40,17 @@ type DB struct {
 // NewDB is a constructor for the leveldb persister
 // It creates the files in the location given as parameter
 func NewDB(path string, batchDelaySeconds int, maxBatchSize int, maxOpenFiles int) (s *DB, err error) {
-	sw := core.NewStopWatch()
-	sw.Start("NewDB")
+	constructorName := "NewDB"
 
-	sw.Start("MkdirAll")
+	sw := core.NewStopWatch()
+	sw.Start(constructorName)
+
+	sw.Start(mkdirAllFunction)
 	err = os.MkdirAll(path, rwxOwner)
 	if err != nil {
 		return nil, err
 	}
-	sw.Stop("MkdirAll")
+	sw.Stop(mkdirAllFunction)
 
 	if maxOpenFiles < 1 {
 		return nil, storage.ErrInvalidNumOpenFiles
@@ -58,12 +62,12 @@ func NewDB(path string, batchDelaySeconds int, maxBatchSize int, maxOpenFiles in
 		OpenFilesCacheCapacity: maxOpenFiles,
 	}
 
-	sw.Start("openLevelDB")
+	sw.Start(openLevelDBFunction)
 	db, err := openLevelDB(path, options)
 	if err != nil {
 		return nil, fmt.Errorf("%w for path %s", err, path)
 	}
-	sw.Stop("openLevelDB")
+	sw.Stop(openLevelDBFunction)
 
 	bldb := &baseLevelDb{
 		db:   db,
@@ -88,7 +92,7 @@ func NewDB(path string, batchDelaySeconds int, maxBatchSize int, maxOpenFiles in
 	})
 
 	crtCounter := atomic.AddUint32(&loggingDBCounter, 1)
-	sw.Stop("NewSerialDB")
+	sw.Stop(constructorName)
 
 	logArguments := []interface{}{"path", path, "created pointer", fmt.Sprintf("%p", bldb.db), "global db counter", crtCounter}
 	logArguments = append(logArguments, sw.GetMeasurements()...)

--- a/storage/leveldb/leveldb.go
+++ b/storage/leveldb/leveldb.go
@@ -21,7 +21,7 @@ var _ storage.Persister = (*DB)(nil)
 
 // read + write + execute for owner only
 const rwxOwner = 0700
-const mkdirAllFunction = "MkdirAll"
+const mkdirAllFunction = "mkdirAll"
 const openLevelDBFunction = "openLevelDB"
 
 var log = logger.GetOrCreate("storage/leveldb")

--- a/storage/leveldb/leveldb.go
+++ b/storage/leveldb/leveldb.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ElrondNetwork/elrond-go-core/core"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/errors"
 	"github.com/ElrondNetwork/elrond-go/storage"
@@ -37,10 +38,15 @@ type DB struct {
 // NewDB is a constructor for the leveldb persister
 // It creates the files in the location given as parameter
 func NewDB(path string, batchDelaySeconds int, maxBatchSize int, maxOpenFiles int) (s *DB, err error) {
+	sw := core.NewStopWatch()
+	sw.Start("NewDB")
+
+	sw.Start("MkdirAll")
 	err = os.MkdirAll(path, rwxOwner)
 	if err != nil {
 		return nil, err
 	}
+	sw.Stop("MkdirAll")
 
 	if maxOpenFiles < 1 {
 		return nil, storage.ErrInvalidNumOpenFiles
@@ -52,10 +58,12 @@ func NewDB(path string, batchDelaySeconds int, maxBatchSize int, maxOpenFiles in
 		OpenFilesCacheCapacity: maxOpenFiles,
 	}
 
+	sw.Start("openLevelDB")
 	db, err := openLevelDB(path, options)
 	if err != nil {
 		return nil, fmt.Errorf("%w for path %s", err, path)
 	}
+	sw.Stop("openLevelDB")
 
 	bldb := &baseLevelDb{
 		db:   db,
@@ -80,7 +88,11 @@ func NewDB(path string, batchDelaySeconds int, maxBatchSize int, maxOpenFiles in
 	})
 
 	crtCounter := atomic.AddUint32(&loggingDBCounter, 1)
-	log.Debug("opened level db persister", "path", path, "created pointer", fmt.Sprintf("%p", bldb.db), "global db counter", crtCounter)
+	sw.Stop("NewSerialDB")
+
+	logArguments := []interface{}{"path", path, "created pointer", fmt.Sprintf("%p", bldb.db), "global db counter", crtCounter}
+	logArguments = append(logArguments, sw.GetMeasurements()...)
+	log.Debug("opened level db persister", logArguments...)
 
 	return dbStore, nil
 }

--- a/storage/leveldb/leveldbSerial.go
+++ b/storage/leveldb/leveldbSerial.go
@@ -35,15 +35,17 @@ type SerialDB struct {
 // NewSerialDB is a constructor for the leveldb persister
 // It creates the files in the location given as parameter
 func NewSerialDB(path string, batchDelaySeconds int, maxBatchSize int, maxOpenFiles int) (s *SerialDB, err error) {
-	sw := core.NewStopWatch()
-	sw.Start("NewSerialDB")
+	constructorName := "NewSerialDB"
 
-	sw.Start("MkdirAll")
+	sw := core.NewStopWatch()
+	sw.Start(constructorName)
+
+	sw.Start(mkdirAllFunction)
 	err = os.MkdirAll(path, rwxOwner)
 	if err != nil {
 		return nil, err
 	}
-	sw.Stop("MkdirAll")
+	sw.Stop(mkdirAllFunction)
 
 	if maxOpenFiles < 1 {
 		return nil, storage.ErrInvalidNumOpenFiles
@@ -55,12 +57,12 @@ func NewSerialDB(path string, batchDelaySeconds int, maxBatchSize int, maxOpenFi
 		OpenFilesCacheCapacity: maxOpenFiles,
 	}
 
-	sw.Start("openLevelDB")
+	sw.Start(openLevelDBFunction)
 	db, err := openLevelDB(path, options)
 	if err != nil {
 		return nil, fmt.Errorf("%w for path %s", err, path)
 	}
-	sw.Stop("openLevelDB")
+	sw.Stop(openLevelDBFunction)
 
 	bldb := &baseLevelDb{
 		db:   db,
@@ -88,7 +90,7 @@ func NewSerialDB(path string, batchDelaySeconds int, maxBatchSize int, maxOpenFi
 	})
 
 	crtCounter := atomic.AddUint32(&loggingDBCounter, 1)
-	sw.Stop("NewSerialDB")
+	sw.Stop(constructorName)
 
 	logArguments := []interface{}{"path", path, "created pointer", fmt.Sprintf("%p", bldb.db), "global db counter", crtCounter}
 	logArguments = append(logArguments, sw.GetMeasurements()...)


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- added more prints in the level DB constructors
- handled some log.Warn and log.Error prints when encountering the `DB is closed` error
- health records parameters adjustments
  
## Proposed Changes
- added prints to determine how much time it takes for the constructor to finish
- added better handling

## Testing procedure
- standard internal testnets procedure
