### PR TITLE
Outport driver stuck prints

### DIFF
--- a/outport/outport.go
+++ b/outport/outport.go
@@ -14,7 +14,7 @@ import (
 
 var log = logger.GetOrCreate("outport")
 
-const maxTimeForDriverCall = time.Second * 300
+const maxTimeForDriverCall = time.Second * 30
 const minimumRetrialInterval = time.Millisecond * 10
 
 type outport struct {
@@ -67,7 +67,7 @@ func (o *outport) monitorCompletionOnDriver(function string, driver Driver) chan
 			o.logHandler(logger.LogDebug, "outport.monitorCompletionOnDriver ended",
 				"function", function, "driver", driverString(driver), "message counter", counter)
 		case <-timer.C:
-			o.logHandler(logger.LogError, "outport.monitorCompletionOnDriver took too long",
+			o.logHandler(logger.LogWarning, "outport.monitorCompletionOnDriver took too long",
 				"function", function, "driver", driverString(driver), "message counter", counter, "time", o.timeForDriverCall)
 		}
 

--- a/outport/outport_test.go
+++ b/outport/outport_test.go
@@ -3,12 +3,15 @@ package outport
 import (
 	"errors"
 	"sync"
+	atomicGo "sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/ElrondNetwork/elrond-go-core/core/atomic"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/indexer"
+	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/outport/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,13 +57,27 @@ func TestOutport_SaveAccounts(t *testing.T) {
 		},
 	}
 	outportHandler, _ := NewOutport(minimumRetrialInterval)
+	numLogDebugCalled := uint32(0)
+	outportHandler.logHandler = func(logLevel logger.LogLevel, message string, args ...interface{}) {
+		if logLevel == logger.LogError {
+			assert.Fail(t, "should have not called log error")
+		}
+		if logLevel == logger.LogDebug {
+			atomicGo.AddUint32(&numLogDebugCalled, 1)
+		}
+	}
+
 	outportHandler.SaveAccounts(0, []data.UserAccountHandler{})
+	time.Sleep(time.Second)
 	_ = outportHandler.SubscribeDriver(driver1)
 	_ = outportHandler.SubscribeDriver(driver2)
 
 	outportHandler.SaveAccounts(0, []data.UserAccountHandler{})
+	time.Sleep(time.Second)
+
 	assert.Equal(t, 10, numCalled1)
 	assert.Equal(t, 1, numCalled2)
+	assert.Equal(t, uint32(4), atomicGo.LoadUint32(&numLogDebugCalled))
 }
 
 func TestOutport_SaveBlock(t *testing.T) {
@@ -86,13 +103,26 @@ func TestOutport_SaveBlock(t *testing.T) {
 		},
 	}
 	outportHandler, _ := NewOutport(minimumRetrialInterval)
+	numLogDebugCalled := uint32(0)
+	outportHandler.logHandler = func(logLevel logger.LogLevel, message string, args ...interface{}) {
+		if logLevel == logger.LogError {
+			assert.Fail(t, "should have not called log error")
+		}
+		if logLevel == logger.LogDebug {
+			atomicGo.AddUint32(&numLogDebugCalled, 1)
+		}
+	}
+
 	outportHandler.SaveBlock(nil)
 	_ = outportHandler.SubscribeDriver(driver1)
 	_ = outportHandler.SubscribeDriver(driver2)
 
 	outportHandler.SaveBlock(nil)
+	time.Sleep(time.Second)
+
 	assert.Equal(t, 10, numCalled1)
 	assert.Equal(t, 1, numCalled2)
+	assert.Equal(t, uint32(4), atomicGo.LoadUint32(&numLogDebugCalled))
 }
 
 func TestOutport_SaveRoundsInfo(t *testing.T) {
@@ -118,13 +148,26 @@ func TestOutport_SaveRoundsInfo(t *testing.T) {
 		},
 	}
 	outportHandler, _ := NewOutport(minimumRetrialInterval)
