### PR TITLE
Trie sync constant extraction

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -911,11 +911,12 @@
     LogFileLifeSpanInSec = 86400 # 1 day
 
 [TrieSync]
-    NumConcurrentTrieSyncers  = 200
-    MaxHardCapForMissingNodes = 5000
+    NumConcurrentTrieSyncers    = 200
+    MaxHardCapForMissingNodes   = 5000
     #available versions: 1 and 2. 1 is the initial version, 2 is updated, more efficient version
-    TrieSyncerVersion         = 2
-    CheckNodesOnDisk          = false
+    TrieSyncerVersion           = 2
+    CheckNodesOnDisk            = false
+    TimeBetweenRechecksInMillis = 10
 
 [Resolvers]
     NumCrossShardPeers  = 2

--- a/config/config.go
+++ b/config/config.go
@@ -582,10 +582,11 @@ type ConfigurationPathsHolder struct {
 
 // TrieSyncConfig represents the trie synchronization configuration area
 type TrieSyncConfig struct {
-	NumConcurrentTrieSyncers  int
-	MaxHardCapForMissingNodes int
-	TrieSyncerVersion         int
-	CheckNodesOnDisk          bool
+	NumConcurrentTrieSyncers    int
+	MaxHardCapForMissingNodes   int
+	TrieSyncerVersion           int
+	CheckNodesOnDisk            bool
+	TimeBetweenRechecksInMillis uint32
 }
 
 // ResolverConfig represents the config options to be used when setting up the resolver instances

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -1044,6 +1044,7 @@ func (e *epochStartBootstrap) syncUserAccountsState(rootHash []byte) error {
 			MaxHardCapForMissingNodes: e.maxHardCapForMissingNodes,
 			TrieSyncerVersion:         e.trieSyncerVersion,
 			CheckNodesOnDisk:          e.checkNodesOnDisk,
+			TimeBetweenRechecks:       time.Millisecond * time.Duration(e.generalConfig.TrieSync.TimeBetweenRechecksInMillis),
 		},
 		ShardId:                e.shardCoordinator.SelfId(),
 		Throttler:              thr,
@@ -1109,6 +1110,7 @@ func (e *epochStartBootstrap) syncValidatorAccountsState(rootHash []byte) error 
 			MaxHardCapForMissingNodes: e.maxHardCapForMissingNodes,
 			TrieSyncerVersion:         e.trieSyncerVersion,
 			CheckNodesOnDisk:          e.checkNodesOnDisk,
+			TimeBetweenRechecks:       time.Millisecond * time.Duration(e.generalConfig.TrieSync.TimeBetweenRechecksInMillis),
 		},
 	}
 	accountsDBSyncer, err := syncer.NewValidatorAccountsSyncer(argsValidatorAccountsSyncer)

--- a/epochStart/bootstrap/process_test.go
+++ b/epochStart/bootstrap/process_test.go
@@ -162,10 +162,11 @@ func createMockEpochStartBootstrapArgs(
 				NumActivePersisters:         2,
 			},
 			TrieSync: config.TrieSyncConfig{
-				NumConcurrentTrieSyncers:  50,
-				MaxHardCapForMissingNodes: 500,
-				TrieSyncerVersion:         2,
-				CheckNodesOnDisk:          false,
+				NumConcurrentTrieSyncers:    50,
+				MaxHardCapForMissingNodes:   500,
+				TrieSyncerVersion:           2,
+				CheckNodesOnDisk:            false,
+				TimeBetweenRechecksInMillis: 10,
 			},
 			ScheduledSCRsStorage: config.StorageConfig{
 				Cache: config.CacheConfig{

--- a/factory/consensusComponents.go
+++ b/factory/consensusComponents.go
@@ -489,6 +489,7 @@ func (ccf *consensusComponentsFactory) createArgsBaseAccountsSyncer(trieStorageM
 		MaxHardCapForMissingNodes: ccf.config.TrieSync.MaxHardCapForMissingNodes,
 		TrieSyncerVersion:         ccf.config.TrieSync.TrieSyncerVersion,
 		CheckNodesOnDisk:          ccf.config.TrieSync.CheckNodesOnDisk,
+		TimeBetweenRechecks:       time.Millisecond * time.Duration(ccf.config.TrieSync.TimeBetweenRechecksInMillis),
 	}
 }
 

--- a/factory/processComponents.go
+++ b/factory/processComponents.go
@@ -1505,6 +1505,7 @@ func (pcf *processComponentsFactory) createExportFactoryHandler(
 		NumConcurrentTrieSyncers:  pcf.config.TrieSync.NumConcurrentTrieSyncers,
 		TrieSyncerVersion:         pcf.config.TrieSync.TrieSyncerVersion,
 		PeersRatingHandler:        pcf.network.PeersRatingHandler(),
+		TimeBetweenRechecks:       time.Millisecond * time.Duration(pcf.config.TrieSync.TimeBetweenRechecksInMillis),
 	}
 	return updateFactory.NewExportHandlerFactory(argsExporter)
 }

