### PR TITLE
Status metrics on node start

### DIFF
--- a/common/statistics/disabled/netStatistics.go
+++ b/common/statistics/disabled/netStatistics.go
@@ -1,0 +1,30 @@
+package disabled
+
+const notAvailable = "N/A"
+
+type netStatistics struct {
+}
+
+// NewDisabledNetStatistics creates a new disabled network statistics
+func NewDisabledNetStatistics() *netStatistics {
+	return &netStatistics{}
+}
+
+// TotalSentInCurrentEpoch will send the notAvailable constant string
+func (stats *netStatistics) TotalSentInCurrentEpoch() string {
+	return notAvailable
+}
+
+// TotalReceivedInCurrentEpoch will send the notAvailable constant string
+func (stats *netStatistics) TotalReceivedInCurrentEpoch() string {
+	return notAvailable
+}
+
+// EpochConfirmed does nothing
+func (stats *netStatistics) EpochConfirmed(_ uint32, _ uint64) {
+}
+
+// IsInterfaceNil returns true if underlying object is nil
+func (stats *netStatistics) IsInterfaceNil() bool {
+	return stats == nil
+}

--- a/common/statistics/disabled/netStatistics_test.go
+++ b/common/statistics/disabled/netStatistics_test.go
@@ -1,0 +1,36 @@
+package disabled
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDisabledNetStatistics(t *testing.T) {
+	t.Parallel()
+
+	stats := NewDisabledNetStatistics()
+	assert.False(t, check.IfNil(stats))
+}
+
+func TestNetStatistics_MethodsShouldNotPanic(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		r := recover()
+		if r != nil {
+			assert.Fail(t, fmt.Sprintf("should have not panicked %v", r))
+		}
+	}()
+
+	stats := NewDisabledNetStatistics()
+	message := stats.TotalReceivedInCurrentEpoch()
+	assert.Equal(t, notAvailable, message)
+
+	message = stats.TotalSentInCurrentEpoch()
+	assert.Equal(t, notAvailable, message)
+
+	stats.EpochConfirmed(0, 0)
+}

--- a/common/statistics/errors.go
+++ b/common/statistics/errors.go
@@ -4,20 +4,8 @@ import (
 	"errors"
 )
 
-// ErrInvalidShardId signals that the shard id is invalid
-var ErrInvalidShardId = errors.New("invalid shard id")
+// ErrNilNetworkStatistics signals that a nil network statistics was provided
+var ErrNilNetworkStatistics = errors.New("nil network statistics")
 
-// ErrInvalidRoundDuration signals that an invalid round duration was provided
-var ErrInvalidRoundDuration = errors.New("invalid round duration")
-
-// ErrNilStatusHandler signals that a nil status handler has been provided
-var ErrNilStatusHandler = errors.New("nil status handler")
-
-// ErrNilInitialTPSBenchmarks signals that nil TPS benchmarks have been provided
-var ErrNilInitialTPSBenchmarks = errors.New("nil initial TPS benchmarks")
-
-// ErrNilConfig signals that a nil config was provided
-var ErrNilConfig = errors.New("nil config")
-
-// ErrNilPathHandler signals that a nil path handler was provided
-var ErrNilPathHandler = errors.New("nil path handler")
+// ErrInvalidRefreshIntervalValue signals that an invalid value for the refresh interval was provided
+var ErrInvalidRefreshIntervalValue = errors.New("invalid refresh interval value")

--- a/common/statistics/errors.go
+++ b/common/statistics/errors.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 )
 
-// ErrNilNetworkStatistics signals that a nil network statistics was provided
-var ErrNilNetworkStatistics = errors.New("nil network statistics")
+// ErrNilNetworkStatisticsProvider signals that a nil network statistics provider was provided
+var ErrNilNetworkStatisticsProvider = errors.New("nil network statistics provider")
 
 // ErrInvalidRefreshIntervalValue signals that an invalid value for the refresh interval was provided
 var ErrInvalidRefreshIntervalValue = errors.New("invalid refresh interval value")

--- a/common/statistics/interface.go
+++ b/common/statistics/interface.go
@@ -15,3 +15,11 @@ type ResourceMonitorHandler interface {
 	Close() error
 	IsInterfaceNil() bool
 }
+
+// NetworkStatisticsProvider is able to provide network statistics
+type NetworkStatisticsProvider interface {
+	TotalSentInCurrentEpoch() string
+	TotalReceivedInCurrentEpoch() string
+	EpochConfirmed(epoch uint32, timestamp uint64)
+	IsInterfaceNil() bool
+}

