### PR TITLE
add guardian data REST api

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -31,6 +31,9 @@ var ErrGetESDTTokens = errors.New("get esdt tokens for account error")
 // ErrGetESDTBalance signals an error in getting esdt balance for given address
 var ErrGetESDTBalance = errors.New("get esdt balance for account error")
 
+// ErrGetGuardianData signals an error in getting the guardian data for given address
+var ErrGetGuardianData = errors.New("get guardian data for account error")
+
 // ErrGetRolesForAccount signals an error in getting esdt tokens and roles for a given address
 var ErrGetRolesForAccount = errors.New("get roles for account error")
 

--- a/api/groups/addressGroup.go
+++ b/api/groups/addressGroup.go
@@ -28,6 +28,7 @@ const (
 	getESDTsRolesPath         = "/:address/esdts/roles"
 	getRegisteredNFTsPath     = "/:address/registered-nfts"
 	getESDTNFTDataPath        = "/:address/nft/:tokenIdentifier/nonce/:nonce"
+	getGuardianData           = "/:address/guardian-data"
 	urlParamOnFinalBlock      = "onFinalBlock"
 	urlParamOnStartOfEpoch    = "onStartOfEpoch"
 	urlParamBlockNonce        = "blockNonce"
@@ -48,6 +49,7 @@ type addressFacadeHandler interface {
 	GetESDTsWithRole(address string, role string, options api.AccountQueryOptions) ([]string, api.BlockInfo, error)
 	GetAllESDTTokens(address string, options api.AccountQueryOptions) (map[string]*esdt.ESDigitalToken, api.BlockInfo, error)
 	GetKeyValuePairs(address string, options api.AccountQueryOptions) (map[string]string, api.BlockInfo, error)
+	GetGuardianData(address string, options api.AccountQueryOptions) (api.GuardianData, api.BlockInfo, error)
 	IsInterfaceNil() bool
 }
 
@@ -142,6 +144,11 @@ func NewAddressGroup(facade addressFacadeHandler) (*addressGroup, error) {
 			Path:    getESDTsRolesPath,
 			Method:  http.MethodGet,
 			Handler: ag.getESDTsRoles,
+		},
+		{
+			Path:    getGuardianData,
+			Method:  http.MethodGet,
+			Handler: ag.getGuardianData,
 		},
 	}
 	ag.endpoints = endpoints
@@ -246,6 +253,29 @@ func (ag *addressGroup) getValueForKey(c *gin.Context) {
 	}
 
 	shared.RespondWithSuccess(c, gin.H{"value": value, "blockInfo": blockInfo})
+}
+
+// getGuardianData returns the guardian data and frozen state for a given account
+func (ag *addressGroup) getGuardianData(c *gin.Context) {
+	addr := c.Param("address")
+	if addr == "" {
+		shared.RespondWithValidationError(c, errors.ErrGetGuardianData, errors.ErrEmptyAddress)
+		return
+	}
+
+	options, err := extractAccountQueryOptions(c)
+	if err != nil {
+		shared.RespondWithValidationError(c, errors.ErrGetGuardianData, err)
+		return
+	}
+
+	guardianData, blockInfo, err := ag.getFacade().GetGuardianData(addr, options)
+	if err != nil {
+		shared.RespondWithInternalError(c, errors.ErrGetGuardianData, err)
+		return
+	}
+
+	shared.RespondWithSuccess(c, gin.H{"guardianData": guardianData, "blockInfo": blockInfo})
 }
 
 // addressGroup returns all the key-value pairs for the given address

--- a/api/groups/addressGroup_test.go
+++ b/api/groups/addressGroup_test.go
@@ -956,7 +956,7 @@ func TestGetGuardianData(t *testing.T) {
 		assert.True(t, strings.Contains(response.Error, expectedErr.Error()))
 
 	})
