### PR TITLE
fix accounts trie remover config value

### DIFF
--- a/storage/databaseremover/factory/customDatabaseRemoverCreator.go
+++ b/storage/databaseremover/factory/customDatabaseRemoverCreator.go
@@ -1,0 +1,17 @@
+package factory
+
+import (
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/storage"
+	"github.com/ElrondNetwork/elrond-go/storage/databaseremover"
+	"github.com/ElrondNetwork/elrond-go/storage/databaseremover/disabled"
+)
+
+// CreateCustomDatabaseRemover will handle the creation of a custom database remover based on the configuration
+func CreateCustomDatabaseRemover(storagePruningConfig config.StoragePruningConfig) (storage.CustomDatabaseRemoverHandler, error) {
+	if storagePruningConfig.AccountsTrieCleanOldEpochsData {
+		return databaseremover.NewCustomDatabaseRemover(storagePruningConfig)
+	}
+
+	return disabled.NewDisabledCustomDatabaseRemover(), nil
+}

--- a/storage/databaseremover/factory/customDatabaseRemoverCreator_test.go
+++ b/storage/databaseremover/factory/customDatabaseRemoverCreator_test.go
@@ -1,0 +1,41 @@
+package factory
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateCustomDatabaseRemover(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should create real custom database remover", func(t *testing.T) {
+		t.Parallel()
+
+		storagePruningArgs := config.StoragePruningConfig{
+			AccountsTrieCleanOldEpochsData:       true,
+			AccountsTrieSkipRemovalCustomPattern: "%1",
+		}
+
+		removerInstance, err := CreateCustomDatabaseRemover(storagePruningArgs)
+		require.NoError(t, err)
+
+		require.Equal(t, "*databaseremover.customDatabaseRemover", fmt.Sprintf("%T", removerInstance))
+	})
+
+	t.Run("should create disabled custom database remover", func(t *testing.T) {
+		t.Parallel()
+
+		storagePruningArgs := config.StoragePruningConfig{
+			AccountsTrieCleanOldEpochsData:       false,
+			AccountsTrieSkipRemovalCustomPattern: "%1",
+		}
+
+		removerInstance, err := CreateCustomDatabaseRemover(storagePruningArgs)
+		require.NoError(t, err)
+
+		require.Equal(t, "*disabled.disabledCustomDatabaseRemover", fmt.Sprintf("%T", removerInstance))
+	})
+}

--- a/storage/factory/pruningStorerFactory.go
+++ b/storage/factory/pruningStorerFactory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/storage/clean"
 	"github.com/ElrondNetwork/elrond-go/storage/databaseremover"
 	"github.com/ElrondNetwork/elrond-go/storage/databaseremover/disabled"
+	"github.com/ElrondNetwork/elrond-go/storage/databaseremover/factory"
 	storageDisabled "github.com/ElrondNetwork/elrond-go/storage/disabled"
 	"github.com/ElrondNetwork/elrond-go/storage/pruning"
 	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
@@ -118,7 +119,7 @@ func (psf *StorageServiceFactory) CreateForShard() (dataRetriever.StorageService
 	// in case of a failure while creating (not opening).
 
 	disabledCustomDatabaseRemover := disabled.NewDisabledCustomDatabaseRemover()
-	customDatabaseRemover, err := databaseremover.NewCustomDatabaseRemover(psf.generalConfig.StoragePruning)
+	customDatabaseRemover, err := factory.CreateCustomDatabaseRemover(psf.generalConfig.StoragePruning)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- The config value `AccountsTrieCleanOldEpochsData` was not used 
  
## Proposed Changes
- Added a factory function that creates either a custom or a disabled db remover, based on the above config value

## Testing procedure
1. should remove
- set an observer's configuration: `AccountsTrieCleanOldEpochsData` to `true` and `AccountsTrieSkipRemovalCustomPattern` to `%2`. When looking in the `db` directory, for epoch older than current - 4 (so if in epoch 8, from epoch 0 to epoch 4)  databases that are not divisible by 2 should not have `AccountsTrie` db for that epoch. Therefore: Epoch_0: should have AccountsTrie, Epoch_1: should not have AccountsTrie, and so on
2. should not remove
- set an observer's configuration `AccountsTrieCleanOldEpochsData` to `false`. In epoch 8, when checking the database dir, no `AccountsTrie` should have been removed