+	numLogDebugCalled := uint32(0)
+	outportHandler.logHandler = func(logLevel logger.LogLevel, message string, args ...interface{}) {
+		if logLevel == logger.LogError {
+			assert.Fail(t, "should have not called log error")
+		}
+		if logLevel == logger.LogDebug {
+			atomicGo.AddUint32(&numLogDebugCalled, 1)
+		}
+	}
+
 	outportHandler.SaveRoundsInfo(nil)
 	_ = outportHandler.SubscribeDriver(driver1)
 	_ = outportHandler.SubscribeDriver(driver2)
 
 	outportHandler.SaveRoundsInfo(nil)
+
+	time.Sleep(time.Second)
 	assert.Equal(t, 10, numCalled1)
 	assert.Equal(t, 1, numCalled2)
+	assert.Equal(t, uint32(4), atomicGo.LoadUint32(&numLogDebugCalled))
 }
 
 func TestOutport_SaveValidatorsPubKeys(t *testing.T) {
@@ -150,13 +193,28 @@ func TestOutport_SaveValidatorsPubKeys(t *testing.T) {
 		},
 	}
 	outportHandler, _ := NewOutport(minimumRetrialInterval)
+	numLogDebugCalled := uint32(0)
+	outportHandler.logHandler = func(logLevel logger.LogLevel, message string, args ...interface{}) {
+		if logLevel == logger.LogError {
+			assert.Fail(t, "should have not called log error")
+		}
+		if logLevel == logger.LogDebug {
+			atomicGo.AddUint32(&numLogDebugCalled, 1)
+		}
+	}
+
 	outportHandler.SaveValidatorsPubKeys(nil, 0)
+	time.Sleep(time.Second)
+
 	_ = outportHandler.SubscribeDriver(driver1)
 	_ = outportHandler.SubscribeDriver(driver2)
 
 	outportHandler.SaveValidatorsPubKeys(nil, 0)
+	time.Sleep(time.Second)
+
 	assert.Equal(t, 10, numCalled1)
 	assert.Equal(t, 1, numCalled2)
+	assert.Equal(t, uint32(4), atomicGo.LoadUint32(&numLogDebugCalled))
 }
 
 func TestOutport_SaveValidatorsRating(t *testing.T) {
@@ -182,13 +240,28 @@ func TestOutport_SaveValidatorsRating(t *testing.T) {
 		},
 	}
 	outportHandler, _ := NewOutport(minimumRetrialInterval)
+	numLogDebugCalled := uint32(0)
+	outportHandler.logHandler = func(logLevel logger.LogLevel, message string, args ...interface{}) {
+		if logLevel == logger.LogError {
+			assert.Fail(t, "should have not called log error")
+		}
+		if logLevel == logger.LogDebug {
+			atomicGo.AddUint32(&numLogDebugCalled, 1)
+		}
+	}
+
 	outportHandler.SaveValidatorsRating("", nil)
+	time.Sleep(time.Second)
+
 	_ = outportHandler.SubscribeDriver(driver1)
 	_ = outportHandler.SubscribeDriver(driver2)
 
 	outportHandler.SaveValidatorsRating("", nil)
+	time.Sleep(time.Second)
+
 	assert.Equal(t, 10, numCalled1)
 	assert.Equal(t, 1, numCalled2)
+	assert.Equal(t, uint32(4), atomicGo.LoadUint32(&numLogDebugCalled))
 }
 
 func TestOutport_RevertIndexedBlock(t *testing.T) {
@@ -214,13 +287,28 @@ func TestOutport_RevertIndexedBlock(t *testing.T) {
 		},
 	}
 	outportHandler, _ := NewOutport(minimumRetrialInterval)
+	numLogDebugCalled := uint32(0)
+	outportHandler.logHandler = func(logLevel logger.LogLevel, message string, args ...interface{}) {
+		if logLevel == logger.LogError {
+			assert.Fail(t, "should have not called log error")
+		}
+		if logLevel == logger.LogDebug {
+			atomicGo.AddUint32(&numLogDebugCalled, 1)
+		}
+	}
+
 	outportHandler.RevertIndexedBlock(nil, nil)
+	time.Sleep(time.Second)
+
 	_ = outportHandler.SubscribeDriver(driver1)
 	_ = outportHandler.SubscribeDriver(driver2)
 
 	outportHandler.RevertIndexedBlock(nil, nil)
+	time.Sleep(time.Second)
+
 	assert.Equal(t, 10, numCalled1)
 	assert.Equal(t, 1, numCalled2)
