### PR TITLE
Add new flags (useful for some observers): "serialize-snapshots", "disable-consensus-watchdog"

### DIFF
--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -327,6 +327,11 @@ var (
 		Name:  "force-start-from-network",
 		Usage: "Flag that will force the start from network bootstrap process",
 	}
+	// disableConsensusWatchdog defines a flag that will disable the consensus watchdog
+	disableConsensusWatchdog = cli.BoolFlag{
+		Name:  "disable-consensus-watchdog",
+		Usage: "Flag that will disable the consensus watchdog",
+	}
 )
 
 func getFlags() []cli.Flag {
@@ -377,6 +382,7 @@ func getFlags() []cli.Flag {
 		memBallast,
 		memoryUsageToCreateProfiles,
 		forceStartFromNetwork,
+		disableConsensusWatchdog,
 	}
 }
 
@@ -400,6 +406,7 @@ func getFlagsConfig(ctx *cli.Context, log logger.Logger) *config.ContextFlagsCon
 	flagsConfig.UseLogView = ctx.GlobalBool(useLogView.Name)
 	flagsConfig.ValidatorKeyIndex = ctx.GlobalInt(validatorKeyIndex.Name)
 	flagsConfig.ForceStartFromNetwork = ctx.GlobalBool(forceStartFromNetwork.Name)
+	flagsConfig.DisableConsensusWatchdog = ctx.GlobalBool(disableConsensusWatchdog.Name)
 	return flagsConfig
 }
 

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -332,6 +332,11 @@ var (
 		Name:  "disable-consensus-watchdog",
 		Usage: "Flag that will disable the consensus watchdog",
 	}
+	// serializeSnapshots defines a flag that will serialize `state snapshotting` and `processing`
+	serializeSnapshots = cli.BoolFlag{
+		Name:  "serialize-snapshots",
+		Usage: "Flag that will serialize `state snapshotting` and `processing`",
+	}
 )
 
 func getFlags() []cli.Flag {
@@ -383,6 +388,7 @@ func getFlags() []cli.Flag {
 		memoryUsageToCreateProfiles,
 		forceStartFromNetwork,
 		disableConsensusWatchdog,
+		serializeSnapshots,
 	}
 }
 
@@ -407,6 +413,7 @@ func getFlagsConfig(ctx *cli.Context, log logger.Logger) *config.ContextFlagsCon
 	flagsConfig.ValidatorKeyIndex = ctx.GlobalInt(validatorKeyIndex.Name)
 	flagsConfig.ForceStartFromNetwork = ctx.GlobalBool(forceStartFromNetwork.Name)
 	flagsConfig.DisableConsensusWatchdog = ctx.GlobalBool(disableConsensusWatchdog.Name)
+	flagsConfig.SerializeSnapshots = ctx.GlobalBool(serializeSnapshots.Name)
 	return flagsConfig
 }
 

--- a/config/contextFlagsConfig.go
+++ b/config/contextFlagsConfig.go
@@ -22,6 +22,7 @@ type ContextFlagsConfig struct {
 	Version                      string
 	ForceStartFromNetwork        bool
 	DisableConsensusWatchdog     bool
+	SerializeSnapshots           bool
 }
 
 // ImportDbConfig will hold the import-db parameters

--- a/config/contextFlagsConfig.go
+++ b/config/contextFlagsConfig.go
@@ -21,6 +21,7 @@ type ContextFlagsConfig struct {
 	EnableRestAPIServerDebugMode bool
 	Version                      string
 	ForceStartFromNetwork        bool
+	DisableConsensusWatchdog     bool
 }
 
 // ImportDbConfig will hold the import-db parameters

