### PR TITLE
remove destroy persisters calls

### DIFF
--- a/storage/factory/pruningStorerFactory.go
+++ b/storage/factory/pruningStorerFactory.go
@@ -108,15 +108,8 @@ func (psf *StorageServiceFactory) CreateForShard() (dataRetriever.StorageService
 	var scheduledSCRsUnit storage.Storer
 	var err error
 
-	successfullyCreatedStorers := make([]storage.Storer, 0)
-	defer func() {
-		// cleanup
-		if err != nil {
-			for _, storer := range successfullyCreatedStorers {
-				_ = storer.DestroyUnit()
-			}
-		}
-	}()
+	// TODO: if there will be a differentiation between the creation or opening of a DB, the DBs could be destroyed on a defer
+	// in case of a failure while creating (not opening).
 
 	disabledCustomDatabaseRemover := disabled.NewDisabledCustomDatabaseRemover()
 	customDatabaseRemover, err := databaseremover.NewCustomDatabaseRemover(psf.generalConfig.StoragePruning)
@@ -129,75 +122,64 @@ func (psf *StorageServiceFactory) CreateForShard() (dataRetriever.StorageService
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, txUnit)
 
 	unsignedTxUnitStorerArgs := psf.createPruningStorerArgs(psf.generalConfig.UnsignedTransactionStorage, disabledCustomDatabaseRemover)
 	unsignedTxUnit, err = psf.createPruningPersister(unsignedTxUnitStorerArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, unsignedTxUnit)
 
 	rewardTxUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.RewardTxStorage, disabledCustomDatabaseRemover)
 	rewardTxUnit, err = psf.createPruningPersister(rewardTxUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, rewardTxUnit)
 
 	miniBlockUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.MiniBlocksStorage, disabledCustomDatabaseRemover)
 	miniBlockUnit, err = psf.createPruningPersister(miniBlockUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, miniBlockUnit)
 
 	peerBlockUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.PeerBlockBodyStorage, disabledCustomDatabaseRemover)
 	peerBlockUnit, err = psf.createPruningPersister(peerBlockUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, peerBlockUnit)
 
 	headerUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.BlockHeaderStorage, disabledCustomDatabaseRemover)
 	headerUnit, err = psf.createPruningPersister(headerUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, headerUnit)
 
 	metaChainHeaderUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.MetaBlockStorage, disabledCustomDatabaseRemover)
 	metachainHeaderUnit, err = psf.createPruningPersister(metaChainHeaderUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, metachainHeaderUnit)
 
 	userAccountsUnit, err = psf.createTriePersister(psf.generalConfig.AccountsTrieStorage, psf.generalConfig.StateTriesConfig, customDatabaseRemover)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, userAccountsUnit)
 
 	peerAccountsUnit, err = psf.createTriePersister(psf.generalConfig.PeerAccountsTrieStorage, psf.generalConfig.StateTriesConfig, customDatabaseRemover)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, peerAccountsUnit)
 
 	userAccountsCheckpointsUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.AccountsTrieCheckpointsStorage, disabledCustomDatabaseRemover)
 	userAccountsCheckpointsUnit, err = psf.createPruningPersister(userAccountsCheckpointsUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, userAccountsCheckpointsUnit)
 
 	peerAccountsCheckpointsUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.PeerAccountsTrieCheckpointsStorage, disabledCustomDatabaseRemover)
 	peerAccountsCheckpointsUnit, err = psf.createPruningPersister(peerAccountsCheckpointsUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, peerAccountsCheckpointsUnit)
 
 	// metaHdrHashNonce is static
 	metaHdrHashNonceUnitConfig := GetDBFromConfig(psf.generalConfig.MetaHdrNonceHashStorage.DB)
@@ -210,7 +192,6 @@ func (psf *StorageServiceFactory) CreateForShard() (dataRetriever.StorageService
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, metaHdrHashNonceUnit)
 
 	// shardHdrHashNonce storer is static
 	shardHdrHashNonceConfig := GetDBFromConfig(psf.generalConfig.ShardHdrNonceHashStorage.DB)
