### PR TITLE
Integrate named identities

### DIFF
--- a/cmd/node/config/prefs.toml
+++ b/cmd/node/config/prefs.toml
@@ -31,3 +31,16 @@
    #  - "disabled" - no connection watching should be made
    #  - "print" - new connection found will be printed in the log file
    ConnectionWatcherType = "disabled"
+
+# NamedIdentity represents an identity that runs nodes on the multisig.
+# There can be multiple identities set just by dupplicating the NamedIdentity
+[[NamedIdentity]]
+   # Identity represents the keybase identity for the current NamedIdentity
+   Identity = ""
+   # NodeName represents the name that will be given to the names of the current identity
+   NodeName = ""
+   # BLSKeys represents the BLS keys assigned to the current NamedIdentity
+   BLSKeys = [
+      "",
+      ""
+   ]

--- a/cmd/node/config/prefs.toml
+++ b/cmd/node/config/prefs.toml
@@ -4,10 +4,12 @@
    # if "disabled" is provided then the node will start in the corresponding shard for its public key or 0 otherwise
    DestinationShardAsObserver = "disabled"
 
-   # NodeDisplayName represents the friendly name a user can pick for his node in the status monitor
+   # NodeDisplayName represents the friendly name a user can pick for his node in the status monitor when the node does not run in multikey mode
+   # In multikey mode, all bls keys not mentioned in NamedIdentity section will use this one as default
    NodeDisplayName = ""
 
-   # Identity represents the keybase's identity
+   # Identity represents the keybase's identity when the node does not run in multikey mode
+   # In multikey mode, all bls keys not mentioned in NamedIdentity section will use this one as default
    Identity = ""
 
    # RedundancyLevel represents the level of redundancy used by the node (-1 = disabled, 0 = main instance (default),
@@ -32,8 +34,8 @@
    #  - "print" - new connection found will be printed in the log file
    ConnectionWatcherType = "disabled"
 
-# NamedIdentity represents an identity that runs nodes on the multisig.
-# There can be multiple identities set just by dupplicating the NamedIdentity
+# NamedIdentity represents an identity that runs nodes on the multikey
+# There can be multiple identities set on the same node, each one of them having different bls keys, just by duplicating the NamedIdentity
 [[NamedIdentity]]
    # Identity represents the keybase identity for the current NamedIdentity
    Identity = ""

--- a/config/prefsConfig.go
+++ b/config/prefsConfig.go
@@ -2,7 +2,8 @@ package config
 
 // Preferences will hold the configuration related to node's preferences
 type Preferences struct {
-	Preferences PreferencesConfig
+	Preferences   PreferencesConfig
+	NamedIdentity []NamedIdentity
 }
 
 // PreferencesConfig will hold the fields which are node specific such as the display name
@@ -14,4 +15,11 @@ type PreferencesConfig struct {
 	PreferredConnections       []string
 	ConnectionWatcherType      string
 	FullArchive                bool
+}
+
+// NamedIdentity will hold the fields which are node named identities
+type NamedIdentity struct {
+	Identity string
+	NodeName string
+	BLSKeys  []string
 }

--- a/keysManagement/errors.go
+++ b/keysManagement/errors.go
@@ -8,4 +8,5 @@ var (
 	errNilKeyGenerator            = errors.New("nil key generator")
 	errNilP2PIdentityGenerator    = errors.New("nil p2p identity generator")
 	errInvalidValue               = errors.New("invalid value")
+	errMissingNamedIdentity       = errors.New("missing named identity")
 )

--- a/keysManagement/errors.go
+++ b/keysManagement/errors.go
@@ -8,4 +8,5 @@ var (
 	errNilKeyGenerator            = errors.New("nil key generator")
 	errNilP2PIdentityGenerator    = errors.New("nil p2p identity generator")
 	errInvalidValue               = errors.New("invalid value")
+	errInvalidKey                 = errors.New("invalid key")
 )

--- a/keysManagement/errors.go
+++ b/keysManagement/errors.go
@@ -8,5 +8,4 @@ var (
 	errNilKeyGenerator            = errors.New("nil key generator")
 	errNilP2PIdentityGenerator    = errors.New("nil p2p identity generator")
 	errInvalidValue               = errors.New("invalid value")
-	errMissingNamedIdentity       = errors.New("missing named identity")
 )

--- a/keysManagement/keysHolder_test.go
+++ b/keysManagement/keysHolder_test.go
@@ -116,6 +116,22 @@ func TestNewVirtualPeersHolder(t *testing.T) {
 		assert.True(t, strings.Contains(err.Error(), "MaxRoundsWithoutReceivedMessages"))
 		assert.True(t, check.IfNil(holder))
 	})
