### PR TITLE
Fix duplicated txs into tx pool api response

### DIFF
--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -797,7 +797,7 @@ func TestApiTransactionProcessor_GetTransactionsPoolForSender(t *testing.T) {
 
 	// if no tx is found in pool for a sender, it isn't an error, but return empty slice
 	newSender := "new-sender"
-	res, err  = atp.GetTransactionsPoolForSender(newSender, "")
+	res, err = atp.GetTransactionsPoolForSender(newSender, "")
 	require.NoError(t, err)
 	require.Equal(t, &common.TransactionsPoolForSenderApiResponse{
 		Transactions: []common.Transaction{},
@@ -807,7 +807,7 @@ func TestApiTransactionProcessor_GetTransactionsPoolForSender(t *testing.T) {
 func TestApiTransactionProcessor_GetLastPoolNonceForSender(t *testing.T) {
 	t.Parallel()
 
-	txHash0, txHash1, txHash2 := []byte("txHash0"), []byte("txHash1"), []byte("txHash2")
+	txHash0, txHash1, txHash2, txHash3, txHash4 := []byte("txHash0"), []byte("txHash1"), []byte("txHash2"), []byte("txHash3"), []byte("txHash4")
 	sender := "alice"
 	lastNonce := uint64(10)
 	txCacheIntraShard, _ := txcache.NewTxCache(txcache.ConfigSourceMe{
@@ -823,31 +823,15 @@ func TestApiTransactionProcessor_GetLastPoolNonceForSender(t *testing.T) {
 	txCacheIntraShard.AddTx(createTx(txHash2, sender, 3))
 	txCacheIntraShard.AddTx(createTx(txHash0, sender, 1))
 	txCacheIntraShard.AddTx(createTx(txHash1, sender, 2))
-
-	txHash3, txHash4 := []byte("txHash3"), []byte("txHash4")
-	txCacheWithMeta, _ := txcache.NewTxCache(txcache.ConfigSourceMe{
-		Name:                       "test-meta",
-		NumChunks:                  4,
-		NumBytesPerSenderThreshold: 1_048_576, // 1 MB
-		CountPerSenderThreshold:    math.MaxUint32,
-	}, &txcachemocks.TxGasHandlerMock{
-		MinimumGasMove:       1,
-		MinimumGasPrice:      1,
-		GasProcessingDivisor: 1,
-	})
-	txCacheWithMeta.AddTx(createTx(txHash3, sender, lastNonce))
-	txCacheWithMeta.AddTx(createTx(txHash4, sender, 5))
+	txCacheIntraShard.AddTx(createTx(txHash3, sender, lastNonce))
+	txCacheIntraShard.AddTx(createTx(txHash4, sender, 5))
 
 	args := createMockArgAPITransactionProcessor()
 	args.DataPool = &dataRetrieverMock.PoolsHolderStub{
 		TransactionsCalled: func() dataRetriever.ShardedDataCacherNotifier {
 			return &testscommon.ShardedDataStub{
 				ShardDataStoreCalled: func(cacheID string) storage.Cacher {
-					if len(cacheID) == 1 { // self shard
-						return txCacheIntraShard
-					}
-
-					return txCacheWithMeta
+					return txCacheIntraShard
 				},
 			}
 		},
@@ -962,11 +946,11 @@ func TestApiTransactionProcessor_GetTransactionsPoolNonceGapsForSender(t *testin
 
 	// if no tx is found in pool for a sender, it isn't an error, but return empty slice
 	newSender := "new-sender"
-	res, err  = atp.GetTransactionsPoolNonceGapsForSender(newSender)
+	res, err = atp.GetTransactionsPoolNonceGapsForSender(newSender)
 	require.NoError(t, err)
 	require.Equal(t, &common.TransactionsPoolNonceGapsForSenderApiResponse{
 		Sender: newSender,
-		Gaps: []common.NonceGapApiResponse{},
+		Gaps:   []common.NonceGapApiResponse{},
 	}, res)
 }
 


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- same tx is displayed multiple times in the response of `/transaction/pool?by-sender=erd1...` as `ShardDataStore` returns the same data storer for all ids "0", "0_1", "0_2", "0_META"
  
## Proposed Changes
- removed the iteration through all data stores with ids `sourceShard_destinationShard` as they all point to the same one, leading to duplicates

## Testing procedure
- scenario:
   - get one or 2 txs in pool(save the sender if possible..if not, get `/transaction/pool` on the observer from the shard you sent txsf and copy a sender address)
   - running `/transaction/pool?by-sender=sender_addr_from_above_point` on either proxy or intra shard observer, tyou should not the duplicates among tx hashes received in response