@@ -223,7 +204,6 @@ func (psf *StorageServiceFactory) CreateForShard() (dataRetriever.StorageService
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, shardHdrHashNonceUnit)
 
 	heartbeatDbConfig := GetDBFromConfig(psf.generalConfig.Heartbeat.HeartbeatStorage.DB)
 	shardId := core.GetShardIDString(psf.shardCoordinator.SelfId())
@@ -235,7 +215,6 @@ func (psf *StorageServiceFactory) CreateForShard() (dataRetriever.StorageService
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, heartbeatStorageUnit)
 
 	statusMetricsDbConfig := GetDBFromConfig(psf.generalConfig.StatusMetricsStorage.DB)
 	shardId = core.GetShardIDString(psf.shardCoordinator.SelfId())
@@ -247,34 +226,29 @@ func (psf *StorageServiceFactory) CreateForShard() (dataRetriever.StorageService
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, statusMetricsStorageUnit)
 
 	trieEpochRootHashStorageUnit, err := psf.createTrieEpochRootHashStorerIfNeeded()
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, trieEpochRootHashStorageUnit)
 
 	bootstrapUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.BootstrapStorage, disabledCustomDatabaseRemover)
 	bootstrapUnit, err = psf.createPruningPersister(bootstrapUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, bootstrapUnit)
 
 	receiptsUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.ReceiptsStorage, disabledCustomDatabaseRemover)
 	receiptsUnit, err = psf.createPruningPersister(receiptsUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, receiptsUnit)
 
 	scheduledSCRsUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.ScheduledSCRsStorage, disabledCustomDatabaseRemover)
 	scheduledSCRsUnit, err = pruning.NewPruningStorer(scheduledSCRsUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, scheduledSCRsUnit)
 
 	store := dataRetriever.NewChainStorer()
 	store.AddStorer(dataRetriever.TransactionUnit, txUnit)
@@ -298,14 +272,12 @@ func (psf *StorageServiceFactory) CreateForShard() (dataRetriever.StorageService
 	store.AddStorer(dataRetriever.PeerAccountsCheckpointsUnit, peerAccountsCheckpointsUnit)
 	store.AddStorer(dataRetriever.ScheduledSCRsUnit, scheduledSCRsUnit)
 
-	createdStorers, err := psf.setupDbLookupExtensions(store)
-	successfullyCreatedStorers = append(successfullyCreatedStorers, createdStorers...)
+	err = psf.setupDbLookupExtensions(store)
 	if err != nil {
 		return nil, err
 	}
 
-	createdStorers, err = psf.setupLogsAndEventsStorer(store)
-	successfullyCreatedStorers = append(successfullyCreatedStorers, createdStorers...)
+	err = psf.setupLogsAndEventsStorer(store)
 	if err != nil {
 		return nil, err
 	}
@@ -335,17 +307,8 @@ func (psf *StorageServiceFactory) CreateForMeta() (dataRetriever.StorageService,
 	var scheduledSCRsUnit storage.Storer
 	var err error
 
-	successfullyCreatedStorers := make([]storage.Storer, 0)
-
-	defer func() {
-		// cleanup
-		if err != nil {
-			log.Error("create meta store", "error", err.Error())
-			for _, storer := range successfullyCreatedStorers {
-				_ = storer.DestroyUnit()
-			}
-		}
-	}()
+	// TODO: if there will be a differentiation between the creation or opening of a DB, the DBs could be destroyed on a defer
+	// in case of a failure while creating (not opening)
 
 	disabledCustomDatabaseRemover := disabled.NewDisabledCustomDatabaseRemover()
 	customDatabaseRemover, err := databaseremover.NewCustomDatabaseRemover(psf.generalConfig.StoragePruning)
@@ -358,42 +321,36 @@ func (psf *StorageServiceFactory) CreateForMeta() (dataRetriever.StorageService,
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, metaBlockUnit)
 
 	headerUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.BlockHeaderStorage, disabledCustomDatabaseRemover)
 	headerUnit, err = psf.createPruningPersister(headerUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, headerUnit)
 
 	userAccountsUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.AccountsTrieStorage, customDatabaseRemover)
 	userAccountsUnit, err = psf.createTriePruningPersister(userAccountsUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, userAccountsUnit)
 
 	peerAccountsUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.PeerAccountsTrieStorage, customDatabaseRemover)
 	peerAccountsUnit, err = psf.createTriePruningPersister(peerAccountsUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, peerAccountsUnit)
 
 	userAccountsCheckpointsUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.AccountsTrieCheckpointsStorage, disabledCustomDatabaseRemover)
 	userAccountsCheckpointsUnit, err = psf.createPruningPersister(userAccountsCheckpointsUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, userAccountsCheckpointsUnit)
 
 	peerAccountsCheckpointsUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.PeerAccountsTrieCheckpointsStorage, disabledCustomDatabaseRemover)
 	peerAccountsCheckpointsUnit, err = psf.createPruningPersister(peerAccountsCheckpointsUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, peerAccountsCheckpointsUnit)
 
 	// metaHdrHashNonce is static
 	metaHdrHashNonceUnitConfig := GetDBFromConfig(psf.generalConfig.MetaHdrNonceHashStorage.DB)