--- a/common/statistics/interface.go
+++ b/common/statistics/interface.go
@@ -10,7 +10,6 @@ type SoftwareVersionChecker interface {
 // ResourceMonitorHandler defines the resource monitor supported actions
 type ResourceMonitorHandler interface {
 	GenerateStatistics() []interface{}
-	SaveStatistics()
 	StartMonitoring()
 	Close() error
 	IsInterfaceNil() bool

--- a/common/statistics/machine/export_test.go
+++ b/common/statistics/machine/export_test.go
@@ -1,0 +1,19 @@
+package machine
+
+import (
+	"context"
+
+	"github.com/shirou/gopsutil/net"
+)
+
+// NewNetTestStatistics -
+func NewNetTestStatistics(getTestStatistics func() ([]net.IOCountersStat, error)) *netStatistics {
+	stats := newNetStatistics(getTestStatistics)
+
+	var ctx context.Context
+	ctx, stats.cancel = context.WithCancel(context.Background())
+
+	go stats.processLoop(ctx)
+
+	return stats
+}

--- a/common/statistics/machine/netStatistics.go
+++ b/common/statistics/machine/netStatistics.go
@@ -26,7 +26,11 @@ type netStatistics struct {
 // NewNetStatistics returns a new instance of the netStatistics
 func NewNetStatistics() *netStatistics {
 	stats := newNetStatistics(getStatistics)
-	stats.startProcessLoop(stats.processLoop)
+
+	var ctx context.Context
+	ctx, stats.cancel = context.WithCancel(context.Background())
+
+	go stats.processLoop(ctx)
 
 	return stats
 }
@@ -37,13 +41,6 @@ func newNetStatistics(getStatisticsHandler func() ([]net.IOCountersStat, error))
 	}
 
 	return stats
-}
-
-func (ns *netStatistics) startProcessLoop(handler func(ctx context.Context)) {
-	var ctx context.Context
-	ctx, ns.cancel = context.WithCancel(context.Background())
-
-	go handler(ctx)
 }
 
 func (ns *netStatistics) processLoop(ctx context.Context) {

--- a/common/statistics/machine/netStatistics_test.go
+++ b/common/statistics/machine/netStatistics_test.go
@@ -274,8 +274,7 @@ func TestNetStatistics_Close(t *testing.T) {
 		atomic.AddUint64(&numCalls, 1)
 		return make([]net.IOCountersStat, 0), nil
 	}
-	ns := newNetStatistics(testGetStats)
-	ns.startProcessLoop(ns.processLoop)
+	ns := NewNetTestStatistics(testGetStats)
 
 	time.Sleep(time.Second*3 + time.Millisecond*500)
 	assert.True(t, atomic.LoadUint64(&numCalls) > 0) // go routine is running

--- a/common/statistics/resourceMonitor.go
+++ b/common/statistics/resourceMonitor.go
@@ -33,7 +33,7 @@ type resourceMonitor struct {
 // NewResourceMonitor creates a new ResourceMonitor instance
 func NewResourceMonitor(config config.Config, netStats NetworkStatisticsProvider) (*resourceMonitor, error) {
 	if check.IfNil(netStats) {
-		return nil, ErrNilNetworkStatistics
+		return nil, ErrNilNetworkStatisticsProvider
 	}
 	if config.ResourceStats.RefreshIntervalInSec < minRefreshTimeInSec {
 		return nil, fmt.Errorf("%w, minimum: %d, provided: %d", ErrInvalidRefreshIntervalValue, minRefreshTimeInSec, config.ResourceStats.RefreshIntervalInSec)
@@ -158,8 +158,8 @@ func GetRuntimeStatistics() []interface{} {
 	}
 }
 
-// SaveStatistics generates and saves statistic data on the disk
-func (rm *resourceMonitor) SaveStatistics() {
+// LogStatistics generates and saves the statistic data in the logs
+func (rm *resourceMonitor) LogStatistics() {
 	stats := rm.GenerateStatistics()
 	log.Debug("node statistics", stats...)
 }
@@ -175,7 +175,7 @@ func (rm *resourceMonitor) StartMonitoring() {
 
 	go func() {
 		for {
-			rm.SaveStatistics()
+			rm.LogStatistics()
 			timer.Reset(refreshTime)
 
 			select {

--- a/common/statistics/resourceMonitor.go
+++ b/common/statistics/resourceMonitor.go
@@ -3,9 +3,6 @@ package statistics
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"path"
-	"path/filepath"
 	"runtime"
 	"time"
 
@@ -14,7 +11,6 @@ import (
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/common/statistics/machine"
 	"github.com/ElrondNetwork/elrond-go/config"
-	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/load"
 	"github.com/shirou/gopsutil/mem"
@@ -22,24 +18,25 @@ import (
 	"github.com/shirou/gopsutil/process"
 )
 
+const minRefreshTimeInSec = 1
+
 var log = logger.GetOrCreate("common/statistics")
 
-// ResourceMonitor outputs statistics about resources used by the binary
-type ResourceMonitor struct {
+// resourceMonitor outputs statistics about resources used by the binary
+type resourceMonitor struct {
 	startTime     time.Time
 	cancelFunc    context.CancelFunc
-	generalConfig *config.Config
-	pathManager   storage.PathManagerHandler
-	shardId       string
+	netStats      NetworkStatisticsProvider
+	generalConfig config.Config
 }
 
 // NewResourceMonitor creates a new ResourceMonitor instance
-func NewResourceMonitor(config *config.Config, pathManager storage.PathManagerHandler, shardId string) (*ResourceMonitor, error) {
-	if config == nil {
-		return nil, ErrNilConfig
+func NewResourceMonitor(config config.Config, netStats NetworkStatisticsProvider) (*resourceMonitor, error) {
+	if check.IfNil(netStats) {
+		return nil, ErrNilNetworkStatistics
 	}
-	if check.IfNil(pathManager) {
-		return nil, ErrNilPathHandler
+	if config.ResourceStats.RefreshIntervalInSec < minRefreshTimeInSec {
+		return nil, fmt.Errorf("%w, minimum: %d, provided: %d", ErrInvalidRefreshIntervalValue, minRefreshTimeInSec, config.ResourceStats.RefreshIntervalInSec)
 	}
 
 	memoryString := "no memory information"
@@ -56,16 +53,27 @@ func NewResourceMonitor(config *config.Config, pathManager storage.PathManagerHa
 
 	log.Debug("newResourceMonitor", "numCores", numCores, "memory", memoryString)
 
-	return &ResourceMonitor{
+	return &resourceMonitor{
 		generalConfig: config,
-		pathManager:   pathManager,
-		shardId:       shardId,
 		startTime:     time.Now(),
+		netStats:      netStats,
 	}, nil
 }
 
 // GenerateStatistics creates a new statistic string
-func (rm *ResourceMonitor) GenerateStatistics() []interface{} {
+func (rm *resourceMonitor) GenerateStatistics() []interface{} {
+	stats := []interface{}{
+		"uptime", time.Duration(time.Now().UnixNano() - rm.startTime.UnixNano()).Round(time.Second),
+	}
+
+	stats = append(stats, GetRuntimeStatistics()...)
+	stats = append(stats, rm.generateProcessStatistics()...)
+	stats = append(stats, rm.generateNetworkStatistics()...)
+
+	return stats
+}
+
+func (rm *resourceMonitor) generateProcessStatistics() []interface{} {
 	fileDescriptors := int32(0)
 	numOpenFiles := 0
 	numConns := 0
@@ -73,6 +81,7 @@ func (rm *ResourceMonitor) GenerateStatistics() []interface{} {
 	ioStatsString := "no io stats info"
 	cpuPercentString := "no cpu percent info"
 	loadAverageString := "no load average info"
+
 	proc, err := machine.GetCurrentProcess()
 	if err == nil {
 		fileDescriptors, _ = proc.NumFDs()
@@ -84,7 +93,7 @@ func (rm *ResourceMonitor) GenerateStatistics() []interface{} {
 
 		loadAvg, errLoadAvg := load.Avg()
 		if errLoadAvg == nil {
-			loadAverageString = fmt.Sprintf("{avg1min:%.2f, avg5min:%.2f, avg15min:%.2f}",
+			loadAverageString = fmt.Sprintf("{avg1min: %.2f, avg5min: %.2f, avg15min: %.2f}",
 				loadAvg.Load1, loadAvg.Load5, loadAvg.Load15)
 		}
 
@@ -95,7 +104,7 @@ func (rm *ResourceMonitor) GenerateStatistics() []interface{} {
 
 		ioStats, errIoCounters := proc.IOCounters()
 		if errIoCounters == nil {
-			ioStatsString = fmt.Sprintf("{readCount:%d, writeCount:%d, readBytes:%s, writeBytes:%s}",
+			ioStatsString = fmt.Sprintf("{readCount: %d, writeCount: %d, readBytes: %s, writeBytes: %s}",
 				ioStats.ReadCount,
 				ioStats.WriteCount,
 				core.ConvertBytes(ioStats.ReadBytes),
@@ -109,39 +118,25 @@ func (rm *ResourceMonitor) GenerateStatistics() []interface{} {
 		}
 	}
 
-	pathManager := rm.pathManager
-	generalConfig := rm.generalConfig
-	shardId := rm.shardId
-
-	trieStoragePath, mainDb := path.Split(pathManager.PathForStatic(shardId, generalConfig.AccountsTrieStorage.DB.FilePath))
-
-	trieDbFilePath := filepath.Join(trieStoragePath, mainDb)
-	evictionWaitingListDbFilePath := filepath.Join(trieStoragePath, generalConfig.EvictionWaitingList.DB.FilePath)
-
-	peerTrieStoragePath, mainDb := path.Split(pathManager.PathForStatic(shardId, generalConfig.PeerAccountsTrieStorage.DB.FilePath))
-
-	peerTrieDbFilePath := filepath.Join(peerTrieStoragePath, mainDb)
-	peerTrieEvictionWaitingListDbFilePath := filepath.Join(peerTrieStoragePath, generalConfig.EvictionWaitingList.DB.FilePath)
-
-	stats := []interface{}{
-		"uptime", time.Duration(time.Now().UnixNano() - rm.startTime.UnixNano()).Round(time.Second),
-	}
-	stats = append(stats, GetRuntimeStatistics()...)
-	stats = append(stats, []interface{}{
+	return []interface{}{
 		"FDs", fileDescriptors,
 		"num opened files", numOpenFiles,
 		"num conns", numConns,
-		"accountsTrieDbMem", getDirMemSize(trieDbFilePath),
-		"evictionDbMem", getDirMemSize(evictionWaitingListDbFilePath),
-		"peerTrieDbMem", getDirMemSize(peerTrieDbFilePath),
-		"peerTrieEvictionDbMem", getDirMemSize(peerTrieEvictionWaitingListDbFilePath),
 		"cpuPercent", cpuPercentString,
 		"cpuLoadAveragePercent", loadAverageString,
 		"ioStatsString", ioStatsString,
-	}...,
+	}
+}
+
+func (rm *resourceMonitor) generateNetworkStatistics() []interface{} {
+	netStatsString := fmt.Sprintf("{total received: %s, total sent: %s}",
+		rm.netStats.TotalReceivedInCurrentEpoch(),
+		rm.netStats.TotalSentInCurrentEpoch(),
 	)
 
-	return stats
+	return []interface{}{
+		"host network data size in epoch", netStatsString,
+	}
 }
 
 // GetRuntimeStatistics will return the statistics regarding the current time, memory consumption and the number of running go routines
@@ -163,32 +158,28 @@ func GetRuntimeStatistics() []interface{} {
 	}
 }
 
-func getDirMemSize(dir string) string {
-	files, _ := ioutil.ReadDir(dir)
-
-	size := int64(0)
-	for _, f := range files {
-		size += f.Size()
-	}
-
-	return core.ConvertBytes(uint64(size))
-}
-
 // SaveStatistics generates and saves statistic data on the disk
-func (rm *ResourceMonitor) SaveStatistics() {
+func (rm *resourceMonitor) SaveStatistics() {
 	stats := rm.GenerateStatistics()
 	log.Debug("node statistics", stats...)
 }
 
 // StartMonitoring starts the monitoring process for saving statistics
-func (rm *ResourceMonitor) StartMonitoring() {
+func (rm *resourceMonitor) StartMonitoring() {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	rm.cancelFunc = cancelFunc
+
+	refreshTime := time.Second * time.Duration(rm.generalConfig.ResourceStats.RefreshIntervalInSec)
+	timer := time.NewTimer(refreshTime)
+	defer timer.Stop()
+
 	go func() {
 		for {
+			rm.SaveStatistics()
+			timer.Reset(refreshTime)
+
 			select {
-			case <-time.After(time.Second * time.Duration(rm.generalConfig.ResourceStats.RefreshIntervalInSec)):
-				rm.SaveStatistics()
+			case <-timer.C:
 			case <-ctx.Done():
 				log.Debug("closing ResourceMonitor.StartMonitoring go routine")
 				return
@@ -198,12 +189,12 @@ func (rm *ResourceMonitor) StartMonitoring() {
 }
 
 // IsInterfaceNil returns true if underlying object is nil
-func (rm *ResourceMonitor) IsInterfaceNil() bool {
+func (rm *resourceMonitor) IsInterfaceNil() bool {
 	return rm == nil
 }
 
 // Close closes all underlying components
-func (rm *ResourceMonitor) Close() error {
+func (rm *resourceMonitor) Close() error {
 	if rm.cancelFunc != nil {
 		rm.cancelFunc()
 	}

--- a/common/statistics/resourceMonitor_test.go
+++ b/common/statistics/resourceMonitor_test.go
@@ -1,40 +1,54 @@
 package statistics_test
 
 import (
+	errorsGo "errors"
 	"fmt"
 	"testing"
 
 	stats "github.com/ElrondNetwork/elrond-go/common/statistics"
+	"github.com/ElrondNetwork/elrond-go/common/statistics/disabled"
 	"github.com/ElrondNetwork/elrond-go/config"
-	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewResourceMonitor_NilConfigShouldErr(t *testing.T) {
-	t.Parallel()
-
-	resourceMonitor, err := stats.NewResourceMonitor(nil, &testscommon.PathManagerStub{}, "")
-
-	assert.Equal(t, stats.ErrNilConfig, err)
-	assert.Nil(t, resourceMonitor)
+func generateMockConfig() config.Config {
+	return config.Config{
+		ResourceStats: config.ResourceStatsConfig{
+			RefreshIntervalInSec: 1,
+		},
+	}
 }
 
-func TestNewResourceMonitor_NilPathManagerShouldErr(t *testing.T) {
+func TestNewResourceMonitor_NilNetStatisticsShouldErr(t *testing.T) {
 	t.Parallel()
 
 	resourceMonitor, err := stats.NewResourceMonitor(
-		&config.Config{AccountsTrieStorage: config.StorageConfig{DB: config.DBConfig{}}},
-		nil,
-		"")
+		generateMockConfig(),
+		nil)
 
-	assert.Equal(t, stats.ErrNilPathHandler, err)
+	assert.Equal(t, stats.ErrNilNetworkStatistics, err)
 	assert.Nil(t, resourceMonitor)
 }
 
-func TestResourceMonitor_NewResourceMonitorShouldPass(t *testing.T) {
+func TestNewResourceMonitor_InvalidRefreshValueShouldErr(t *testing.T) {
 	t.Parallel()
 
-	resourceMonitor, err := stats.NewResourceMonitor(&config.Config{AccountsTrieStorage: config.StorageConfig{DB: config.DBConfig{}}}, &testscommon.PathManagerStub{}, "")
+	resourceMonitor, err := stats.NewResourceMonitor(
+		config.Config{
+			ResourceStats: config.ResourceStatsConfig{
+				RefreshIntervalInSec: 0,
+			},
+		},
+		disabled.NewDisabledNetStatistics())
+
+	assert.True(t, errorsGo.Is(err, stats.ErrInvalidRefreshIntervalValue))
+	assert.Nil(t, resourceMonitor)
+}
+
+func TestResourceMonitor_NewResourceMonitorShouldWork(t *testing.T) {
+	t.Parallel()
+
+	resourceMonitor, err := stats.NewResourceMonitor(generateMockConfig(), disabled.NewDisabledNetStatistics())
 
 	assert.Nil(t, err)
 	assert.NotNil(t, resourceMonitor)
@@ -43,7 +57,7 @@ func TestResourceMonitor_NewResourceMonitorShouldPass(t *testing.T) {
 func TestResourceMonitor_GenerateStatisticsShouldPass(t *testing.T) {
 	t.Parallel()
 
-	resourceMonitor, err := stats.NewResourceMonitor(&config.Config{AccountsTrieStorage: config.StorageConfig{DB: config.DBConfig{}}}, &testscommon.PathManagerStub{}, "")
+	resourceMonitor, err := stats.NewResourceMonitor(generateMockConfig(), disabled.NewDisabledNetStatistics())
 
 	assert.Nil(t, err)
 	statistics := resourceMonitor.GenerateStatistics()
@@ -61,7 +75,7 @@ func TestResourceMonitor_SaveStatisticsShouldNotPanic(t *testing.T) {
 		}
 	}()
 
-	resourceMonitor, err := stats.NewResourceMonitor(&config.Config{AccountsTrieStorage: config.StorageConfig{DB: config.DBConfig{}}}, &testscommon.PathManagerStub{}, "")
+	resourceMonitor, err := stats.NewResourceMonitor(generateMockConfig(), disabled.NewDisabledNetStatistics())
 
 	assert.Nil(t, err)
 	resourceMonitor.SaveStatistics()

--- a/common/statistics/resourceMonitor_test.go
+++ b/common/statistics/resourceMonitor_test.go
@@ -19,14 +19,14 @@ func generateMockConfig() config.Config {
 	}
 }
 
-func TestNewResourceMonitor_NilNetStatisticsShouldErr(t *testing.T) {
+func TestNewResourceMonitor_NilNetStatisticsProviderShouldErr(t *testing.T) {
 	t.Parallel()
 
 	resourceMonitor, err := stats.NewResourceMonitor(
 		generateMockConfig(),
 		nil)
 
-	assert.Equal(t, stats.ErrNilNetworkStatistics, err)
+	assert.Equal(t, stats.ErrNilNetworkStatisticsProvider, err)
 	assert.Nil(t, resourceMonitor)
 }
 
@@ -78,5 +78,5 @@ func TestResourceMonitor_SaveStatisticsShouldNotPanic(t *testing.T) {
 	resourceMonitor, err := stats.NewResourceMonitor(generateMockConfig(), disabled.NewDisabledNetStatistics())
 
 	assert.Nil(t, err)
-	resourceMonitor.SaveStatistics()
+	resourceMonitor.LogStatistics()
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -134,6 +134,9 @@ var ErrNilConsensusWorker = errors.New("nil consensus worker")
 // ErrNilCoreComponents signals that an operation has been attempted with nil core components
 var ErrNilCoreComponents = errors.New("nil core components provided")
 
+// ErrNilStatusCoreComponents signals that an operation has been attempted with nil status core components
+var ErrNilStatusCoreComponents = errors.New("nil status core components provided")
+
 // ErrNilCoreComponentsHolder signals that a nil core components holder was provided
 var ErrNilCoreComponentsHolder = errors.New("nil core components holder")
 
@@ -428,6 +431,9 @@ var ErrConsensusComponentsFactoryCreate = errors.New("consensusComponentsFactory
 // ErrCoreComponentsFactoryCreate signals that an error occured on coreComponentsFactory create
 var ErrCoreComponentsFactoryCreate = errors.New("coreComponentsFactory create failed")
 
+// ErrStatusCoreComponentsFactoryCreate signals that an error occured on statusCoreComponentsFactory create
+var ErrStatusCoreComponentsFactoryCreate = errors.New("statusCoreComponentsFactory create failed")
+
 // ErrCryptoComponentsFactoryCreate signals that an error occured on cryptoComponentsFactory create
 var ErrCryptoComponentsFactoryCreate = errors.New("cryptoComponentsFactory create failed")
 
@@ -517,3 +523,9 @@ var ErrInvalidSignature = errors.New("invalid signature")
 
 // ErrInvalidHeartbeatV2Config signals that an invalid heartbeat v2 configuration has been provided
 var ErrInvalidHeartbeatV2Config = errors.New("invalid heartbeat v2 configuration")
+
+// ErrNilNetworkStatistics signals that a nil network statistics was provided
+var ErrNilNetworkStatistics = errors.New("nil network statistics")
+
+// ErrNilResourceMonitor signals that a nil resource monitor was provided
+var ErrNilResourceMonitor = errors.New("nil resource monitor")

--- a/factory/bootstrap/bootstrapComponentsHandler.go
+++ b/factory/bootstrap/bootstrapComponentsHandler.go
@@ -65,8 +65,8 @@ func (mbf *managedBootstrapComponents) Close() error {
 
 // CheckSubcomponents verifies all subcomponents
 func (mbf *managedBootstrapComponents) CheckSubcomponents() error {
-	mbf.mutBootstrapComponents.Lock()
-	defer mbf.mutBootstrapComponents.Unlock()
+	mbf.mutBootstrapComponents.RLock()
+	defer mbf.mutBootstrapComponents.RUnlock()
 
 	if mbf.bootstrapComponents == nil {
 		return errors.ErrNilBootstrapComponentsHolder

--- a/factory/consensus/consensusComponentsHandler.go
+++ b/factory/consensus/consensusComponentsHandler.go
@@ -115,8 +115,8 @@ func (mcc *managedConsensusComponents) ConsensusGroupSize() (int, error) {
 
 // CheckSubcomponents verifies all subcomponents
 func (mcc *managedConsensusComponents) CheckSubcomponents() error {
-	mcc.mutConsensusComponents.Lock()
-	defer mcc.mutConsensusComponents.Unlock()
+	mcc.mutConsensusComponents.RLock()
+	defer mcc.mutConsensusComponents.RUnlock()
 
 	if mcc.consensusComponents == nil {
 		return errors.ErrNilConsensusComponentsHolder

--- a/factory/constants.go
+++ b/factory/constants.go
@@ -7,6 +7,8 @@ const (
 	ConsensusComponentsName = "managedConsensusComponents"
 	// CoreComponentsName is the core components identifier
 	CoreComponentsName = "managedCoreComponents"
+	// StatusCoreComponentsName is the status core components identifier
+	StatusCoreComponentsName = "managedStatusCoreComponents"
 	// CryptoComponentsName is the crypto components identifier
 	CryptoComponentsName = "managedCryptoComponents"
 	// DataComponentsName is the data components identifier

--- a/factory/core/coreComponentsHandler.go
+++ b/factory/core/coreComponentsHandler.go
@@ -81,8 +81,8 @@ func (mcc *managedCoreComponents) Close() error {
 
 // CheckSubcomponents verifies all subcomponents
 func (mcc *managedCoreComponents) CheckSubcomponents() error {
-	mcc.mutCoreComponents.Lock()
-	defer mcc.mutCoreComponents.Unlock()
+	mcc.mutCoreComponents.RLock()
+	defer mcc.mutCoreComponents.RUnlock()
 
 	if mcc.coreComponents == nil {
 		return errors.ErrNilCoreComponents

--- a/factory/crypto/cryptoComponentsHandler.go
+++ b/factory/crypto/cryptoComponentsHandler.go
@@ -73,8 +73,8 @@ func (mcc *managedCryptoComponents) Close() error {
 
 // CheckSubcomponents verifies all subcomponents
 func (mcc *managedCryptoComponents) CheckSubcomponents() error {
-	mcc.mutCryptoComponents.Lock()
-	defer mcc.mutCryptoComponents.Unlock()
+	mcc.mutCryptoComponents.RLock()
+	defer mcc.mutCryptoComponents.RUnlock()
 
 	if mcc.cryptoComponents == nil {
 		return errors.ErrNilCryptoComponents

--- a/factory/data/dataComponentsHandler.go
+++ b/factory/data/dataComponentsHandler.go
@@ -68,8 +68,8 @@ func (mdc *managedDataComponents) Close() error {
 
 // CheckSubcomponents verifies all subcomponents
 func (mdc *managedDataComponents) CheckSubcomponents() error {
-	mdc.mutDataComponents.Lock()
-	defer mdc.mutDataComponents.Unlock()
+	mdc.mutDataComponents.RLock()
+	defer mdc.mutDataComponents.RUnlock()
 
 	if mdc.dataComponents == nil {
 		return errors.ErrNilDataComponents

--- a/factory/heartbeat/heartbeatComponentsHandler.go
+++ b/factory/heartbeat/heartbeatComponentsHandler.go
@@ -66,8 +66,8 @@ func (mhc *managedHeartbeatComponents) Close() error {
 
 // CheckSubcomponents verifies all subcomponents
 func (mhc *managedHeartbeatComponents) CheckSubcomponents() error {
-	mhc.mutHeartbeatComponents.Lock()
-	defer mhc.mutHeartbeatComponents.Unlock()
+	mhc.mutHeartbeatComponents.RLock()
+	defer mhc.mutHeartbeatComponents.RUnlock()
 
 	if mhc.heartbeatComponents == nil {
 		return errors.ErrNilHeartbeatComponents

--- a/factory/interface.go
+++ b/factory/interface.go
@@ -143,6 +143,19 @@ type CoreComponentsHandler interface {
 	CoreComponentsHolder
 }
 
+// StatusCoreComponentsHolder holds the status core components
+type StatusCoreComponentsHolder interface {
+	ResourceMonitor() ResourceMonitor
+	NetworkStatistics() NetworkStatisticsProvider
+	IsInterfaceNil() bool
+}
+
+// StatusCoreComponentsHandler defines the status core components handler actions
+type StatusCoreComponentsHandler interface {
+	ComponentHandler
+	StatusCoreComponentsHolder
+}
+
 // CryptoParamsHolder permits access to crypto parameters such as the private and public keys
 type CryptoParamsHolder interface {
 	PublicKey() crypto.PublicKey
@@ -511,4 +524,27 @@ type ReceiptsRepository interface {
 // ProcessDebuggerSetter allows setting a debugger on the process component
 type ProcessDebuggerSetter interface {
 	SetProcessDebugger(debugger process.Debugger) error
+}
+
+// ResourceMonitor defines the function implemented by a struct that can monitor resources
+type ResourceMonitor interface {
+	Close() error
+	IsInterfaceNil() bool
+}
+
+// NetworkStatisticsProvider is able to provide network statistics
+type NetworkStatisticsProvider interface {
+	BpsSent() uint64
+	BpsRecv() uint64
+	BpsSentPeak() uint64
+	BpsRecvPeak() uint64
+	PercentSent() uint64
+	PercentRecv() uint64
+	TotalBytesSentInCurrentEpoch() uint64
+	TotalBytesReceivedInCurrentEpoch() uint64
+	TotalSentInCurrentEpoch() string
+	TotalReceivedInCurrentEpoch() string
+	EpochConfirmed(epoch uint32, timestamp uint64)
+	Close() error
+	IsInterfaceNil() bool
 }

--- a/factory/network/networkComponentsHandler.go
+++ b/factory/network/networkComponentsHandler.go
@@ -68,8 +68,8 @@ func (mnc *managedNetworkComponents) Close() error {
 
 // CheckSubcomponents verifies all subcomponents
 func (mnc *managedNetworkComponents) CheckSubcomponents() error {
-	mnc.mutNetworkComponents.Lock()
-	defer mnc.mutNetworkComponents.Unlock()
+	mnc.mutNetworkComponents.RLock()
+	defer mnc.mutNetworkComponents.RUnlock()
 
 	if mnc.networkComponents == nil {
 		return errors.ErrNilNetworkComponents

--- a/factory/processing/blockProcessorCreator_test.go
+++ b/factory/processing/blockProcessorCreator_test.go
@@ -35,10 +35,11 @@ func Test_newBlockProcessorCreatorForShard(t *testing.T) {
 	}
 
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
-	pcf, _ := processComp.NewProcessComponentsFactory(componentsMock.GetProcessComponentsFactoryArgs(shardCoordinator))
+	pcf, err := processComp.NewProcessComponentsFactory(componentsMock.GetProcessComponentsFactoryArgs(shardCoordinator))
+	require.NoError(t, err)
 	require.NotNil(t, pcf)
 
-	_, err := pcf.Create()
+	_, err = pcf.Create()
 	require.NoError(t, err)
 
 	bp, vmFactoryForSimulate, err := pcf.NewBlockProcessor(

--- a/factory/processing/processComponentsHandler.go
+++ b/factory/processing/processComponentsHandler.go
@@ -73,8 +73,8 @@ func (m *managedProcessComponents) Close() error {
 
 // CheckSubcomponents verifies all subcomponents
 func (m *managedProcessComponents) CheckSubcomponents() error {
-	m.mutProcessComponents.Lock()
-	defer m.mutProcessComponents.Unlock()
+	m.mutProcessComponents.RLock()
+	defer m.mutProcessComponents.RUnlock()
 
 	if m.processComponents == nil {
 		return errors.ErrNilProcessComponents

--- a/factory/state/stateComponentsHandler.go
+++ b/factory/state/stateComponentsHandler.go
@@ -67,8 +67,8 @@ func (msc *managedStateComponents) Close() error {
 
 // CheckSubcomponents verifies all subcomponents
 func (msc *managedStateComponents) CheckSubcomponents() error {
-	msc.mutStateComponents.Lock()
-	defer msc.mutStateComponents.Unlock()
+	msc.mutStateComponents.RLock()
+	defer msc.mutStateComponents.RUnlock()
 
 	if msc.stateComponents == nil {
 		return errors.ErrNilStateComponents

--- a/factory/status/statusComponents.go
+++ b/factory/status/statusComponents.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 	"github.com/ElrondNetwork/elrond-go/sharding/nodesCoordinator"
-	"github.com/ElrondNetwork/elrond-go/storage"
 )
 
 // TODO: move app status handler initialization here
@@ -39,32 +38,34 @@ type statusComponents struct {
 
 // StatusComponentsFactoryArgs redefines the arguments structure needed for the status components factory
 type StatusComponentsFactoryArgs struct {
-	Config             config.Config
-	ExternalConfig     config.ExternalConfig
-	EconomicsConfig    config.EconomicsConfig
-	ShardCoordinator   sharding.Coordinator
-	NodesCoordinator   nodesCoordinator.NodesCoordinator
-	EpochStartNotifier factory.EpochStartNotifier
-	CoreComponents     factory.CoreComponentsHolder
-	DataComponents     factory.DataComponentsHolder
-	NetworkComponents  factory.NetworkComponentsHolder
-	StateComponents    factory.StateComponentsHolder
-	IsInImportMode     bool
+	Config               config.Config
+	ExternalConfig       config.ExternalConfig
+	EconomicsConfig      config.EconomicsConfig
+	ShardCoordinator     sharding.Coordinator
+	NodesCoordinator     nodesCoordinator.NodesCoordinator
+	EpochStartNotifier   factory.EpochStartNotifier
+	CoreComponents       factory.CoreComponentsHolder
+	StatusCoreComponents factory.StatusCoreComponentsHolder
+	DataComponents       factory.DataComponentsHolder
+	NetworkComponents    factory.NetworkComponentsHolder
+	StateComponents      factory.StateComponentsHolder
+	IsInImportMode       bool
 }
 
 type statusComponentsFactory struct {
-	config             config.Config
-	externalConfig     config.ExternalConfig
-	economicsConfig    config.EconomicsConfig
-	shardCoordinator   sharding.Coordinator
-	nodesCoordinator   nodesCoordinator.NodesCoordinator
-	epochStartNotifier factory.EpochStartNotifier
-	forkDetector       process.ForkDetector
-	coreComponents     factory.CoreComponentsHolder
-	dataComponents     factory.DataComponentsHolder
-	networkComponents  factory.NetworkComponentsHolder
-	stateComponents    factory.StateComponentsHolder
-	isInImportMode     bool
+	config               config.Config
+	externalConfig       config.ExternalConfig
+	economicsConfig      config.EconomicsConfig
+	shardCoordinator     sharding.Coordinator
+	nodesCoordinator     nodesCoordinator.NodesCoordinator
+	epochStartNotifier   factory.EpochStartNotifier
+	forkDetector         process.ForkDetector
+	coreComponents       factory.CoreComponentsHolder
+	statusCoreComponents factory.StatusCoreComponentsHolder
+	dataComponents       factory.DataComponentsHolder
+	networkComponents    factory.NetworkComponentsHolder
+	stateComponents      factory.StateComponentsHolder
+	isInImportMode       bool
 }
 
 var log = logger.GetOrCreate("factory")
@@ -95,36 +96,29 @@ func NewStatusComponentsFactory(args StatusComponentsFactoryArgs) (*statusCompon
 	if check.IfNil(args.EpochStartNotifier) {
 		return nil, errors.ErrNilEpochStartNotifier
 	}
+	if check.IfNil(args.StatusCoreComponents) {
+		return nil, errors.ErrNilStatusCoreComponents
+	}
 
 	return &statusComponentsFactory{
-		config:             args.Config,
-		externalConfig:     args.ExternalConfig,
-		economicsConfig:    args.EconomicsConfig,
-		shardCoordinator:   args.ShardCoordinator,
-		nodesCoordinator:   args.NodesCoordinator,
-		epochStartNotifier: args.EpochStartNotifier,
-		coreComponents:     args.CoreComponents,
-		dataComponents:     args.DataComponents,
-		networkComponents:  args.NetworkComponents,
-		stateComponents:    args.StateComponents,
-		isInImportMode:     args.IsInImportMode,
+		config:               args.Config,
+		externalConfig:       args.ExternalConfig,
+		economicsConfig:      args.EconomicsConfig,
+		shardCoordinator:     args.ShardCoordinator,
+		nodesCoordinator:     args.NodesCoordinator,
+		epochStartNotifier:   args.EpochStartNotifier,
+		coreComponents:       args.CoreComponents,
+		statusCoreComponents: args.StatusCoreComponents,
+		dataComponents:       args.DataComponents,
+		networkComponents:    args.NetworkComponents,
+		stateComponents:      args.StateComponents,
+		isInImportMode:       args.IsInImportMode,
 	}, nil
 }
 
 // Create will create and return the status components
 func (scf *statusComponentsFactory) Create() (*statusComponents, error) {
 	var err error
-	var resMon *statistics.ResourceMonitor
-	log.Trace("initializing stats file")
-	if scf.config.ResourceStats.Enabled {
-		resMon, err = startStatisticsMonitor(
-			&scf.config,
-			scf.coreComponents.PathHandler(),
-			core.GetShardIDString(scf.shardCoordinator.SelfId()))
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	log.Trace("creating software checker structure")
 	softwareVersionCheckerFactory, err := swVersionFactory.NewSoftwareVersionFactory(
@@ -159,7 +153,6 @@ func (scf *statusComponentsFactory) Create() (*statusComponents, error) {
 		softwareVersion:  softwareVersionChecker,
 		outportHandler:   outportHandler,
 		statusHandler:    scf.coreComponents.StatusHandler(),
-		resourceMonitor:  resMon,
 		cancelFunc:       cancelFunc,
 	}
 
@@ -198,10 +191,6 @@ func (pc *statusComponents) Close() error {
 
 	if !check.IfNil(pc.softwareVersion) {
 		log.LogIfError(pc.softwareVersion.Close())
-	}
-
-	if !check.IfNil(pc.resourceMonitor) {
-		log.LogIfError(pc.resourceMonitor.Close())
 	}
 
 	return nil
@@ -271,22 +260,4 @@ func (scf *statusComponentsFactory) makeCovalentIndexerArgs() *covalentFactory.A
 		Marshaller:           scf.coreComponents.InternalMarshalizer(),
 		ShardCoordinator:     scf.shardCoordinator,
 	}
-}
-
-func startStatisticsMonitor(
-	generalConfig *config.Config,
-	pathManager storage.PathManagerHandler,
-	shardId string,
-) (*statistics.ResourceMonitor, error) {
-	if generalConfig.ResourceStats.RefreshIntervalInSec < 1 {
-		return nil, fmt.Errorf("invalid RefreshIntervalInSec in section [ResourceStats]. Should be an integer higher than 1")
-	}
-	resMon, err := statistics.NewResourceMonitor(generalConfig, pathManager, shardId)
-	if err != nil {
-		return nil, err
-	}
-
-	resMon.StartMonitoring()
-
-	return resMon, nil
 }

--- a/factory/status/statusComponentsHandler.go
+++ b/factory/status/statusComponentsHandler.go
@@ -87,8 +87,8 @@ func (msc *managedStatusComponents) Close() error {
 
 // CheckSubcomponents verifies all subcomponents
 func (msc *managedStatusComponents) CheckSubcomponents() error {
-	msc.mutStatusComponents.Lock()
-	defer msc.mutStatusComponents.Unlock()
+	msc.mutStatusComponents.RLock()
+	defer msc.mutStatusComponents.RUnlock()
 
 	if msc.statusComponents == nil {
 		return errors.ErrNilStatusComponents

--- a/factory/status/statusComponentsHandler.go
+++ b/factory/status/statusComponentsHandler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/p2p"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/sharding"
-	"github.com/ElrondNetwork/elrond-go/sharding/nodesCoordinator"
 )
 
 var _ factory.ComponentHandler = (*managedStatusComponents)(nil)
@@ -344,7 +343,9 @@ func (msc *managedStatusComponents) startMachineStatisticsPolling(ctx context.Co
 		return err
 	}
 
-	err = registerNetStatistics(ctx, appStatusPollingHandler, msc.statusComponentsFactory.epochStartNotifier)
+	netStats := msc.statusComponentsFactory.statusCoreComponents.NetworkStatistics()
+	epochNotifier := msc.statusComponentsFactory.coreComponents.EpochNotifier()
+	err = registerNetStatistics(appStatusPollingHandler, netStats, epochNotifier)
 	if err != nil {
 		return err
 	}
@@ -367,20 +368,8 @@ func registerMemStatistics(_ context.Context, appStatusPollingHandler *appStatus
 	})
 }
 
-func registerNetStatistics(ctx context.Context, appStatusPollingHandler *appStatusPolling.AppStatusPolling, notifier nodesCoordinator.EpochStartEventNotifier) error {
-	netStats := machine.NewNetStatistics()
-	notifier.RegisterHandler(netStats.EpochStartEventHandler())
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				log.Debug("registerNetStatistics go routine is stopping...")
-				return
-			default:
-			}
-			netStats.ComputeStatistics()
-		}
-	}()
+func registerNetStatistics(appStatusPollingHandler *appStatusPolling.AppStatusPolling, netStats factory.NetworkStatisticsProvider, epochNotifier process.EpochNotifier) error {
+	epochNotifier.RegisterNotifyHandler(netStats)
 
 	return appStatusPollingHandler.RegisterPollingFunc(func(appStatusHandler core.AppStatusHandler) {
 		appStatusHandler.SetUInt64Value(common.MetricNetworkRecvBps, netStats.BpsRecv())

--- a/factory/status/statusComponents_test.go
+++ b/factory/status/statusComponents_test.go
@@ -106,17 +106,18 @@ func TestNewStatusComponents_InvalidRoundDurationShouldErr(t *testing.T) {
 	stateComponents := componentsMock.GetStateComponents(coreComponents, shardCoordinator)
 
 	statusArgs := statusComp.StatusComponentsFactoryArgs{
-		Config:             testscommon.GetGeneralConfig(),
-		ExternalConfig:     config.ExternalConfig{},
-		ShardCoordinator:   shardCoordinator,
-		NodesCoordinator:   &shardingMocks.NodesCoordinatorMock{},
-		EpochStartNotifier: &mock.EpochStartNotifierStub{},
-		CoreComponents:     coreComponents,
-		DataComponents:     dataComponents,
-		NetworkComponents:  networkComponents,
-		StateComponents:    stateComponents,
-		IsInImportMode:     false,
-		EconomicsConfig:    config.EconomicsConfig{},
+		Config:               testscommon.GetGeneralConfig(),
+		ExternalConfig:       config.ExternalConfig{},
+		ShardCoordinator:     shardCoordinator,
+		NodesCoordinator:     &shardingMocks.NodesCoordinatorMock{},
+		EpochStartNotifier:   &mock.EpochStartNotifierStub{},
+		CoreComponents:       coreComponents,
+		DataComponents:       dataComponents,
+		NetworkComponents:    networkComponents,
+		StateComponents:      stateComponents,
+		IsInImportMode:       false,
+		EconomicsConfig:      config.EconomicsConfig{},
+		StatusCoreComponents: componentsMock.GetStatusCoreComponents(),
 	}
 	scf, err := statusComp.NewStatusComponentsFactory(statusArgs)
 	assert.Nil(t, err)

--- a/factory/statusCore/statusCoreComponents.go
+++ b/factory/statusCore/statusCoreComponents.go
@@ -1,0 +1,68 @@
+package statusCore
+
+import (
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go/common/statistics"
+	"github.com/ElrondNetwork/elrond-go/common/statistics/machine"
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/factory"
+)
+
+// StatusCoreComponentsFactoryArgs holds the arguments needed for creating a status core components factory
+type StatusCoreComponentsFactoryArgs struct {
+	Config config.Config
+}
+
+// statusCoreComponentsFactory is responsible for creating the status core components
+type statusCoreComponentsFactory struct {
+	config config.Config
+}
+
+// statusCoreComponents is the DTO used for core components
+type statusCoreComponents struct {
+	resourceMonitor   factory.ResourceMonitor
+	networkStatistics factory.NetworkStatisticsProvider
+}
+
+// NewStatusCoreComponentsFactory initializes the factory which is responsible to creating status core components
+func NewStatusCoreComponentsFactory(args StatusCoreComponentsFactoryArgs) *statusCoreComponentsFactory {
+	return &statusCoreComponentsFactory{
+		config: args.Config,
+	}
+}
+
+// Create creates the status core components
+func (sccf *statusCoreComponentsFactory) Create() (*statusCoreComponents, error) {
+	netStats := machine.NewNetStatistics()
+
+	resourceMonitor, err := statistics.NewResourceMonitor(sccf.config, netStats)
+	if err != nil {
+		return nil, err
+	}
+
+	if sccf.config.ResourceStats.Enabled {
+		resourceMonitor.StartMonitoring()
+	}
+
+	return &statusCoreComponents{
+		resourceMonitor:   resourceMonitor,
+		networkStatistics: netStats,
+	}, nil
+}
+
+// Close closes all underlying components
+func (scc *statusCoreComponents) Close() error {
+	var errNetStats error
+	var errResourceMonitor error
+	if !check.IfNil(scc.networkStatistics) {
+		errNetStats = scc.networkStatistics.Close()
+	}
+	if !check.IfNil(scc.resourceMonitor) {
+		errResourceMonitor = scc.resourceMonitor.Close()
+	}
+
+	if errNetStats != nil {
+		return errNetStats
+	}
+	return errResourceMonitor
+}

--- a/factory/statusCore/statusCoreComponentsHandler.go
+++ b/factory/statusCore/statusCoreComponentsHandler.go
@@ -1,0 +1,118 @@
+package statusCore
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go/errors"
+	"github.com/ElrondNetwork/elrond-go/factory"
+)
+
+var _ factory.ComponentHandler = (*managedStatusCoreComponents)(nil)
+var _ factory.StatusCoreComponentsHolder = (*managedStatusCoreComponents)(nil)
+var _ factory.StatusCoreComponentsHandler = (*managedStatusCoreComponents)(nil)
+
+// managedStatusCoreComponents is an implementation of status core components handler that can create, close and access the status core components
+type managedStatusCoreComponents struct {
+	statusCoreComponentsFactory *statusCoreComponentsFactory
+	*statusCoreComponents
+	mutCoreComponents sync.RWMutex
+}
+
+// NewManagedStatusCoreComponents creates a new status core components handler implementation
+func NewManagedStatusCoreComponents(sccf *statusCoreComponentsFactory) (*managedStatusCoreComponents, error) {
+	if sccf == nil {
+		return nil, errors.ErrNilCoreComponentsFactory
+	}
+
+	mcc := &managedStatusCoreComponents{
+		statusCoreComponents:        nil,
+		statusCoreComponentsFactory: sccf,
+	}
+	return mcc, nil
+}
+
+// Create creates the core components
+func (mscc *managedStatusCoreComponents) Create() error {
+	scc, err := mscc.statusCoreComponentsFactory.Create()
+	if err != nil {
+		return fmt.Errorf("%w: %v", errors.ErrStatusCoreComponentsFactoryCreate, err)
+	}
+
+	mscc.mutCoreComponents.Lock()
+	mscc.statusCoreComponents = scc
+	mscc.mutCoreComponents.Unlock()
+
+	return nil
+}
+
+// Close closes the managed core components
+func (mscc *managedStatusCoreComponents) Close() error {
+	mscc.mutCoreComponents.Lock()
+	defer mscc.mutCoreComponents.Unlock()
+
+	if mscc.statusCoreComponents == nil {
+		return nil
+	}
+
+	err := mscc.statusCoreComponents.Close()
+	if err != nil {
+		return err
+	}
+	mscc.statusCoreComponents = nil
+
+	return nil
+}
+
+// CheckSubcomponents verifies all subcomponents
+func (mscc *managedStatusCoreComponents) CheckSubcomponents() error {
+	mscc.mutCoreComponents.Lock()
+	defer mscc.mutCoreComponents.Unlock()
+
+	if mscc.statusCoreComponents == nil {
+		return errors.ErrNilStatusCoreComponents
+	}
+	if check.IfNil(mscc.networkStatistics) {
+		return errors.ErrNilNetworkStatistics
+	}
+	if check.IfNil(mscc.resourceMonitor) {
+		return errors.ErrNilResourceMonitor
+	}
+
+	return nil
+}
+
+// NetworkStatistics returns the network statistics instance
+func (mscc *managedStatusCoreComponents) NetworkStatistics() factory.NetworkStatisticsProvider {
+	mscc.mutCoreComponents.RLock()
+	defer mscc.mutCoreComponents.RUnlock()
+
+	if mscc.statusCoreComponents == nil {
+		return nil
+	}
+
+	return mscc.statusCoreComponents.networkStatistics
+}
+
+// ResourceMonitor returns the resource monitor instance
+func (mscc *managedStatusCoreComponents) ResourceMonitor() factory.ResourceMonitor {
+	mscc.mutCoreComponents.RLock()
+	defer mscc.mutCoreComponents.RUnlock()
+
+	if mscc.statusCoreComponents == nil {
+		return nil
+	}
+
+	return mscc.statusCoreComponents.resourceMonitor
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (mscc *managedStatusCoreComponents) IsInterfaceNil() bool {
+	return mscc == nil
+}
+
+// String returns the name of the component
+func (mscc *managedStatusCoreComponents) String() string {
+	return factory.StatusCoreComponentsName
+}

--- a/factory/statusCore/statusCoreComponentsHandler.go
+++ b/factory/statusCore/statusCoreComponentsHandler.go
@@ -67,8 +67,8 @@ func (mscc *managedStatusCoreComponents) Close() error {
 
 // CheckSubcomponents verifies all subcomponents
 func (mscc *managedStatusCoreComponents) CheckSubcomponents() error {
-	mscc.mutCoreComponents.Lock()
-	defer mscc.mutCoreComponents.Unlock()
+	mscc.mutCoreComponents.RLock()
+	defer mscc.mutCoreComponents.RUnlock()
 
 	if mscc.statusCoreComponents == nil {
 		return errors.ErrNilStatusCoreComponents

--- a/factory/statusCore/statusCoreComponentsHandler_test.go
+++ b/factory/statusCore/statusCoreComponentsHandler_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ------------ Test ManagedStatusCoreComponents --------------------
 func TestManagedStatusCoreComponents_CreateWithInvalidArgsShouldErr(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {

--- a/factory/statusCore/statusCoreComponentsHandler_test.go
+++ b/factory/statusCore/statusCoreComponentsHandler_test.go
@@ -1,0 +1,68 @@
+package statusCore_test
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/factory/statusCore"
+	componentsMock "github.com/ElrondNetwork/elrond-go/testscommon/components"
+	"github.com/stretchr/testify/require"
+)
+
+// ------------ Test ManagedStatusCoreComponents --------------------
+func TestManagedStatusCoreComponents_CreateWithInvalidArgsShouldErr(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	args := componentsMock.GetStatusCoreArgs()
+	args.Config.ResourceStats.RefreshIntervalInSec = 0
+
+	statusCoreComponentsFactory := statusCore.NewStatusCoreComponentsFactory(args)
+	managedStatusCoreComponents, err := statusCore.NewManagedStatusCoreComponents(statusCoreComponentsFactory)
+	require.NoError(t, err)
+
+	err = managedStatusCoreComponents.Create()
+	require.Error(t, err)
+	require.Nil(t, managedStatusCoreComponents.ResourceMonitor())
+}
+
+func TestManagedStatusCoreComponents_CreateShouldWork(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	args := componentsMock.GetStatusCoreArgs()
+	statusCoreComponentsFactory := statusCore.NewStatusCoreComponentsFactory(args)
+	managedStatusCoreComponents, err := statusCore.NewManagedStatusCoreComponents(statusCoreComponentsFactory)
+	require.NoError(t, err)
+
+	require.Nil(t, managedStatusCoreComponents.ResourceMonitor())
+	require.Nil(t, managedStatusCoreComponents.NetworkStatistics())
+
+	err = managedStatusCoreComponents.Create()
+	require.NoError(t, err)
+
+	require.NotNil(t, managedStatusCoreComponents.ResourceMonitor())
+	require.NotNil(t, managedStatusCoreComponents.NetworkStatistics())
+}
+
+func TestManagedCoreComponents_Close(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	args := componentsMock.GetStatusCoreArgs()
+	statusCoreComponentsFactory := statusCore.NewStatusCoreComponentsFactory(args)
+	managedStatusCoreComponents, err := statusCore.NewManagedStatusCoreComponents(statusCoreComponentsFactory)
+	require.NoError(t, err)
+
+	err = managedStatusCoreComponents.Create()
+	require.NoError(t, err)
+
+	err = managedStatusCoreComponents.Close()
+	require.NoError(t, err)
+	require.Nil(t, managedStatusCoreComponents.ResourceMonitor())
+}

--- a/factory/statusCore/statusCoreComponents_test.go
+++ b/factory/statusCore/statusCoreComponents_test.go
@@ -1,0 +1,73 @@
+package statusCore_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/common/statistics"
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/factory/statusCore"
+	componentsMock "github.com/ElrondNetwork/elrond-go/testscommon/components"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStatusCoreComponentsFactory_OkValuesShouldWork(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	args := componentsMock.GetStatusCoreArgs()
+	sccf := statusCore.NewStatusCoreComponentsFactory(args)
+
+	require.NotNil(t, sccf)
+}
+
+func TestStatusCoreComponentsFactory_InvalidValueShouldErr(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	args := componentsMock.GetStatusCoreArgs()
+	args.Config = config.Config{
+		ResourceStats: config.ResourceStatsConfig{
+			RefreshIntervalInSec: 0,
+		},
+	}
+	sccf := statusCore.NewStatusCoreComponentsFactory(args)
+
+	cc, err := sccf.Create()
+	require.Nil(t, cc)
+	require.True(t, errors.Is(err, statistics.ErrInvalidRefreshIntervalValue))
+}
+
+func TestStatusCoreComponentsFactory_CreateStatusCoreComponentsShouldWork(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	args := componentsMock.GetStatusCoreArgs()
+	sccf := statusCore.NewStatusCoreComponentsFactory(args)
+
+	cc, err := sccf.Create()
+	require.NoError(t, err)
+	require.NotNil(t, cc)
+}
+
+// ------------ Test CoreComponents --------------------
+func TestStatusCoreComponents_CloseShouldWork(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	args := componentsMock.GetStatusCoreArgs()
+	sccf := statusCore.NewStatusCoreComponentsFactory(args)
+	cc, err := sccf.Create()
+	require.NoError(t, err)
+
+	err = cc.Close()
+	require.NoError(t, err)
+}

--- a/integrationTests/factory/consensusComponents/consensusComponents_test.go
+++ b/integrationTests/factory/consensusComponents/consensusComponents_test.go
@@ -34,6 +34,8 @@ func TestConsensusComponents_Close_ShouldWork(t *testing.T) {
 	chanStopNodeProcess := make(chan endProcess.ArgEndProcess)
 	nr, err := node.NewNodeRunner(configs)
 	require.Nil(t, err)
+	managedStatusCoreComponents, err := nr.CreateManagedStatusCoreComponents()
+	require.Nil(t, err)
 	managedCoreComponents, err := nr.CreateManagedCoreComponents(chanStopNodeProcess)
 	require.Nil(t, err)
 	managedCryptoComponents, err := nr.CreateManagedCryptoComponents(managedCoreComponents)
@@ -71,6 +73,7 @@ func TestConsensusComponents_Close_ShouldWork(t *testing.T) {
 	)
 	require.Nil(t, err)
 	managedStatusComponents, err := nr.CreateManagedStatusComponents(
+		managedStatusCoreComponents,
 		managedCoreComponents,
 		managedNetworkComponents,
 		managedBootstrapComponents,
@@ -139,6 +142,8 @@ func TestConsensusComponents_Close_ShouldWork(t *testing.T) {
 	err = managedCryptoComponents.Close()
 	require.Nil(t, err)
 	err = managedCoreComponents.Close()
+	require.Nil(t, err)
+	err = managedStatusCoreComponents.Close()
 	require.Nil(t, err)
 
 	time.Sleep(5 * time.Second)

--- a/integrationTests/factory/processComponents/processComponents_test.go
+++ b/integrationTests/factory/processComponents/processComponents_test.go
@@ -35,6 +35,8 @@ func TestProcessComponents_Close_ShouldWork(t *testing.T) {
 	nr, err := node.NewNodeRunner(configs)
 	require.Nil(t, err)
 
+	managedStatusCoreComponents, err := nr.CreateManagedStatusCoreComponents()
+	require.Nil(t, err)
 	managedCoreComponents, err := nr.CreateManagedCoreComponents(chanStopNodeProcess)
 	require.Nil(t, err)
 	managedCryptoComponents, err := nr.CreateManagedCryptoComponents(managedCoreComponents)
@@ -72,6 +74,7 @@ func TestProcessComponents_Close_ShouldWork(t *testing.T) {
 	)
 	require.Nil(t, err)
 	managedStatusComponents, err := nr.CreateManagedStatusComponents(
+		managedStatusCoreComponents,
 		managedCoreComponents,
 		managedNetworkComponents,
 		managedBootstrapComponents,
@@ -126,6 +129,8 @@ func TestProcessComponents_Close_ShouldWork(t *testing.T) {
 	err = managedCryptoComponents.Close()
 	require.Nil(t, err)
 	err = managedCoreComponents.Close()
+	require.Nil(t, err)
+	err = managedStatusCoreComponents.Close()
 	require.Nil(t, err)
 
 	time.Sleep(5 * time.Second)

--- a/integrationTests/factory/statusComponents/statusComponents_test.go
+++ b/integrationTests/factory/statusComponents/statusComponents_test.go
@@ -35,6 +35,8 @@ func TestStatusComponents_Create_Close_ShouldWork(t *testing.T) {
 	nr, err := node.NewNodeRunner(configs)
 	require.Nil(t, err)
 
+	managedStatusCoreComponents, err := nr.CreateManagedStatusCoreComponents()
+	require.Nil(t, err)
 	managedCoreComponents, err := nr.CreateManagedCoreComponents(chanStopNodeProcess)
 	require.Nil(t, err)
 	managedCryptoComponents, err := nr.CreateManagedCryptoComponents(managedCoreComponents)
@@ -72,6 +74,7 @@ func TestStatusComponents_Create_Close_ShouldWork(t *testing.T) {
 	)
 	require.Nil(t, err)
 	managedStatusComponents, err := nr.CreateManagedStatusComponents(
+		managedStatusCoreComponents,
 		managedCoreComponents,
 		managedNetworkComponents,
 		managedBootstrapComponents,
@@ -126,6 +129,8 @@ func TestStatusComponents_Create_Close_ShouldWork(t *testing.T) {
 	err = managedCryptoComponents.Close()
 	require.Nil(t, err)
 	err = managedCoreComponents.Close()
+	require.Nil(t, err)
+	err = managedStatusCoreComponents.Close()
 	require.Nil(t, err)
 
 	time.Sleep(5 * time.Second)

--- a/integrationTests/factory/statusCoreComponents/statusCoreComponents_test.go
+++ b/integrationTests/factory/statusCoreComponents/statusCoreComponents_test.go
@@ -1,0 +1,44 @@
+package coreComponents
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go/integrationTests/factory"
+	"github.com/ElrondNetwork/elrond-go/node"
+	"github.com/ElrondNetwork/elrond-go/testscommon/goroutines"
+	"github.com/stretchr/testify/require"
+)
+
+// ------------ Test StatusCoreComponents --------------------
+func TestStatusCoreComponents_CreateCloseShouldWork(t *testing.T) {
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	defer factory.CleanupWorkingDir()
+	time.Sleep(time.Second * 4)
+
+	gc := goroutines.NewGoCounter(goroutines.TestsRelevantGoRoutines)
+	idxInitial, _ := gc.Snapshot()
+	factory.PrintStack()
+
+	configs := factory.CreateDefaultConfig()
+	nr, err := node.NewNodeRunner(configs)
+	require.Nil(t, err)
+	statusCoreComponents, err := nr.CreateManagedStatusCoreComponents()
+	require.Nil(t, err)
+	require.NotNil(t, statusCoreComponents)
+
+	time.Sleep(2 * time.Second)
+
+	err = statusCoreComponents.Close()
+	require.Nil(t, err)
+
+	time.Sleep(2 * time.Second)
+
+	idx, _ := gc.Snapshot()
+	diff := gc.DiffGoRoutines(idxInitial, idx)
+	require.Equal(t, 0, len(diff), fmt.Sprintf("%v", diff))
+}

--- a/node/errors.go
+++ b/node/errors.go
@@ -61,9 +61,6 @@ var ErrInvalidReceiverUsernameLength = errors.New("invalid receiver username len
 // ErrDataFieldTooBig signals that the data field is too big
 var ErrDataFieldTooBig = errors.New("data field is too big")
 
-// ErrNilHardforkTrigger signals that a nil hardfork trigger has been provided
-var ErrNilHardforkTrigger = errors.New("nil hardfork trigger")
-
 // ErrNilNodeStopChannel signals that a nil channel for node process stop has been provided
 var ErrNilNodeStopChannel = errors.New("nil node stop channel")
 
@@ -90,6 +87,9 @@ var ErrNilBootstrapComponents = errors.New("nil bootstrap componennts")
 
 // ErrNilCoreComponents signals that a nil core components instance has been provided
 var ErrNilCoreComponents = errors.New("nil core components")
+
+// ErrNilStatusCoreComponents signals that a nil status core components has been provided
+var ErrNilStatusCoreComponents = errors.New("nil status core components")
 
 // ErrNilCryptoComponents signals that a nil crypto components instance has been provided
 var ErrNilCryptoComponents = errors.New("nil crypto components")
@@ -132,9 +132,3 @@ var ErrCannotCastUserAccountHandlerToVmCommonUserAccountHandler = errors.New("ca
 
 // ErrTrieOperationsTimeout signals that a trie operation took too long
 var ErrTrieOperationsTimeout = errors.New("trie operations timeout")
-
-// ErrNotImplemented signals that a feature is not yet implemented
-var ErrNotImplemented = errors.New("feature not implemented")
-
-// ErrNotSupported signals that an operation is not supported
-var ErrNotSupported = errors.New("operation not supported")

--- a/node/nodeHelper.go
+++ b/node/nodeHelper.go
@@ -36,6 +36,7 @@ func prepareOpenTopics(
 // CreateNode is the node factory
 func CreateNode(
 	config *config.Config,
+	statusCoreComponents factory.StatusCoreComponentsHandler,
 	bootstrapComponents factory.BootstrapComponentsHandler,
 	coreComponents factory.CoreComponentsHandler,
 	cryptoComponents factory.CryptoComponentsHandler,
@@ -86,6 +87,7 @@ func CreateNode(
 
 	var nd *Node
 	nd, err = NewNode(
+		WithStatusCoreComponents(statusCoreComponents),
 		WithCoreComponents(coreComponents),
 		WithCryptoComponents(cryptoComponents),
 		WithBootstrapComponents(bootstrapComponents),

--- a/node/options.go
+++ b/node/options.go
@@ -47,6 +47,21 @@ func WithCoreComponents(coreComponents factory.CoreComponentsHandler) Option {
 	}
 }
 
+// WithStatusCoreComponents sets up the Node status core components
+func WithStatusCoreComponents(statusCoreComponents factory.StatusCoreComponentsHandler) Option {
+	return func(n *Node) error {
+		if check.IfNil(statusCoreComponents) {
+			return ErrNilStatusCoreComponents
+		}
+		err := statusCoreComponents.CheckSubcomponents()
+		if err != nil {
+			return err
+		}
+		n.closableComponents = append(n.closableComponents, statusCoreComponents)
+		return nil
+	}
+}
+
 // WithCryptoComponents sets up Node crypto components
 func WithCryptoComponents(cryptoComponents factory.CryptoComponentsHandler) Option {
 	return func(n *Node) error {

--- a/state/syncer/baseAccountsSyncer.go
+++ b/state/syncer/baseAccountsSyncer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/common"
-	"github.com/ElrondNetwork/elrond-go/common/statistics"
 	"github.com/ElrondNetwork/elrond-go/state"
 	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/ElrondNetwork/elrond-go/trie"
@@ -150,7 +149,6 @@ func (b *baseAccountsSyncer) printStatistics(ssh common.SizeSyncStatisticsHandle
 				"peak processing speed", peakSpeed,
 				"average processing speed", averageSpeed,
 			)
-			log.Debug("trie sync node statistics", statistics.GetRuntimeStatistics()...)
 			return
 		case <-time.After(timeBetweenStatisticsPrints):
 			bytesReceivedDelta := ssh.NumBytesReceived() - lastDataReceived
@@ -178,7 +176,6 @@ func (b *baseAccountsSyncer) printStatistics(ssh common.SizeSyncStatisticsHandle
 				"iterations", ssh.NumIterations(),
 				"CPU time", ssh.ProcessingTime(),
 				"processing speed", speed)
-			log.Debug("trie sync node statistics", statistics.GetRuntimeStatistics()...)
 		}
 	}
 }

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -29,6 +29,7 @@ import (
 	processComp "github.com/ElrondNetwork/elrond-go/factory/processing"
 	stateComp "github.com/ElrondNetwork/elrond-go/factory/state"
 	statusComp "github.com/ElrondNetwork/elrond-go/factory/status"
+	"github.com/ElrondNetwork/elrond-go/factory/statusCore"
 	"github.com/ElrondNetwork/elrond-go/genesis"
 	"github.com/ElrondNetwork/elrond-go/genesis/data"
 	"github.com/ElrondNetwork/elrond-go/p2p"
@@ -75,92 +76,7 @@ type LoadKeysFunc func(string, int) ([]byte, string, error)
 // GetCoreArgs -
 func GetCoreArgs() coreComp.CoreComponentsFactoryArgs {
 	return coreComp.CoreComponentsFactoryArgs{
-		Config: config.Config{
-			EpochStartConfig: GetEpochStartConfig(),
-			PublicKeyPeerId: config.CacheConfig{
-				Type:     "LRU",
-				Capacity: 5000,
-				Shards:   16,
-			},
-			PublicKeyShardId: config.CacheConfig{
-				Type:     "LRU",
-				Capacity: 5000,
-				Shards:   16,
-			},
-			PeerIdShardId: config.CacheConfig{
-				Type:     "LRU",
-				Capacity: 5000,
-				Shards:   16,
-			},
-			PeerHonesty: config.CacheConfig{
-				Type:     "LRU",
-				Capacity: 5000,
-				Shards:   16,
-			},
-			GeneralSettings: config.GeneralSettingsConfig{
-				ChainID:                  "undefined",
-				MinTransactionVersion:    1,
-				GenesisMaxNumberOfShards: 3,
-			},
-			Marshalizer: config.MarshalizerConfig{
-				Type:           TestMarshalizer,
-				SizeCheckDelta: 0,
-			},
-			Hasher: config.TypeConfig{
-				Type: TestHasher,
-			},
-			VmMarshalizer: config.TypeConfig{
-				Type: TestMarshalizer,
-			},
-			TxSignMarshalizer: config.TypeConfig{
-				Type: TestMarshalizer,
-			},
-			TxSignHasher: config.TypeConfig{
-				Type: TestHasher,
-			},
-			AddressPubkeyConverter: config.PubkeyConfig{
-				Length:          32,
-				Type:            "bech32",
-				SignatureLength: 0,
-			},
-			ValidatorPubkeyConverter: config.PubkeyConfig{
-				Length:          96,
-				Type:            "hex",
-				SignatureLength: 48,
-			},
-			Consensus: config.ConsensusConfig{
-				Type: "bls",
-			},
-			ValidatorStatistics: config.ValidatorStatisticsConfig{
-				CacheRefreshIntervalInSec: uint32(100),
-			},
-			SoftwareVersionConfig: config.SoftwareVersionConfig{
-				PollingIntervalInMinutes: 30,
-			},
-			Versions: config.VersionsConfig{
-				DefaultVersion:   "1",
-				VersionsByEpochs: nil,
-				Cache: config.CacheConfig{
-					Type:     "LRU",
-					Capacity: 1000,
-					Shards:   1,
-				},
-			},
-			PeersRatingConfig: config.PeersRatingConfig{
-				TopRatedCacheCapacity: 1000,
-				BadRatedCacheCapacity: 1000,
-			},
-			PoolsCleanersConfig: config.PoolsCleanersConfig{
-				MaxRoundsToKeepUnprocessedMiniBlocks:   50,
-				MaxRoundsToKeepUnprocessedTransactions: 50,
-			},
-			Hardfork: config.HardforkConfig{
-				PublicKeyToListenFrom: DummyPk,
-			},
-			HeartbeatV2: config.HeartbeatV2Config{
-				HeartbeatExpiryTimespanInSec: 10,
-			},
-		},
+		Config: GetGeneralConfig(),
 		ConfigPathsHolder: config.ConfigurationPathsHolder{
 			GasScheduleDirectoryName: "../../cmd/node/config/gasSchedules",
 		},
@@ -187,6 +103,13 @@ func GetCoreArgs() coreComp.CoreComponentsFactoryArgs {
 				},
 			},
 		},
+	}
+}
+
+// GetStatusCoreArgs -
+func GetStatusCoreArgs() statusCore.StatusCoreComponentsFactoryArgs {
+	return statusCore.StatusCoreComponentsFactoryArgs{
+		Config: GetGeneralConfig(),
 	}
 }
 
@@ -707,15 +630,16 @@ func GetStatusComponents(
 				EnabledIndexes: []string{"transactions", "blocks"},
 			},
 		},
-		EconomicsConfig:    config.EconomicsConfig{},
-		ShardCoordinator:   shardCoordinator,
-		NodesCoordinator:   nodesCoordinator,
-		EpochStartNotifier: coreComponents.EpochStartNotifierWithConfirm(),
-		CoreComponents:     coreComponents,
-		DataComponents:     dataComponents,
-		NetworkComponents:  networkComponents,
-		StateComponents:    stateComponents,
-		IsInImportMode:     false,
+		EconomicsConfig:      config.EconomicsConfig{},
+		ShardCoordinator:     shardCoordinator,
+		NodesCoordinator:     nodesCoordinator,
+		EpochStartNotifier:   coreComponents.EpochStartNotifierWithConfirm(),
+		CoreComponents:       coreComponents,
+		DataComponents:       dataComponents,
+		NetworkComponents:    networkComponents,
+		StateComponents:      stateComponents,
+		IsInImportMode:       false,
+		StatusCoreComponents: GetStatusCoreComponents(),
 	}
 
 	statusComponentsFactory, _ := statusComp.NewStatusComponentsFactory(statusArgs)
@@ -747,6 +671,7 @@ func GetStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator shardin
 		cryptoComponents,
 		stateComponents,
 	)
+	statusCoreComponents := GetStatusCoreComponents()
 
 	indexerURL := "url"
 	elasticUsername := "user"
@@ -762,15 +687,16 @@ func GetStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator shardin
 				EnabledIndexes: []string{"transactions", "blocks"},
 			},
 		},
-		EconomicsConfig:    config.EconomicsConfig{},
-		ShardCoordinator:   mock.NewMultiShardsCoordinatorMock(2),
-		NodesCoordinator:   &shardingMocks.NodesCoordinatorMock{},
-		EpochStartNotifier: &mock.EpochStartNotifierStub{},
-		CoreComponents:     coreComponents,
-		DataComponents:     dataComponents,
-		NetworkComponents:  networkComponents,
-		StateComponents:    stateComponents,
-		IsInImportMode:     false,
+		EconomicsConfig:      config.EconomicsConfig{},
+		ShardCoordinator:     mock.NewMultiShardsCoordinatorMock(2),
+		NodesCoordinator:     &shardingMocks.NodesCoordinatorMock{},
+		EpochStartNotifier:   &mock.EpochStartNotifierStub{},
+		CoreComponents:       coreComponents,
+		DataComponents:       dataComponents,
+		NetworkComponents:    networkComponents,
+		StateComponents:      stateComponents,
+		StatusCoreComponents: statusCoreComponents,
+		IsInImportMode:       false,
 	}, processComponents
 }
 
@@ -832,6 +758,26 @@ func GetStateComponents(coreComponents factory.CoreComponentsHolder, shardCoordi
 		return nil
 	}
 	return stateComponents
+}
+
+// GetStatusCoreComponents -
+func GetStatusCoreComponents() factory.StatusCoreComponentsHolder {
+	args := GetStatusCoreArgs()
+	statusCoreFactory := statusCore.NewStatusCoreComponentsFactory(args)
+
+	statusCoreComponents, err := statusCore.NewManagedStatusCoreComponents(statusCoreFactory)
+	if err != nil {
+		log.Error("GetStatusCoreComponents NewManagedStatusCoreComponents", "error", err.Error())
+		return nil
+	}
+
+	err = statusCoreComponents.Create()
+	if err != nil {
+		log.Error("statusCoreComponents Create", "error", err.Error())
+		return nil
+	}
+
+	return statusCoreComponents
 }
 
 // GetProcessComponents -

--- a/testscommon/components/configs.go
+++ b/testscommon/components/configs.go
@@ -9,13 +9,13 @@ func GetGeneralConfig() config.Config {
 	return config.Config{
 		AddressPubkeyConverter: config.PubkeyConfig{
 			Length:          32,
-			Type:            "hex",
+			Type:            "bech32",
 			SignatureLength: 0,
 		},
 		ValidatorPubkeyConverter: config.PubkeyConfig{
 			Length:          96,
 			Type:            "hex",
-			SignatureLength: 0,
+			SignatureLength: 48,
 		},
 		StateTriesConfig: config.StateTriesConfig{
 			CheckpointRoundsModulus:     5,
@@ -142,6 +142,75 @@ func GetGeneralConfig() config.Config {
 				"erd1najnxxweyw6plhg8efql330nttrj6l5cf87wqsuym85s9ha0hmdqnqgenp", //shard 2
 			},
 			MaxNumAddressesInTransferRole: 100,
+		},
+		EpochStartConfig: GetEpochStartConfig(),
+		PublicKeyPeerId: config.CacheConfig{
+			Type:     "LRU",
+			Capacity: 5000,
+			Shards:   16,
+		},
+		PublicKeyShardId: config.CacheConfig{
+			Type:     "LRU",
+			Capacity: 5000,
+			Shards:   16,
+		},
+		PeerIdShardId: config.CacheConfig{
+			Type:     "LRU",
+			Capacity: 5000,
+			Shards:   16,
+		},
+		PeerHonesty: config.CacheConfig{
+			Type:     "LRU",
+			Capacity: 5000,
+			Shards:   16,
+		},
+		GeneralSettings: config.GeneralSettingsConfig{
+			ChainID:                  "undefined",
+			MinTransactionVersion:    1,
+			GenesisMaxNumberOfShards: 3,
+		},
+		Marshalizer: config.MarshalizerConfig{
+			Type:           TestMarshalizer,
+			SizeCheckDelta: 0,
+		},
+		Hasher: config.TypeConfig{
+			Type: TestHasher,
+		},
+		VmMarshalizer: config.TypeConfig{
+			Type: TestMarshalizer,
+		},
+		TxSignMarshalizer: config.TypeConfig{
+			Type: TestMarshalizer,
+		},
+		TxSignHasher: config.TypeConfig{
+			Type: TestHasher,
+		},
+		Consensus: config.ConsensusConfig{
+			Type: "bls",
+		},
+		ValidatorStatistics: config.ValidatorStatisticsConfig{
+			CacheRefreshIntervalInSec: uint32(100),
+		},
+		SoftwareVersionConfig: config.SoftwareVersionConfig{
+			PollingIntervalInMinutes: 30,
+		},
+		Versions: config.VersionsConfig{
+			DefaultVersion:   "1",
+			VersionsByEpochs: nil,
+			Cache: config.CacheConfig{
+				Type:     "LRU",
+				Capacity: 1000,
+				Shards:   1,
+			},
+		},
+		Hardfork: config.HardforkConfig{
+			PublicKeyToListenFrom: DummyPk,
+		},
+		HeartbeatV2: config.HeartbeatV2Config{
+			HeartbeatExpiryTimespanInSec: 10,
+		},
+		ResourceStats: config.ResourceStatsConfig{
+			RefreshIntervalInSec: 1,
 		},
 	}
 }


### PR DESCRIPTION
## Description of the reasoning behind the pull request 
- we needed resource statistics right from the start of the node. Also, network usage was missing from the periodic resource log prints.
  
## Proposed Changes
- refactored resourceMonitor and netStats implementation
- added a new component handler called statusCoreComponents that is initialized first on a node

## Testing procedure
- standard system test, grepping the log files on `node statistics` string. This string should be present on the first few lines of the log and repeated on exactly 30 seconds. We should monitor also the logs after shuffle out, we should not be able to see `node statistics` at intervals less than 30 seconds (that will show a programming error) 
