### PR TITLE
log txhash as well for too long sc calls

### DIFF
--- a/process/smartContract/process.go
+++ b/process/smartContract/process.go
@@ -262,7 +262,12 @@ func (sc *scProcessor) ExecuteSmartContractTransaction(
 	duration := sw.GetMeasurement("execute")
 
 	if duration > executeDurationAlarmThreshold {
-		log.Debug(fmt.Sprintf("scProcessor.ExecuteSmartContractTransaction(): execution took > %s", executeDurationAlarmThreshold), "sc", tx.GetRcvAddr(), "duration", duration, "returnCode", returnCode, "err", err, "data", string(tx.GetData()))
+		txHashToDisplay := []byte("N/A")
+		txHash, errCalculateHash := core.CalculateHash(sc.marshalizer, sc.hasher, tx)
+		if len(txHash) > 0 && errCalculateHash == nil {
+			txHashToDisplay = txHash
+		}
+		log.Debug(fmt.Sprintf("scProcessor.ExecuteSmartContractTransaction(): execution took > %s", executeDurationAlarmThreshold), "tx hash", txHashToDisplay, "sc", tx.GetRcvAddr(), "duration", duration, "returnCode", returnCode, "err", err, "data", string(tx.GetData()))
 	} else {
 		log.Trace("scProcessor.ExecuteSmartContractTransaction()", "sc", tx.GetRcvAddr(), "duration", duration, "returnCode", returnCode, "err", err, "data", string(tx.GetData()))
 	}


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- When tracing smart contract calls whose execution took longer than the current threshold (100ms), the tx hash was not displayed, making the debugging harder
  
## Proposed Changes
- Log the tx hash as well in case of a SC call taking too long

## Testing procedure
- regular scenario + verify the log