+	t.Run("invalid key from config should error", func(t *testing.T) {
+		t.Parallel()
+
+		providedInvalidKey := "invalid key"
+		args := createMockArgsVirtualPeersHolder()
+		args.PrefsConfig.NamedIdentity = []config.NamedIdentity{
+			{
+				BLSKeys: []string{providedInvalidKey},
+			},
+		}
+		holder, err := NewVirtualPeersHolder(args)
+
+		assert.True(t, errors.Is(err, errInvalidKey))
+		assert.True(t, strings.Contains(err.Error(), providedInvalidKey))
+		assert.True(t, check.IfNil(holder))
+	})
 	t.Run("valid arguments should work", func(t *testing.T) {
 		t.Parallel()
 

--- a/keysManagement/keysHolder_test.go
+++ b/keysManagement/keysHolder_test.go
@@ -260,32 +260,6 @@ func TestVirtualPeersHolder_AddVirtualPeer(t *testing.T) {
 		assert.Equal(t, providedIdentity, pInfo.nodeIdentity)
 		assert.Equal(t, providedName, pInfo.nodeName)
 	})
-	t.Run("invalid key in config should use default values", func(t *testing.T) {
-		providedKey := []byte("invalid public key")
-		providedSk := []byte("invalid private key")
-		args := createMockArgsVirtualPeersHolder()
-		args.PrefsConfig.NamedIdentity = []config.NamedIdentity{
-			{
-				Identity: "invalid key identity",
-				NodeName: "invalid key name",
-				BLSKeys:  []string{string(providedKey)},
-			},
-		}
-
-		holder, _ := NewVirtualPeersHolder(args)
-		err := holder.AddVirtualPeer(providedSk)
-		assert.Nil(t, err)
-
-		pInfo := holder.getPeerInfo(providedKey)
-		assert.NotNil(t, pInfo)
-		assert.Equal(t, pid, pInfo.pid)
-		assert.Equal(t, p2pPrivateKey, pInfo.p2pPrivateKeyBytes)
-		skBytesRecovered, _ := pInfo.privateKey.ToByteArray()
-		assert.Equal(t, providedSk, skBytesRecovered)
-		assert.Equal(t, 10, len(pInfo.machineID))
-		assert.Equal(t, defaultIdentity, pInfo.nodeIdentity)
-		assert.Equal(t, defaultName, pInfo.nodeName)
-	})
 	t.Run("should error when trying to add the same pk", func(t *testing.T) {
 		args := createMockArgsVirtualPeersHolder()
 

--- a/keysManagement/keysHolder_test.go
+++ b/keysManagement/keysHolder_test.go
@@ -3,6 +3,7 @@ package keysManagement
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -13,18 +14,21 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-crypto"
+	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/keysManagement/mock"
 	"github.com/ElrondNetwork/elrond-go/testscommon/cryptoMocks"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
-	p2pPrivateKey = []byte("p2p private key")
-	pid           = core.PeerID("pid")
-	skBytes0      = []byte("private key 0")
-	skBytes1      = []byte("private key 1")
-	pkBytes0      = []byte("public key 0")
-	pkBytes1      = []byte("public key 1")
+	p2pPrivateKey   = []byte("p2p private key")
+	pid             = core.PeerID("pid")
+	skBytes0        = []byte("private key 0")
+	skBytes1        = []byte("private key 1")
+	pkBytes0        = []byte("public key 0")
+	pkBytes1        = []byte("public key 1")
+	defaultName     = "default node name"
+	defaultIdentity = "default node identity"
 )
 
 func createMockArgsVirtualPeersHolder() ArgsVirtualPeersHolder {
@@ -37,6 +41,12 @@ func createMockArgsVirtualPeersHolder() ArgsVirtualPeersHolder {
 		},
 		IsMainMachine:                    true,
 		MaxRoundsWithoutReceivedMessages: 1,
+		PrefsConfig: config.Preferences{
+			Preferences: config.PreferencesConfig{
+				Identity:        defaultIdentity,
+				NodeDisplayName: defaultName,
+			},
+		},
 	}
 }
 
@@ -160,7 +170,7 @@ func TestVirtualPeersHolder_AddVirtualPeer(t *testing.T) {
 
 		assert.True(t, errors.Is(err, expectedErr))
 	})
