### PR TITLE
Fix hb v2 metrics issues + hb status returned

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -929,6 +929,7 @@
     MaxDurationPeerUnresponsiveInSec                 = 900  # 15min
     HideInactiveValidatorIntervalInSec               = 1800 # 30min TODO: change this for mainnet/devnet/testnet to ~1h
     HardforkTimeBetweenSendsInSec                    = 60   # 1min
+    TimeBetweenConnectionsMetricsUpdateInSec         = 30   # 30sec
     [HeartbeatV2.PeerAuthenticationPool]
         DefaultSpanInSec = 3600 # 1h
         CacheExpiryInSec = 3600 # 1h

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -927,7 +927,7 @@
     DelayBetweenConnectionNotificationsInSec         = 60   # 1min
     MaxMissingKeysInRequest                          = 1000
     MaxDurationPeerUnresponsiveInSec                 = 900  # 15min
-    HideInactiveValidatorIntervalInSec               = 1800 # 30min TODO: change this for mainnet/devnet/testnet to ~1h
+    HideInactiveValidatorIntervalInSec               = 3600 # 1h
     HardforkTimeBetweenSendsInSec                    = 60   # 1min
     TimeBetweenConnectionsMetricsUpdateInSec         = 30   # 30sec
     [HeartbeatV2.PeerAuthenticationPool]

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -927,7 +927,7 @@
     DelayBetweenConnectionNotificationsInSec         = 60   # 1min
     MaxMissingKeysInRequest                          = 1000
     MaxDurationPeerUnresponsiveInSec                 = 900  # 15min
-    HideInactiveValidatorIntervalInSec               = 3600 # 1h
+    HideInactiveValidatorIntervalInSec               = 1800 # 30min TODO: change this for mainnet/devnet/testnet at ~1 epoch
     HardforkTimeBetweenSendsInSec                    = 60   # 1min
     [HeartbeatV2.PeerAuthenticationPool]
         DefaultSpanInSec = 3600 # 1h

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -927,7 +927,7 @@
     DelayBetweenConnectionNotificationsInSec         = 60   # 1min
     MaxMissingKeysInRequest                          = 1000
     MaxDurationPeerUnresponsiveInSec                 = 900  # 15min
-    HideInactiveValidatorIntervalInSec               = 1800 # 30min TODO: change this for mainnet/devnet/testnet at ~1 epoch
+    HideInactiveValidatorIntervalInSec               = 1800 # 30min TODO: change this for mainnet/devnet/testnet to ~1h
     HardforkTimeBetweenSendsInSec                    = 60   # 1min
     [HeartbeatV2.PeerAuthenticationPool]
         DefaultSpanInSec = 3600 # 1h

--- a/config/config.go
+++ b/config/config.go
@@ -123,6 +123,7 @@ type HeartbeatV2Config struct {
 	PeerAuthenticationPool                           PeerAuthenticationPoolConfig
 	HeartbeatPool                                    CacheConfig
 	HardforkTimeBetweenSendsInSec                    int64
+	TimeBetweenConnectionsMetricsUpdateInSec         int64
 }
 
 // PeerAuthenticationPoolConfig will hold the configuration for peer authentication pool

--- a/factory/heartbeatV2Components_test.go
+++ b/factory/heartbeatV2Components_test.go
@@ -43,6 +43,7 @@ func createMockHeartbeatV2ComponentsFactoryArgs() factory.ArgHeartbeatV2Componen
 				MaxDurationPeerUnresponsiveInSec:                 10,
 				HideInactiveValidatorIntervalInSec:               60,
 				HardforkTimeBetweenSendsInSec:                    5,