+	assert.Equal(t, uint32(4), atomicGo.LoadUint32(&numLogDebugCalled))
 }
 
 func TestOutport_FinalizedBlock(t *testing.T) {
@@ -246,13 +334,28 @@ func TestOutport_FinalizedBlock(t *testing.T) {
 		},
 	}
 	outportHandler, _ := NewOutport(minimumRetrialInterval)
+	numLogDebugCalled := uint32(0)
+	outportHandler.logHandler = func(logLevel logger.LogLevel, message string, args ...interface{}) {
+		if logLevel == logger.LogError {
+			assert.Fail(t, "should have not called log error")
+		}
+		if logLevel == logger.LogDebug {
+			atomicGo.AddUint32(&numLogDebugCalled, 1)
+		}
+	}
+
 	outportHandler.FinalizedBlock(nil)
+	time.Sleep(time.Second)
+
 	_ = outportHandler.SubscribeDriver(driver1)
 	_ = outportHandler.SubscribeDriver(driver2)
 
 	outportHandler.FinalizedBlock(nil)
+	time.Sleep(time.Second)
+
 	assert.Equal(t, 10, numCalled1)
 	assert.Equal(t, 1, numCalled2)
+	assert.Equal(t, uint32(4), atomicGo.LoadUint32(&numLogDebugCalled))
 }
 
 func TestOutport_SubscribeDriver(t *testing.T) {
@@ -387,4 +490,34 @@ func TestOutport_CloseWhileDriverIsStuckInContinuousErrors(t *testing.T) {
 	case <-time.After(time.Second):
 		require.Fail(t, "unable to close all drivers because of a stuck driver")
 	}
+}
+
+func TestOutport_SaveBlockDriverStuck(t *testing.T) {
+	t.Parallel()
+
+	outportHandler, _ := NewOutport(minimumRetrialInterval)
+	outportHandler.timeForDriverCall = time.Second
+	logErrorCalled := atomic.Flag{}
+	numLogDebugCalled := uint32(0)
+	outportHandler.logHandler = func(logLevel logger.LogLevel, message string, args ...interface{}) {
+		if logLevel == logger.LogError {
+			logErrorCalled.SetValue(true)
+			assert.Equal(t, "outport.monitorCompletionOnDriver took too long", message)
+		}
+		if logLevel == logger.LogDebug {
+			atomicGo.AddUint32(&numLogDebugCalled, 1)
+		}
+	}
+
+	_ = outportHandler.SubscribeDriver(&mock.DriverStub{
+		SaveBlockCalled: func(args *indexer.ArgsSaveBlockData) error {
+			time.Sleep(time.Second * 5)
+			return nil
+		},
+	})
+
+	outportHandler.SaveBlock(nil)
+
+	assert.True(t, logErrorCalled.IsSet())
+	assert.Equal(t, uint32(1), atomicGo.LoadUint32(&numLogDebugCalled))
 }

--- a/outport/outport_test.go
+++ b/outport/outport_test.go
@@ -504,7 +504,7 @@ func TestOutport_SaveBlockDriverStuck(t *testing.T) {
 	logErrorCalled := atomic.Flag{}
 	numLogDebugCalled := uint32(0)
 	outportHandler.logHandler = func(logLevel logger.LogLevel, message string, args ...interface{}) {
-		if logLevel == logger.LogError {
+		if logLevel == logger.LogWarning {
 			logErrorCalled.SetValue(true)
 			assert.Equal(t, "outport.monitorCompletionOnDriver took too long", message)
 			assert.Equal(t, currentCounter+1, args[counterPositionInLogMessage])


### PR DESCRIPTION
## Description of the reasoning behind the pull request 
- Whenever an outport driver gets stuck the node will stop processing new blocks as to disallow dropping information from the chain for each driver. The stop is done without much information in the node's log so any integrator hitting in to this issue will have no clue what it's happening.
  
## Proposed Changes
- added timeout log prints whenever a driver gets stuck

## Testing procedure
- standard testing procedure
- start a system testnet, stop an observer, edit the external.toml file enabling the EventNotifierConnector driver without attaching a go notifier and restart the node. The node should stop adding new blocks, after ~30seconds we should have a warning log print stating `outport.monitorCompletionOnDriver took too long` 
