### PR TITLE
Upgrade indexer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ElrondNetwork/arwen-wasm-vm/v1_4 v1.4.58
 	github.com/ElrondNetwork/concurrent-map v0.1.3
 	github.com/ElrondNetwork/covalent-indexer-go v1.0.6
-	github.com/ElrondNetwork/elastic-indexer-go v1.2.39
+	github.com/ElrondNetwork/elastic-indexer-go v1.2.40
 	github.com/ElrondNetwork/elrond-go-core v1.1.19
 	github.com/ElrondNetwork/elrond-go-crypto v1.0.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/ElrondNetwork/concurrent-map v0.1.3 h1:j2LtPrNJuerannC1cQDE79STvi/P04
 github.com/ElrondNetwork/concurrent-map v0.1.3/go.mod h1:3XwSwn4JHI0lrKxWLZvtp53Emr8BXYTmNQGwcukHJEE=
 github.com/ElrondNetwork/covalent-indexer-go v1.0.6 h1:+LNKItUc+Pb7WuTbil3VuiLMmdQ1AY7lBJM476PtVNE=
 github.com/ElrondNetwork/covalent-indexer-go v1.0.6/go.mod h1:j3h2g96vqhJAuj3aEX2PWhomae2/o7YfXGEfweNXEeQ=
-github.com/ElrondNetwork/elastic-indexer-go v1.2.39 h1:NnhTF6yVnzAQNC7JibeGvR3anUSiA1I5UbWU9sn/U5E=
-github.com/ElrondNetwork/elastic-indexer-go v1.2.39/go.mod h1:w+J48ssy1kxOawG2lwiOUR4JYPA092g8Zjk88kRVDNA=
+github.com/ElrondNetwork/elastic-indexer-go v1.2.40 h1:imqD4OdTG9hxHdedDP/Ru4h2pm7VGjUQtDsNqupyfkI=
+github.com/ElrondNetwork/elastic-indexer-go v1.2.40/go.mod h1:w+J48ssy1kxOawG2lwiOUR4JYPA092g8Zjk88kRVDNA=
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-core v1.1.13/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
-  Update the elastic indexer module to version v1.2.40
 - PRs from indexer: https://github.com/ElrondNetwork/elastic-indexer-go/pull/169
## Proposed Changes
- The new indexer version will extend the block structure with extra fields about the execution of a miniblock (the block structure will contain the indices of the first and last transaction processed from a specific miniblock)

## Testing procedure
- Run a system test with a lot of transactions.
- Find a block with partial executed miniblocks.
- Check if the specific block indexed in the ES contains information about the execution of the miniblock.
