### PR TITLE
FEAT: Remove covalent indexer from node

### DIFF
--- a/cmd/node/config/external.toml
+++ b/cmd/node/config/external.toml
@@ -33,14 +33,3 @@
 
     # Password is used to authorize an observer to push event data
     Password = ""
-
-# CovalentConnector defines settings related to covalent indexer
-[CovalentConnector]
-    # This flag shall only be used for observer nodes
-    Enabled = false
-    URL = "localhost:21111"
-    # Route used to send blocks which are encoded as binary data
-    # defined by a specific avro schema
-    RouteSendData = "/block"
-    # Route used to acknowledge sent blocks
-    RouteAcknowledgeData = "/acknowledge"

--- a/config/externalConfig.go
+++ b/config/externalConfig.go
@@ -4,7 +4,6 @@ package config
 type ExternalConfig struct {
 	ElasticSearchConnector ElasticSearchConfig
 	EventNotifierConnector EventNotifierConfig
-	CovalentConnector      CovalentConfig
 }
 
 // ElasticSearchConfig will hold the configuration for the elastic search
@@ -26,12 +25,4 @@ type EventNotifierConfig struct {
 	ProxyUrl         string
 	Username         string
 	Password         string
-}
-
-// CovalentConfig will hold the configurations for covalent indexer
-type CovalentConfig struct {
-	Enabled              bool
-	URL                  string
-	RouteSendData        string
-	RouteAcknowledgeData string
 }