-	t.Run("OK", func(t *testing.T) {
+	t.Run("should work", func(t *testing.T) {
 		expectedGuardianData := api.GuardianData{
 			ActiveGuardian: &api.Guardian{
 				Address: "guardian1",

--- a/api/groups/addressGroup_test.go
+++ b/api/groups/addressGroup_test.go
@@ -93,6 +93,16 @@ type esdtTokenResponse struct {
 	Code  string                `json:"code"`
 }
 
+type guardianDataResponseData struct {
+	GuardianData api.GuardianData `json:"guardianData"`
+}
+
+type guardianDataResponse struct {
+	Data  guardianDataResponseData `json:"data"`
+	Error string                   `json:"error"`
+	Code  string                   `json:"code"`
+}
+
 type esdtNFTResponse struct {
 	Data  esdtNFTResponseData `json:"data"`
 	Error string              `json:"error"`
@@ -900,6 +910,86 @@ func TestGetKeyValuePairs_ShouldWork(t *testing.T) {
 	assert.Equal(t, pairs, response.Data.Pairs)
 }
 
+func TestGetGuardianData(t *testing.T) {
+	t.Parallel()
+
+	testAddress := "address"
+	t.Run("with empty address should err", func(t *testing.T) {
+		facade := mock.FacadeStub{}
+		addrGroup, err := groups.NewAddressGroup(&facade)
+		require.Nil(t, err)
+
+		ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+		emptyAddress := ""
+		req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/guardian-data", emptyAddress), nil)
+		resp := httptest.NewRecorder()
+		ws.ServeHTTP(resp, req)
+
+		response := shared.GenericAPIResponse{}
+		loadResponse(resp.Body, &response)
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.NotEmpty(t, response)
+		assert.True(t, strings.Contains(response.Error,
+			fmt.Sprintf("%s: %s", apiErrors.ErrGetGuardianData.Error(), apiErrors.ErrEmptyAddress.Error()),
+		))
+	})
+	t.Run("with node fail should err", func(t *testing.T) {
+		expectedErr := errors.New("expected error")
+		facade := mock.FacadeStub{
+			GetGuardianDataCalled: func(address string, options api.AccountQueryOptions) (api.GuardianData, api.BlockInfo, error) {
+				return api.GuardianData{}, api.BlockInfo{}, expectedErr
+			},
+		}
+		addrGroup, err := groups.NewAddressGroup(&facade)
+		require.NoError(t, err)
+
+		ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+		req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/guardian-data", testAddress), nil)
+		resp := httptest.NewRecorder()
+		ws.ServeHTTP(resp, req)
+
+		response := &shared.GenericAPIResponse{}
+		loadResponse(resp.Body, &response)
+		assert.Equal(t, http.StatusInternalServerError, resp.Code)
+		assert.True(t, strings.Contains(response.Error, expectedErr.Error()))
+
+	})
+	t.Run("OK", func(t *testing.T) {
+		expectedGuardianData := api.GuardianData{
+			ActiveGuardian: &api.Guardian{
+				Address: "guardian1",
+				Epoch:   0,
+			},
+			PendingGuardian: &api.Guardian{
+				Address: "guardian2",
+				Epoch:   10,
+			},
+			Frozen: true,
+		}
+		facade := mock.FacadeStub{
+			GetGuardianDataCalled: func(address string, options api.AccountQueryOptions) (api.GuardianData, api.BlockInfo, error) {
+				return expectedGuardianData, api.BlockInfo{}, nil
+			},
+		}
+
+		addrGroup, err := groups.NewAddressGroup(&facade)
+		require.NoError(t, err)
+
+		ws := startWebServer(addrGroup, "address", getAddressRoutesConfig())
+
+		req, _ := http.NewRequest("GET", fmt.Sprintf("/address/%s/guardian-data", testAddress), nil)
+		resp := httptest.NewRecorder()
+		ws.ServeHTTP(resp, req)
+
+		response := guardianDataResponse{}
+		loadResponse(resp.Body, &response)
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, expectedGuardianData, response.Data.GuardianData)
+	})
+}
+
 func TestGetESDTsRoles_WithEmptyAddressShouldReturnError(t *testing.T) {
 	t.Parallel()
 	facade := mock.FacadeStub{}
@@ -1032,6 +1122,7 @@ func getAddressRoutesConfig() config.ApiRoutesConfig {
 			"address": {
 				Routes: []config.RouteConfig{
 					{Name: "/:address", Open: true},
+					{Name: "/:address/guardian-data", Open: true},
 					{Name: "/:address/balance", Open: true},
 					{Name: "/:address/username", Open: true},
 					{Name: "/:address/keys", Open: true},

--- a/api/mock/facadeStub.go
+++ b/api/mock/facadeStub.go
@@ -20,14 +20,14 @@ import (
 
 // FacadeStub is the mock implementation of a node router handler
 type FacadeStub struct {
-	ShouldErrorStart                        bool
-	ShouldErrorStop                         bool
-	GetHeartbeatsHandler                    func() ([]data.PubKeyHeartbeat, error)
-	GetBalanceCalled                          func(address string, options api.AccountQueryOptions) (*big.Int, api.BlockInfo, error)
-	GetAccountCalled                       func(address string, options api.AccountQueryOptions) (api.AccountResponse, api.BlockInfo,error)
-	GenerateTransactionHandler              func(sender string, receiver string, value *big.Int, code string) (*transaction.Transaction, error)
-	GetTransactionHandler                   func(hash string, withResults bool) (*transaction.ApiTransactionResult, error)
-	CreateTransactionHandler                func(txArgs *external.ArgsCreateTransaction) (*transaction.Transaction, []byte, error)
+	ShouldErrorStart                            bool
+	ShouldErrorStop                             bool
+	GetHeartbeatsHandler                        func() ([]data.PubKeyHeartbeat, error)
+	GetBalanceCalled                            func(address string, options api.AccountQueryOptions) (*big.Int, api.BlockInfo, error)
+	GetAccountCalled                            func(address string, options api.AccountQueryOptions) (api.AccountResponse, api.BlockInfo, error)
+	GenerateTransactionHandler                  func(sender string, receiver string, value *big.Int, code string) (*transaction.Transaction, error)
+	GetTransactionHandler                       func(hash string, withResults bool) (*transaction.ApiTransactionResult, error)
+	CreateTransactionHandler                    func(txArgs *external.ArgsCreateTransaction) (*transaction.Transaction, []byte, error)
 	ValidateTransactionHandler                  func(tx *transaction.Transaction) error
 	ValidateTransactionForSimulationHandler     func(tx *transaction.Transaction, bypassSignature bool) error
 	SendBulkTransactionsHandler                 func(txs []*transaction.Transaction) (uint64, error)
@@ -38,6 +38,7 @@ type FacadeStub struct {
 	NodeConfigCalled                            func() map[string]interface{}
 	GetQueryHandlerCalled                       func(name string) (debug.QueryHandler, error)
 	GetValueForKeyCalled                        func(address string, key string, options api.AccountQueryOptions) (string, api.BlockInfo, error)
+	GetGuardianDataCalled                       func(address string, options api.AccountQueryOptions) (api.GuardianData, api.BlockInfo, error)
 	GetPeerInfoCalled                           func(pid string) ([]core.QueryP2PPeerInfo, error)
 	GetThrottlerForEndpointCalled               func(endpoint string) (core.Throttler, bool)
 	GetUsernameCalled                           func(address string, options api.AccountQueryOptions) (string, api.BlockInfo, error)
@@ -181,6 +182,14 @@ func (f *FacadeStub) GetKeyValuePairs(address string, options api.AccountQueryOp
 	}
 
 	return nil, api.BlockInfo{}, nil
+}
+
+// GetGuardianData -
+func (f *FacadeStub) GetGuardianData(address string, options api.AccountQueryOptions) (api.GuardianData, api.BlockInfo, error) {
+	if f.GetGuardianDataCalled != nil {
+		return f.GetGuardianDataCalled(address, options)
+	}
+	return api.GuardianData{}, api.BlockInfo{}, nil
 }
 
 // GetESDTData -

--- a/api/shared/interface.go
+++ b/api/shared/interface.go
@@ -70,6 +70,7 @@ type FacadeHandler interface {
 	GetESDTsWithRole(address string, role string, options api.AccountQueryOptions) ([]string, api.BlockInfo, error)
 	GetAllESDTTokens(address string, options api.AccountQueryOptions) (map[string]*esdt.ESDigitalToken, api.BlockInfo, error)
 	GetKeyValuePairs(address string, options api.AccountQueryOptions) (map[string]string, api.BlockInfo, error)
+	GetGuardianData(address string, options api.AccountQueryOptions) (api.GuardianData, api.BlockInfo, error)
 	GetBlockByHash(hash string, options api.BlockQueryOptions) (*api.Block, error)
 	GetBlockByNonce(nonce uint64, options api.BlockQueryOptions) (*api.Block, error)
 	GetBlockByRound(round uint64, options api.BlockQueryOptions) (*api.Block, error)

--- a/cmd/node/config/api.toml
+++ b/cmd/node/config/api.toml
@@ -49,6 +49,9 @@
         # /address/:address/key/:key will return the value of a key for a given account
         { Name = "/:address/key/:key", Open = true },
 
+        # /:address/guardian-data will return the guardian data for the given account
+        { Name = "/:address/guardian-data", Open = true},
+
         # /address/:address/esdt will return the list of esdt tokens for a given account
         { Name = "/:address/esdt", Open = true },
 

--- a/facade/initial/initialNodeFacade.go
+++ b/facade/initial/initialNodeFacade.go
@@ -288,6 +288,11 @@ func (inf *initialNodeFacade) GetKeyValuePairs(_ string, _ api.AccountQueryOptio
 	return nil, api.BlockInfo{}, errNodeStarting
 }
 
+// GetGuardianData returns error
+func (inf *initialNodeFacade) GetGuardianData(_ string, _ api.AccountQueryOptions) (api.GuardianData, api.BlockInfo, error) {
+	return api.GuardianData{}, api.BlockInfo{}, errNodeStarting
+}
+
 // GetDirectStakedList returns empty slice
 func (inf *initialNodeFacade) GetDirectStakedList() ([]*api.DirectStakedValue, error) {
 	return nil, errNodeStarting

--- a/facade/initial/initialNodeFacade_test.go
+++ b/facade/initial/initialNodeFacade_test.go
@@ -207,5 +207,9 @@ func TestDisabledNodeFacade_AllMethodsShouldNotPanic(t *testing.T) {
 	assert.Equal(t, uint64(0), nonce)
 	assert.Equal(t, errNodeStarting, err)
 
+	guardianData, _, err := inf.GetGuardianData("", api.AccountQueryOptions{})
+	assert.Equal(t, api.GuardianData{}, guardianData)
+	assert.Equal(t, errNodeStarting, err)
+
 	assert.False(t, check.IfNil(inf))
 }

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -29,6 +29,9 @@ type NodeHandler interface {
 	// GetValueForKey returns the value of a key from a given account
 	GetValueForKey(address string, key string, options api.AccountQueryOptions) (string, api.BlockInfo, error)
 
+	// GetGuardianData returns the guardian data for given account
+	GetGuardianData(address string, options api.AccountQueryOptions) (api.GuardianData, api.BlockInfo, error)
+
 	// GetKeyValuePairs returns the key-value pairs under a given address
 	GetKeyValuePairs(address string, options api.AccountQueryOptions, ctx context.Context) (map[string]string, api.BlockInfo, error)
 

--- a/facade/mock/nodeStub.go
+++ b/facade/mock/nodeStub.go
@@ -18,9 +18,8 @@ import (
 
 // NodeStub -
 type NodeStub struct {
-
 	ConnectToAddressesHandler                      func([]string) error
-	GetBalanceCalled                              func(address string, options api.AccountQueryOptions) (*big.Int, api.BlockInfo,error)
+	GetBalanceCalled                               func(address string, options api.AccountQueryOptions) (*big.Int, api.BlockInfo, error)
 	GenerateTransactionHandler                     func(sender string, receiver string, amount string, code string) (*transaction.Transaction, error)
 	CreateTransactionHandler                       func(txArgs *external.ArgsCreateTransaction) (*transaction.Transaction, []byte, error)
 	ValidateTransactionHandler                     func(tx *transaction.Transaction) error
@@ -37,6 +36,7 @@ type NodeStub struct {
 	IsSelfTriggerCalled                            func() bool
 	GetQueryHandlerCalled                          func(name string) (debug.QueryHandler, error)
 	GetValueForKeyCalled                           func(address string, key string, options api.AccountQueryOptions) (string, api.BlockInfo, error)
+	GetGuardianDataCalled                          func(address string, options api.AccountQueryOptions) (api.GuardianData, api.BlockInfo, error)
 	GetPeerInfoCalled                              func(pid string) ([]core.QueryP2PPeerInfo, error)
 	GetUsernameCalled                              func(address string, options api.AccountQueryOptions) (string, api.BlockInfo, error)
 	GetESDTDataCalled                              func(address string, key string, nonce uint64, options api.AccountQueryOptions) (*esdt.ESDigitalToken, api.BlockInfo, error)
@@ -103,6 +103,14 @@ func (ns *NodeStub) GetValueForKey(address string, key string, options api.Accou
 	}
 
 	return "", api.BlockInfo{}, nil
+}
+
+// GetGuardianData -
+func (ns *NodeStub) GetGuardianData(address string, options api.AccountQueryOptions) (api.GuardianData, api.BlockInfo, error) {
+	if ns.GetGuardianDataCalled != nil {
+		return ns.GetGuardianDataCalled(address, options)
+	}
+	return api.GuardianData{}, api.BlockInfo{}, nil
 }
 
 // EncodeAddressPubkey -

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -218,6 +218,11 @@ func (nf *nodeFacade) GetKeyValuePairs(address string, options apiData.AccountQu
 	return nf.node.GetKeyValuePairs(address, options, ctx)
 }
 
+// GetGuardianData returns the guardian data for the provided address
+func (nf *nodeFacade) GetGuardianData(address string, options apiData.AccountQueryOptions) (apiData.GuardianData, apiData.BlockInfo, error) {
+	return nf.node.GetGuardianData(address, options)
+}
+
 // GetAllESDTTokens returns all the esdt tokens for a given address
 func (nf *nodeFacade) GetAllESDTTokens(address string, options apiData.AccountQueryOptions) (map[string]*esdt.ESDigitalToken, apiData.BlockInfo, error) {
 	ctx, cancel := nf.getContextForApiTrieRangeOperations()

--- a/facade/nodeFacade_test.go
+++ b/facade/nodeFacade_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -698,7 +697,7 @@ func TestNodeFacade_GetGuardianData(t *testing.T) {
 	}
 	arg.Node = &mock.NodeStub{
 		GetGuardianDataCalled: func(address string, options api.AccountQueryOptions) (api.GuardianData, api.BlockInfo, error) {
-			if strings.Compare(testAddress, address) == 0 {
+			if testAddress == address {
 				return expectedGuardianData, api.BlockInfo{}, nil
 			}
 			return emptyGuardianData, api.BlockInfo{}, expectedErr

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ElrondNetwork/concurrent-map v0.1.3
 	github.com/ElrondNetwork/covalent-indexer-go v1.0.6
 	github.com/ElrondNetwork/elastic-indexer-go v1.2.38
-	github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220825075514-8e8d8ff0312b
+	github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220826090131-09d9dba97612
 	github.com/ElrondNetwork/elrond-go-crypto v1.0.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7
 	github.com/ElrondNetwork/elrond-vm-common v1.3.15-0.20220823131107-727e254268b6

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,9 @@ github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6y
 github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-core v1.1.15-0.20220517131228-41edc685421f/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-core v1.1.16-0.20220414130405-e3cc29bc7711/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
-github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220825075514-8e8d8ff0312b h1:OUxvUPQNftjoz8HEfl1Zr3cvTbgRMQtFosfKnrXUNNU=
 github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220825075514-8e8d8ff0312b/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
+github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220826090131-09d9dba97612 h1:FlYipmdMSFZr0asbAJOHwcXrNBpQ07jrSXevUK4pUCU=
+github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220826090131-09d9dba97612/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.0/go.mod h1:DGiR7/j1xv729Xg8SsjYaUzWXL5svMd44REXjWS/gAc=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.1 h1:xJUUshIZQ7h+rG7Art/9QHVyaPRV1wEjrxXYBdpmRlM=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.1/go.mod h1:uunsvweBrrhVojL8uiQSaTPsl3YIQ9iBqtYGM6xs4s0=

--- a/integrationTests/interface.go
+++ b/integrationTests/interface.go
@@ -67,6 +67,7 @@ type Facade interface {
 	GetAllESDTTokens(address string, options api.AccountQueryOptions) (map[string]*esdt.ESDigitalToken, api.BlockInfo, error)
 	GetESDTsRoles(address string, options api.AccountQueryOptions) (map[string][]string, api.BlockInfo, error)
 	GetKeyValuePairs(address string, options api.AccountQueryOptions) (map[string]string, api.BlockInfo, error)
+	GetGuardianData(address string, options api.AccountQueryOptions) (api.GuardianData, api.BlockInfo, error)
 	GetBlockByHash(hash string, options api.BlockQueryOptions) (*dataApi.Block, error)
 	GetBlockByNonce(nonce uint64, options api.BlockQueryOptions) (*dataApi.Block, error)
 	GetBlockByRound(round uint64, options api.BlockQueryOptions) (*dataApi.Block, error)

--- a/node/export_test.go
+++ b/node/export_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/factory"
+	"github.com/ElrondNetwork/elrond-go/state"
 )
 
 // GetClosableComponentName -
@@ -46,4 +47,10 @@ func ExtractApiBlockInfoIfErrAccountNotFoundAtBlock(err error) (api.BlockInfo, b
 // SetTxGuardianData -
 func (n *Node) SetTxGuardianData(guardian string, guardianSigHex string, tx *transaction.Transaction) error {
 	return n.setTxGuardianData(guardian, guardianSigHex, tx)
+}
+
+func (n *Node) GetPendingAndActiveGuardians(
+	userAccount state.UserAccountHandler,
+) (activeGuardian *api.Guardian, pendingGuardian *api.Guardian, err error) {
+	return n.getPendingAndActiveGuardians(userAccount)
 }

--- a/node/node.go
+++ b/node/node.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/api"
 	"github.com/ElrondNetwork/elrond-go-core/data/endProcess"
 	"github.com/ElrondNetwork/elrond-go-core/data/esdt"
+	"github.com/ElrondNetwork/elrond-go-core/data/guardians"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	disabledSig "github.com/ElrondNetwork/elrond-go-crypto/signing/disabled/singlesig"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
@@ -316,6 +317,41 @@ func (n *Node) GetValueForKey(address string, key string, options api.AccountQue
 	}
 
 	return hex.EncodeToString(valueBytes), blockInfo, nil
+}
+
+// GetGuardianData returns the guardian data for given account
+func (n *Node) GetGuardianData(address string, options api.AccountQueryOptions) (api.GuardianData, api.BlockInfo, error) {
+	userAccount, blockInfo, err := n.loadUserAccountHandlerByAddress(address, options)
+	if err != nil {
+		return api.GuardianData{}, api.BlockInfo{}, err
+	}
+
+	var active, pending *guardians.Guardian
+	gah := n.bootstrapComponents.GuardedAccountHandler()
+	active, pending, err = gah.GetConfiguredGuardians(userAccount)
+	if err != nil {
+		return api.GuardianData{}, api.BlockInfo{}, err
+	}
+
+	var activeGuardian, pendingGuardian *api.Guardian
+	if active != nil {
+		activeGuardian = &api.Guardian{
+			Address: n.coreComponents.AddressPubKeyConverter().Encode(active.Address),
+			Epoch:   active.ActivationEpoch,
+		}
+	}
+	if pending != nil {
+		pendingGuardian = &api.Guardian{
+			Address: n.coreComponents.AddressPubKeyConverter().Encode(pending.Address),
+			Epoch:   pending.ActivationEpoch,
+		}
+	}
+
+	return api.GuardianData{
+		ActiveGuardian:  activeGuardian,
+		PendingGuardian: pendingGuardian,
+		Frozen:          userAccount.IsFrozen(),
+	}, blockInfo, nil
 }
 
 // GetESDTData returns the esdt balance and properties from a given account

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/api"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/esdt"
+	"github.com/ElrondNetwork/elrond-go-core/data/guardians"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
 	"github.com/ElrondNetwork/elrond-go-core/hashing/sha256"
@@ -2213,6 +2214,7 @@ func TestCreateTransaction_AddressPubKeyConverterDecode(t *testing.T) {
 
 		assert.Nil(t, tx)
 		assert.Nil(t, txHash)
+		assert.NotNil(t, err)
 		assert.True(t, strings.Contains(err.Error(), "receiver address"))
 	})
 
@@ -2244,6 +2246,7 @@ func TestCreateTransaction_AddressPubKeyConverterDecode(t *testing.T) {
 
 		assert.Nil(t, tx)
 		assert.Nil(t, txHash)
+		assert.NotNil(t, err)
 		assert.True(t, strings.Contains(err.Error(), "sender address"))
 	})
 }
@@ -4045,6 +4048,114 @@ func TestNode_setTxGuardianData(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, guardianPubKey, tx.GuardianAddr)
 		require.Equal(t, guardianSig, tx.GuardianSignature)
+	})
+}
+
+func TestNode_getPendingAndActiveGuardians(t *testing.T) {
+	coreComponents := getDefaultCoreComponents()
+	bootstrapComponents := getDefaultBootstrapComponents()
+	expectedErr := errors.New("expected err")
+	g1PubKey := bytes.Repeat([]byte{1}, 32)
+	g2PubKey := bytes.Repeat([]byte{2}, 32)
+	g1 := &guardians.Guardian{
+		Address:         g1PubKey,
+		ActivationEpoch: 10,
+	}
+	g2 := &guardians.Guardian{
+		Address:         g2PubKey,
+		ActivationEpoch: 1,
+	}
+
+	expectedG1 := &api.Guardian{
+		Address: coreComponents.AddrPubKeyConv.Encode(g1.Address),
+		Epoch:   g1.ActivationEpoch,
+	}
+	expectedG2 := &api.Guardian{
+		Address: coreComponents.AddrPubKeyConv.Encode(g2.Address),
+		Epoch:   g2.ActivationEpoch,
+	}
+
+	t.Run("get configured guardians with error should propagate error", func(t *testing.T) {
+		bootstrapComponents.GuardedAccountHandlerField = &guardianMocks.GuardedAccountHandlerStub{
+			GetConfiguredGuardiansCalled: func(uah state.UserAccountHandler) (active *guardians.Guardian, pending *guardians.Guardian, err error) {
+				return nil, nil, expectedErr
+			},
+		}
+		n, _ := node.NewNode(
+			node.WithCoreComponents(coreComponents),
+			node.WithBootstrapComponents(bootstrapComponents),
+		)
+
+		activeGuardian, pendingGuardian, err := n.GetPendingAndActiveGuardians(&stateMock.UserAccountStub{})
+		require.Nil(t, activeGuardian)
+		require.Nil(t, pendingGuardian)
+		require.Equal(t, expectedErr, err)
+	})
+	t.Run("no pending and no active but no error", func(t *testing.T) {
+		bootstrapComponents.GuardedAccountHandlerField = &guardianMocks.GuardedAccountHandlerStub{
+			GetConfiguredGuardiansCalled: func(uah state.UserAccountHandler) (active *guardians.Guardian, pending *guardians.Guardian, err error) {
+				return nil, nil, nil
+			},
+		}
+		n, _ := node.NewNode(
+			node.WithCoreComponents(coreComponents),
+			node.WithBootstrapComponents(bootstrapComponents),
+		)
+		activeGuardian, pendingGuardian, err := n.GetPendingAndActiveGuardians(&stateMock.UserAccountStub{})
+		require.Nil(t, activeGuardian)
+		require.Nil(t, pendingGuardian)
+		require.Nil(t, err)
+	})
+	t.Run("one active", func(t *testing.T) {
+		bootstrapComponents.GuardedAccountHandlerField = &guardianMocks.GuardedAccountHandlerStub{
+			GetConfiguredGuardiansCalled: func(uah state.UserAccountHandler) (active *guardians.Guardian, pending *guardians.Guardian, err error) {
+				return g1, nil, nil
+			},
+		}
+		n, _ := node.NewNode(
+			node.WithCoreComponents(coreComponents),
+			node.WithBootstrapComponents(bootstrapComponents),
+		)
+		activeGuardian, pendingGuardian, err := n.GetPendingAndActiveGuardians(&stateMock.UserAccountStub{})
+		require.NotNil(t, activeGuardian)
+
+		require.Equal(t, expectedG1, activeGuardian)
+		require.Nil(t, pendingGuardian)
+		require.Nil(t, err)
+	})
+	t.Run("one pending", func(t *testing.T) {
+		bootstrapComponents.GuardedAccountHandlerField = &guardianMocks.GuardedAccountHandlerStub{
+			GetConfiguredGuardiansCalled: func(uah state.UserAccountHandler) (active *guardians.Guardian, pending *guardians.Guardian, err error) {
+				return nil, g1, nil
+			},
+		}
+		n, _ := node.NewNode(
+			node.WithCoreComponents(coreComponents),
+			node.WithBootstrapComponents(bootstrapComponents),
+		)
+		activeGuardian, pendingGuardian, err := n.GetPendingAndActiveGuardians(&stateMock.UserAccountStub{})
+		require.NotNil(t, pendingGuardian)
+		require.Equal(t, expectedG1, pendingGuardian)
+		require.Nil(t, activeGuardian)
+		require.Nil(t, err)
+	})
+	t.Run("one active one pending", func(t *testing.T) {
+		bootstrapComponents.GuardedAccountHandlerField = &guardianMocks.GuardedAccountHandlerStub{
+			GetConfiguredGuardiansCalled: func(uah state.UserAccountHandler) (active *guardians.Guardian, pending *guardians.Guardian, err error) {
+				return g1, g2, nil
+			},
+		}
+		n, _ := node.NewNode(
+			node.WithCoreComponents(coreComponents),
+			node.WithBootstrapComponents(bootstrapComponents),
+		)
+
+		activeGuardian, pendingGuardian, err := n.GetPendingAndActiveGuardians(&stateMock.UserAccountStub{})
+		require.NotNil(t, activeGuardian)
+		require.NotNil(t, pendingGuardian)
+		require.Equal(t, expectedG2, pendingGuardian)
+		require.Equal(t, expectedG1, activeGuardian)
+		require.Nil(t, err)
 	})
 }
 

--- a/process/guardian/disabled/disabledGuardedAccount.go
+++ b/process/guardian/disabled/disabledGuardedAccount.go
@@ -1,6 +1,7 @@
 package disabled
 
 import (
+	"github.com/ElrondNetwork/elrond-go-core/data/guardians"
 	"github.com/ElrondNetwork/elrond-go/state"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
@@ -34,6 +35,11 @@ func (dga *disabledGuardedAccount) SetGuardian(_ vmcommon.UserAccountHandler, _ 
 
 // CleanOtherThanActive does nothing as this is a disabled implementation
 func (dga *disabledGuardedAccount) CleanOtherThanActive(_ vmcommon.UserAccountHandler) {}
+
+// GetConfiguredGuardians returns nil, nil, nil as this is a disabled component
+func (dga *disabledGuardedAccount) GetConfiguredGuardians(_ state.UserAccountHandler) (active *guardians.Guardian, pending *guardians.Guardian, err error) {
+	return nil, nil, nil
+}
 
 // IsInterfaceNil returns true if there is no value under the interface
 func (dga *disabledGuardedAccount) IsInterfaceNil() bool {

--- a/process/guardian/guardedAccount.go
+++ b/process/guardian/guardedAccount.go
@@ -287,6 +287,19 @@ func (agc *guardedAccount) getActiveGuardian(gs *guardians.Guardians) (*guardian
 	return selectedGuardian, nil
 }
 
+// GetConfiguredGuardians returns the configured guardians for an account
+func (agc *guardedAccount) GetConfiguredGuardians(uah state.UserAccountHandler) (active *guardians.Guardian, pending *guardians.Guardian, err error) {
+	configuredGuardians, err := agc.getConfiguredGuardians(uah)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	active, _ = agc.getActiveGuardian(configuredGuardians)
+	pending, _ = agc.getPendingGuardian(configuredGuardians)
+
+	return
+}
+
 func (agc *guardedAccount) getPendingGuardian(gs *guardians.Guardians) (*guardians.Guardian, error) {
 	if gs == nil {
 		return nil, process.ErrAccountHasNoPendingGuardian

--- a/process/interface.go
+++ b/process/interface.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/endProcess"
 	"github.com/ElrondNetwork/elrond-go-core/data/esdt"
+	"github.com/ElrondNetwork/elrond-go-core/data/guardians"
 	"github.com/ElrondNetwork/elrond-go-core/data/rewardTx"
 	"github.com/ElrondNetwork/elrond-go-core/data/scheduled"
 	"github.com/ElrondNetwork/elrond-go-core/data/smartContractResult"
@@ -1255,6 +1256,7 @@ type GuardedAccountHandler interface {
 	HasPendingGuardian(uah state.UserAccountHandler) bool
 	SetGuardian(uah vmcommon.UserAccountHandler, guardianAddress []byte, txGuardianAddress []byte) error
 	CleanOtherThanActive(uah vmcommon.UserAccountHandler)
+	GetConfiguredGuardians(uah state.UserAccountHandler) (active *guardians.Guardian, pending *guardians.Guardian, err error)
 	IsInterfaceNil() bool
 }
 

--- a/testscommon/guardianMocks/guardianAccountHandlerStub.go
+++ b/testscommon/guardianMocks/guardianAccountHandlerStub.go
@@ -1,17 +1,19 @@
 package guardianMocks
 
 import (
+	"github.com/ElrondNetwork/elrond-go-core/data/guardians"
 	"github.com/ElrondNetwork/elrond-go/state"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
 
 // GuardedAccountHandlerStub -
 type GuardedAccountHandlerStub struct {
-	GetActiveGuardianCalled    func(handler vmcommon.UserAccountHandler) ([]byte, error)
-	SetGuardianCalled          func(uah vmcommon.UserAccountHandler, guardianAddress []byte, txGuardianAddress []byte) error
-	HasPendingGuardianCalled   func(uah state.UserAccountHandler) bool
-	HasActiveGuardianCalled    func(uah state.UserAccountHandler) bool
-	CleanOtherThanActiveCalled func(uah vmcommon.UserAccountHandler)
+	GetActiveGuardianCalled      func(handler vmcommon.UserAccountHandler) ([]byte, error)
+	SetGuardianCalled            func(uah vmcommon.UserAccountHandler, guardianAddress []byte, txGuardianAddress []byte) error
+	HasPendingGuardianCalled     func(uah state.UserAccountHandler) bool
+	HasActiveGuardianCalled      func(uah state.UserAccountHandler) bool
+	CleanOtherThanActiveCalled   func(uah vmcommon.UserAccountHandler)
+	GetConfiguredGuardiansCalled func(uah state.UserAccountHandler) (active *guardians.Guardian, pending *guardians.Guardian, err error)
 }
 
 // GetActiveGuardian -
@@ -51,6 +53,14 @@ func (gahs *GuardedAccountHandlerStub) CleanOtherThanActive(uah vmcommon.UserAcc
 	if gahs.CleanOtherThanActiveCalled != nil {
 		gahs.CleanOtherThanActiveCalled(uah)
 	}
+}
+
+// GetConfiguredGuardians -
+func (gahs *GuardedAccountHandlerStub) GetConfiguredGuardians(uah state.UserAccountHandler) (active *guardians.Guardian, pending *guardians.Guardian, err error) {
+	if gahs.GetConfiguredGuardiansCalled != nil {
+		return gahs.GetConfiguredGuardiansCalled(uah)
+	}
+	return nil, nil, nil
 }
 
 // IsInterfaceNil -


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
This PR adds a rest API for getting the guardian data of an address
  
## Proposed Changes
The guardianData returned on the API will give several useful information such as
 - the active guardian (bech32 if any) and its activation epoch
 - the pending guardian (bech32 if any) and its activation epoch
- frozen state of the account - bool

## Testing procedure
- add guardian on an account and use the API to check the guardian data (one pending guardian)
- wait the expected time for the guardian to become active, then use the API to check the guardian data is as expected (one active guardian)
- add another guardian and use the API to check the guardian data (one active one pending)
- set account in frozen state then check the guardian data (one active guardian, the pending was cleared by freeze account action, and account is in frozen state)
- set another guardian (through an ungarded tx) and check the guardian data (one active, one pending, account frozen) 