+				TimeBetweenConnectionsMetricsUpdateInSec:         10,
 				PeerAuthenticationPool: config.PeerAuthenticationPoolConfig{
 					DefaultSpanInSec: 30,
 					CacheExpiryInSec: 30,

--- a/factory/interface.go
+++ b/factory/interface.go
@@ -357,6 +357,7 @@ type HeartbeatComponentsHandler interface {
 type HeartbeatV2Monitor interface {
 	GetHeartbeats() []heartbeatData.PubKeyHeartbeat
 	IsInterfaceNil() bool
+	Close() error
 }
 
 // HeartbeatV2ComponentsHolder holds the heartbeatV2 components

--- a/heartbeat/monitor/monitor.go
+++ b/heartbeat/monitor/monitor.go
@@ -148,7 +148,7 @@ func (monitor *heartbeatV2Monitor) parseMessage(pid core.PeerID, message interfa
 	crtTime := time.Now()
 	messageAge := monitor.getMessageAge(crtTime, payload.Timestamp)
 	stringType := monitor.computePeerType(peerInfo.PkBytes)
-	if monitor.shouldSkipMessage(messageAge, stringType) {
+	if monitor.shouldSkipMessage(messageAge) {
 		return pubKeyHeartbeat, heartbeat.ErrShouldSkipValidator
 	}
 
@@ -205,12 +205,9 @@ func (monitor *heartbeatV2Monitor) isActive(messageAge time.Duration) bool {
 	return messageAge <= monitor.maxDurationPeerUnresponsive
 }
 
-func (monitor *heartbeatV2Monitor) shouldSkipMessage(messageAge time.Duration, peerType string) bool {
+func (monitor *heartbeatV2Monitor) shouldSkipMessage(messageAge time.Duration) bool {
 	isActive := monitor.isActive(messageAge)
-	isInactiveObserver := !isActive &&
-		peerType != string(common.EligibleList) &&
-		peerType != string(common.WaitingList)
-	if isInactiveObserver {
+	if !isActive {
 		return messageAge > monitor.hideInactiveValidatorInterval
 	}
 

--- a/heartbeat/monitor/monitor.go
+++ b/heartbeat/monitor/monitor.go
@@ -146,6 +146,7 @@ func (monitor *heartbeatV2Monitor) parseMessage(pid core.PeerID, message interfa
 	peerInfo := monitor.peerShardMapper.GetPeerInfo(pid)
 
 	crtTime := time.Now()
+	messageTime := time.Unix(payload.Timestamp, 0)
 	messageAge := monitor.getMessageAge(crtTime, payload.Timestamp)
 	stringType := monitor.computePeerType(peerInfo.PkBytes)
 	if monitor.shouldSkipMessage(messageAge) {
@@ -161,7 +162,7 @@ func (monitor *heartbeatV2Monitor) parseMessage(pid core.PeerID, message interfa
 
 	pubKeyHeartbeat = data.PubKeyHeartbeat{
 		PublicKey:       pk,
-		TimeStamp:       crtTime,
+		TimeStamp:       messageTime,
 		IsActive:        monitor.isActive(messageAge),
 		ReceivedShardID: monitor.shardId,
 		ComputedShardID: peerInfo.ShardID,

--- a/heartbeat/monitor/monitor_test.go
+++ b/heartbeat/monitor/monitor_test.go
@@ -298,11 +298,11 @@ func TestHeartbeatV2Monitor_shouldSkipMessage(t *testing.T) {
 	assert.False(t, check.IfNil(monitor))
 
 	// active
-	assert.False(t, monitor.shouldSkipMessage(time.Second, string(common.EligibleList)))
-	// inactive observer but should not hide yet
-	assert.False(t, monitor.shouldSkipMessage(args.HideInactiveValidatorInterval-time.Second, string(common.ObserverList)))
-	// inactive observer and too old should be hidden
-	assert.True(t, monitor.shouldSkipMessage(args.HideInactiveValidatorInterval+time.Second, string(common.ObserverList)))
+	assert.False(t, monitor.shouldSkipMessage(time.Second))
+	// inactive but should not hide yet
+	assert.False(t, monitor.shouldSkipMessage(args.HideInactiveValidatorInterval-time.Second))
+	// inactive and too old should be hidden
+	assert.True(t, monitor.shouldSkipMessage(args.HideInactiveValidatorInterval+time.Second))
 }
 
 func TestHeartbeatV2Monitor_GetHeartbeats(t *testing.T) {

--- a/heartbeat/process/monitor.go
+++ b/heartbeat/process/monitor.go
@@ -469,6 +469,9 @@ func (m *Monitor) computeInactiveHeartbeatMessages() {
 // GetHeartbeats returns the heartbeat status
 func (m *Monitor) GetHeartbeats() []data.PubKeyHeartbeat {
 	m.Cleanup()
+	if m.flagHeartbeatDisableEpoch.IsSet() {
+		return make([]data.PubKeyHeartbeat, 0)
+	}
 
 	m.mutHeartbeatMessages.Lock()
 	status := make([]data.PubKeyHeartbeat, 0, len(m.heartbeatMessages))

--- a/heartbeat/process/monitor_test.go
+++ b/heartbeat/process/monitor_test.go
@@ -550,6 +550,7 @@ func TestMonitor_RemoveInactiveValidatorsIfIntervalExceeded(t *testing.T) {
 		HideInactiveValidatorIntervalInSec: 600,
 		AppStatusHandler:                   &statusHandlerMock.AppStatusHandlerStub{},
 		EpochNotifier:                      &epochNotifier.EpochNotifierStub{},
+		HeartbeatDisableEpoch:              10000,
 	}
 	mon, _ := process.NewMonitor(arg)
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pkValidator)})
@@ -731,4 +732,19 @@ func TestMonitor_CleanupShouldWork(t *testing.T) {
 
 	assert.Equal(t, 0, mon.GetNumHearbeatMessages())
 	assert.Equal(t, 0, mon.GetNumDoubleSignerPeers())
+}
+
+func TestNewMonitor_GetHeartbeatsReturnsEmptySliceIfDisabled(t *testing.T) {
+	t.Parallel()
+
+	arg := createMockArgHeartbeatMonitor()
+	arg.HeartbeatDisableEpoch = 0
+	arg.PubKeysMap = map[uint32][]string{0: {"pk1", "pk2"}}
+	mon, err := process.NewMonitor(arg)
+
+	assert.Nil(t, err)
+	assert.False(t, check.IfNil(mon))
+
+	hbStatus := mon.GetHeartbeats()
+	assert.Equal(t, 0, len(hbStatus))
 }

--- a/heartbeat/sender/sender.go
+++ b/heartbeat/sender/sender.go
@@ -33,6 +33,8 @@ type ArgSender struct {
 	HardforkTrigger                             heartbeat.HardforkTrigger
 	HardforkTimeBetweenSends                    time.Duration
 	HardforkTriggerPubKey                       []byte
+	PeerTypeProvider                            heartbeat.PeerTypeProviderHandler
+	AppStatusHandler                            core.AppStatusHandler
 }
 
 // sender defines the component which sends authentication and heartbeat messages
@@ -84,6 +86,8 @@ func NewSender(args ArgSender) (*sender, error) {
 		identity:             args.Identity,
 		peerSubType:          args.PeerSubType,
 		currentBlockProvider: args.CurrentBlockProvider,
+		peerTypeProvider:     args.PeerTypeProvider,
+		appStatusHandler:     args.AppStatusHandler,
 	})
 	if err != nil {
 		return nil, err
@@ -133,6 +137,8 @@ func checkSenderArgs(args ArgSender) error {
 		identity:             args.Identity,
 		peerSubType:          args.PeerSubType,
 		currentBlockProvider: args.CurrentBlockProvider,
+		peerTypeProvider:     args.PeerTypeProvider,
+		appStatusHandler:     args.AppStatusHandler,
 	}
 	return checkHeartbeatSenderArgs(hbsArgs)
 }

--- a/heartbeat/sender/sender_test.go
+++ b/heartbeat/sender/sender_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon/cryptoMocks"
 	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	"github.com/ElrondNetwork/elrond-go/testscommon/shardingMocks"
+	"github.com/ElrondNetwork/elrond-go/testscommon/statusHandler"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,6 +42,8 @@ func createMockSenderArgs() ArgSender {
 		HardforkTrigger:                             &testscommon.HardforkTriggerStub{},
 		HardforkTimeBetweenSends:                    time.Second,
 		HardforkTriggerPubKey:                       providedHardforkPubKey,
+		PeerTypeProvider:                            &mock.PeerTypeProviderStub{},
+		AppStatusHandler:                            &statusHandler.AppStatusHandlerStub{},
 	}
 }
 
@@ -247,6 +250,26 @@ func TestNewSender(t *testing.T) {
 		assert.Nil(t, sender)
 		assert.True(t, errors.Is(err, heartbeat.ErrInvalidValue))
 		assert.True(t, strings.Contains(err.Error(), "hardfork"))
+	})
+	t.Run("nil peer type provider should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockSenderArgs()
+		args.PeerTypeProvider = nil
+		sender, err := NewSender(args)
+
+		assert.Nil(t, sender)
+		assert.Equal(t, heartbeat.ErrNilPeerTypeProvider, err)
+	})
+	t.Run("nil status handler should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockSenderArgs()
+		args.AppStatusHandler = nil
+		sender, err := NewSender(args)
+
+		assert.Nil(t, sender)
+		assert.Equal(t, heartbeat.ErrNilAppStatusHandler, err)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()

--- a/integrationTests/testHeartbeatNode.go
+++ b/integrationTests/testHeartbeatNode.go
@@ -46,6 +46,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon/nodeTypeProviderMock"
 	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	"github.com/ElrondNetwork/elrond-go/testscommon/shardingMocks"
+	"github.com/ElrondNetwork/elrond-go/testscommon/statusHandler"
 	trieMock "github.com/ElrondNetwork/elrond-go/testscommon/trie"
 	"github.com/ElrondNetwork/elrond-go/update"
 	"github.com/stretchr/testify/require"
@@ -412,6 +413,8 @@ func (thn *TestHeartbeatNode) initSender() {
 		NodesCoordinator:        thn.NodesCoordinator,
 		HardforkTrigger:         &testscommon.HardforkTriggerStub{},
 		HardforkTriggerPubKey:   []byte(providedHardforkPubKey),
+		PeerTypeProvider:        &mock.PeerTypeProviderStub{},
+		AppStatusHandler:        &statusHandler.AppStatusHandlerStub{},
 
 		PeerAuthenticationTimeBetweenSends:          timeBetweenPeerAuths,
 		PeerAuthenticationTimeBetweenSendsWhenError: timeBetweenSendsWhenError,

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -3004,6 +3004,7 @@ func (tpn *TestProcessorNode) createHeartbeatWithHardforkTrigger() {
 		MaxDurationPeerUnresponsiveInSec:                 10,
 		HideInactiveValidatorIntervalInSec:               60,
 		HardforkTimeBetweenSendsInSec:                    2,
+		TimeBetweenConnectionsMetricsUpdateInSec:         10,
 		PeerAuthenticationPool: config.PeerAuthenticationPoolConfig{
 			DefaultSpanInSec: 30,
 			CacheExpiryInSec: 30,

--- a/testscommon/cacherMock.go
+++ b/testscommon/cacherMock.go
@@ -102,6 +102,9 @@ func (cacher *CacherMock) Remove(key []byte) {
 
 // Keys -
 func (cacher *CacherMock) Keys() [][]byte {
+	cacher.mut.RLock()
+	defer cacher.mut.RUnlock()
+
 	keys := make([][]byte, len(cacher.dataMap))
 	idx := 0
 	for k := range cacher.dataMap {

--- a/testscommon/generalConfig.go
+++ b/testscommon/generalConfig.go
@@ -277,6 +277,7 @@ func GetGeneralConfig() config.Config {
 			MaxDurationPeerUnresponsiveInSec:                 10,
 			HideInactiveValidatorIntervalInSec:               60,
 			HardforkTimeBetweenSendsInSec:                    5,
+			TimeBetweenConnectionsMetricsUpdateInSec:         10,
 			PeerAuthenticationPool: config.PeerAuthenticationPoolConfig{
 				DefaultSpanInSec: 30,
 				CacheExpiryInSec: 30,


### PR DESCRIPTION
## Description of the reasoning behind the pull request 
- when validators change their shards in the normal shuffle out process, they no longer output messages on the old shard's heartbeat topic. The old shard's nodes will make them inactive **but keep them in the cache** because they are still validators. This will pollute the node's API response for the heartbeat status with a lot of old messages. 
- some metrics were not updated at all with this hb v2 system
- termui reported some misleading information now that the heartbeat v2 subsystem is running. Also, heartbeat v1 subsystem still pushed some metrics.
  
## Proposed Changes
- the solution here is to allow the deletion from the cache of old nodes despite the fact that the nodes are validators or observers
- push statuses in app status handler from both sender & monitor components
- make hb v1 subsystem not return any stored nodes statuses when the disabled epoch was reached

## Testing procedure
- standard all-in procedure
- connect a node running this branch to the testnet. Observe the list returned for the /node/heartbeatstatus as it should not contain old validators that are not active
