### PR TITLE
Remove unnecessary gasComputation.Reset call

### DIFF
--- a/process/block/preprocess/basePreProcess.go
+++ b/process/block/preprocess/basePreProcess.go
@@ -491,7 +491,6 @@ func (bpp *basePreProcess) updateGasConsumedWithGasRefundedAndGasPenalized(
 func (bpp *basePreProcess) handleProcessTransactionInit(preProcessorExecutionInfoHandler process.PreProcessorExecutionInfoHandler, txHash []byte) int {
 	snapshot := bpp.accounts.JournalLen()
 	preProcessorExecutionInfoHandler.InitProcessedTxsResults(txHash)
-	bpp.gasHandler.Reset(txHash)
 	return snapshot
 }
 

--- a/process/block/preprocess/basePreProcess_test.go
+++ b/process/block/preprocess/basePreProcess_test.go
@@ -1,0 +1,47 @@
+package preprocess
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/ElrondNetwork/elrond-go/testscommon/state"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasePreProcess_handleProcessTransactionInit(t *testing.T) {
+	t.Parallel()
+
+	txHash := []byte("tx hash")
+	initProcessedTxsCalled := false
+
+	preProcessorExecutionInfoHandler := &testscommon.PreProcessorExecutionInfoHandlerMock{
+		InitProcessedTxsResultsCalled: func(key []byte) {
+			if !bytes.Equal(key, txHash) {
+				return
+			}
+
+			initProcessedTxsCalled = true
+		},
+	}
+
+	journalLen := 262845
+	bp := &basePreProcess{
+		accounts: &state.AccountsStub{
+			JournalLenCalled: func() int {
+				return journalLen
+			},
+		},
+		gasTracker: gasTracker{
+			gasHandler: &testscommon.GasHandlerStub{
+				ResetCalled: func(hash []byte) {
+					assert.Fail(t, "should have not called gasComputation.Reset")
+				},
+			},
+		},
+	}
+
+	recoveredJournalLen := bp.handleProcessTransactionInit(preProcessorExecutionInfoHandler, txHash)
+	assert.Equal(t, journalLen, recoveredJournalLen)
+	assert.True(t, initProcessedTxsCalled)
+}


### PR DESCRIPTION
## Description of the reasoning behind the pull request
- gasComputation component started to consume large amounts of time when the calls to `SetGasProvided` were done on a several hundreds of transactions and up. The time consumed was caused that each transaction hash from the miniblock was added as record in the map that was latter used to append each executed hash, causing exponential time of execution consumed.
  
## Proposed Changes
- removed unnecessary gasComputation.Reset call from the basePreProcess.handleProcessTransactionInit call

## Testing procedure
- standard system tests
- half network tests, before and after the partial miniblock execution enable epoch