--- a/factory/statusComponents.go
+++ b/factory/statusComponents.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	covalentFactory "github.com/ElrondNetwork/covalent-indexer-go/factory"
 	indexerFactory "github.com/ElrondNetwork/elastic-indexer-go/factory"
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
@@ -208,10 +207,9 @@ func (pc *statusComponents) Close() error {
 func (scf *statusComponentsFactory) createOutportDriver() (outport.OutportHandler, error) {
 
 	outportFactoryArgs := &outportDriverFactory.OutportFactoryArgs{
-		RetrialInterval:            common.RetrialIntervalForOutportDriver,
-		ElasticIndexerFactoryArgs:  scf.makeElasticIndexerArgs(),
-		EventNotifierFactoryArgs:   scf.makeEventNotifierArgs(),
-		CovalentIndexerFactoryArgs: scf.makeCovalentIndexerArgs(),
+		RetrialInterval:           common.RetrialIntervalForOutportDriver,
+		ElasticIndexerFactoryArgs: scf.makeElasticIndexerArgs(),
+		EventNotifierFactoryArgs:  scf.makeEventNotifierArgs(),
 	}
 
 	return outportDriverFactory.CreateOutport(outportFactoryArgs)
@@ -251,20 +249,6 @@ func (scf *statusComponentsFactory) makeEventNotifierArgs() *outportDriverFactor
 		Marshaller:       scf.coreComponents.InternalMarshalizer(),
 		Hasher:           scf.coreComponents.Hasher(),
 		PubKeyConverter:  scf.coreComponents.AddressPubKeyConverter(),
-	}
-}
-
-func (scf *statusComponentsFactory) makeCovalentIndexerArgs() *covalentFactory.ArgsCovalentIndexerFactory {
-	return &covalentFactory.ArgsCovalentIndexerFactory{
-		Enabled:              scf.externalConfig.CovalentConnector.Enabled,
-		URL:                  scf.externalConfig.CovalentConnector.URL,
-		RouteSendData:        scf.externalConfig.CovalentConnector.RouteSendData,
-		RouteAcknowledgeData: scf.externalConfig.CovalentConnector.RouteAcknowledgeData,
-		PubKeyConverter:      scf.coreComponents.AddressPubKeyConverter(),
-		Accounts:             scf.stateComponents.AccountsAdapter(),
-		Hasher:               scf.coreComponents.Hasher(),
-		Marshaller:           scf.coreComponents.InternalMarshalizer(),
-		ShardCoordinator:     scf.shardCoordinator,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/ElrondNetwork/arwen-wasm-vm/v1_3 v1.3.42-0.20220729115131-85ecca868e90
 	github.com/ElrondNetwork/arwen-wasm-vm/v1_4 v1.4.59-0.20220729115431-a6c93119bdda
 	github.com/ElrondNetwork/concurrent-map v0.1.3
-	github.com/ElrondNetwork/covalent-indexer-go v1.0.6
 	github.com/ElrondNetwork/elastic-indexer-go v1.2.39
 	github.com/ElrondNetwork/elrond-go-core v1.1.19
 	github.com/ElrondNetwork/elrond-go-crypto v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,6 @@ github.com/ElrondNetwork/big-int-util v0.1.0 h1:vTMoJ5azhVmr7jhpSD3JUjQdkdyXoEPV
 github.com/ElrondNetwork/big-int-util v0.1.0/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg1IJLPAK6GVHMbC7Aw4=
 github.com/ElrondNetwork/concurrent-map v0.1.3 h1:j2LtPrNJuerannC1cQDE79STvi/P04gd61sNYo04Zf0=
 github.com/ElrondNetwork/concurrent-map v0.1.3/go.mod h1:3XwSwn4JHI0lrKxWLZvtp53Emr8BXYTmNQGwcukHJEE=
-github.com/ElrondNetwork/covalent-indexer-go v1.0.6 h1:+LNKItUc+Pb7WuTbil3VuiLMmdQ1AY7lBJM476PtVNE=
-github.com/ElrondNetwork/covalent-indexer-go v1.0.6/go.mod h1:j3h2g96vqhJAuj3aEX2PWhomae2/o7YfXGEfweNXEeQ=
 github.com/ElrondNetwork/elastic-indexer-go v1.2.39 h1:NnhTF6yVnzAQNC7JibeGvR3anUSiA1I5UbWU9sn/U5E=
 github.com/ElrondNetwork/elastic-indexer-go v1.2.39/go.mod h1:w+J48ssy1kxOawG2lwiOUR4JYPA092g8Zjk88kRVDNA=
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
@@ -71,7 +69,6 @@ github.com/ElrondNetwork/elrond-go-logger v1.0.5/go.mod h1:cBfgx0ST/CJx8jrxJSC5a
 github.com/ElrondNetwork/elrond-go-logger v1.0.7 h1:Ldl1rVS0RGKc1IsW8jIaGCb6Zwei04gsMvyjL05X6mE=
 github.com/ElrondNetwork/elrond-go-logger v1.0.7/go.mod h1:cBfgx0ST/CJx8jrxJSC5aiSrvkGzcnF7sK06RD8mFxQ=
 github.com/ElrondNetwork/elrond-vm-common v1.1.0/go.mod h1:w3i6f8uiuRkE68Ie/gebRcLgTuHqvruJSYrFyZWuLrE=
-github.com/ElrondNetwork/elrond-vm-common v1.2.9/go.mod h1:B/Y8WiqHyDd7xsjNYsaYbVMp1jQgQ+z4jTJkFvj/EWI=
 github.com/ElrondNetwork/elrond-vm-common v1.3.7/go.mod h1:seROQuR7RJCoCS7mgRXVAlvjztltY1c+UroAgWr/USE=
 github.com/ElrondNetwork/elrond-vm-common v1.3.15-0.20220729115029-e70fd191b2f0/go.mod h1:seROQuR7RJCoCS7mgRXVAlvjztltY1c+UroAgWr/USE=
 github.com/ElrondNetwork/elrond-vm-common v1.3.16 h1:/pLt3ckAhi5vE6Lde6tog7VNUg5BBm5sTDXnJBSvj7E=
@@ -220,8 +217,6 @@ github.com/elastic/go-elasticsearch/v7 v7.12.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyEr
 github.com/elastic/gosigar v0.12.0/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/elastic/gosigar v0.14.2 h1:Dg80n8cr90OZ7x+bAax/QjoW/XqTI11RmA79ZwIm9/4=
 github.com/elastic/gosigar v0.14.2/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
-github.com/elodina/go-avro v0.0.0-20160406082632-0c8185d9a3ba h1:QkK2L3uvEaZJ40iFZbiMKz/yQF/MI2uaNO2iyV/ve6w=
-github.com/elodina/go-avro v0.0.0-20160406082632-0c8185d9a3ba/go.mod h1:3A7SOsr8WBIpkWUsqzMpR3tIQbanKqxZcis2GSl12Nk=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -385,8 +380,6 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/outport/factory/outportFactory.go
+++ b/outport/factory/outportFactory.go
@@ -3,17 +3,15 @@ package factory
 import (
 	"time"
 
-	covalentFactory "github.com/ElrondNetwork/covalent-indexer-go/factory"
 	indexerFactory "github.com/ElrondNetwork/elastic-indexer-go/factory"
 	"github.com/ElrondNetwork/elrond-go/outport"
 )
 
 // OutportFactoryArgs holds the factory arguments of different outport drivers
 type OutportFactoryArgs struct {
-	RetrialInterval            time.Duration
-	ElasticIndexerFactoryArgs  *indexerFactory.ArgsIndexerFactory
-	EventNotifierFactoryArgs   *EventNotifierFactoryArgs
-	CovalentIndexerFactoryArgs *covalentFactory.ArgsCovalentIndexerFactory
+	RetrialInterval           time.Duration
+	ElasticIndexerFactoryArgs *indexerFactory.ArgsIndexerFactory
+	EventNotifierFactoryArgs  *EventNotifierFactoryArgs
 }
 
 // CreateOutport will create a new instance of OutportHandler
@@ -47,28 +45,7 @@ func createAndSubscribeDrivers(outport outport.OutportHandler, args *OutportFact
 		return err
 	}
 
-	err = createAndSubscribeCovalentDriverIfNeeded(outport, args.CovalentIndexerFactoryArgs)
-	if err != nil {
-		return err
-	}
-
 	return nil
-}
-
-func createAndSubscribeCovalentDriverIfNeeded(
-	outport outport.OutportHandler,
-	args *covalentFactory.ArgsCovalentIndexerFactory,
-) error {
-	if !args.Enabled {
-		return nil
-	}
-
-	covalentDriver, err := covalentFactory.CreateCovalentIndexer(args)
-	if err != nil {
-		return err
-	}
-
-	return outport.SubscribeDriver(covalentDriver)
 }
 
 func createAndSubscribeElasticDriverIfNeeded(


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- Covalent team decided not to use websockets anymore, but use RestAPI instead

## Proposed Changes
- Removed covalent indexer from node

## Testing procedure
- Nonce, code is deleted