-	t.Run("identity creation errors should errors", func(t *testing.T) {
+	t.Run("identity creation errors", func(t *testing.T) {
 		args := createMockArgsVirtualPeersHolder()
 		args.P2PIdentityGenerator = &mock.IdentityGeneratorStub{
 			CreateRandomP2PIdentityCalled: func() ([]byte, core.PeerID, error) {
@@ -187,6 +197,78 @@ func TestVirtualPeersHolder_AddVirtualPeer(t *testing.T) {
 		skBytesRecovered, _ := pInfo.privateKey.ToByteArray()
 		assert.Equal(t, skBytes0, skBytesRecovered)
 		assert.Equal(t, 10, len(pInfo.machineID))
+		assert.Equal(t, defaultIdentity, pInfo.nodeIdentity)
+		assert.Equal(t, defaultName, pInfo.nodeName)
+	})
+	t.Run("should work for a new pk with identity from config", func(t *testing.T) {
+		providedAddress := []byte("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
+		providedHex := hex.EncodeToString(providedAddress)
+		providedName := "provided name"
+		providedIdentity := "provided identity"
+		args := createMockArgsVirtualPeersHolder()
+		args.KeyGenerator = &cryptoMocks.KeyGenStub{
+			PrivateKeyFromByteArrayStub: func(b []byte) (crypto.PrivateKey, error) {
+				return &cryptoMocks.PrivateKeyStub{
+					GeneratePublicStub: func() crypto.PublicKey {
+						return &cryptoMocks.PublicKeyStub{
+							ToByteArrayStub: func() ([]byte, error) {
+								return providedAddress, nil
+							},
+						}
+					},
+					ToByteArrayStub: func() ([]byte, error) {
+						return providedAddress, nil
+					},
+				}, nil
+			},
+		}
+		args.PrefsConfig.NamedIdentity = []config.NamedIdentity{
+			{
+				Identity: providedIdentity,
+				NodeName: providedName,
+				BLSKeys:  []string{providedHex},
+			},
+		}
+
+		holder, _ := NewVirtualPeersHolder(args)
+		err := holder.AddVirtualPeer(skBytes0)
+		assert.Nil(t, err)
+
+		pInfo := holder.getPeerInfo(providedAddress)
+		assert.NotNil(t, pInfo)
+		assert.Equal(t, pid, pInfo.pid)
+		assert.Equal(t, p2pPrivateKey, pInfo.p2pPrivateKeyBytes)
+		skBytesRecovered, _ := pInfo.privateKey.ToByteArray()
+		assert.Equal(t, providedAddress, skBytesRecovered)
+		assert.Equal(t, 10, len(pInfo.machineID))
+		assert.Equal(t, providedIdentity, pInfo.nodeIdentity)
+		assert.Equal(t, providedName, pInfo.nodeName)
+	})
+	t.Run("invalid key in config should use default values", func(t *testing.T) {
+		providedKey := []byte("invalid public key")
+		providedSk := []byte("invalid private key")
+		args := createMockArgsVirtualPeersHolder()
+		args.PrefsConfig.NamedIdentity = []config.NamedIdentity{
+			{
+				Identity: "invalid key identity",
+				NodeName: "invalid key name",
+				BLSKeys:  []string{string(providedKey)},
+			},
+		}
+
+		holder, _ := NewVirtualPeersHolder(args)
+		err := holder.AddVirtualPeer(providedSk)
+		assert.Nil(t, err)
+
+		pInfo := holder.getPeerInfo(providedKey)
+		assert.NotNil(t, pInfo)
+		assert.Equal(t, pid, pInfo.pid)
+		assert.Equal(t, p2pPrivateKey, pInfo.p2pPrivateKeyBytes)
+		skBytesRecovered, _ := pInfo.privateKey.ToByteArray()
+		assert.Equal(t, providedSk, skBytesRecovered)
+		assert.Equal(t, 10, len(pInfo.machineID))
+		assert.Equal(t, defaultIdentity, pInfo.nodeIdentity)
+		assert.Equal(t, defaultName, pInfo.nodeName)
 	})
 	t.Run("should error when trying to add the same pk", func(t *testing.T) {
 		args := createMockArgsVirtualPeersHolder()

--- a/keysManagement/peerInfo.go
+++ b/keysManagement/peerInfo.go
@@ -7,11 +7,17 @@ import (
 	crypto "github.com/ElrondNetwork/elrond-go-crypto"
 )
 
+type namedIdentity struct {
+	name     string
+	identity string
+}
+
 type peerInfo struct {
 	pid                core.PeerID
 	p2pPrivateKeyBytes []byte
 	privateKey         crypto.PrivateKey
 	machineID          string
+	namedIdentity      namedIdentity
 
 	mutChangeableData             sync.RWMutex
 	roundsWithoutReceivedMessages int

--- a/keysManagement/peerInfo.go
+++ b/keysManagement/peerInfo.go
@@ -7,17 +7,13 @@ import (
 	crypto "github.com/ElrondNetwork/elrond-go-crypto"
 )
 
-type namedIdentity struct {
-	name     string
-	identity string
-}
-
 type peerInfo struct {
 	pid                core.PeerID
 	p2pPrivateKeyBytes []byte
 	privateKey         crypto.PrivateKey
 	machineID          string
-	namedIdentity      namedIdentity
+	nodeName           string
+	nodeIdentity       string
 
 	mutChangeableData             sync.RWMutex
 	roundsWithoutReceivedMessages int


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- integrate changes on prefs config, which now provides identities that runs nodes on the multisig
  
## Proposed Changes
- extend `peerInfo` structure to hold node name and identity as well
- use bls keys + name and identity from prefs config on `keysHolder`

## Testing procedure
- system test
