### PR TITLE
New flag for async call fix

### DIFF
--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -218,6 +218,9 @@
     # MiniBlockPartialExecutionEnableEpoch represents the epoch when mini block partial execution will be enabled
     MiniBlockPartialExecutionEnableEpoch = 3
 
+    # FixAsyncCallBackArgsListEnableEpoch represents the epoch when the async callback arguments lists fix will be enabled
+    FixAsyncCallBackArgsListEnableEpoch = 6
+
     # MaxNodesChangeEnableEpoch holds configuration for changing the maximum number of nodes and the enabling epoch
     MaxNodesChangeEnableEpoch = [
         { EpochEnable = 0, MaxNumNodes = 36, NodesToShufflePerShard = 4 },

--- a/config/epochConfig.go
+++ b/config/epochConfig.go
@@ -85,6 +85,7 @@ type EnableEpochs struct {
 	HeartbeatDisableEpoch                             uint32
 	MiniBlockPartialExecutionEnableEpoch              uint32
 	ESDTMetadataContinuousCleanupEnableEpoch          uint32
+	FixAsyncCallBackArgsListEnableEpoch               uint32
 }
 
 // GasScheduleByEpochs represents a gas schedule toml entry that will be applied from the provided epoch

--- a/config/tomlConfig_test.go
+++ b/config/tomlConfig_test.go
@@ -665,6 +665,9 @@ func TestEnableEpochConfig(t *testing.T) {
 	# ESDTMetadataContinuousCleanupEnableEpoch represents the epoch when esdt metadata is automatically deleted according to inshard liquidity
 	ESDTMetadataContinuousCleanupEnableEpoch = 56
 
+    # FixAsyncCallBackArgsListEnableEpoch represents the epoch when the async callback arguments lists fix will be enabled
+    FixAsyncCallBackArgsListEnableEpoch = 57
+
     # MaxNodesChangeEnableEpoch holds configuration for changing the maximum number of nodes and the enabling epoch
     MaxNodesChangeEnableEpoch = [
         { EpochEnable = 44, MaxNumNodes = 2169, NodesToShufflePerShard = 80 },
@@ -748,6 +751,7 @@ func TestEnableEpochConfig(t *testing.T) {
 			ManagedCryptoAPIsEnableEpoch:                54,
 			HeartbeatDisableEpoch:                       55,
 			ESDTMetadataContinuousCleanupEnableEpoch:    56,
+			FixAsyncCallBackArgsListEnableEpoch:         57,
 		},
 		GasSchedule: GasScheduleConfig{
 			GasScheduleByEpochs: []GasScheduleByEpochs{

--- a/integrationTests/multiShard/smartContract/polynetworkbridge/bridge_test.go
+++ b/integrationTests/multiShard/smartContract/polynetworkbridge/bridge_test.go
@@ -28,9 +28,9 @@ func TestBridgeSetupAndBurn(t *testing.T) {
 	numMetachainNodes := 1
 
 	enableEpochs := config.EnableEpochs{
-		GlobalMintBurnDisableEpoch:               10,
-		BuiltInFunctionOnMetaEnableEpoch:         10,
-		ESDTMetadataContinuousCleanupEnableEpoch: 10,
+		GlobalMintBurnDisableEpoch:          10,
+		BuiltInFunctionOnMetaEnableEpoch:    10,
+		FixAsyncCallBackArgsListEnableEpoch: 10,
 	}
 	nodes := integrationTests.CreateNodesWithEnableEpochs(
 		numOfShards,

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -182,6 +182,7 @@ func printEnableEpochs(configs *config.Configs) {
 	log.Debug(readEpochFor("refactor contexts"), "epoch", enableEpochs.RefactorContextEnableEpoch)
 	log.Debug(readEpochFor("disable heartbeat v1"), "epoch", enableEpochs.HeartbeatDisableEpoch)
 	log.Debug(readEpochFor("mini block partial execution"), "epoch", enableEpochs.MiniBlockPartialExecutionEnableEpoch)
+	log.Debug(readEpochFor("fix async callback arguments list"), "epoch", enableEpochs.FixAsyncCallBackArgsListEnableEpoch)
 	gasSchedule := configs.EpochConfig.GasSchedule
 
 	log.Debug(readEpochFor("gas schedule directories paths"), "epoch", gasSchedule.GasScheduleByEpochs)

--- a/process/smartContract/process.go
+++ b/process/smartContract/process.go
@@ -86,6 +86,7 @@ type scProcessor struct {
 	scrSizeInvariantOnBuiltInResultEnableEpoch  uint32
 	deleteWrongArgAsyncAfterBuiltInEnableEpoch  uint32
 	fixAsyncCallBackArgParserEnableEpoch        uint32
+	fixAsyncCallBackArgsListEnableEpoch         uint32
 	flagStakingV2                               atomic.Flag
 	flagDeploy                                  atomic.Flag
 	flagBuiltin                                 atomic.Flag
@@ -108,6 +109,7 @@ type scProcessor struct {
 	flagSCRSizeInvariantOnBuiltInResult         atomic.Flag
 	flagDeleteWrongArgAsyncAfterBuiltIn         atomic.Flag
 	flagFixAsyncCallBackArgumentsParser         atomic.Flag
+	flagFixAsyncCallBackArgumentsList           atomic.Flag
 
 	badTxForwarder process.IntermediateTransactionHandler
 	scrForwarder   process.IntermediateTransactionHandler
@@ -260,6 +262,7 @@ func NewSmartContractProcessor(args ArgsNewSmartContractProcessor) (*scProcessor
 		scrSizeInvariantOnBuiltInResultEnableEpoch:  args.EnableEpochs.SCRSizeInvariantOnBuiltInResultEnableEpoch,
 		deleteWrongArgAsyncAfterBuiltInEnableEpoch:  args.EnableEpochs.ManagedCryptoAPIsEnableEpoch,
 		fixAsyncCallBackArgParserEnableEpoch:        args.EnableEpochs.ESDTMetadataContinuousCleanupEnableEpoch,
+		fixAsyncCallBackArgsListEnableEpoch:         args.EnableEpochs.FixAsyncCallBackArgsListEnableEpoch,
 	}
 
 	var err error
@@ -2353,7 +2356,7 @@ func (sc *scProcessor) useLastTransferAsAsyncCallBackWhenNeeded(
 		return false
 	}
 
-	if sc.flagFixAsyncCallBackArgumentsParser.IsSet() {
+	if sc.flagFixAsyncCallBackArgumentsList.IsSet() {
 		result.Data = append(result.Data, []byte("@"+core.ConvertToEvenHex(int(vmOutput.ReturnCode)))...)
 	}
 
@@ -2952,6 +2955,9 @@ func (sc *scProcessor) EpochConfirmed(epoch uint32, _ uint64) {
 
 	sc.flagFixAsyncCallBackArgumentsParser.SetValue(epoch >= sc.fixAsyncCallBackArgParserEnableEpoch)
 	log.Debug("scProcessor: fix async callback arguments parser", "enabled", sc.flagFixAsyncCallBackArgumentsParser.IsSet())
+
+	sc.flagFixAsyncCallBackArgumentsList.SetValue(epoch >= sc.fixAsyncCallBackArgsListEnableEpoch)
+	log.Debug("scProcessor: fix async callback arguments list", "enabled", sc.flagFixAsyncCallBackArgumentsList.IsSet())
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/process/smartContract/process_test.go
+++ b/process/smartContract/process_test.go
@@ -11,10 +11,12 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/data"
+	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/smartContractResult"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	vmData "github.com/ElrondNetwork/elrond-go-core/data/vm"
 	"github.com/ElrondNetwork/elrond-go/common"
+	"github.com/ElrondNetwork/elrond-go/common/forking"
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/block/postprocess"
@@ -2749,6 +2751,8 @@ func TestScProcessor_CreateCrossShardTransactionsWithAsyncCalls(t *testing.T) {
 	}
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(5)
 	arguments := createMockSmartContractProcessorArguments()
+	arguments.EpochNotifier = forking.NewGenericEpochNotifier()
+	arguments.EnableEpochs.FixAsyncCallBackArgsListEnableEpoch = 1
 	arguments.AccountsDB = accountsDB
 	arguments.ShardCoordinator = shardCoordinator
 	sc, err := NewSmartContractProcessor(arguments)
@@ -2798,14 +2802,29 @@ func TestScProcessor_CreateCrossShardTransactionsWithAsyncCalls(t *testing.T) {
 	require.Equal(t, len(outputAccounts), len(scTxs))
 	require.True(t, createdAsyncSCR)
 
-	lastScTx := scTxs[len(scTxs)-1].(*smartContractResult.SmartContractResult)
-	require.Equal(t, vmData.AsynchronousCallBack, lastScTx.CallType)
-	require.Equal(t, lastScTx.Data, []byte("@"+core.ConvertToEvenHex(int(vmcommon.Ok))))
+	t.Run("backwards compatibility", func(t *testing.T) {
+		lastScTx := scTxs[len(scTxs)-1].(*smartContractResult.SmartContractResult)
+		require.Equal(t, vmData.AsynchronousCallBack, lastScTx.CallType)
+		require.Equal(t, []byte(nil), lastScTx.Data)
+	})
+	arguments.EpochNotifier.CheckEpoch(
+		&block.Header{
+			Epoch: 1,
+		},
+	)
+
+	createdAsyncSCR, scTxs, err = sc.processSCOutputAccounts(&vmcommon.VMOutput{GasRemaining: 1000}, vmData.AsynchronousCall, outputAccounts, tx, txHash)
+	t.Run("fix enabled, data field is correctly populated", func(t *testing.T) {
+		lastScTx := scTxs[len(scTxs)-1].(*smartContractResult.SmartContractResult)
+		require.Equal(t, vmData.AsynchronousCallBack, lastScTx.CallType)
+		require.Equal(t, []byte("@"+core.ConvertToEvenHex(int(vmcommon.Ok))), lastScTx.Data)
+	})
 
 	tx.Value = big.NewInt(0)
 	scTxs, err = sc.processVMOutput(&vmcommon.VMOutput{GasRemaining: 1000}, txHash, tx, vmData.AsynchronousCall, 10000)
 	require.Nil(t, err)
 	require.Equal(t, 1, len(scTxs))
+	lastScTx := scTxs[len(scTxs)-1].(*smartContractResult.SmartContractResult)
 	lastScTx = scTxs[len(scTxs)-1].(*smartContractResult.SmartContractResult)
 	require.Equal(t, vmData.AsynchronousCallBack, lastScTx.CallType)
 }

--- a/process/smartContract/process_test.go
+++ b/process/smartContract/process_test.go
@@ -2801,9 +2801,9 @@ func TestScProcessor_CreateCrossShardTransactionsWithAsyncCalls(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, len(outputAccounts), len(scTxs))
 	require.True(t, createdAsyncSCR)
+	lastScTx := scTxs[len(scTxs)-1].(*smartContractResult.SmartContractResult)
 
 	t.Run("backwards compatibility", func(t *testing.T) {
-		lastScTx := scTxs[len(scTxs)-1].(*smartContractResult.SmartContractResult)
 		require.Equal(t, vmData.AsynchronousCallBack, lastScTx.CallType)
 		require.Equal(t, []byte(nil), lastScTx.Data)
 	})
@@ -2813,9 +2813,12 @@ func TestScProcessor_CreateCrossShardTransactionsWithAsyncCalls(t *testing.T) {
 		},
 	)
 
-	createdAsyncSCR, scTxs, err = sc.processSCOutputAccounts(&vmcommon.VMOutput{GasRemaining: 1000}, vmData.AsynchronousCall, outputAccounts, tx, txHash)
+	_, scTxs, err = sc.processSCOutputAccounts(&vmcommon.VMOutput{GasRemaining: 1000}, vmData.AsynchronousCall, outputAccounts, tx, txHash)
+	require.Nil(t, err)
+	require.Equal(t, len(outputAccounts), len(scTxs))
+	require.True(t, createdAsyncSCR)
+	lastScTx = scTxs[len(scTxs)-1].(*smartContractResult.SmartContractResult)
 	t.Run("fix enabled, data field is correctly populated", func(t *testing.T) {
-		lastScTx := scTxs[len(scTxs)-1].(*smartContractResult.SmartContractResult)
 		require.Equal(t, vmData.AsynchronousCallBack, lastScTx.CallType)
 		require.Equal(t, []byte("@"+core.ConvertToEvenHex(int(vmcommon.Ok))), lastScTx.Data)
 	})
@@ -2824,7 +2827,6 @@ func TestScProcessor_CreateCrossShardTransactionsWithAsyncCalls(t *testing.T) {
 	scTxs, err = sc.processVMOutput(&vmcommon.VMOutput{GasRemaining: 1000}, txHash, tx, vmData.AsynchronousCall, 10000)
 	require.Nil(t, err)
 	require.Equal(t, 1, len(scTxs))
-	lastScTx := scTxs[len(scTxs)-1].(*smartContractResult.SmartContractResult)
 	lastScTx = scTxs[len(scTxs)-1].(*smartContractResult.SmartContractResult)
 	require.Equal(t, vmData.AsynchronousCallBack, lastScTx.CallType)
 }


### PR DESCRIPTION
## Description of the reasoning behind the pull request 
- the async callback fix was not backwards compatible with the testnet and devnet versions
  
## Proposed Changes
- added new flag for the fix

## Testing procedure
- standard system testing procedure
- async callback fix. Before epoch 6 should not return the data, starting from epoch 6 it should return the data parameter