@@ -406,7 +363,6 @@ func (psf *StorageServiceFactory) CreateForMeta() (dataRetriever.StorageService,
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, metaHdrHashNonceUnit)
 
 	shardHdrHashNonceUnits := make([]*storageUnit.Unit, psf.shardCoordinator.NumberOfShards())
 	for i := uint32(0); i < psf.shardCoordinator.NumberOfShards(); i++ {
@@ -420,8 +376,6 @@ func (psf *StorageServiceFactory) CreateForMeta() (dataRetriever.StorageService,
 		if err != nil {
 			return nil, err
 		}
-
-		successfullyCreatedStorers = append(successfullyCreatedStorers, shardHdrHashNonceUnits[i])
 	}
 
 	shardId := core.GetShardIDString(psf.shardCoordinator.SelfId())
@@ -434,7 +388,6 @@ func (psf *StorageServiceFactory) CreateForMeta() (dataRetriever.StorageService,
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, heartbeatStorageUnit)
 
 	statusMetricsDbConfig := GetDBFromConfig(psf.generalConfig.StatusMetricsStorage.DB)
 	shardId = core.GetShardIDString(psf.shardCoordinator.SelfId())
@@ -446,62 +399,53 @@ func (psf *StorageServiceFactory) CreateForMeta() (dataRetriever.StorageService,
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, statusMetricsStorageUnit)
 
 	trieEpochRootHashStorageUnit, err := psf.createTrieEpochRootHashStorerIfNeeded()
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, trieEpochRootHashStorageUnit)
 
 	txUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.TxStorage, disabledCustomDatabaseRemover)
 	txUnit, err = psf.createPruningPersister(txUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, txUnit)
 
 	unsignedTxUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.UnsignedTransactionStorage, disabledCustomDatabaseRemover)
 	unsignedTxUnit, err = psf.createPruningPersister(unsignedTxUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, unsignedTxUnit)
 
 	rewardTxUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.RewardTxStorage, disabledCustomDatabaseRemover)
 	rewardTxUnit, err = psf.createPruningPersister(rewardTxUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, rewardTxUnit)
 
 	miniBlockUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.MiniBlocksStorage, disabledCustomDatabaseRemover)
 	miniBlockUnit, err = psf.createPruningPersister(miniBlockUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, miniBlockUnit)
 
 	bootstrapUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.BootstrapStorage, disabledCustomDatabaseRemover)
 	bootstrapUnit, err = psf.createPruningPersister(bootstrapUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, bootstrapUnit)
 
 	receiptsUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.ReceiptsStorage, disabledCustomDatabaseRemover)
 	receiptsUnit, err = psf.createPruningPersister(receiptsUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, receiptsUnit)
 
 	scheduledSCRsUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.ScheduledSCRsStorage, disabledCustomDatabaseRemover)
 	scheduledSCRsUnit, err = pruning.NewPruningStorer(scheduledSCRsUnitArgs)
 	if err != nil {
 		return nil, err
 	}
-	successfullyCreatedStorers = append(successfullyCreatedStorers, scheduledSCRsUnit)
 
 	store := dataRetriever.NewChainStorer()
 	store.AddStorer(dataRetriever.MetaBlockUnit, metaBlockUnit)
