### PR TITLE
async callback arguments inconsitency fix

### DIFF
--- a/integrationTests/multiShard/smartContract/polynetworkbridge/bridge_test.go
+++ b/integrationTests/multiShard/smartContract/polynetworkbridge/bridge_test.go
@@ -28,8 +28,9 @@ func TestBridgeSetupAndBurn(t *testing.T) {
 	numMetachainNodes := 1
 
 	enableEpochs := config.EnableEpochs{
-		GlobalMintBurnDisableEpoch:       10,
-		BuiltInFunctionOnMetaEnableEpoch: 10,
+		GlobalMintBurnDisableEpoch:               10,
+		BuiltInFunctionOnMetaEnableEpoch:         10,
+		ESDTMetadataContinuousCleanupEnableEpoch: 10,
 	}
 	nodes := integrationTests.CreateNodesWithEnableEpochs(
 		numOfShards,

--- a/process/smartContract/process.go
+++ b/process/smartContract/process.go
@@ -2353,10 +2353,14 @@ func (sc *scProcessor) useLastTransferAsAsyncCallBackWhenNeeded(
 		return false
 	}
 
+	if sc.flagFixAsyncCallBackArgumentsParser.IsSet() {
+		result.Data = append(result.Data, []byte("@"+core.ConvertToEvenHex(int(vmOutput.ReturnCode)))...)
+	}
+
 	addReturnDataToSCR(vmOutput, result)
 	result.CallType = vmData.AsynchronousCallBack
 	result.GasLimit, _ = core.SafeAddUint64(result.GasLimit, vmOutput.GasRemaining)
-
+	log.Error("result", "data", string(result.Data))
 	return true
 }
 

--- a/process/smartContract/process.go
+++ b/process/smartContract/process.go
@@ -2360,7 +2360,7 @@ func (sc *scProcessor) useLastTransferAsAsyncCallBackWhenNeeded(
 	addReturnDataToSCR(vmOutput, result)
 	result.CallType = vmData.AsynchronousCallBack
 	result.GasLimit, _ = core.SafeAddUint64(result.GasLimit, vmOutput.GasRemaining)
-	log.Error("result", "data", string(result.Data))
+
 	return true
 }
 

--- a/process/smartContract/process_test.go
+++ b/process/smartContract/process_test.go
@@ -2800,6 +2800,7 @@ func TestScProcessor_CreateCrossShardTransactionsWithAsyncCalls(t *testing.T) {
 
 	lastScTx := scTxs[len(scTxs)-1].(*smartContractResult.SmartContractResult)
 	require.Equal(t, vmData.AsynchronousCallBack, lastScTx.CallType)
+	require.Equal(t, lastScTx.Data, []byte("@"+core.ConvertToEvenHex(int(vmcommon.Ok))))
 
 	tx.Value = big.NewInt(0)
 	scTxs, err = sc.processVMOutput(&vmcommon.VMOutput{GasRemaining: 1000}, txHash, tx, vmData.AsynchronousCall, 10000)


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
Inconsistency  of arguments when creating asynchronous callback SCR from an output transfer

## Proposed Changes
Added missing argument. Only after activation of special flag (backward compatibility issues).

## Testing procedure
Deploy a contract, issue a token from that contract through asnycCall, check one of the resulting SCRs which is with type AsyncchronousCallback. It should start with "@00" after activation. Before activation this one is missing.
