### PR TITLE
Rename api guardian field

### DIFF
--- a/api/groups/addressGroup_test.go
+++ b/api/groups/addressGroup_test.go
@@ -960,11 +960,11 @@ func TestGetGuardianData(t *testing.T) {
 		expectedGuardianData := api.GuardianData{
 			ActiveGuardian: &api.Guardian{
 				Address: "guardian1",
-				Epoch:   0,
+				ActivationEpoch:   0,
 			},
 			PendingGuardian: &api.Guardian{
 				Address: "guardian2",
-				Epoch:   10,
+				ActivationEpoch:   10,
 			},
 			Frozen: true,
 		}

--- a/facade/nodeFacade_test.go
+++ b/facade/nodeFacade_test.go
@@ -687,11 +687,11 @@ func TestNodeFacade_GetGuardianData(t *testing.T) {
 	expectedGuardianData := api.GuardianData{
 		ActiveGuardian: &api.Guardian{
 			Address: "guardian1",
-			Epoch:   0,
+			ActivationEpoch:   0,
 		},
 		PendingGuardian: &api.Guardian{
 			Address: "guardian2",
-			Epoch:   10,
+			ActivationEpoch:   10,
 		},
 		Frozen: true,
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ElrondNetwork/concurrent-map v0.1.3
 	github.com/ElrondNetwork/covalent-indexer-go v1.0.6
 	github.com/ElrondNetwork/elastic-indexer-go v1.2.39
-	github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220826090131-09d9dba97612
+	github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220831143637-7057edfa2d4e
 	github.com/ElrondNetwork/elrond-go-crypto v1.0.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7
 	github.com/ElrondNetwork/elrond-vm-common v1.3.16-0.20220830135147-b69441f225cb

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoC
 github.com/ElrondNetwork/elrond-go-core v1.1.15-0.20220517131228-41edc685421f/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-core v1.1.16-0.20220414130405-e3cc29bc7711/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220825075514-8e8d8ff0312b/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
-github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220826090131-09d9dba97612 h1:FlYipmdMSFZr0asbAJOHwcXrNBpQ07jrSXevUK4pUCU=
-github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220826090131-09d9dba97612/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
+github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220831143637-7057edfa2d4e h1:IlLgEcn7LK5rzHJNxU/NY5rl4dJk3ACH8gVlivGYP8M=
+github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220831143637-7057edfa2d4e/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.0/go.mod h1:DGiR7/j1xv729Xg8SsjYaUzWXL5svMd44REXjWS/gAc=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.1 h1:xJUUshIZQ7h+rG7Art/9QHVyaPRV1wEjrxXYBdpmRlM=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.1/go.mod h1:uunsvweBrrhVojL8uiQSaTPsl3YIQ9iBqtYGM6xs4s0=

--- a/node/node.go
+++ b/node/node.go
@@ -350,14 +350,14 @@ func (n *Node) getPendingAndActiveGuardians(
 
 	if active != nil {
 		activeGuardian = &api.Guardian{
-			Address: n.coreComponents.AddressPubKeyConverter().Encode(active.Address),
-			Epoch:   active.ActivationEpoch,
+			Address:         n.coreComponents.AddressPubKeyConverter().Encode(active.Address),
+			ActivationEpoch: active.ActivationEpoch,
 		}
 	}
 	if pending != nil {
 		pendingGuardian = &api.Guardian{
-			Address: n.coreComponents.AddressPubKeyConverter().Encode(pending.Address),
-			Epoch:   pending.ActivationEpoch,
+			Address:         n.coreComponents.AddressPubKeyConverter().Encode(pending.Address),
+			ActivationEpoch: pending.ActivationEpoch,
 		}
 	}
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -4086,11 +4086,11 @@ func TestNode_GetGuardianData(t *testing.T) {
 	}
 	apiG1 := &api.Guardian{
 		Address: coreComponents.AddressPubKeyConverter().Encode(g1.Address),
-		Epoch: g1.ActivationEpoch,
+		ActivationEpoch: g1.ActivationEpoch,
 	}
 	apiG2 := &api.Guardian{
 		Address: coreComponents.AddressPubKeyConverter().Encode(g2.Address),
-		Epoch: g2.ActivationEpoch,
+		ActivationEpoch: g2.ActivationEpoch,
 	}
 	t.Run("error on loadUserAccountHandlerByAddress", func(t *testing.T) {
 		accDB := &stateMock.AccountsStub{
@@ -4262,11 +4262,11 @@ func TestNode_getPendingAndActiveGuardians(t *testing.T) {
 
 	expectedG1 := &api.Guardian{
 		Address: coreComponents.AddrPubKeyConv.Encode(g1.Address),
-		Epoch:   g1.ActivationEpoch,
+		ActivationEpoch:   g1.ActivationEpoch,
 	}
 	expectedG2 := &api.Guardian{
 		Address: coreComponents.AddrPubKeyConv.Encode(g2.Address),
-		Epoch:   g2.ActivationEpoch,
+		ActivationEpoch:   g2.ActivationEpoch,
 	}
 
 	t.Run("get configured guardians with error should propagate error", func(t *testing.T) {


### PR DESCRIPTION
## Description of the reasoning behind the pull request
elrond-go-core API field name change propagation
  
## Proposed Changes
Adapt code to the changed fieldname

## Testing procedure
Use the API and check the results for an account that has a guardian
/address/:address/guardian-data
