### PR TITLE
Integrate vm-common: v1.3.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7
 	github.com/ElrondNetwork/elrond-go-p2p v1.0.2
 	github.com/ElrondNetwork/elrond-go-storage v1.0.1
-	github.com/ElrondNetwork/elrond-vm-common v1.3.17
+	github.com/ElrondNetwork/elrond-vm-common v1.3.18
 	github.com/beevik/ntp v0.3.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/elastic/go-elasticsearch/v7 v7.12.0

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/ElrondNetwork/elrond-vm-common v1.1.0/go.mod h1:w3i6f8uiuRkE68Ie/gebR
 github.com/ElrondNetwork/elrond-vm-common v1.2.9/go.mod h1:B/Y8WiqHyDd7xsjNYsaYbVMp1jQgQ+z4jTJkFvj/EWI=
 github.com/ElrondNetwork/elrond-vm-common v1.3.7/go.mod h1:seROQuR7RJCoCS7mgRXVAlvjztltY1c+UroAgWr/USE=
 github.com/ElrondNetwork/elrond-vm-common v1.3.15-0.20220729115029-e70fd191b2f0/go.mod h1:seROQuR7RJCoCS7mgRXVAlvjztltY1c+UroAgWr/USE=
-github.com/ElrondNetwork/elrond-vm-common v1.3.17 h1:oeZ8AuVETpBv2mmaQg7MT9m3eAFF9ro50WGjQrQFGUI=
-github.com/ElrondNetwork/elrond-vm-common v1.3.17/go.mod h1:seROQuR7RJCoCS7mgRXVAlvjztltY1c+UroAgWr/USE=
+github.com/ElrondNetwork/elrond-vm-common v1.3.18 h1:fbgmOEH1DUvd19oGBeTWiA6R7UCn2zJ9H4zCNzCo2Rc=
+github.com/ElrondNetwork/elrond-vm-common v1.3.18/go.mod h1:seROQuR7RJCoCS7mgRXVAlvjztltY1c+UroAgWr/USE=
 github.com/ElrondNetwork/go-libp2p-pubsub v0.6.1-rc1 h1:Nu/uwYQg/QbfoQ0uD6GahYTwgtAkAwtzsB0HVfSP58I=
 github.com/ElrondNetwork/go-libp2p-pubsub v0.6.1-rc1/go.mod h1:pJfaShe+i5aWZx8NhSkQjvOYQYLoqPztmFUlKjToOzM=
 github.com/ElrondNetwork/protobuf v1.3.2 h1:qoCSYiO+8GtXBEZWEjw0WPcZfM3g7QuuJrwpN+y6Mvg=


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- Previously, information about the _frozen_ or _wiped_ _amount_ was not present on the logs / events `ESDTFreeze` and `ESDTWipe`
- Related PR: https://github.com/ElrondNetwork/elrond-vm-common/pull/134
  
## Proposed Changes
 - Reference newest `vm-common v1.3.18`, which implements the fix:
   - In the event / log `ESDTFreeze`, add the frozen amount as `topics[2]` (previously fixed to `0`).
   - In the event / log `ESDTWipe`, add the wiped amount as `topics[2]` (previously fixed to `0`).

## Testing procedure
- Standard testing (including ESDT / NFT operations)
- Testing using `rosetta-cli` checker & ESDT support.
