### PR TITLE
Create static storer for meta if snapshots are disabled

### DIFF
--- a/storage/factory/pruningStorerFactory.go
+++ b/storage/factory/pruningStorerFactory.go
@@ -328,14 +328,12 @@ func (psf *StorageServiceFactory) CreateForMeta() (dataRetriever.StorageService,
 		return nil, err
 	}
 
-	userAccountsUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.AccountsTrieStorage, customDatabaseRemover)
-	userAccountsUnit, err = psf.createTriePruningPersister(userAccountsUnitArgs)
+	userAccountsUnit, err = psf.createTriePersister(psf.generalConfig.AccountsTrieStorage, psf.generalConfig.StateTriesConfig, customDatabaseRemover)
 	if err != nil {
 		return nil, err
 	}
 
-	peerAccountsUnitArgs := psf.createPruningStorerArgs(psf.generalConfig.PeerAccountsTrieStorage, customDatabaseRemover)
-	peerAccountsUnit, err = psf.createTriePruningPersister(peerAccountsUnitArgs)
+	peerAccountsUnit, err = psf.createTriePersister(psf.generalConfig.PeerAccountsTrieStorage, psf.generalConfig.StateTriesConfig, customDatabaseRemover)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- If snapshots are disabled, the trie should use a static storer instead of a pruning storer (that creates a db for each epoch). The meta is using a pruning storer even if snapshots are disabled.
  
## Proposed Changes
- Use static storer for meta if snapshots are disabled.

## Testing procedure
- Normal test
- Test with snapshots disabled
