### PR TITLE
State snapshot improvement

### DIFF
--- a/testscommon/snapshotPruningStorerMock.go
+++ b/testscommon/snapshotPruningStorerMock.go
@@ -1,5 +1,7 @@
 package testscommon
 
+import "github.com/ElrondNetwork/elrond-go-core/core"
+
 // SnapshotPruningStorerMock -
 type SnapshotPruningStorerMock struct {
 	*MemDbMock
@@ -11,8 +13,10 @@ func NewSnapshotPruningStorerMock() *SnapshotPruningStorerMock {
 }
 
 // GetFromOldEpochsWithoutAddingToCache -
-func (spsm *SnapshotPruningStorerMock) GetFromOldEpochsWithoutAddingToCache(key []byte) ([]byte, error) {
-	return spsm.Get(key)
+func (spsm *SnapshotPruningStorerMock) GetFromOldEpochsWithoutAddingToCache(key []byte) ([]byte, core.OptionalUint32, error) {
+	val, err := spsm.Get(key)
+
+	return val, core.OptionalUint32{}, err
 }
 
 // PutInEpoch -

--- a/testscommon/trie/snapshotPruningStorerStub.go
+++ b/testscommon/trie/snapshotPruningStorerStub.go
@@ -1,13 +1,14 @@
 package trie
 
 import (
+	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 )
 
 // SnapshotPruningStorerStub -
 type SnapshotPruningStorerStub struct {
 	*testscommon.MemDbMock
-	GetFromOldEpochsWithoutAddingToCacheCalled func(key []byte) ([]byte, error)
+	GetFromOldEpochsWithoutAddingToCacheCalled func(key []byte) ([]byte, core.OptionalUint32, error)
 	GetFromLastEpochCalled                     func(key []byte) ([]byte, error)
 	GetFromCurrentEpochCalled                  func(key []byte) ([]byte, error)
 	GetFromEpochCalled                         func(key []byte, epoch uint32) ([]byte, error)
@@ -18,12 +19,12 @@ type SnapshotPruningStorerStub struct {
 }
 
 // GetFromOldEpochsWithoutAddingToCache -
-func (spss *SnapshotPruningStorerStub) GetFromOldEpochsWithoutAddingToCache(key []byte) ([]byte, error) {
+func (spss *SnapshotPruningStorerStub) GetFromOldEpochsWithoutAddingToCache(key []byte) ([]byte, core.OptionalUint32, error) {
 	if spss.GetFromOldEpochsWithoutAddingToCacheCalled != nil {
 		return spss.GetFromOldEpochsWithoutAddingToCacheCalled(key)
 	}
 
-	return nil, nil
+	return nil, core.OptionalUint32{}, nil
 }
 
 // PutInEpoch -

--- a/trie/interface.go
+++ b/trie/interface.go
@@ -97,7 +97,7 @@ type epochStorer interface {
 
 type snapshotPruningStorer interface {
 	common.DBWriteCacher
-	GetFromOldEpochsWithoutAddingToCache(key []byte) ([]byte, error)
+	GetFromOldEpochsWithoutAddingToCache(key []byte) ([]byte, core.OptionalUint32, error)
 	GetFromLastEpoch(key []byte) ([]byte, error)
 	PutInEpoch(key []byte, data []byte, epoch uint32) error
 	PutInEpochWithoutCache(key []byte, data []byte, epoch uint32) error

--- a/trie/snapshotTrieStorageManager.go
+++ b/trie/snapshotTrieStorageManager.go
@@ -67,6 +67,7 @@ func (stsm *snapshotTrieStorageManager) putInPreviousStorerIfAbsent(key []byte, 
 		return
 	}
 
+	log.Trace("put missing hash in snapshot storer", "hash", key, "epoch", stsm.epoch-1)
 	err := stsm.mainSnapshotStorer.PutInEpoch(key, val, stsm.epoch-1)
 	if err != nil {
 		log.Warn("can not put in epoch",

--- a/trie/snapshotTrieStorageManager.go
+++ b/trie/snapshotTrieStorageManager.go
@@ -55,6 +55,10 @@ func (stsm *snapshotTrieStorageManager) putInPreviousStorerIfAbsent(key []byte, 
 		return
 	}
 
+	if stsm.epoch == 0 {
+		return
+	}
+
 	if epoch.Value >= stsm.epoch-1 {
 		return
 	}

--- a/trie/snapshotTrieStorageManager.go
+++ b/trie/snapshotTrieStorageManager.go
@@ -1,8 +1,11 @@
 package trie
 
 import (
+	"bytes"
 	"fmt"
 
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/errors"
 )
 
@@ -35,15 +38,38 @@ func (stsm *snapshotTrieStorageManager) Get(key []byte) ([]byte, error) {
 		return nil, errors.ErrContextClosing
 	}
 
-	val, err := stsm.mainSnapshotStorer.GetFromOldEpochsWithoutAddingToCache(key)
+	val, epoch, err := stsm.mainSnapshotStorer.GetFromOldEpochsWithoutAddingToCache(key)
 	if errors.IsClosingError(err) {
 		return nil, err
 	}
 	if len(val) != 0 {
+		stsm.putInPreviousStorerIfAbsent(key, val, epoch)
 		return val, nil
 	}
 
 	return stsm.getFromOtherStorers(key)
+}
+
+func (stsm *snapshotTrieStorageManager) putInPreviousStorerIfAbsent(key []byte, val []byte, epoch core.OptionalUint32) {
+	if !epoch.HasValue {
+		return
+	}
+
+	if epoch.Value >= stsm.epoch-1 {
+		return
+	}
+
+	if bytes.Equal(key, []byte(common.ActiveDBKey)) || bytes.Equal(key, []byte(common.TrieSyncedKey)) {
+		return
+	}
+
+	err := stsm.mainSnapshotStorer.PutInEpoch(key, val, stsm.epoch-1)
+	if err != nil {
+		log.Warn("can not put in epoch",
+			"error", err,
+			"epoch", stsm.epoch-1,
+		)
+	}
 }
 
 // Put adds the given value to the main storer

--- a/trie/snapshotTrieStorageManager_test.go
+++ b/trie/snapshotTrieStorageManager_test.go
@@ -4,11 +4,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/testscommon/trie"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewSnapshotTrieStorageManagerInvalidStorerType(t *testing.T) {
+	t.Parallel()
+
 	_, trieStorage := newEmptyTrie()
 
 	stsm, err := newSnapshotTrieStorageManager(trieStorage, 0)
@@ -17,6 +21,8 @@ func TestNewSnapshotTrieStorageManagerInvalidStorerType(t *testing.T) {
 }
 
 func TestNewSnapshotTrieStorageManager(t *testing.T) {
+	t.Parallel()
+
 	_, trieStorage := newEmptyTrie()
 	trieStorage.mainStorer = &trie.SnapshotPruningStorerStub{}
 	stsm, err := newSnapshotTrieStorageManager(trieStorage, 0)
@@ -25,12 +31,14 @@ func TestNewSnapshotTrieStorageManager(t *testing.T) {
 }
 
 func TestNewSnapshotTrieStorageManager_GetFromOldEpochsWithoutCache(t *testing.T) {
+	t.Parallel()
+
 	_, trieStorage := newEmptyTrie()
 	getFromOldEpochsWithoutCacheCalled := false
 	trieStorage.mainStorer = &trie.SnapshotPruningStorerStub{
-		GetFromOldEpochsWithoutAddingToCacheCalled: func(_ []byte) ([]byte, error) {
+		GetFromOldEpochsWithoutAddingToCacheCalled: func(_ []byte) ([]byte, core.OptionalUint32, error) {
 			getFromOldEpochsWithoutCacheCalled = true
-			return nil, nil
+			return nil, core.OptionalUint32{}, nil
 		},
 	}
 	stsm, _ := newSnapshotTrieStorageManager(trieStorage, 0)
@@ -40,6 +48,8 @@ func TestNewSnapshotTrieStorageManager_GetFromOldEpochsWithoutCache(t *testing.T
 }
 
 func TestNewSnapshotTrieStorageManager_PutWithoutCache(t *testing.T) {
+	t.Parallel()
+
 	_, trieStorage := newEmptyTrie()
 	putWithoutCacheCalled := false
 	trieStorage.mainStorer = &trie.SnapshotPruningStorerStub{
@@ -55,6 +65,8 @@ func TestNewSnapshotTrieStorageManager_PutWithoutCache(t *testing.T) {
 }
 
 func TestNewSnapshotTrieStorageManager_GetFromLastEpoch(t *testing.T) {
+	t.Parallel()
+
 	_, trieStorage := newEmptyTrie()
 	getFromLastEpochCalled := false
 	trieStorage.mainStorer = &trie.SnapshotPruningStorerStub{
@@ -67,4 +79,112 @@ func TestNewSnapshotTrieStorageManager_GetFromLastEpoch(t *testing.T) {
 
 	_, _ = stsm.GetFromLastEpoch([]byte("key"))
 	assert.True(t, getFromLastEpochCalled)
+}
+
+func TestSnapshotTrieStorageManager_AlsoAddInPreviousEpoch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HasValue is false", func(t *testing.T) {
+		val := []byte("val")
+		_, trieStorage := newEmptyTrie()
+		trieStorage.mainStorer = &trie.SnapshotPruningStorerStub{
+			GetFromOldEpochsWithoutAddingToCacheCalled: func(_ []byte) ([]byte, core.OptionalUint32, error) {
+				return val, core.OptionalUint32{}, nil
+			},
+			PutInEpochCalled: func(_ []byte, _ []byte, _ uint32) error {
+				assert.Fail(t, "this should not have been called")
+				return nil
+			},
+		}
+		stsm, _ := newSnapshotTrieStorageManager(trieStorage, 5)
+
+		returnedVal, _ := stsm.Get([]byte("key"))
+		assert.Equal(t, val, returnedVal)
+	})
+	t.Run("epoch is previous epoch", func(t *testing.T) {
+		val := []byte("val")
+		_, trieStorage := newEmptyTrie()
+		trieStorage.mainStorer = &trie.SnapshotPruningStorerStub{
+			GetFromOldEpochsWithoutAddingToCacheCalled: func(_ []byte) ([]byte, core.OptionalUint32, error) {
+				epoch := core.OptionalUint32{
+					Value:    4,
+					HasValue: true,
+				}
+				return []byte("val"), epoch, nil
+			},
+			PutInEpochCalled: func(_ []byte, _ []byte, _ uint32) error {
+				assert.Fail(t, "this should not have been called")
+				return nil
+			},
+		}
+		stsm, _ := newSnapshotTrieStorageManager(trieStorage, 5)
+
+		returnedVal, _ := stsm.Get([]byte("key"))
+		assert.Equal(t, val, returnedVal)
+	})
+	t.Run("key is ActiveDBKey", func(t *testing.T) {
+		val := []byte("val")
+		_, trieStorage := newEmptyTrie()
+		trieStorage.mainStorer = &trie.SnapshotPruningStorerStub{
+			GetFromOldEpochsWithoutAddingToCacheCalled: func(_ []byte) ([]byte, core.OptionalUint32, error) {
+				epoch := core.OptionalUint32{
+					Value:    3,
+					HasValue: true,
+				}
+				return []byte("val"), epoch, nil
+			},
+			PutInEpochCalled: func(_ []byte, _ []byte, _ uint32) error {
+				assert.Fail(t, "this should not have been called")
+				return nil
+			},
+		}
+		stsm, _ := newSnapshotTrieStorageManager(trieStorage, 5)
+
+		returnedVal, _ := stsm.Get([]byte(common.ActiveDBKey))
+		assert.Equal(t, val, returnedVal)
+	})
+	t.Run("key is TrieSyncedKey", func(t *testing.T) {
+		val := []byte("val")
+		_, trieStorage := newEmptyTrie()
+		trieStorage.mainStorer = &trie.SnapshotPruningStorerStub{
+			GetFromOldEpochsWithoutAddingToCacheCalled: func(_ []byte) ([]byte, core.OptionalUint32, error) {
+				epoch := core.OptionalUint32{
+					Value:    3,
+					HasValue: true,
+				}
+				return []byte("val"), epoch, nil
+			},
+			PutInEpochCalled: func(_ []byte, _ []byte, _ uint32) error {
+				assert.Fail(t, "this should not have been called")
+				return nil
+			},
+		}
+		stsm, _ := newSnapshotTrieStorageManager(trieStorage, 5)
+
+		returnedVal, _ := stsm.Get([]byte(common.TrieSyncedKey))
+		assert.Equal(t, val, returnedVal)
+	})
+	t.Run("add in previous epoch", func(t *testing.T) {
+		val := []byte("val")
+		putInEpochCalled := false
+		_, trieStorage := newEmptyTrie()
+		trieStorage.mainStorer = &trie.SnapshotPruningStorerStub{
+			GetFromOldEpochsWithoutAddingToCacheCalled: func(_ []byte) ([]byte, core.OptionalUint32, error) {
+				epoch := core.OptionalUint32{
+					Value:    3,
+					HasValue: true,
+				}
+				return []byte("val"), epoch, nil
+			},
+			PutInEpochCalled: func(_ []byte, _ []byte, _ uint32) error {
+				putInEpochCalled = true
+				return nil
+			},
+		}
+		stsm, _ := newSnapshotTrieStorageManager(trieStorage, 5)
+
+		returnedVal, _ := stsm.Get([]byte("key"))
+		assert.Equal(t, val, returnedVal)
+		assert.True(t, putInEpochCalled)
+	})
 }

--- a/trie/snapshotTrieStorageManager_test.go
+++ b/trie/snapshotTrieStorageManager_test.go
@@ -122,6 +122,27 @@ func TestSnapshotTrieStorageManager_AlsoAddInPreviousEpoch(t *testing.T) {
 		returnedVal, _ := stsm.Get([]byte("key"))
 		assert.Equal(t, val, returnedVal)
 	})
+	t.Run("epoch is 0", func(t *testing.T) {
+		val := []byte("val")
+		_, trieStorage := newEmptyTrie()
+		trieStorage.mainStorer = &trie.SnapshotPruningStorerStub{
+			GetFromOldEpochsWithoutAddingToCacheCalled: func(_ []byte) ([]byte, core.OptionalUint32, error) {
+				epoch := core.OptionalUint32{
+					Value:    4,
+					HasValue: true,
+				}
+				return []byte("val"), epoch, nil
+			},
+			PutInEpochCalled: func(_ []byte, _ []byte, _ uint32) error {
+				assert.Fail(t, "this should not have been called")
+				return nil
+			},
+		}
+		stsm, _ := newSnapshotTrieStorageManager(trieStorage, 0)
+
+		returnedVal, _ := stsm.Get([]byte("key"))
+		assert.Equal(t, val, returnedVal)
+	})
 	t.Run("key is ActiveDBKey", func(t *testing.T) {
 		val := []byte("val")
 		_, trieStorage := newEmptyTrie()

--- a/trie/trieStorageManager.go
+++ b/trie/trieStorageManager.go
@@ -431,17 +431,6 @@ func (tsm *trieStorageManager) takeSnapshot(snapshotEntry *snapshotsQueueEntry, 
 
 	log.Trace("trie snapshot started", "rootHash", snapshotEntry.rootHash)
 
-	newRoot, err := newSnapshotNode(tsm, msh, hsh, snapshotEntry.rootHash)
-	if err != nil {
-		writeInChanNonBlocking(snapshotEntry.errChan, err)
-		treatSnapshotError(err,
-			"trie storage manager: newSnapshotNode takeSnapshot",
-			snapshotEntry.rootHash,
-			snapshotEntry.mainTrieRootHash,
-		)
-		return
-	}
-
 	stsm, err := newSnapshotTrieStorageManager(tsm, snapshotEntry.epoch)
 	if err != nil {
 		writeInChanNonBlocking(snapshotEntry.errChan, err)
@@ -449,6 +438,17 @@ func (tsm *trieStorageManager) takeSnapshot(snapshotEntry *snapshotsQueueEntry, 
 			"rootHash", snapshotEntry.rootHash,
 			"main trie rootHash", snapshotEntry.mainTrieRootHash,
 			"err", err.Error())
+		return
+	}
+
+	newRoot, err := newSnapshotNode(stsm, msh, hsh, snapshotEntry.rootHash)
+	if err != nil {
+		writeInChanNonBlocking(snapshotEntry.errChan, err)
+		treatSnapshotError(err,
+			"trie storage manager: newSnapshotNode takeSnapshot",
+			snapshotEntry.rootHash,
+			snapshotEntry.mainTrieRootHash,
+		)
 		return
 	}
 

--- a/trie/trieStorageManager_test.go
+++ b/trie/trieStorageManager_test.go
@@ -356,6 +356,7 @@ func TestTrieStorageManager_TakeSnapshotWithGetNodeFromDBError(t *testing.T) {
 	t.Parallel()
 
 	args := getNewTrieStorageManagerArgs()
+	args.MainStorer = testscommon.NewSnapshotPruningStorerMock()
 	ts, _ := trie.NewTrieStorageManager(args)
 
 	rootHash := []byte("rootHash")


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- There are some edgecases in which a certain trie node is not saved in the proper storer. The problem is that we will have storers that do not have the complete state.
  
## Proposed Changes
- During the snapshot process, if a trie node is not present in the previous storer (which should have had the entire state), it will also be saved there.

## Testing procedure
- Normal test, but with "*:DEBUG,trie:TRACE" log level, and we will see in the logs that the missing nodes are also saved in the  previous storer.