--- a/integrationTests/consensus/consensus_test.go
+++ b/integrationTests/consensus/consensus_test.go
@@ -113,10 +113,11 @@ func startNodesWithCommitBlock(nodes []*testNode, mutex *sync.Mutex, nonceForRou
 					SignatureLength: 48,
 				},
 				TrieSync: config.TrieSyncConfig{
-					NumConcurrentTrieSyncers:  5,
-					MaxHardCapForMissingNodes: 5,
-					TrieSyncerVersion:         2,
-					CheckNodesOnDisk:          false,
+					NumConcurrentTrieSyncers:    5,
+					MaxHardCapForMissingNodes:   5,
+					TrieSyncerVersion:           2,
+					CheckNodesOnDisk:            false,
+					TimeBetweenRechecksInMillis: 10,
 				},
 				GeneralSettings: config.GeneralSettingsConfig{
 					SyncProcessTimeInMillis: 6000,

--- a/integrationTests/multiShard/hardFork/hardFork_test.go
+++ b/integrationTests/multiShard/hardFork/hardFork_test.go
@@ -621,6 +621,7 @@ func createHardForkExporter(
 			TrieSyncerVersion:         2,
 			PeersRatingHandler:        node.PeersRatingHandler,
 			CheckNodesOnDisk:          false,
+			TimeBetweenRechecks:       time.Millisecond * 10,
 		}
 
 		exportHandler, err := factory.NewExportHandlerFactory(argsExportHandler)
@@ -674,18 +675,18 @@ func verifyIfAddedShardHeadersAreWithNewEpoch(
 		shardHDrStorage, err := node.Storage.GetStorer(dataRetriever.BlockHeaderUnit)
 		assert.Nil(t, err)
 		for _, shardInfo := range currentMetaHdr.ShardInfo {
-			header, err := node.DataPool.Headers().GetHeaderByHash(shardInfo.HeaderHash)
-			if err == nil {
+			header, errGet := node.DataPool.Headers().GetHeaderByHash(shardInfo.HeaderHash)
+			if errGet == nil {
 				assert.Equal(t, currentMetaHdr.GetEpoch(), header.GetEpoch())
 				continue
 			}
 
-			buff, err := shardHDrStorage.Get(shardInfo.HeaderHash)
-			assert.Nil(t, err)
+			buff, errGet := shardHDrStorage.Get(shardInfo.HeaderHash)
+			assert.Nil(t, errGet)
 
 			shardHeader := block.Header{}
-			err = integrationTests.TestMarshalizer.Unmarshal(&shardHeader, buff)
-			assert.Nil(t, err)
+			errUnmarshal := integrationTests.TestMarshalizer.Unmarshal(&shardHeader, buff)
+			assert.Nil(t, errUnmarshal)
 			assert.Equal(t, shardHeader.GetEpoch(), currentMetaHdr.GetEpoch())
 		}
 	}

--- a/integrationTests/state/stateTrieSync/stateTrieSync_test.go
+++ b/integrationTests/state/stateTrieSync/stateTrieSync_test.go
@@ -126,6 +126,7 @@ func TestNode_RequestInterceptTrieNodesWithMessenger(t *testing.T) {
 		TimeoutHandler:            testscommon.NewTimeoutHandlerMock(timeout),
 		MaxHardCapForMissingNodes: 10000,
 		CheckNodesOnDisk:          false,
+		TimeBetweenRechecks:       time.Millisecond * 10,
 	}
 	trieSyncer, _ := trie.NewDoubleListTrieSyncer(arg)
 
@@ -256,6 +257,7 @@ func TestNode_RequestInterceptTrieNodesWithMessengerNotSyncingShouldErr(t *testi
 		TimeoutHandler:            testscommon.NewTimeoutHandlerMock(timeout),
 		MaxHardCapForMissingNodes: 10000,
 		CheckNodesOnDisk:          false,
+		TimeBetweenRechecks:       time.Millisecond * 10,
 	}
 	trieSyncer, _ := trie.NewDoubleListTrieSyncer(arg)
 
@@ -362,6 +364,7 @@ func testMultipleDataTriesSync(t *testing.T, numAccounts int, numDataTrieLeaves 
 			MaxHardCapForMissingNodes: 5000,
 			TrieSyncerVersion:         2,
 			CheckNodesOnDisk:          false,
+			TimeBetweenRechecks:       time.Millisecond * 10,
 		},
 		ShardId:                shardID,
 		Throttler:              thr,

--- a/process/errors.go
+++ b/process/errors.go
@@ -221,20 +221,8 @@ var ErrNilShardedDataCacherNotifier = errors.New("nil sharded data cacher notifi
 // ErrInvalidTxInPool signals an invalid transaction in the transactions pool
 var ErrInvalidTxInPool = errors.New("invalid transaction in the transactions pool")
 
-// ErrInvalidValidatorInfoInPool signals an invalid validator info in the validators info pool
-var ErrInvalidValidatorInfoInPool = errors.New("invalid validator info in the validators info pool")
-
 // ErrTxNotFound signals that a transaction has not found
 var ErrTxNotFound = errors.New("transaction not found")
-
-// ErrValidatorInfoNotFound signals that a validator info has not found
-var ErrValidatorInfoNotFound = errors.New("validator info not found")
-
-// ErrNilHeadersStorage signals that a nil header storage has been provided
-var ErrNilHeadersStorage = errors.New("nil headers storage")
-
-// ErrNilHeadersNonceHashStorage signals that a nil header nonce hash storage has been provided
-var ErrNilHeadersNonceHashStorage = errors.New("nil headers nonce hash storage")
 
 // ErrNilTransactionPool signals that a nil transaction pool was used
 var ErrNilTransactionPool = errors.New("nil transaction pool")

--- a/state/syncer/baseAccountsSyncer.go
+++ b/state/syncer/baseAccountsSyncer.go
@@ -32,6 +32,7 @@ type baseAccountsSyncer struct {
 	name                      string
 	maxHardCapForMissingNodes int
 	checkNodesOnDisk          bool
+	timeBetweenRechecks       time.Duration
 
 	trieSyncerVersion int
 	numTriesSynced    int32
@@ -52,6 +53,7 @@ type ArgsNewBaseAccountsSyncer struct {
 	MaxHardCapForMissingNodes int
 	TrieSyncerVersion         int
 	CheckNodesOnDisk          bool
+	TimeBetweenRechecks       time.Duration
 }
 
 func checkArgs(args ArgsNewBaseAccountsSyncer) error {
@@ -74,7 +76,12 @@ func checkArgs(args ArgsNewBaseAccountsSyncer) error {
 		return state.ErrInvalidMaxHardCapForMissingNodes
 	}
 
-	return trie.CheckTrieSyncerVersion(args.TrieSyncerVersion)
+	err := trie.CheckTrieSyncerVersion(args.TrieSyncerVersion)
+	if err != nil {
+		return err
+	}
+
+	return trie.CheckTimeBetweenRechecks(args.TimeBetweenRechecks)
 }
 
 func (b *baseAccountsSyncer) syncMainTrie(
@@ -105,6 +112,7 @@ func (b *baseAccountsSyncer) syncMainTrie(
 		TimeoutHandler:            b.timeoutHandler,
 		MaxHardCapForMissingNodes: b.maxHardCapForMissingNodes,
 		CheckNodesOnDisk:          b.checkNodesOnDisk,
+		TimeBetweenRechecks:       b.timeBetweenRechecks,
 	}
 	trieSyncer, err := trie.CreateTrieSyncer(arg, b.trieSyncerVersion)
 	if err != nil {

--- a/state/syncer/userAccountsSyncer.go
+++ b/state/syncer/userAccountsSyncer.go
@@ -88,6 +88,7 @@ func NewUserAccountsSyncer(args ArgsNewUserAccountsSyncer) (*userAccountsSyncer,
 		maxHardCapForMissingNodes: args.MaxHardCapForMissingNodes,
 		trieSyncerVersion:         args.TrieSyncerVersion,
 		checkNodesOnDisk:          args.CheckNodesOnDisk,
+		timeBetweenRechecks:       args.TimeBetweenRechecks,
 	}
 
 	u := &userAccountsSyncer{
@@ -160,6 +161,7 @@ func (u *userAccountsSyncer) syncDataTrie(rootHash []byte, ssh common.SizeSyncSt
 		TimeoutHandler:            u.timeoutHandler,
 		MaxHardCapForMissingNodes: u.maxHardCapForMissingNodes,
 		CheckNodesOnDisk:          u.checkNodesOnDisk,
+		TimeBetweenRechecks:       u.timeBetweenRechecks,
 	}
 	trieSyncer, err := trie.CreateTrieSyncer(arg, u.trieSyncerVersion)
 	if err != nil {

--- a/state/syncer/validatorAccountsSyncer.go
+++ b/state/syncer/validatorAccountsSyncer.go
@@ -48,6 +48,7 @@ func NewValidatorAccountsSyncer(args ArgsNewValidatorAccountsSyncer) (*validator
 		maxHardCapForMissingNodes: args.MaxHardCapForMissingNodes,
 		trieSyncerVersion:         args.TrieSyncerVersion,
 		checkNodesOnDisk:          args.CheckNodesOnDisk,
+		timeBetweenRechecks:       args.TimeBetweenRechecks,
 	}
 
 	u := &validatorAccountsSyncer{

--- a/testscommon/generalConfig.go
+++ b/testscommon/generalConfig.go
@@ -385,10 +385,11 @@ func GetGeneralConfig() config.Config {
 			PollingIntervalInMinutes: 30,
 		},
 		TrieSync: config.TrieSyncConfig{
-			NumConcurrentTrieSyncers:  50,
-			MaxHardCapForMissingNodes: 500,
-			TrieSyncerVersion:         2,
-			CheckNodesOnDisk:          false,
+			NumConcurrentTrieSyncers:    50,
+			MaxHardCapForMissingNodes:   500,
+			TrieSyncerVersion:           2,
+			CheckNodesOnDisk:            false,
+			TimeBetweenRechecksInMillis: 10,
 		},
 		Antiflood: config.AntifloodConfig{
 			NumConcurrentResolverJobs: 2,

--- a/trie/doubleListSync.go
+++ b/trie/doubleListSync.go
@@ -27,7 +27,7 @@ type doubleListTrieSyncer struct {
 	shardId                   uint32
 	topic                     string
 	rootHash                  []byte
-	waitTimeBetweenChecks     time.Duration
+	timeBetweenRechecks       time.Duration
 	marshalizer               marshal.Marshalizer
 	hasher                    hashing.Hasher
 	db                        common.DBWriteCacher
@@ -66,7 +66,7 @@ func NewDoubleListTrieSyncer(arg ArgTrieSyncer) (*doubleListTrieSyncer, error) {
 		hasher:                    arg.Hasher,
 		topic:                     arg.Topic,
 		shardId:                   arg.ShardId,
-		waitTimeBetweenChecks:     time.Millisecond * 100,
+		timeBetweenRechecks:       arg.TimeBetweenRechecks,
 		handlerID:                 core.UniqueIdentifier(),
 		trieSyncStatistics:        arg.TrieSyncStatistics,
 		timeoutHandler:            arg.TimeoutHandler,
@@ -116,7 +116,7 @@ func (d *doubleListTrieSyncer) StartSyncing(rootHash []byte, ctx context.Context
 		}
 
 		select {
-		case <-time.After(d.waitTimeBetweenChecks):
+		case <-time.After(d.timeBetweenRechecks):
 			continue
 		case <-ctx.Done():
 			return errors.ErrContextClosing

--- a/trie/doubleListSync_test.go
+++ b/trie/doubleListSync_test.go
@@ -121,23 +121,24 @@ func hashInList(hash []byte, list [][]byte) bool {
 	return false
 }
 
-func TestNewDoubleListTrieSyncer_InvalidParametersShouldErr(t *testing.T) {
-	t.Parallel()
-
-	arg := createMockArgument(time.Minute)
-	arg.RequestHandler = nil
-	d, err := NewDoubleListTrieSyncer(arg)
-	assert.True(t, check.IfNil(d))
-	assert.Equal(t, ErrNilRequestHandler, err)
-}
-
 func TestNewDoubleListTrieSyncer(t *testing.T) {
-	t.Parallel()
+	t.Run("invalid request handler should error", func(t *testing.T) {
+		t.Parallel()
 
-	arg := createMockArgument(time.Minute)
-	d, err := NewDoubleListTrieSyncer(arg)
-	assert.False(t, check.IfNil(d))
-	assert.Nil(t, err)
+		arg := createMockArgument(time.Minute)
+		arg.RequestHandler = nil
+		d, err := NewDoubleListTrieSyncer(arg)
+		assert.True(t, check.IfNil(d))
+		assert.Equal(t, ErrNilRequestHandler, err)
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgument(time.Minute)
+		d, err := NewDoubleListTrieSyncer(arg)
+		assert.False(t, check.IfNil(d))
+		assert.Nil(t, err)
+	})
 }
 
 func TestDoubleListTrieSyncer_StartSyncingNilRootHashShouldReturnNil(t *testing.T) {

--- a/trie/errors.go
+++ b/trie/errors.go
@@ -108,3 +108,6 @@ var ErrNilIdleNodeProvider = errors.New("nil idle node provider")
 
 // ErrNilRootHashHolder signals that a nil root hash holder was provided
 var ErrNilRootHashHolder = errors.New("nil root hash holder provided")
+
+// ErrInvalidValue signals that an invalid value was provided
+var ErrInvalidValue = errors.New("invalid value provided")

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -128,7 +128,8 @@ func checkArguments(arg ArgTrieSyncer) error {
 // CheckTimeBetweenRechecks will check the provided value against the minimum allowed
 func CheckTimeBetweenRechecks(timeBetweenRechecks time.Duration) error {
 	if timeBetweenRechecks < minTimeBetweenRechecks {
-		return fmt.Errorf("%w for TimeBetweenRechecks", ErrInvalidValue)
+		return fmt.Errorf("%w for TimeBetweenRechecks, provided %v, minimum %v",
+			ErrInvalidValue, timeBetweenRechecks, minTimeBetweenRechecks)
 	}
 
 	return nil

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -3,6 +3,8 @@ package trie
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -143,6 +145,8 @@ func TestNewTrieSyncer(t *testing.T) {
 		ts, err := NewTrieSyncer(arg)
 		assert.True(t, check.IfNil(ts))
 		assert.True(t, errors.Is(err, ErrInvalidValue))
+		expectedString := fmt.Sprintf("for TimeBetweenRechecks, provided %v, minimum 1ms", arg.TimeBetweenRechecks)
+		assert.True(t, strings.Contains(err.Error(), expectedString))
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()

--- a/update/factory/accountDBSyncerContainerFactory.go
+++ b/update/factory/accountDBSyncerContainerFactory.go
@@ -33,6 +33,7 @@ type ArgsNewAccountsDBSyncersContainerFactory struct {
 	TrieSyncerVersion         int
 	CheckNodesOnDisk          bool
 	AddressPubKeyConverter    core.PubkeyConverter
+	TimeBetweenRechecks       time.Duration
 }
 
 type accountDBSyncersContainerFactory struct {
@@ -50,6 +51,7 @@ type accountDBSyncersContainerFactory struct {
 	trieSyncerVersion         int
 	checkNodesOnDisk          bool
 	addressPubKeyConverter    core.PubkeyConverter
+	timeBetweenRechecks       time.Duration
 }
 
 // NewAccountsDBSContainerFactory creates a factory for trie syncers container
@@ -100,6 +102,7 @@ func NewAccountsDBSContainerFactory(args ArgsNewAccountsDBSyncersContainerFactor
 		trieSyncerVersion:         args.TrieSyncerVersion,
 		checkNodesOnDisk:          args.CheckNodesOnDisk,
 		addressPubKeyConverter:    args.AddressPubKeyConverter,
+		timeBetweenRechecks:       args.TimeBetweenRechecks,
 	}
 
 	return t, nil
@@ -147,6 +150,7 @@ func (a *accountDBSyncersContainerFactory) createUserAccountsSyncer(shardId uint
 			MaxHardCapForMissingNodes: a.maxHardCapForMissingNodes,
 			TrieSyncerVersion:         a.trieSyncerVersion,
 			CheckNodesOnDisk:          a.checkNodesOnDisk,
+			TimeBetweenRechecks:       a.timeBetweenRechecks,
 		},
 		ShardId:                shardId,
 		Throttler:              thr,
@@ -174,6 +178,7 @@ func (a *accountDBSyncersContainerFactory) createValidatorAccountsSyncer(shardId
 			MaxHardCapForMissingNodes: a.maxHardCapForMissingNodes,
 			TrieSyncerVersion:         a.trieSyncerVersion,
 			CheckNodesOnDisk:          a.checkNodesOnDisk,
+			TimeBetweenRechecks:       a.timeBetweenRechecks,
 		},
 	}
 	accountSyncer, err := syncer.NewValidatorAccountsSyncer(args)

--- a/update/factory/exportHandlerFactory.go
+++ b/update/factory/exportHandlerFactory.go
@@ -68,6 +68,7 @@ type ArgsExporter struct {
 	NumConcurrentTrieSyncers  int
 	TrieSyncerVersion         int
 	CheckNodesOnDisk          bool
+	TimeBetweenRechecks       time.Duration
 }
 
 type exportHandlerFactory struct {
@@ -105,6 +106,7 @@ type exportHandlerFactory struct {
 	numConcurrentTrieSyncers  int
 	trieSyncerVersion         int
 	checkNodesOnDisk          bool
+	timeBetweenRechecks       time.Duration
 }
 
 // NewExportHandlerFactory creates an exporter factory
@@ -252,6 +254,7 @@ func NewExportHandlerFactory(args ArgsExporter) (*exportHandlerFactory, error) {
 		numConcurrentTrieSyncers:  args.NumConcurrentTrieSyncers,
 		trieSyncerVersion:         args.TrieSyncerVersion,
 		checkNodesOnDisk:          args.CheckNodesOnDisk,
+		timeBetweenRechecks:       args.TimeBetweenRechecks,
 	}
 
 	return e, nil
@@ -371,6 +374,7 @@ func (e *exportHandlerFactory) Create() (update.ExportHandler, error) {
 		TrieSyncerVersion:         e.trieSyncerVersion,
 		CheckNodesOnDisk:          e.checkNodesOnDisk,
 		AddressPubKeyConverter:    e.CoreComponents.AddressPubKeyConverter(),
+		TimeBetweenRechecks:       e.timeBetweenRechecks,
 	}
 	accountsDBSyncerFactory, err := NewAccountsDBSContainerFactory(argsAccountsSyncers)
 	if err != nil {


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- adjusting the constant used in the trie syncer was a cumbersome process that required binary recompilation. Also, a new, better value was found during mainnet testing.
  
## Proposed Changes
- extracted constant, adjusted it to ~10ms. Original value was ~100ms.

## Testing procedure
- standard testing procedure
- mainnet sync comparison