@@ -526,14 +470,12 @@ func (psf *StorageServiceFactory) CreateForMeta() (dataRetriever.StorageService,
 	store.AddStorer(dataRetriever.PeerAccountsCheckpointsUnit, peerAccountsCheckpointsUnit)
 	store.AddStorer(dataRetriever.ScheduledSCRsUnit, scheduledSCRsUnit)
 
-	createdStorers, err := psf.setupDbLookupExtensions(store)
-	successfullyCreatedStorers = append(successfullyCreatedStorers, createdStorers...)
+	err = psf.setupDbLookupExtensions(store)
 	if err != nil {
 		return nil, err
 	}
 
-	createdStorers, err = psf.setupLogsAndEventsStorer(store)
-	successfullyCreatedStorers = append(successfullyCreatedStorers, createdStorers...)
+	err = psf.setupLogsAndEventsStorer(store)
 	if err != nil {
 		return nil, err
 	}
@@ -546,9 +488,7 @@ func (psf *StorageServiceFactory) CreateForMeta() (dataRetriever.StorageService,
 	return store, err
 }
 
-func (psf *StorageServiceFactory) setupLogsAndEventsStorer(chainStorer *dataRetriever.ChainStorer) ([]storage.Storer, error) {
-	createdStorers := make([]storage.Storer, 0)
-
+func (psf *StorageServiceFactory) setupLogsAndEventsStorer(chainStorer *dataRetriever.ChainStorer) error {
 	var txLogsUnit storage.Storer
 	txLogsUnit = storageDisabled.NewStorer()
 
@@ -561,21 +501,18 @@ func (psf *StorageServiceFactory) setupLogsAndEventsStorer(chainStorer *dataRetr
 		txLogsUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.LogsAndEvents.TxLogsStorage, disabled.NewDisabledCustomDatabaseRemover())
 		txLogsUnit, err = psf.createPruningPersister(txLogsUnitArgs)
 		if err != nil {
-			return createdStorers, err
+			return err
 		}
 	}
 
-	createdStorers = append(createdStorers, txLogsUnit)
 	chainStorer.AddStorer(dataRetriever.TxLogsUnit, txLogsUnit)
 
-	return createdStorers, nil
+	return nil
 }
 
-func (psf *StorageServiceFactory) setupDbLookupExtensions(chainStorer *dataRetriever.ChainStorer) ([]storage.Storer, error) {
-	createdStorers := make([]storage.Storer, 0)
-
+func (psf *StorageServiceFactory) setupDbLookupExtensions(chainStorer *dataRetriever.ChainStorer) error {
 	if !psf.generalConfig.DbLookupExtensions.Enabled {
-		return createdStorers, nil
+		return nil
 	}
 
 	shardID := core.GetShardIDString(psf.shardCoordinator.SelfId())
@@ -585,10 +522,9 @@ func (psf *StorageServiceFactory) setupDbLookupExtensions(chainStorer *dataRetri
 	eventsHashesByTxHashStorerArgs := psf.createPruningStorerArgs(eventsHashesByTxHashConfig, disabled.NewDisabledCustomDatabaseRemover())
 	eventsHashesByTxHashPruningStorer, err := psf.createPruningPersister(eventsHashesByTxHashStorerArgs)
 	if err != nil {
-		return createdStorers, err
+		return err
 	}
 
-	createdStorers = append(createdStorers, eventsHashesByTxHashPruningStorer)
 	chainStorer.AddStorer(dataRetriever.ResultsHashesByTxHashUnit, eventsHashesByTxHashPruningStorer)
 
 	// Create the miniblocksMetadata (PRUNING) storer
@@ -596,10 +532,9 @@ func (psf *StorageServiceFactory) setupDbLookupExtensions(chainStorer *dataRetri
 	miniblocksMetadataPruningStorerArgs := psf.createPruningStorerArgs(miniblocksMetadataConfig, disabled.NewDisabledCustomDatabaseRemover())
 	miniblocksMetadataPruningStorer, err := psf.createPruningPersister(miniblocksMetadataPruningStorerArgs)
 	if err != nil {
-		return createdStorers, err
+		return err
 	}
 
-	createdStorers = append(createdStorers, miniblocksMetadataPruningStorer)
 	chainStorer.AddStorer(dataRetriever.MiniblocksMetadataUnit, miniblocksMetadataPruningStorer)
 
 	// Create the miniblocksHashByTxHash (STATIC) storer
@@ -609,10 +544,9 @@ func (psf *StorageServiceFactory) setupDbLookupExtensions(chainStorer *dataRetri
 	miniblockHashByTxHashCacherConfig := GetCacherFromConfig(miniblockHashByTxHashConfig.Cache)
 	miniblockHashByTxHashUnit, err := storageUnit.NewStorageUnitFromConf(miniblockHashByTxHashCacherConfig, miniblockHashByTxHashDbConfig)
 	if err != nil {
-		return createdStorers, err
+		return err
 	}
 
-	createdStorers = append(createdStorers, miniblockHashByTxHashUnit)
 	chainStorer.AddStorer(dataRetriever.MiniblockHashByTxHashUnit, miniblockHashByTxHashUnit)
 
 	// Create the blockHashByRound (STATIC) storer
@@ -622,10 +556,9 @@ func (psf *StorageServiceFactory) setupDbLookupExtensions(chainStorer *dataRetri
 	blockHashByRoundCacherConfig := GetCacherFromConfig(blockHashByRoundConfig.Cache)
 	blockHashByRoundUnit, err := storageUnit.NewStorageUnitFromConf(blockHashByRoundCacherConfig, blockHashByRoundDBConfig)
 	if err != nil {
-		return createdStorers, err
+		return err
 	}
 
-	createdStorers = append(createdStorers, blockHashByRoundUnit)
 	chainStorer.AddStorer(dataRetriever.RoundHdrHashDataUnit, blockHashByRoundUnit)
 
 	// Create the epochByHash (STATIC) storer
@@ -635,10 +568,9 @@ func (psf *StorageServiceFactory) setupDbLookupExtensions(chainStorer *dataRetri
 	epochByHashCacherConfig := GetCacherFromConfig(epochByHashConfig.Cache)
 	epochByHashUnit, err := storageUnit.NewStorageUnitFromConf(epochByHashCacherConfig, epochByHashDbConfig)
 	if err != nil {
-		return createdStorers, err
+		return err
 	}
 
-	createdStorers = append(createdStorers, epochByHashUnit)
 	chainStorer.AddStorer(dataRetriever.EpochByHashUnit, epochByHashUnit)
 
 	esdtSuppliesConfig := psf.generalConfig.DbLookupExtensions.ESDTSuppliesStorageConfig
@@ -647,13 +579,12 @@ func (psf *StorageServiceFactory) setupDbLookupExtensions(chainStorer *dataRetri
 	esdtSuppliesCacherConfig := GetCacherFromConfig(esdtSuppliesConfig.Cache)
 	esdtSuppliesUnit, err := storageUnit.NewStorageUnitFromConf(esdtSuppliesCacherConfig, esdtSuppliesDbConfig)
 	if err != nil {
-		return createdStorers, err
+		return err
 	}
 
-	createdStorers = append(createdStorers, esdtSuppliesUnit)
 	chainStorer.AddStorer(dataRetriever.ESDTSuppliesUnit, esdtSuppliesUnit)
 
-	return createdStorers, nil
+	return nil
 }
 
 func (psf *StorageServiceFactory) createPruningStorerArgs(

--- a/storage/storageUnit/storageunit.go
+++ b/storage/storageUnit/storageunit.go
@@ -281,11 +281,8 @@ func NewStorageUnitFromConf(cacheConf CacheConfig, dbConf DBConfig) (*Unit, erro
 	var db storage.Persister
 	var err error
 
-	defer func() {
-		if err != nil && db != nil {
-			_ = db.Destroy()
-		}
-	}()
+	// TODO: if there will be a differentiation between the creation or opening of a DB, the DB could be destroyed
+	// in case of a failure while creating (not opening).
 
 	if dbConf.MaxBatchSize > int(cacheConf.Capacity) {
 		return nil, storage.ErrCacheSizeIsLowerThanBatchSize


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- if a persister could have not been created (for example, when extra tweaking the configuration and the system's ulimit was too low), all the opened DBs would have been destroyed, which should only be valid if the databases are created (not opened)
  
## Proposed Changes
- remove the code block that called `DestroyUnit()`

## Testing procedure
- specific scenario already tested and validated
- these changes don't affect other storage operations
