### PR TITLE
Remove mutex use in interceptor

### DIFF
--- a/process/interceptors/singleDataInterceptor.go
+++ b/process/interceptors/singleDataInterceptor.go
@@ -75,9 +75,6 @@ func NewSingleDataInterceptor(arg ArgSingleDataInterceptor) (*SingleDataIntercep
 // ProcessReceivedMessage is the callback func from the p2p.Messenger and will be called each time a new message was received
 // (for the topic this validator was registered to)
 func (sdi *SingleDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedPeer core.PeerID) error {
-	sdi.mutDebugHandler.RLock()
-	defer sdi.mutDebugHandler.RUnlock()
-
 	err := sdi.preProcessMesage(message, fromConnectedPeer)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- there was a bug in the `SingleDataInterceptor` that caused a mutex to be held for too much time. The mutex involved is `mutDebugHandler` that protects the `debugHandler` resource and is correctly used in the `baseDataInterceptor` common struct. The extra usage in `SingleDataInterceptor` remained from the last refactor that was carried ~2 years ago.
  
## Proposed Changes
- remove the extra usage of the mutex in the `SingleDataInterceptor`

## Testing procedure
- standard testing procedure
