### PR TITLE
Fixes guardian api

### DIFF
--- a/process/guardian/guardedAccount.go
+++ b/process/guardian/guardedAccount.go
@@ -308,7 +308,7 @@ func (agc *guardedAccount) getPendingGuardian(gs *guardians.Guardians) (*guardia
 		if guardian == nil {
 			continue
 		}
-		if guardian.ActivationEpoch < agc.currentEpoch {
+		if guardian.ActivationEpoch <= agc.currentEpoch {
 			continue
 		}
 		return guardian, nil


### PR DESCRIPTION
Remove active guardian from getPendingGuardian result (guardians with activation epoch == current epoch are active not pending)
