### PR TITLE
Fix direct connections processor

### DIFF
--- a/factory/heartbeatV2Components.go
+++ b/factory/heartbeatV2Components.go
@@ -172,6 +172,7 @@ func (hcf *heartbeatV2ComponentsFactory) Create() (*heartbeatV2Components, error
 		Marshaller:                hcf.coreComponents.InternalMarshalizer(),
 		ShardCoordinator:          hcf.boostrapComponents.ShardCoordinator(),
 		DelayBetweenNotifications: time.Second * time.Duration(cfg.DelayBetweenConnectionNotificationsInSec),
+		NodesCoordinator:          hcf.processComponents.NodesCoordinator(),
 	}
 	directConnectionsProcessor, err := processor.NewDirectConnectionsProcessor(argsDirectConnectionsProcessor)
 	if err != nil {

--- a/heartbeat/processor/directConnectionsProcessor.go
+++ b/heartbeat/processor/directConnectionsProcessor.go
@@ -99,7 +99,7 @@ func (dcp *directConnectionsProcessor) startProcessLoop(ctx context.Context) {
 
 func (dcp *directConnectionsProcessor) sendMessageToNewConnections() {
 	if dcp.isCurrentNodeValidator() {
-		log.Debug("directConnectionsProcessor.sendMessageToNewConnections current node is validator, will not send send messages to connected peers")
+		log.Debug("directConnectionsProcessor.sendMessageToNewConnections current node is validator, will not send messages to connected peers")
 		return
 	}
 

--- a/heartbeat/processor/directConnectionsProcessor.go
+++ b/heartbeat/processor/directConnectionsProcessor.go
@@ -95,6 +95,7 @@ func (dcp *directConnectionsProcessor) sendMessageToNewConnections() {
 	connectedPeers := dcp.messenger.ConnectedPeers()
 	newPeers := dcp.computeNewPeers(connectedPeers)
 	dcp.notifyNewPeers(newPeers)
+	dcp.recreateNotifiedPeers(newPeers, connectedPeers)
 }
 
 func (dcp *directConnectionsProcessor) computeNewPeers(connectedPeers []core.PeerID) []core.PeerID {
@@ -111,8 +112,6 @@ func (dcp *directConnectionsProcessor) computeNewPeers(connectedPeers []core.Pee
 }
 
 func (dcp *directConnectionsProcessor) notifyNewPeers(newPeers []core.PeerID) {
-	dcp.notifiedPeersMap = make(map[core.PeerID]struct{})
-
 	shardValidatorInfo := &message.DirectConnectionInfo{
 		ShardId: fmt.Sprintf("%d", dcp.shardCoordinator.SelfId()),
 	}
@@ -130,6 +129,19 @@ func (dcp *directConnectionsProcessor) notifyNewPeers(newPeers []core.PeerID) {
 		}
 
 		dcp.notifiedPeersMap[newPeer] = struct{}{}
+	}
+}
+
+func (dcp *directConnectionsProcessor) recreateNotifiedPeers(newPeers []core.PeerID, connectedPeers []core.PeerID) {
+	dcp.notifiedPeersMap = make(map[core.PeerID]struct{})
+
+	dcp.addPeersToNotifiedPeersMap(newPeers)
+	dcp.addPeersToNotifiedPeersMap(connectedPeers)
+}
+
+func (dcp *directConnectionsProcessor) addPeersToNotifiedPeersMap(peers []core.PeerID) {
+	for _, peer := range peers {
+		dcp.notifiedPeersMap[peer] = struct{}{}
 	}
 }
 

--- a/heartbeat/processor/directConnectionsProcessor.go
+++ b/heartbeat/processor/directConnectionsProcessor.go
@@ -22,6 +22,7 @@ type ArgDirectConnectionsProcessor struct {
 	Marshaller                marshal.Marshalizer
 	ShardCoordinator          sharding.Coordinator
 	DelayBetweenNotifications time.Duration
+	NodesCoordinator          NodesCoordinator
 }
 
 type directConnectionsProcessor struct {
@@ -31,6 +32,7 @@ type directConnectionsProcessor struct {
 	delayBetweenNotifications time.Duration
 	notifiedPeersMap          map[core.PeerID]struct{}
 	cancel                    func()
+	nodesCoordinator          NodesCoordinator
 }
 
 // NewDirectConnectionsProcessor creates a new instance of directConnectionsProcessor
@@ -46,6 +48,7 @@ func NewDirectConnectionsProcessor(args ArgDirectConnectionsProcessor) (*directC
 		shardCoordinator:          args.ShardCoordinator,
 		delayBetweenNotifications: args.DelayBetweenNotifications,
 		notifiedPeersMap:          make(map[core.PeerID]struct{}),
+		nodesCoordinator:          args.NodesCoordinator,
 	}
 
 	var ctx context.Context
@@ -70,6 +73,9 @@ func checkArgDirectConnectionsProcessor(args ArgDirectConnectionsProcessor) erro
 		return fmt.Errorf("%w for DelayBetweenNotifications, provided %d, min expected %d",
 			heartbeat.ErrInvalidTimeDuration, args.DelayBetweenNotifications, minDelayBetweenRequests)
 	}
+	if check.IfNil(args.NodesCoordinator) {
+		return heartbeat.ErrNilNodesCoordinator
+	}
 
 	return nil
 }
@@ -92,10 +98,22 @@ func (dcp *directConnectionsProcessor) startProcessLoop(ctx context.Context) {
 }
 
 func (dcp *directConnectionsProcessor) sendMessageToNewConnections() {
+	if dcp.isCurrentNodeValidator() {
+		log.Debug("directConnectionsProcessor.sendMessageToNewConnections current node is validator, will not send send messages to connected peers")
+		return
+	}
+
 	connectedPeers := dcp.messenger.ConnectedPeers()
 	newPeers := dcp.computeNewPeers(connectedPeers)
 	dcp.notifyNewPeers(newPeers)
 	dcp.recreateNotifiedPeers(connectedPeers)
+}
+
+func (dcp *directConnectionsProcessor) isCurrentNodeValidator() bool {
+	currentBLSKey := dcp.nodesCoordinator.GetOwnPublicKey()
+	_, _, err := dcp.nodesCoordinator.GetValidatorWithPublicKey(currentBLSKey)
+
+	return err == nil
 }
 
 func (dcp *directConnectionsProcessor) computeNewPeers(connectedPeers []core.PeerID) []core.PeerID {
@@ -122,6 +140,8 @@ func (dcp *directConnectionsProcessor) notifyNewPeers(newPeers []core.PeerID) {
 	}
 
 	for _, newPeer := range newPeers {
+		log.Trace("directConnectionsProcessor.notifyNewPeers sending message", "pid", newPeer.Pretty())
+
 		errNotCritical := dcp.messenger.SendToConnectedPeer(common.ConnectionTopic, shardValidatorInfoBuff, newPeer)
 		if errNotCritical != nil {
 			log.Trace("directConnectionsProcessor.notifyNewPeers", "pid", newPeer.Pretty(), "error", errNotCritical)

--- a/heartbeat/processor/directConnectionsProcessor.go
+++ b/heartbeat/processor/directConnectionsProcessor.go
@@ -95,7 +95,7 @@ func (dcp *directConnectionsProcessor) sendMessageToNewConnections() {
 	connectedPeers := dcp.messenger.ConnectedPeers()
 	newPeers := dcp.computeNewPeers(connectedPeers)
 	dcp.notifyNewPeers(newPeers)
-	dcp.recreateNotifiedPeers(newPeers, connectedPeers)
+	dcp.recreateNotifiedPeers(connectedPeers)
 }
 
 func (dcp *directConnectionsProcessor) computeNewPeers(connectedPeers []core.PeerID) []core.PeerID {
@@ -132,15 +132,10 @@ func (dcp *directConnectionsProcessor) notifyNewPeers(newPeers []core.PeerID) {
 	}
 }
 
-func (dcp *directConnectionsProcessor) recreateNotifiedPeers(newPeers []core.PeerID, connectedPeers []core.PeerID) {
+func (dcp *directConnectionsProcessor) recreateNotifiedPeers(connectedPeers []core.PeerID) {
 	dcp.notifiedPeersMap = make(map[core.PeerID]struct{})
 
-	dcp.addPeersToNotifiedPeersMap(newPeers)
-	dcp.addPeersToNotifiedPeersMap(connectedPeers)
-}
-
-func (dcp *directConnectionsProcessor) addPeersToNotifiedPeersMap(peers []core.PeerID) {
-	for _, peer := range peers {
+	for _, peer := range connectedPeers {
 		dcp.notifiedPeersMap[peer] = struct{}{}
 	}
 }

--- a/heartbeat/processor/export_test.go
+++ b/heartbeat/processor/export_test.go
@@ -17,6 +17,7 @@ func NewDirectConnectionsProcessorNoGoRoutine(args ArgDirectConnectionsProcessor
 		shardCoordinator:          args.ShardCoordinator,
 		delayBetweenNotifications: args.DelayBetweenNotifications,
 		notifiedPeersMap:          make(map[core.PeerID]struct{}),
+		nodesCoordinator:          args.NodesCoordinator,
 	}
 
 	return dcp, nil

--- a/heartbeat/processor/interface.go
+++ b/heartbeat/processor/interface.go
@@ -1,0 +1,10 @@
+package processor
+
+import nodesCoord "github.com/ElrondNetwork/elrond-go/sharding/nodesCoordinator"
+
+// NodesCoordinator defines the operations for a struct that is able to determine if a key is a validator or not
+type NodesCoordinator interface {
+	GetOwnPublicKey() []byte
+	GetValidatorWithPublicKey(publicKey []byte) (nodesCoord.Validator, uint32, error)
+	IsInterfaceNil() bool
+}

--- a/integrationTests/node/heartbeat/heartbeat_test.go
+++ b/integrationTests/node/heartbeat/heartbeat_test.go
@@ -141,7 +141,7 @@ func TestHeartbeatV2_DeactivationOfHeartbeat(t *testing.T) {
 	nodes := make([]*integrationTests.TestHeartbeatNode, interactingNodes)
 	p2pConfig := integrationTests.CreateP2PConfigWithNoDiscovery()
 	for i := 0; i < interactingNodes; i++ {
-		nodes[i] = integrationTests.NewTestHeartbeatNode(3, 0, interactingNodes, p2pConfig)
+		nodes[i] = integrationTests.NewTestHeartbeatNode(t, 3, 0, interactingNodes, p2pConfig)
 	}
 	assert.Equal(t, interactingNodes, len(nodes))
 
@@ -163,7 +163,7 @@ func TestHeartbeatV2_DeactivationOfHeartbeat(t *testing.T) {
 	time.Sleep(time.Second * 6)
 
 	heartbeats := monitor.GetHeartbeats()
-	assert.False(t, heartbeats[0].IsActive) //first one is the monitor which is inactive
+	assert.False(t, heartbeats[0].IsActive) // first one is the monitor which is inactive
 
 	for _, hb := range heartbeats[1:] {
 		assert.True(t, hb.IsActive)

--- a/integrationTests/node/heartbeatV2/heartbeatV2_test.go
+++ b/integrationTests/node/heartbeatV2/heartbeatV2_test.go
@@ -19,7 +19,7 @@ func TestHeartbeatV2_AllPeersSendMessages(t *testing.T) {
 	nodes := make([]*integrationTests.TestHeartbeatNode, interactingNodes)
 	p2pConfig := integrationTests.CreateP2PConfigWithNoDiscovery()
 	for i := 0; i < interactingNodes; i++ {
-		nodes[i] = integrationTests.NewTestHeartbeatNode(3, 0, interactingNodes, p2pConfig)
+		nodes[i] = integrationTests.NewTestHeartbeatNode(t, 3, 0, interactingNodes, p2pConfig)
 	}
 	assert.Equal(t, interactingNodes, len(nodes))
 
@@ -46,7 +46,7 @@ func TestHeartbeatV2_PeerJoiningLate(t *testing.T) {
 	nodes := make([]*integrationTests.TestHeartbeatNode, interactingNodes)
 	p2pConfig := integrationTests.CreateP2PConfigWithNoDiscovery()
 	for i := 0; i < interactingNodes; i++ {
-		nodes[i] = integrationTests.NewTestHeartbeatNode(3, 0, interactingNodes, p2pConfig)
+		nodes[i] = integrationTests.NewTestHeartbeatNode(t, 3, 0, interactingNodes, p2pConfig)
 	}
 	assert.Equal(t, interactingNodes, len(nodes))
 
@@ -60,7 +60,7 @@ func TestHeartbeatV2_PeerJoiningLate(t *testing.T) {
 	checkMessages(t, nodes, maxMessageAgeAllowed)
 
 	// Add new delayed node which requests messages
-	delayedNode := integrationTests.NewTestHeartbeatNode(3, 0, 0, p2pConfig)
+	delayedNode := integrationTests.NewTestHeartbeatNode(t, 3, 0, 0, p2pConfig)
 	nodes = append(nodes, delayedNode)
 	connectNodes(nodes, len(nodes))
 	// Wait for messages to broadcast and requests to finish

--- a/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
+++ b/integrationTests/p2p/networkSharding-hbv2/networkSharding_test.go
@@ -96,7 +96,7 @@ func testConnectionsInNetworkSharding(t *testing.T, p2pConfig config.P2PConfig) 
 	}
 
 	fmt.Println("Initializing nodes components...")
-	initNodes(nodesMap)
+	initNodes(t, nodesMap)
 
 	for i := 0; i < 5; i++ {
 		fmt.Println("\n" + integrationTests.MakeDisplayTableForHeartbeatNodes(nodesMap))
@@ -135,10 +135,10 @@ func startNodes(nodesMap map[uint32][]*integrationTests.TestHeartbeatNode) {
 	}
 }
 
-func initNodes(nodesMap map[uint32][]*integrationTests.TestHeartbeatNode) {
+func initNodes(tb testing.TB, nodesMap map[uint32][]*integrationTests.TestHeartbeatNode) {
 	for _, nodes := range nodesMap {
 		for _, n := range nodes {
-			n.InitTestHeartbeatNode(0)
+			n.InitTestHeartbeatNode(tb, 0)
 		}
 	}
 }

--- a/integrationTests/testHeartbeatNode.go
+++ b/integrationTests/testHeartbeatNode.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strconv"
+	"testing"
 	"time"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
@@ -46,6 +47,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon/shardingMocks"
 	trieMock "github.com/ElrondNetwork/elrond-go/testscommon/trie"
 	"github.com/ElrondNetwork/elrond-go/update"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -101,6 +103,7 @@ type TestHeartbeatNode struct {
 
 // NewTestHeartbeatNode returns a new TestHeartbeatNode instance with a libp2p messenger
 func NewTestHeartbeatNode(
+	tb testing.TB,
 	maxShards uint32,
 	nodeShardId uint32,
 	minPeersWaiting int,
@@ -184,7 +187,7 @@ func NewTestHeartbeatNode(
 	}
 
 	// start a go routine in order to allow peers to connect first
-	go thn.InitTestHeartbeatNode(minPeersWaiting)
+	go thn.InitTestHeartbeatNode(tb, minPeersWaiting)
 
 	return thn
 }
@@ -358,13 +361,13 @@ func CreateNodesWithTestHeartbeatNode(
 }
 
 // InitTestHeartbeatNode initializes all the components and starts sender
-func (thn *TestHeartbeatNode) InitTestHeartbeatNode(minPeersWaiting int) {
+func (thn *TestHeartbeatNode) InitTestHeartbeatNode(tb testing.TB, minPeersWaiting int) {
 	thn.initStorage()
 	thn.initDataPools()
 	thn.initRequestedItemsHandler()
 	thn.initResolvers()
 	thn.initInterceptors()
-	thn.initDirectConnectionsProcessor()
+	thn.initDirectConnectionsProcessor(tb)
 
 	for len(thn.Messenger.Peers()) < minPeersWaiting {
 		time.Sleep(time.Second)
@@ -611,15 +614,18 @@ func (thn *TestHeartbeatNode) initRequestsProcessor() {
 	thn.RequestsProcessor, _ = processor.NewPeerAuthenticationRequestsProcessor(args)
 }
 
-func (thn *TestHeartbeatNode) initDirectConnectionsProcessor() {
+func (thn *TestHeartbeatNode) initDirectConnectionsProcessor(tb testing.TB) {
 	args := processor.ArgDirectConnectionsProcessor{
 		Messenger:                 thn.Messenger,
 		Marshaller:                TestMarshaller,
 		ShardCoordinator:          thn.ShardCoordinator,
 		DelayBetweenNotifications: 5 * time.Second,
+		NodesCoordinator:          thn.NodesCoordinator,
 	}
 
-	thn.DirectConnectionsProcessor, _ = processor.NewDirectConnectionsProcessor(args)
+	var err error
+	thn.DirectConnectionsProcessor, err = processor.NewDirectConnectionsProcessor(args)
+	require.Nil(tb, err)
 }
 
 // ConnectTo will try to initiate a connection to the provided parameter

--- a/process/errors.go
+++ b/process/errors.go
@@ -1122,10 +1122,10 @@ var ErrMissingMiniBlock = errors.New("missing mini block")
 // ErrIndexIsOutOfBound signals that the given index is out of bound
 var ErrIndexIsOutOfBound = errors.New("index is out of bound")
 
-// ErrIndexDoesNotMatchWithPartialExecuted signals that the given index does not match with a partial executed mini block
+// ErrIndexDoesNotMatchWithPartialExecutedMiniBlock signals that the given index does not match with a partial executed mini block
 var ErrIndexDoesNotMatchWithPartialExecutedMiniBlock = errors.New("index does not match with a partial executed mini block")
 
-// ErrIndexDoesNotMatchWithFullyExecuted signals that the given index does not match with a fully executed mini block
+// ErrIndexDoesNotMatchWithFullyExecutedMiniBlock signals that the given index does not match with a fully executed mini block
 var ErrIndexDoesNotMatchWithFullyExecutedMiniBlock = errors.New("index does not match with a fully executed mini block")
 
 // ErrNilProcessedMiniBlocksTracker signals that a nil processed mini blocks tracker has been provided


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- Fixed the direct connection processor to not continuously send messages to the connected peers
  
## Proposed Changes
- clean the map only after notifying the new peers and then insert all connected peers so in case of no connected peers changes we won't resend the messages.

## Testing procedure
- standard testing procedure should reveal problems (continuously resend) if the test is carried with the log level `*:DEBUG,heartbeat/processor:TRACE`. If ran with this branch the sending will be done only on new connected peers.