--- a/factory/consensusComponents.go
+++ b/factory/consensusComponents.go
@@ -26,31 +26,33 @@ import (
 
 // ConsensusComponentsFactoryArgs holds the arguments needed to create a consensus components factory
 type ConsensusComponentsFactoryArgs struct {
-	Config              config.Config
-	BootstrapRoundIndex uint64
-	CoreComponents      CoreComponentsHolder
-	NetworkComponents   NetworkComponentsHolder
-	CryptoComponents    CryptoComponentsHolder
-	DataComponents      DataComponentsHolder
-	ProcessComponents   ProcessComponentsHolder
-	StateComponents     StateComponentsHolder
-	StatusComponents    StatusComponentsHolder
-	ScheduledProcessor  consensus.ScheduledProcessor
-	IsInImportMode      bool
+	Config                config.Config
+	BootstrapRoundIndex   uint64
+	CoreComponents        CoreComponentsHolder
+	NetworkComponents     NetworkComponentsHolder
+	CryptoComponents      CryptoComponentsHolder
+	DataComponents        DataComponentsHolder
+	ProcessComponents     ProcessComponentsHolder
+	StateComponents       StateComponentsHolder
+	StatusComponents      StatusComponentsHolder
+	ScheduledProcessor    consensus.ScheduledProcessor
+	IsInImportMode        bool
+	ShouldDisableWatchdog bool
 }
 
 type consensusComponentsFactory struct {
-	config              config.Config
-	bootstrapRoundIndex uint64
-	coreComponents      CoreComponentsHolder
-	networkComponents   NetworkComponentsHolder
-	cryptoComponents    CryptoComponentsHolder
-	dataComponents      DataComponentsHolder
-	processComponents   ProcessComponentsHolder
-	stateComponents     StateComponentsHolder
-	statusComponents    StatusComponentsHolder
-	scheduledProcessor  consensus.ScheduledProcessor
-	isInImportMode      bool
+	config                config.Config
+	bootstrapRoundIndex   uint64
+	coreComponents        CoreComponentsHolder
+	networkComponents     NetworkComponentsHolder
+	cryptoComponents      CryptoComponentsHolder
+	dataComponents        DataComponentsHolder
+	processComponents     ProcessComponentsHolder
+	stateComponents       StateComponentsHolder
+	statusComponents      StatusComponentsHolder
+	scheduledProcessor    consensus.ScheduledProcessor
+	isInImportMode        bool
+	shouldDisableWatchdog bool
 }
 
 type consensusComponents struct {
@@ -90,17 +92,18 @@ func NewConsensusComponentsFactory(args ConsensusComponentsFactoryArgs) (*consen
 	}
 
 	return &consensusComponentsFactory{
-		config:              args.Config,
-		bootstrapRoundIndex: args.BootstrapRoundIndex,
-		coreComponents:      args.CoreComponents,
-		networkComponents:   args.NetworkComponents,
-		cryptoComponents:    args.CryptoComponents,
-		dataComponents:      args.DataComponents,
-		processComponents:   args.ProcessComponents,
-		stateComponents:     args.StateComponents,
-		statusComponents:    args.StatusComponents,
-		scheduledProcessor:  args.ScheduledProcessor,
-		isInImportMode:      args.IsInImportMode,
+		config:                args.Config,
+		bootstrapRoundIndex:   args.BootstrapRoundIndex,
+		coreComponents:        args.CoreComponents,
+		networkComponents:     args.NetworkComponents,
+		cryptoComponents:      args.CryptoComponents,
+		dataComponents:        args.DataComponents,
+		processComponents:     args.ProcessComponents,
+		stateComponents:       args.StateComponents,
+		statusComponents:      args.StatusComponents,
+		scheduledProcessor:    args.ScheduledProcessor,
+		isInImportMode:        args.IsInImportMode,
+		shouldDisableWatchdog: args.ShouldDisableWatchdog,
 	}, nil
 }
 
@@ -306,6 +309,10 @@ func (ccf *consensusComponentsFactory) createChronology() (consensus.ChronologyH
 	if ccf.isInImportMode {
 		log.Warn("node is running in import mode. Chronology watchdog will be turned off as " +
 			"it is incompatible with the import-db process.")
+		wd = &watchdog.DisabledWatchdog{}
+	}
+	if ccf.shouldDisableWatchdog {
+		log.Warn("Chronology watchdog will be turned off (explicitly).")
 		wd = &watchdog.DisabledWatchdog{}
 	}
 

--- a/factory/stateComponents.go
+++ b/factory/stateComponents.go
@@ -21,23 +21,25 @@ import (
 
 // StateComponentsFactoryArgs holds the arguments needed for creating a state components factory
 type StateComponentsFactoryArgs struct {
-	Config           config.Config
-	EnableEpochs     config.EnableEpochs
-	ShardCoordinator sharding.Coordinator
-	Core             CoreComponentsHolder
-	StorageService   dataRetriever.StorageService
-	ProcessingMode   common.NodeProcessingMode
-	ChainHandler     chainData.ChainHandler
+	Config                   config.Config
+	EnableEpochs             config.EnableEpochs
+	ShardCoordinator         sharding.Coordinator
+	Core                     CoreComponentsHolder
+	StorageService           dataRetriever.StorageService
+	ProcessingMode           common.NodeProcessingMode
+	ShouldSerializeSnapshots bool
+	ChainHandler             chainData.ChainHandler
 }
 
 type stateComponentsFactory struct {
-	config           config.Config
-	shardCoordinator sharding.Coordinator
-	core             CoreComponentsHolder
-	storageService   dataRetriever.StorageService
-	enableEpochs     config.EnableEpochs
-	processingMode   common.NodeProcessingMode
-	chainHandler     chainData.ChainHandler
+	config                   config.Config
+	shardCoordinator         sharding.Coordinator
+	core                     CoreComponentsHolder
+	storageService           dataRetriever.StorageService
+	enableEpochs             config.EnableEpochs
+	processingMode           common.NodeProcessingMode
+	shouldSerializeSnapshots bool
+	chainHandler             chainData.ChainHandler
 }
 
 // stateComponents struct holds the state components of the Elrond protocol
@@ -75,13 +77,14 @@ func NewStateComponentsFactory(args StateComponentsFactoryArgs) (*stateComponent
 	}
 
 	return &stateComponentsFactory{
-		config:           args.Config,
-		shardCoordinator: args.ShardCoordinator,
-		core:             args.Core,
-		storageService:   args.StorageService,
-		enableEpochs:     args.EnableEpochs,
-		processingMode:   args.ProcessingMode,
-		chainHandler:     args.ChainHandler,
+		config:                   args.Config,
+		shardCoordinator:         args.ShardCoordinator,
+		core:                     args.Core,
+		storageService:           args.StorageService,
+		enableEpochs:             args.EnableEpochs,
+		processingMode:           args.ProcessingMode,
+		shouldSerializeSnapshots: args.ShouldSerializeSnapshots,
+		chainHandler:             args.ChainHandler,
 	}, nil
 }
 
@@ -125,13 +128,14 @@ func (scf *stateComponentsFactory) createAccountsAdapters(triesContainer common.
 	}
 
 	argsProcessingAccountsDB := state.ArgsAccountsDB{
-		Trie:                  merkleTrie,
-		Hasher:                scf.core.Hasher(),
-		Marshaller:            scf.core.InternalMarshalizer(),
-		AccountFactory:        accountFactory,
-		StoragePruningManager: storagePruning,
-		ProcessingMode:        scf.processingMode,
-		ProcessStatusHandler:  scf.core.ProcessStatusHandler(),
+		Trie:                     merkleTrie,
+		Hasher:                   scf.core.Hasher(),
+		Marshaller:               scf.core.InternalMarshalizer(),
+		AccountFactory:           accountFactory,
+		StoragePruningManager:    storagePruning,
+		ProcessingMode:           scf.processingMode,
+		ShouldSerializeSnapshots: scf.shouldSerializeSnapshots,
+		ProcessStatusHandler:     scf.core.ProcessStatusHandler(),
 	}
 	accountsAdapter, err := state.NewAccountsDB(argsProcessingAccountsDB)
 	if err != nil {
@@ -186,13 +190,14 @@ func (scf *stateComponentsFactory) createPeerAdapter(triesContainer common.Tries
 	}
 
 	argsProcessingPeerAccountsDB := state.ArgsAccountsDB{
-		Trie:                  merkleTrie,
-		Hasher:                scf.core.Hasher(),
-		Marshaller:            scf.core.InternalMarshalizer(),
-		AccountFactory:        accountFactory,
-		StoragePruningManager: storagePruning,
-		ProcessingMode:        scf.processingMode,
-		ProcessStatusHandler:  scf.core.ProcessStatusHandler(),
+		Trie:                     merkleTrie,
+		Hasher:                   scf.core.Hasher(),
+		Marshaller:               scf.core.InternalMarshalizer(),
+		AccountFactory:           accountFactory,
+		StoragePruningManager:    storagePruning,
+		ProcessingMode:           scf.processingMode,
+		ShouldSerializeSnapshots: scf.shouldSerializeSnapshots,
+		ProcessStatusHandler:     scf.core.ProcessStatusHandler(),
 	}
 	peerAdapter, err := state.NewPeerAccountsDB(argsProcessingPeerAccountsDB)
 	if err != nil {

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -663,17 +663,18 @@ func (nr *nodeRunner) CreateManagedConsensusComponents(
 	}
 
 	consensusArgs := mainFactory.ConsensusComponentsFactoryArgs{
-		Config:              *nr.configs.GeneralConfig,
-		BootstrapRoundIndex: nr.configs.FlagsConfig.BootstrapRoundIndex,
-		CoreComponents:      coreComponents,
-		NetworkComponents:   networkComponents,
-		CryptoComponents:    cryptoComponents,
-		DataComponents:      dataComponents,
-		ProcessComponents:   processComponents,
-		StateComponents:     stateComponents,
-		StatusComponents:    statusComponents,
-		ScheduledProcessor:  scheduledProcessor,
-		IsInImportMode:      nr.configs.ImportDbConfig.IsImportDBMode,
+		Config:                *nr.configs.GeneralConfig,
+		BootstrapRoundIndex:   nr.configs.FlagsConfig.BootstrapRoundIndex,
+		CoreComponents:        coreComponents,
+		NetworkComponents:     networkComponents,
+		CryptoComponents:      cryptoComponents,
+		DataComponents:        dataComponents,
+		ProcessComponents:     processComponents,
+		StateComponents:       stateComponents,
+		StatusComponents:      statusComponents,
+		ScheduledProcessor:    scheduledProcessor,
+		IsInImportMode:        nr.configs.ImportDbConfig.IsImportDBMode,
+		ShouldDisableWatchdog: nr.configs.FlagsConfig.DisableConsensusWatchdog,
 	}
 
 	consensusFactory, err := mainFactory.NewConsensusComponentsFactory(consensusArgs)

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -1141,13 +1141,14 @@ func (nr *nodeRunner) CreateManagedStateComponents(
 		processingMode = common.ImportDb
 	}
 	stateArgs := mainFactory.StateComponentsFactoryArgs{
-		Config:           *nr.configs.GeneralConfig,
-		EnableEpochs:     nr.configs.EpochConfig.EnableEpochs,
-		ShardCoordinator: bootstrapComponents.ShardCoordinator(),
-		Core:             coreComponents,
-		StorageService:   dataComponents.StorageService(),
-		ProcessingMode:   processingMode,
-		ChainHandler:     dataComponents.Blockchain(),
+		Config:                   *nr.configs.GeneralConfig,
+		EnableEpochs:             nr.configs.EpochConfig.EnableEpochs,
+		ShardCoordinator:         bootstrapComponents.ShardCoordinator(),
+		Core:                     coreComponents,
+		StorageService:           dataComponents.StorageService(),
+		ProcessingMode:           processingMode,
+		ShouldSerializeSnapshots: nr.configs.FlagsConfig.SerializeSnapshots,
+		ChainHandler:             dataComponents.Blockchain(),
 	}
 
 	stateComponentsFactory, err := mainFactory.NewStateComponentsFactory(stateArgs)

--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -1231,9 +1231,9 @@ func (adb *AccountsDB) setStateCheckpoint(rootHash []byte) {
 }
 
 func (adb *AccountsDB) waitForCompletionIfRunningInImportDB(stats common.SnapshotStatisticsHandler) {
-	if adb.processingMode != common.ImportDb {
-		return
-	}
+	// if adb.processingMode != common.ImportDb {
+	// 	return
+	// }
 
 	log.Debug("manually setting idle on the process status handler in order to be able to start & complete the snapshotting/checkpointing process")
 	adb.processStatusHandler.SetIdle()

--- a/state/accountsDB_test.go
+++ b/state/accountsDB_test.go
@@ -2541,7 +2541,7 @@ func BenchmarkAccountsDb_GetCodeEntry(b *testing.B) {
 	}
 }
 
-func TestAccountsDB_waitForCompletionIfRunningInImportDB(t *testing.T) {
+func TestAccountsDB_waitForCompletionIfAppropriate(t *testing.T) {
 	t.Parallel()
 
 	t.Run("not in import db", func(t *testing.T) {
@@ -2555,7 +2555,7 @@ func TestAccountsDB_waitForCompletionIfRunningInImportDB(t *testing.T) {
 			},
 		}
 		adb, _ := state.NewAccountsDB(argsAccountsDB)
-		adb.WaitForCompletionIfRunningInImportDB(&trieMock.MockStatistics{})
+		adb.WaitForCompletionIfAppropriate(&trieMock.MockStatistics{})
 	})
 	t.Run("in import db", func(t *testing.T) {
 		t.Parallel()
@@ -2575,7 +2575,7 @@ func TestAccountsDB_waitForCompletionIfRunningInImportDB(t *testing.T) {
 			waitForSnapshotsToFinishCalled = true
 		}
 		adb, _ := state.NewAccountsDB(argsAccountsDB)
-		adb.WaitForCompletionIfRunningInImportDB(stats)
+		adb.WaitForCompletionIfAppropriate(stats)
 		assert.True(t, idleWasSet)
 		assert.True(t, waitForSnapshotsToFinishCalled)
 	})

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -37,9 +37,9 @@ func (adb *AccountsDB) GetObsoleteHashes() map[string][][]byte {
 	return adb.obsoleteDataTrieHashes
 }
 
-// WaitForCompletionIfRunningInImportDB -
-func (adb *AccountsDB) WaitForCompletionIfRunningInImportDB(stats common.SnapshotStatisticsHandler) {
-	adb.waitForCompletionIfRunningInImportDB(stats)
+// WaitForCompletionIfAppropriate -
+func (adb *AccountsDB) WaitForCompletionIfAppropriate(stats common.SnapshotStatisticsHandler) {
+	adb.waitForCompletionIfAppropriate(stats)
 }
 
 // GetCode -

--- a/state/peerAccountsDB.go
+++ b/state/peerAccountsDB.go
@@ -103,7 +103,7 @@ func (adb *PeerAccountsDB) SnapshotState(rootHash []byte) {
 
 	go adb.markActiveDBAfterSnapshot(stats, errChan, rootHash, "snapshotState peer trie", epoch)
 
-	adb.waitForCompletionIfRunningInImportDB(stats)
+	adb.waitForCompletionIfAppropriate(stats)
 }
 
 // SetStateCheckpoint triggers the checkpointing process of the state trie
@@ -123,7 +123,7 @@ func (adb *PeerAccountsDB) SetStateCheckpoint(rootHash []byte) {
 	//  that will be present in the errChan var
 	go stats.PrintStats("setStateCheckpoint peer trie", rootHash)
 
-	adb.waitForCompletionIfRunningInImportDB(stats)
+	adb.waitForCompletionIfAppropriate(stats)
 }
 
 // RecreateAllTries recreates all the tries from the accounts DB


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
 - During import-db, _snapshotting procedures_ and _processing procedures_ are serialized, which leads to **fast** snapshotting.
 - When an observer is fully synchronized and in it's in the _normal_ processing mode, snapshotting is **fast**, as well (at the beginning of a new epoch).
 - Syncing a large number of epochs for a full history devnet observer leads to snapshots that are concurrent with the syncing procedures. In this case (syncing from the past, plus concurrent snapshots), snapshotting happens **slowly** (which can often be problematic).
  
## Proposed Changes
 - Add new CLI flag: `--serialize-snapshots` - this will force the state snapshotting to be serialized with processing.
 - Add new CLI flag: `--disable-consensus-watchdog` - necessary to allow snapshotting that takes more than 10 rounds (which is always the time), in conjunction with `--serialize-snapshots`.

## Testing procedure
 - Synchronize a full history observer on devnet (e.g. shard 0), which starts with a large number of epochs (e.g. 20, 30) behind blockchain tip. Look for snapshotting logs. No processing happens while snapshotting, no concurrent snapshots take place. Tested in rosetta scenarios :heavy_check_mark: 
 - Regular internal testnet, but having observers started with the flags: `--serialize-snapshots --disable-consensus-watchdog`. When they will perform the snapshots, they will be out of sync for a few minutes (that is expected).