### PR TITLE
Fix missing epoch on peer authentication messages requests

### DIFF
--- a/dataRetriever/requestHandlers/requestHandler.go
+++ b/dataRetriever/requestHandlers/requestHandler.go
@@ -740,6 +740,7 @@ func (rrh *resolverRequestHandler) RequestPeerAuthenticationsByHashes(destShardI
 		"topic", common.PeerAuthenticationTopic,
 		"shard", destShardID,
 		"num hashes", len(hashes),
+		"epoch", rrh.epoch,
 	)
 
 	resolver, err := rrh.resolversFinder.MetaChainResolver(common.PeerAuthenticationTopic)
@@ -748,6 +749,7 @@ func (rrh *resolverRequestHandler) RequestPeerAuthenticationsByHashes(destShardI
 			"error", err.Error(),
 			"topic", common.PeerAuthenticationTopic,
 			"shard", destShardID,
+			"epoch", rrh.epoch,
 		)
 		return
 	}
@@ -764,6 +766,7 @@ func (rrh *resolverRequestHandler) RequestPeerAuthenticationsByHashes(destShardI
 			"error", err.Error(),
 			"topic", common.PeerAuthenticationTopic,
 			"shard", destShardID,
+			"epoch", rrh.epoch,
 		)
 	}
 }

--- a/dataRetriever/resolvers/peerAuthenticationResolver.go
+++ b/dataRetriever/resolvers/peerAuthenticationResolver.go
@@ -74,18 +74,19 @@ func checkArgPeerAuthenticationResolver(arg ArgPeerAuthenticationResolver) error
 }
 
 // RequestDataFromHash requests peer authentication data from other peers having input a public key hash
-func (res *peerAuthenticationResolver) RequestDataFromHash(hash []byte, _ uint32) error {
+func (res *peerAuthenticationResolver) RequestDataFromHash(hash []byte, epoch uint32) error {
 	return res.SendOnRequestTopic(
 		&dataRetriever.RequestData{
 			Type:  dataRetriever.HashType,
 			Value: hash,
+			Epoch: epoch,
 		},
 		[][]byte{hash},
 	)
 }
 
 // RequestDataFromHashArray requests peer authentication data from other peers having input multiple public key hashes
-func (res *peerAuthenticationResolver) RequestDataFromHashArray(hashes [][]byte, _ uint32) error {
+func (res *peerAuthenticationResolver) RequestDataFromHashArray(hashes [][]byte, epoch uint32) error {
 	b := &batch.Batch{
 		Data: hashes,
 	}
@@ -98,6 +99,7 @@ func (res *peerAuthenticationResolver) RequestDataFromHashArray(hashes [][]byte,
 		&dataRetriever.RequestData{
 			Type:  dataRetriever.HashArrayType,
 			Value: buffHashes,
+			Epoch: epoch,
 		},
 		hashes,
 	)

--- a/dataRetriever/resolvers/peerAuthenticationResolver_test.go
+++ b/dataRetriever/resolvers/peerAuthenticationResolver_test.go
@@ -470,9 +470,11 @@ func TestPeerAuthenticationResolver_ProcessReceivedMessage(t *testing.T) {
 func TestPeerAuthenticationResolver_RequestShouldError(t *testing.T) {
 	t.Parallel()
 
+	providedEpoch := uint32(30)
 	arg := createMockArgPeerAuthenticationResolver()
 	arg.SenderResolver = &mock.TopicResolverSenderStub{
 		SendOnRequestTopicCalled: func(rd *dataRetriever.RequestData, originalHashes [][]byte) error {
+			assert.Equal(t, providedEpoch, rd.Epoch)
 			return expectedErr
 		},
 	}
@@ -481,13 +483,13 @@ func TestPeerAuthenticationResolver_RequestShouldError(t *testing.T) {
 	assert.False(t, res.IsInterfaceNil())
 
 	t.Run("RequestDataFromHash", func(t *testing.T) {
-		err = res.RequestDataFromHash([]byte(""), 0)
+		err = res.RequestDataFromHash([]byte(""), providedEpoch)
 		assert.Equal(t, expectedErr, err)
 	})
 	t.Run("RequestDataFromChunk - error on SendOnRequestTopic", func(t *testing.T) {
 		hashes := make([][]byte, 0)
 		hashes = append(hashes, []byte("pk"))
-		err = res.RequestDataFromHashArray(hashes, 0)
+		err = res.RequestDataFromHashArray(hashes, providedEpoch)
 		assert.Equal(t, expectedErr, err)
 	})
 }
@@ -495,9 +497,11 @@ func TestPeerAuthenticationResolver_RequestShouldError(t *testing.T) {
 func TestPeerAuthenticationResolver_RequestShouldWork(t *testing.T) {
 	t.Parallel()
 
+	providedEpoch := uint32(30)
 	arg := createMockArgPeerAuthenticationResolver()
 	arg.SenderResolver = &mock.TopicResolverSenderStub{
 		SendOnRequestTopicCalled: func(rd *dataRetriever.RequestData, originalHashes [][]byte) error {
+			assert.Equal(t, providedEpoch, rd.Epoch)
 			return nil
 		},
 	}
@@ -506,7 +510,7 @@ func TestPeerAuthenticationResolver_RequestShouldWork(t *testing.T) {
 	assert.False(t, res.IsInterfaceNil())
 
 	t.Run("RequestDataFromHash", func(t *testing.T) {
-		err = res.RequestDataFromHash([]byte(""), 0)
+		err = res.RequestDataFromHash([]byte(""), providedEpoch)
 		assert.Nil(t, err)
 	})
 }


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- epoch is missing from `RequestData` object, while requesting peer authentication messages, leading to always requesting from epoch 0, which sometimes therefore leads to querying nodes from full history list, which may be empty
  
## Proposed Changes
- add epoch on `RequestData` object

## Testing procedure
- standard system test, looking for `peer list is empty or errors during the sending, topic: peerAuthentication` **not to be present**
