### PR TITLE
Integrate new p2p repo version

### DIFF
--- a/cmd/seednode/main.go
+++ b/cmd/seednode/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/facade"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 	p2pConfig "github.com/ElrondNetwork/elrond-go/p2p/config"
+	p2pFactory "github.com/ElrondNetwork/elrond-go/p2p/factory"
 	"github.com/urfave/cli"
 )
 
@@ -245,11 +246,11 @@ func loadMainConfig(filepath string) (*config.Config, error) {
 }
 
 func createNode(p2pConfig p2pConfig.P2PConfig, marshalizer marshal.Marshalizer, p2pKeyBytes []byte) (p2p.Messenger, error) {
-	arg := p2p.ArgsNetworkMessenger{
+	arg := p2pFactory.ArgsNetworkMessenger{
 		Marshalizer:           marshalizer,
 		ListenAddress:         p2p.ListenAddrWithIp4AndTcp,
 		P2pConfig:             p2pConfig,
-		SyncTimer:             &p2p.LocalSyncTimer{},
+		SyncTimer:             &p2pFactory.LocalSyncTimer{},
 		PreferredPeersHolder:  disabled.NewPreferredPeersHolder(),
 		NodeOperationMode:     p2p.NormalOperation,
 		PeersRatingHandler:    disabled.NewDisabledPeersRatingHandler(),
@@ -257,7 +258,7 @@ func createNode(p2pConfig p2pConfig.P2PConfig, marshalizer marshal.Marshalizer, 
 		P2pPrivateKeyBytes:    p2pKeyBytes,
 	}
 
-	return p2p.NewNetworkMessenger(arg)
+	return p2pFactory.NewNetworkMessenger(arg)
 }
 
 func displayMessengerInfo(messenger p2p.Messenger) {

--- a/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
+++ b/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/random"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-go-p2p/message"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	resolverDebug "github.com/ElrondNetwork/elrond-go/debug/resolver"
 	"github.com/ElrondNetwork/elrond-go/p2p"
@@ -281,7 +282,7 @@ func (trs *topicResolverSender) Send(buff []byte, peer core.PeerID) error {
 }
 
 func (trs *topicResolverSender) sendToConnectedPeer(topic string, buff []byte, peer core.PeerID) error {
-	msg := &p2p.Message{
+	msg := &message.Message{
 		DataField:  buff,
 		PeerField:  peer,
 		TopicField: topic,

--- a/dataRetriever/txpool/memorytests/memory_test.go
+++ b/dataRetriever/txpool/memorytests/memory_test.go
@@ -33,10 +33,10 @@ func TestShardedTxPool_MemoryFootprint(t *testing.T) {
 
 	// Scenarios where source == me
 
-	journals = append(journals, runScenario(t, newScenario(200, 1, core.MegabyteSize, "0"), memoryAssertion{200, 205}, memoryAssertion{0, 1}))
-	journals = append(journals, runScenario(t, newScenario(10, 1000, 20480, "0"), memoryAssertion{190, 215}, memoryAssertion{1, 4}))
+	journals = append(journals, runScenario(t, newScenario(200, 1, core.MegabyteSize, "0"), memoryAssertion{200, 200}, memoryAssertion{0, 1}))
+	journals = append(journals, runScenario(t, newScenario(10, 1000, 20480, "0"), memoryAssertion{190, 205}, memoryAssertion{1, 4}))
 	journals = append(journals, runScenario(t, newScenario(10000, 1, 1024, "0"), memoryAssertion{10, 16}, memoryAssertion{4, 10}))
-	journals = append(journals, runScenario(t, newScenario(1, 60000, 256, "0"), memoryAssertion{30, 36}, memoryAssertion{10, 16}))
+	journals = append(journals, runScenario(t, newScenario(1, 60000, 256, "0"), memoryAssertion{30, 32}, memoryAssertion{10, 16}))
 	journals = append(journals, runScenario(t, newScenario(10, 10000, 100, "0"), memoryAssertion{36, 40}, memoryAssertion{16, 24}))
 	journals = append(journals, runScenario(t, newScenario(100000, 1, 1024, "0"), memoryAssertion{120, 128}, memoryAssertion{56, 60}))
 

--- a/factory/network/networkComponents.go
+++ b/factory/network/networkComponents.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/factory"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 	p2pConfig "github.com/ElrondNetwork/elrond-go/p2p/config"
+	p2pFactory "github.com/ElrondNetwork/elrond-go/p2p/factory"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/rating/peerHonesty"
 	antifloodFactory "github.com/ElrondNetwork/elrond-go/process/throttle/antiflood/factory"
@@ -105,7 +106,7 @@ func NewNetworkComponentsFactory(
 
 // Create creates and returns the network components
 func (ncf *networkComponentsFactory) Create() (*networkComponents, error) {
-	ph, err := p2p.NewPeersHolder(ncf.preferredPeersSlices)
+	ph, err := p2pFactory.NewPeersHolder(ncf.preferredPeersSlices)
 	if err != nil {
 		return nil, err
 	}
@@ -118,11 +119,11 @@ func (ncf *networkComponentsFactory) Create() (*networkComponents, error) {
 	if err != nil {
 		return nil, err
 	}
-	argsPeersRatingHandler := p2p.ArgPeersRatingHandler{
+	argsPeersRatingHandler := p2pFactory.ArgPeersRatingHandler{
 		TopRatedCache: topRatedCache,
 		BadRatedCache: badRatedCache,
 	}
-	peersRatingHandler, err := p2p.NewPeersRatingHandler(argsPeersRatingHandler)
+	peersRatingHandler, err := p2pFactory.NewPeersRatingHandler(argsPeersRatingHandler)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +133,7 @@ func (ncf *networkComponentsFactory) Create() (*networkComponents, error) {
 		return nil, err
 	}
 
-	arg := p2p.ArgsNetworkMessenger{
+	arg := p2pFactory.ArgsNetworkMessenger{
 		Marshalizer:           ncf.marshalizer,
 		ListenAddress:         ncf.listenAddress,
 		P2pConfig:             ncf.p2pConfig,
@@ -143,7 +144,7 @@ func (ncf *networkComponentsFactory) Create() (*networkComponents, error) {
 		ConnectionWatcherType: ncf.connectionWatcherType,
 		P2pPrivateKeyBytes:    p2pPrivateKeyBytes,
 	}
-	netMessenger, err := p2p.NewNetworkMessenger(arg)
+	netMessenger, err := p2pFactory.NewNetworkMessenger(arg)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ElrondNetwork/elrond-go-core v1.1.20
 	github.com/ElrondNetwork/elrond-go-crypto v1.2.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7
-	github.com/ElrondNetwork/elrond-go-p2p v1.0.1
+	github.com/ElrondNetwork/elrond-go-p2p v1.0.2-0.20220928125439-a2b5a0a5f5b2
 	github.com/ElrondNetwork/elrond-go-storage v1.0.1
 	github.com/ElrondNetwork/elrond-vm-common v1.3.17
 	github.com/beevik/ntp v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ElrondNetwork/elrond-go-core v1.1.20
 	github.com/ElrondNetwork/elrond-go-crypto v1.2.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7
-	github.com/ElrondNetwork/elrond-go-p2p v1.0.2-0.20220928125439-a2b5a0a5f5b2
+	github.com/ElrondNetwork/elrond-go-p2p v1.0.2
 	github.com/ElrondNetwork/elrond-go-storage v1.0.1
 	github.com/ElrondNetwork/elrond-vm-common v1.3.17
 	github.com/beevik/ntp v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/ElrondNetwork/elrond-go-logger v1.0.7 h1:Ldl1rVS0RGKc1IsW8jIaGCb6Zwei
 github.com/ElrondNetwork/elrond-go-logger v1.0.7/go.mod h1:cBfgx0ST/CJx8jrxJSC5aiSrvkGzcnF7sK06RD8mFxQ=
 github.com/ElrondNetwork/elrond-go-p2p v1.0.1 h1:1ZwkIL3LVBUt1oPDvl1VKNA3f7muW2D1Wh3AW4YokwY=
 github.com/ElrondNetwork/elrond-go-p2p v1.0.1/go.mod h1:cJWOF4Ek2hBq7LOLS9zMoybuOXblBnWPcsV6dBjsTyc=
+github.com/ElrondNetwork/elrond-go-p2p v1.0.2-0.20220928125439-a2b5a0a5f5b2 h1:+NY7NWoQgtApU+iiKVd8YAIWBvQ0011Nnlyyv58nHMA=
+github.com/ElrondNetwork/elrond-go-p2p v1.0.2-0.20220928125439-a2b5a0a5f5b2/go.mod h1:cJWOF4Ek2hBq7LOLS9zMoybuOXblBnWPcsV6dBjsTyc=
 github.com/ElrondNetwork/elrond-go-storage v1.0.1 h1:T5pmTAu97aFNbUPpqxJprBEOs+uWsTaJSbCwY9xWPRA=
 github.com/ElrondNetwork/elrond-go-storage v1.0.1/go.mod h1:Dht8Vt0BJvyUrr+mDSjYo2pu2fIMZfmUa0yznPG9zGw=
 github.com/ElrondNetwork/elrond-vm-common v1.1.0/go.mod h1:w3i6f8uiuRkE68Ie/gebRcLgTuHqvruJSYrFyZWuLrE=

--- a/go.sum
+++ b/go.sum
@@ -71,10 +71,8 @@ github.com/ElrondNetwork/elrond-go-logger v1.0.4/go.mod h1:e5D+c97lKUfFdAzFX7rrI
 github.com/ElrondNetwork/elrond-go-logger v1.0.5/go.mod h1:cBfgx0ST/CJx8jrxJSC5aiSrvkGzcnF7sK06RD8mFxQ=
 github.com/ElrondNetwork/elrond-go-logger v1.0.7 h1:Ldl1rVS0RGKc1IsW8jIaGCb6Zwei04gsMvyjL05X6mE=
 github.com/ElrondNetwork/elrond-go-logger v1.0.7/go.mod h1:cBfgx0ST/CJx8jrxJSC5aiSrvkGzcnF7sK06RD8mFxQ=
-github.com/ElrondNetwork/elrond-go-p2p v1.0.1 h1:1ZwkIL3LVBUt1oPDvl1VKNA3f7muW2D1Wh3AW4YokwY=
-github.com/ElrondNetwork/elrond-go-p2p v1.0.1/go.mod h1:cJWOF4Ek2hBq7LOLS9zMoybuOXblBnWPcsV6dBjsTyc=
-github.com/ElrondNetwork/elrond-go-p2p v1.0.2-0.20220928125439-a2b5a0a5f5b2 h1:+NY7NWoQgtApU+iiKVd8YAIWBvQ0011Nnlyyv58nHMA=
-github.com/ElrondNetwork/elrond-go-p2p v1.0.2-0.20220928125439-a2b5a0a5f5b2/go.mod h1:cJWOF4Ek2hBq7LOLS9zMoybuOXblBnWPcsV6dBjsTyc=
+github.com/ElrondNetwork/elrond-go-p2p v1.0.2 h1:EoriS5K1xJ+1RMHkrj92Jjfo8T97cuo5EhrlWeEUwOU=
+github.com/ElrondNetwork/elrond-go-p2p v1.0.2/go.mod h1:cJWOF4Ek2hBq7LOLS9zMoybuOXblBnWPcsV6dBjsTyc=
 github.com/ElrondNetwork/elrond-go-storage v1.0.1 h1:T5pmTAu97aFNbUPpqxJprBEOs+uWsTaJSbCwY9xWPRA=
 github.com/ElrondNetwork/elrond-go-storage v1.0.1/go.mod h1:Dht8Vt0BJvyUrr+mDSjYo2pu2fIMZfmUa0yznPG9zGw=
 github.com/ElrondNetwork/elrond-vm-common v1.1.0/go.mod h1:w3i6f8uiuRkE68Ie/gebRcLgTuHqvruJSYrFyZWuLrE=

--- a/heartbeat/processor/directConnectionsProcessor.go
+++ b/heartbeat/processor/directConnectionsProcessor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/heartbeat"
 	"github.com/ElrondNetwork/elrond-go/p2p"
+	"github.com/ElrondNetwork/elrond-go/p2p/factory"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 )
@@ -129,7 +130,7 @@ func (dcp *directConnectionsProcessor) computeNewPeers(connectedPeers []core.Pee
 }
 
 func (dcp *directConnectionsProcessor) notifyNewPeers(newPeers []core.PeerID) {
-	shardValidatorInfo := &p2p.DirectConnectionInfo{
+	shardValidatorInfo := &factory.DirectConnectionInfo{
 		ShardId: fmt.Sprintf("%d", dcp.shardCoordinator.SelfId()),
 	}
 

--- a/heartbeat/processor/directConnectionsProcessor_test.go
+++ b/heartbeat/processor/directConnectionsProcessor_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/heartbeat"
-	"github.com/ElrondNetwork/elrond-go/p2p"
+	p2pFactory "github.com/ElrondNetwork/elrond-go/p2p/factory"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/sharding/nodesCoordinator"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
@@ -111,7 +111,7 @@ func TestNewDirectConnectionsProcessor(t *testing.T) {
 				mutNotifiedPeers.Lock()
 				defer mutNotifiedPeers.Unlock()
 
-				shardValidatorInfo := &p2p.DirectConnectionInfo{}
+				shardValidatorInfo := &p2pFactory.DirectConnectionInfo{}
 				err := args.Marshaller.Unmarshal(shardValidatorInfo, buff)
 				assert.Nil(t, err)
 				assert.Equal(t, expectedShard, shardValidatorInfo.ShardId)
@@ -261,7 +261,7 @@ func Test_directConnectionsProcessor_notifyNewPeers(t *testing.T) {
 		expectedShard := fmt.Sprintf("%d", args.ShardCoordinator.SelfId())
 		args.Messenger = &p2pmocks.MessengerStub{
 			SendToConnectedPeerCalled: func(topic string, buff []byte, peerID core.PeerID) error {
-				shardValidatorInfo := &p2p.DirectConnectionInfo{}
+				shardValidatorInfo := &p2pFactory.DirectConnectionInfo{}
 				err := args.Marshaller.Unmarshal(shardValidatorInfo, buff)
 				assert.Nil(t, err)
 				assert.Equal(t, expectedShard, shardValidatorInfo.ShardId)

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/node"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 	p2pConfig "github.com/ElrondNetwork/elrond-go/p2p/config"
+	p2pFactory "github.com/ElrondNetwork/elrond-go/p2p/factory"
 	"github.com/ElrondNetwork/elrond-go/process"
 	procFactory "github.com/ElrondNetwork/elrond-go/process/factory"
 	"github.com/ElrondNetwork/elrond-go/process/headerCheck"
@@ -147,18 +148,18 @@ func CreateMessengerWithKadDht(initialAddr string) p2p.Messenger {
 	if len(initialAddr) > 0 {
 		initialAddresses = append(initialAddresses, initialAddr)
 	}
-	arg := p2p.ArgsNetworkMessenger{
+	arg := p2pFactory.ArgsNetworkMessenger{
 		Marshalizer:           TestMarshalizer,
 		ListenAddress:         p2p.ListenLocalhostAddrWithIp4AndTcp,
 		P2pConfig:             createP2PConfig(initialAddresses),
-		SyncTimer:             &p2p.LocalSyncTimer{},
+		SyncTimer:             &p2pFactory.LocalSyncTimer{},
 		PreferredPeersHolder:  &p2pmocks.PeersHolderStub{},
 		NodeOperationMode:     p2p.NormalOperation,
 		PeersRatingHandler:    &p2pmocks.PeersRatingHandlerStub{},
 		ConnectionWatcherType: p2p.ConnectionWatcherTypePrint,
 	}
 
-	libP2PMes, err := p2p.NewNetworkMessenger(arg)
+	libP2PMes, err := p2pFactory.NewNetworkMessenger(arg)
 	log.LogIfError(err)
 
 	return libP2PMes
@@ -166,11 +167,11 @@ func CreateMessengerWithKadDht(initialAddr string) p2p.Messenger {
 
 // CreateMessengerFromConfig creates a new libp2p messenger with provided configuration
 func CreateMessengerFromConfig(p2pConfig p2pConfig.P2PConfig) p2p.Messenger {
-	arg := p2p.ArgsNetworkMessenger{
+	arg := p2pFactory.ArgsNetworkMessenger{
 		Marshalizer:           TestMarshalizer,
 		ListenAddress:         p2p.ListenLocalhostAddrWithIp4AndTcp,
 		P2pConfig:             p2pConfig,
-		SyncTimer:             &p2p.LocalSyncTimer{},
+		SyncTimer:             &p2pFactory.LocalSyncTimer{},
 		PreferredPeersHolder:  &p2pmocks.PeersHolderStub{},
 		NodeOperationMode:     p2p.NormalOperation,
 		PeersRatingHandler:    &p2pmocks.PeersRatingHandlerStub{},
@@ -182,7 +183,7 @@ func CreateMessengerFromConfig(p2pConfig p2pConfig.P2PConfig) p2p.Messenger {
 		arg.NodeOperationMode = p2p.FullArchiveMode
 	}
 
-	libP2PMes, err := p2p.NewNetworkMessenger(arg)
+	libP2PMes, err := p2pFactory.NewNetworkMessenger(arg)
 	log.LogIfError(err)
 
 	return libP2PMes
@@ -190,11 +191,11 @@ func CreateMessengerFromConfig(p2pConfig p2pConfig.P2PConfig) p2p.Messenger {
 
 // CreateMessengerFromConfigWithPeersRatingHandler creates a new libp2p messenger with provided configuration
 func CreateMessengerFromConfigWithPeersRatingHandler(p2pConfig p2pConfig.P2PConfig, peersRatingHandler p2p.PeersRatingHandler) p2p.Messenger {
-	arg := p2p.ArgsNetworkMessenger{
+	arg := p2pFactory.ArgsNetworkMessenger{
 		Marshalizer:           TestMarshalizer,
 		ListenAddress:         p2p.ListenLocalhostAddrWithIp4AndTcp,
 		P2pConfig:             p2pConfig,
-		SyncTimer:             &p2p.LocalSyncTimer{},
+		SyncTimer:             &p2pFactory.LocalSyncTimer{},
 		PreferredPeersHolder:  &p2pmocks.PeersHolderStub{},
 		NodeOperationMode:     p2p.NormalOperation,
 		PeersRatingHandler:    peersRatingHandler,
@@ -206,7 +207,7 @@ func CreateMessengerFromConfigWithPeersRatingHandler(p2pConfig p2pConfig.P2PConf
 		arg.NodeOperationMode = p2p.FullArchiveMode
 	}
 
-	libP2PMes, err := p2p.NewNetworkMessenger(arg)
+	libP2PMes, err := p2pFactory.NewNetworkMessenger(arg)
 	log.LogIfError(err)
 
 	return libP2PMes

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -58,6 +58,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/node/external"
 	"github.com/ElrondNetwork/elrond-go/node/nodeDebugFactory"
 	"github.com/ElrondNetwork/elrond-go/p2p"
+	p2pFactory "github.com/ElrondNetwork/elrond-go/p2p/factory"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/block"
 	"github.com/ElrondNetwork/elrond-go/process/block/bootstrapStorage"
@@ -406,8 +407,8 @@ func newBaseTestProcessorNode(args ArgTestProcessorNode) *TestProcessorNode {
 		nodesCoordinatorInstance = getDefaultNodesCoordinator(args.MaxShards, pksBytes)
 	}
 
-	peersRatingHandler, _ := p2p.NewPeersRatingHandler(
-		p2p.ArgPeersRatingHandler{
+	peersRatingHandler, _ := p2pFactory.NewPeersRatingHandler(
+		p2pFactory.ArgPeersRatingHandler{
 			TopRatedCache: testscommon.NewCacherMock(),
 			BadRatedCache: testscommon.NewCacherMock(),
 		})

--- a/node/external/timemachine/fee/memoryFootprint/memory_test.go
+++ b/node/external/timemachine/fee/memoryFootprint/memory_test.go
@@ -15,7 +15,7 @@ import (
 // keep this test in a separate package as to not be influenced by other the tests from the same package
 func TestFeeComputer_MemoryFootprint(t *testing.T) {
 	numEpochs := 10000
-	maxFootprintNumBytes := 30_000_000
+	maxFootprintNumBytes := 20_000_000
 
 	journal := &memoryFootprintJournal{}
 	journal.before = getMemStats()

--- a/p2p/constants.go
+++ b/p2p/constants.go
@@ -2,7 +2,6 @@ package p2p
 
 import (
 	p2p "github.com/ElrondNetwork/elrond-go-p2p"
-	"github.com/ElrondNetwork/elrond-go-p2p/libp2p"
 )
 
 // NodeOperation defines the p2p node operation
@@ -24,7 +23,7 @@ const NilListSharder = p2p.NilListSharder
 const ConnectionWatcherTypePrint = p2p.ConnectionWatcherTypePrint
 
 // ListenAddrWithIp4AndTcp defines the listening address with ip v.4 and TCP
-const ListenAddrWithIp4AndTcp = libp2p.ListenAddrWithIp4AndTcp
+const ListenAddrWithIp4AndTcp = "/ip4/0.0.0.0/tcp/"
 
 // ListenLocalhostAddrWithIp4AndTcp defines the local host listening ip v.4 address and TCP
-const ListenLocalhostAddrWithIp4AndTcp = libp2p.ListenLocalhostAddrWithIp4AndTcp
+const ListenLocalhostAddrWithIp4AndTcp = "/ip4/127.0.0.1/tcp/"

--- a/p2p/factory/factory.go
+++ b/p2p/factory/factory.go
@@ -1,11 +1,11 @@
-package p2p
+package factory
 
 import (
-	p2p "github.com/ElrondNetwork/elrond-go-p2p"
 	"github.com/ElrondNetwork/elrond-go-p2p/libp2p"
 	"github.com/ElrondNetwork/elrond-go-p2p/message"
 	"github.com/ElrondNetwork/elrond-go-p2p/peersHolder"
 	"github.com/ElrondNetwork/elrond-go-p2p/rating"
+	"github.com/ElrondNetwork/elrond-go/p2p"
 )
 
 // ArgsNetworkMessenger defines the options used to create a p2p wrapper

--- a/process/interceptors/factory/interceptedDirectConnectionInfoFactory_test.go
+++ b/process/interceptors/factory/interceptedDirectConnectionInfoFactory_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
-	"github.com/ElrondNetwork/elrond-go/p2p"
+	p2pFactory "github.com/ElrondNetwork/elrond-go/p2p/factory"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/stretchr/testify/assert"
 )
@@ -56,7 +56,7 @@ func TestNewInterceptedDirectConnectionInfoFactory(t *testing.T) {
 		assert.Nil(t, err)
 		assert.False(t, check.IfNil(idcif))
 
-		msg := &p2p.DirectConnectionInfo{
+		msg := &p2pFactory.DirectConnectionInfo{
 			ShardId: "5",
 		}
 		msgBuff, _ := arg.CoreComponents.InternalMarshalizer().Marshal(msg)

--- a/process/interceptors/processor/directConnectionInfoInterceptorProcessor_test.go
+++ b/process/interceptors/processor/directConnectionInfoInterceptorProcessor_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	heartbeatMessages "github.com/ElrondNetwork/elrond-go/heartbeat"
-	"github.com/ElrondNetwork/elrond-go/p2p"
+	p2pFactory "github.com/ElrondNetwork/elrond-go/p2p/factory"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/heartbeat"
 	"github.com/ElrondNetwork/elrond-go/process/mock"
@@ -87,7 +87,7 @@ func TestDirectConnectionInfoInterceptorProcessor_Save(t *testing.T) {
 		assert.Nil(t, err)
 		assert.False(t, check.IfNil(processor))
 
-		msg := &p2p.DirectConnectionInfo{
+		msg := &p2pFactory.DirectConnectionInfo{
 			ShardId: "invalid shard",
 		}
 		marshaller := marshal.GogoProtoMarshalizer{}
@@ -118,7 +118,7 @@ func TestDirectConnectionInfoInterceptorProcessor_Save(t *testing.T) {
 		assert.Nil(t, err)
 		assert.False(t, check.IfNil(processor))
 
-		msg := &p2p.DirectConnectionInfo{
+		msg := &p2pFactory.DirectConnectionInfo{
 			ShardId: "5",
 		}
 		marshaller := marshal.GogoProtoMarshalizer{}

--- a/process/p2p/interceptedDirectConnectionInfo.go
+++ b/process/p2p/interceptedDirectConnectionInfo.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/common"
-	"github.com/ElrondNetwork/elrond-go/p2p"
+	p2pFactory "github.com/ElrondNetwork/elrond-go/p2p/factory"
 	"github.com/ElrondNetwork/elrond-go/process"
 )
 
@@ -22,7 +22,7 @@ type ArgInterceptedDirectConnectionInfo struct {
 
 // interceptedDirectConnectionInfo is a wrapper over DirectConnectionInfo
 type interceptedDirectConnectionInfo struct {
-	directConnectionInfo p2p.DirectConnectionInfo
+	directConnectionInfo p2pFactory.DirectConnectionInfo
 	numOfShards          uint32
 }
 
@@ -58,8 +58,8 @@ func checkArgs(args ArgInterceptedDirectConnectionInfo) error {
 	return nil
 }
 
-func createDirectConnectionInfo(marshaller marshal.Marshalizer, buff []byte) (*p2p.DirectConnectionInfo, error) {
-	directConnectionInfo := &p2p.DirectConnectionInfo{}
+func createDirectConnectionInfo(marshaller marshal.Marshalizer, buff []byte) (*p2pFactory.DirectConnectionInfo, error) {
+	directConnectionInfo := &p2pFactory.DirectConnectionInfo{}
 	err := marshaller.Unmarshal(directConnectionInfo, buff)
 	if err != nil {
 		return nil, err

--- a/process/p2p/interceptedDirectConnectionInfo_test.go
+++ b/process/p2p/interceptedDirectConnectionInfo_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
-	"github.com/ElrondNetwork/elrond-go/p2p"
+	p2pFactory "github.com/ElrondNetwork/elrond-go/p2p/factory"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/stretchr/testify/assert"
 )
@@ -17,7 +17,7 @@ const providedShard = "5"
 
 func createMockArgInterceptedDirectConnectionInfo() ArgInterceptedDirectConnectionInfo {
 	marshaller := &marshal.GogoProtoMarshalizer{}
-	msg := &p2p.DirectConnectionInfo{
+	msg := &p2pFactory.DirectConnectionInfo{
 		ShardId: providedShard,
 	}
 	msgBuff, _ := marshaller.Marshal(msg)
@@ -87,7 +87,7 @@ func Test_interceptedDirectConnectionInfo_CheckValidity(t *testing.T) {
 		t.Parallel()
 
 		args := createMockArgInterceptedDirectConnectionInfo()
-		msg := &p2p.DirectConnectionInfo{
+		msg := &p2pFactory.DirectConnectionInfo{
 			ShardId: "invalid shard",
 		}
 		msgBuff, _ := args.Marshaller.Marshal(msg)

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/genesis/data"
 	"github.com/ElrondNetwork/elrond-go/p2p"
 	p2pConfig "github.com/ElrondNetwork/elrond-go/p2p/config"
+	p2pFactory "github.com/ElrondNetwork/elrond-go/p2p/factory"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 	"github.com/ElrondNetwork/elrond-go/sharding/nodesCoordinator"
 	"github.com/ElrondNetwork/elrond-go/state"
@@ -430,7 +431,7 @@ func GetNetworkFactoryArgs() networkComp.NetworkComponentsFactoryArgs {
 				UnitValue:                    1.0,
 			},
 		},
-		Syncer:            &p2p.LocalSyncTimer{},
+		Syncer:            &p2pFactory.LocalSyncTimer{},
 		NodeOperationMode: p2p.NormalOperation,
 	}
 }


### PR DESCRIPTION
## Description of the reasoning behind the pull request 
-  some tests that computed the amount of memory consumed sometimes failed. This was due to the fact that unnecessary libp2p components were running due to the poor code decoupling

## Proposed Changes
- integrated new p2p version
- removed code un-necessary dependency
- reverted some tests values

## Testing procedure
- standard system test
- half network test
