### PR TITLE
Workaround: get logs on a best-effort basis (handle epoch-change edge-case)

### DIFF
--- a/node/external/logs/logsRepository.go
+++ b/node/external/logs/logsRepository.go
@@ -28,7 +28,7 @@ func newLogsRepository(storageService dataRetriever.StorageService, marshaller m
 // It searches for logs both in epoch N and epoch N-1, in order to overcome epoch-changing edge-cases.
 func (repository *logsRepository) getLog(logKey []byte, epoch uint32) (*transaction.Log, error) {
 	txLog, err := repository.doGetLog(logKey, epoch)
-	if err != nil {
+	if err != nil && epoch > 0 {
 		txLog, errPreviousEpoch := repository.doGetLog(logKey, epoch-1)
 		if errPreviousEpoch == nil {
 			return txLog, nil
@@ -63,13 +63,15 @@ func (repository *logsRepository) getLogs(logsKeys [][]byte, epoch uint32) (map[
 		return nil, err
 	}
 
-	logsMapPreviousEpoch, err := repository.doGetLogs(logsKeys, epoch-1)
-	if err != nil {
-		return nil, err
-	}
+	if epoch > 0 {
+		logsMapPreviousEpoch, err := repository.doGetLogs(logsKeys, epoch-1)
+		if err != nil {
+			return nil, err
+		}
 
-	for key, value := range logsMapPreviousEpoch {
-		logsMap[key] = value
+		for key, value := range logsMapPreviousEpoch {
+			logsMap[key] = value
+		}
 	}
 
 	return logsMap, nil

--- a/node/external/logs/logsRepository.go
+++ b/node/external/logs/logsRepository.go
@@ -24,7 +24,23 @@ func newLogsRepository(storageService dataRetriever.StorageService, marshaller m
 	}
 }
 
+// getLog loads event & logs on a best-effort basis.
+// It searches for logs both in epoch N and epoch N-1, in order to overcome epoch-changing edge-cases.
 func (repository *logsRepository) getLog(logKey []byte, epoch uint32) (*transaction.Log, error) {
+	txLog, err := repository.doGetLog(logKey, epoch)
+	if err != nil {
+		txLog, errPreviousEpoch := repository.doGetLog(logKey, epoch-1)
+		if errPreviousEpoch == nil {
+			return txLog, nil
+		}
+
+		// We ignore errPreviousEpoch.
+	}
+
+	return txLog, err
+}
+
+func (repository *logsRepository) doGetLog(logKey []byte, epoch uint32) (*transaction.Log, error) {
 	bytes, err := repository.storer.GetFromEpoch(logKey, epoch)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v, epoch = %d, key = %s", errCannotLoadLogs, err, epoch, hex.EncodeToString(logKey))
@@ -39,9 +55,29 @@ func (repository *logsRepository) getLog(logKey []byte, epoch uint32) (*transact
 	return txLog, nil
 }
 
+// getLogs loads event & logs on a best-effort basis.
+// It searches for logs both in epoch N and epoch N-1, in order to overcome epoch-changing edge-cases.
+func (repository *logsRepository) getLogs(logsKeys [][]byte, epoch uint32) (map[string]*transaction.Log, error) {
+	logsMap, err := repository.doGetLogs(logsKeys, epoch)
+	if err != nil {
+		return nil, err
+	}
+
+	logsMapPreviousEpoch, err := repository.doGetLogs(logsKeys, epoch-1)
+	if err != nil {
+		return nil, err
+	}
+
+	for key, value := range logsMapPreviousEpoch {
+		logsMap[key] = value
+	}
+
+	return logsMap, nil
+}
+
 // Since a lookup table of logs is useful in the "logsFacade" to JOIN "txs" with "logs" ON "tx.hash" == "log.key",
 // we'll return such a structure here (the returned logs don't have to be in any particular order).
-func (repository *logsRepository) getLogs(logsKeys [][]byte, epoch uint32) (map[string]*transaction.Log, error) {
+func (repository *logsRepository) doGetLogs(logsKeys [][]byte, epoch uint32) (map[string]*transaction.Log, error) {
 	keyValuePairs, err := repository.storer.GetBulkFromEpoch(logsKeys, epoch)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v, epoch = %d", errCannotLoadLogs, err, epoch)

--- a/node/external/logs/logsRepository_test.go
+++ b/node/external/logs/logsRepository_test.go
@@ -1,11 +1,16 @@
 package logs
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
+	storageCore "github.com/ElrondNetwork/elrond-go-core/storage"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
+	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/ElrondNetwork/elrond-go/testscommon/genericMocks"
+	testsCommonStorage "github.com/ElrondNetwork/elrond-go/testscommon/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,6 +45,80 @@ func TestLogsRepository_GetLogsShouldWork(t *testing.T) {
 	noLogsFetched, err := repository.getLogs([][]byte{{0xcc}, {0xdd}}, epoch)
 	require.Nil(t, err)
 	require.Len(t, noLogsFetched, 0)
+}
+
+func TestLogsRepository_GetLogShouldFallbackToPreviousEpoch(t *testing.T) {
+	storageService := genericMocks.NewChainStorerMock(uint32(0))
+	marshaller := &marshal.GogoProtoMarshalizer{}
+	repository := newLogsRepository(storageService, marshaller)
+
+	logEntry := &transaction.Log{Events: []*transaction.Event{{Identifier: []byte("foo")}}}
+	logEntryBytes, _ := marshaller.Marshal(logEntry)
+	_ = storageService.Logs.PutInEpoch([]byte{0xaa}, logEntryBytes, 41)
+
+	// logEntry is missing in epoch 42 (edge-case), but is present in epoch 41
+	logEntryFetched, err := repository.getLog([]byte{0xaa}, 42)
+	require.Nil(t, err)
+	require.Equal(t, []byte("foo"), logEntryFetched.Events[0].Identifier)
+}
+
+func TestLogsRepository_GetLogShouldNotFallbackToPreviousEpochIfZero(t *testing.T) {
+	marshaller := &marshal.GogoProtoMarshalizer{}
+	storageService := &testsCommonStorage.ChainStorerStub{
+		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
+			return &testsCommonStorage.StorerStub{
+				GetFromEpochCalled: func(key []byte, epoch uint32) ([]byte, error) {
+					if epoch != 0 {
+						require.Fail(t, "unexpected")
+					}
+
+					return nil, errors.New("expected")
+				},
+			}
+		},
+	}
+
+	repository := newLogsRepository(storageService, marshaller)
+	_, err := repository.getLog([]byte{0xaa}, 0)
+	require.Error(t, err, "expected")
+}
+
+func TestLogsRepository_GetLogsShouldFallbackToPreviousEpoch(t *testing.T) {
+	storageService := genericMocks.NewChainStorerMock(uint32(0))
+	marshaller := &marshal.GogoProtoMarshalizer{}
+	repository := newLogsRepository(storageService, marshaller)
+
+	fooBytes, _ := marshaller.Marshal(&transaction.Log{Events: []*transaction.Event{{Identifier: []byte("foo")}}})
+	barBytes, _ := marshaller.Marshal(&transaction.Log{Events: []*transaction.Event{{Identifier: []byte("bar")}}})
+	_ = storageService.Logs.PutInEpoch([]byte{0xaa}, fooBytes, 41)
+	_ = storageService.Logs.PutInEpoch([]byte{0xbb}, barBytes, 41)
+
+	// entries are missing in epoch 42 (edge-case), but are present in epoch 41
+	logEntriesFetched, err := repository.getLogs([][]byte{{0xaa}, {0xbb}}, 42)
+	require.Nil(t, err)
+	require.Equal(t, []byte("foo"), logEntriesFetched[string([]byte{0xaa})].Events[0].Identifier)
+	require.Equal(t, []byte("bar"), logEntriesFetched[string([]byte{0xbb})].Events[0].Identifier)
+}
+
+func TestLogsRepository_GetLogsShouldNotFallbackToPreviousEpochIfZero(t *testing.T) {
+	marshaller := &marshal.GogoProtoMarshalizer{}
+	storageService := &testsCommonStorage.ChainStorerStub{
+		GetStorerCalled: func(unitType dataRetriever.UnitType) storage.Storer {
+			return &testsCommonStorage.StorerStub{
+				GetBulkFromEpochCalled: func(keys [][]byte, epoch uint32) ([]storageCore.KeyValuePair, error) {
+					if epoch != 0 {
+						require.Fail(t, "unexpected")
+					}
+
+					return nil, errors.New("expected")
+				},
+			}
+		},
+	}
+
+	repository := newLogsRepository(storageService, marshaller)
+	_, err := repository.getLogs([][]byte{{0xaa}, {0xbb}}, 0)
+	require.Error(t, err, "expected")
 }
 
 func TestLogsRepository_GetLogsShouldErr(t *testing.T) {


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- In some rare cases, right at the beginning of an epoch, `logs & events` of a transaction can we mistakenly saved in the storage associated with the previous epoch.
  
## Proposed Changes
- In this PR, we attempt to load `logs & events` both from the requested epoch `N`, and from the epoch `N-1`.

## Testing procedure
- Regular testing
- `rosetta-cli` checker (with ESDT) against devnet (e.g. shard 0)
