### PR TITLE
Fix old database cleaner

### DIFF
--- a/storage/clean/oldDatabaseCleaner.go
+++ b/storage/clean/oldDatabaseCleaner.go
@@ -192,10 +192,6 @@ func (odc *oldDatabaseCleaner) cleanOldEpochs(currentEpoch uint32) error {
 		return nil
 	}
 
-	if len(sortedEpochs) == 0 {
-		return nil
-	}
-
 	for idx, epoch := range sortedEpochs {
 		if epoch >= epochToDeleteTo {
 			break

--- a/storage/clean/oldDatabaseCleaner.go
+++ b/storage/clean/oldDatabaseCleaner.go
@@ -101,7 +101,7 @@ func (odc *oldDatabaseCleaner) handleEpochChangeAction(epoch uint32) error {
 	odc.Unlock()
 
 	shouldClean := odc.shouldCleanOldData(epoch, newOldestEpoch)
-	log.Debug("old database cleaner", "epoch", epoch, "should clean", shouldClean, "inner map", odc.oldestEpochsToKeep)
+	log.Debug("old database cleaner", "epoch", epoch, "should clean", shouldClean, "oldest epoch", newOldestEpoch, "inner map", odc.oldestEpochsToKeep)
 	if !shouldClean {
 		return nil
 	}
@@ -192,7 +192,9 @@ func (odc *oldDatabaseCleaner) cleanOldEpochs(currentEpoch uint32) error {
 		return nil
 	}
 
+	wasCleaned := false
 	for idx, epoch := range sortedEpochs {
+		wasCleaned = true
 		if epoch >= epochToDeleteTo {
 			break
 		}
@@ -205,7 +207,10 @@ func (odc *oldDatabaseCleaner) cleanOldEpochs(currentEpoch uint32) error {
 		}
 	}
 
-	odc.cleanMap(currentEpoch)
+	if wasCleaned {
+		// clean the map only if the directories were removed
+		odc.cleanMap(currentEpoch)
+	}
 
 	return nil
 }

--- a/storage/clean/oldDatabaseCleaner.go
+++ b/storage/clean/oldDatabaseCleaner.go
@@ -192,9 +192,11 @@ func (odc *oldDatabaseCleaner) cleanOldEpochs(currentEpoch uint32) error {
 		return nil
 	}
 
-	wasCleaned := false
+	if len(sortedEpochs) == 0 {
+		return nil
+	}
+
 	for idx, epoch := range sortedEpochs {
-		wasCleaned = true
 		if epoch >= epochToDeleteTo {
 			break
 		}
@@ -207,10 +209,7 @@ func (odc *oldDatabaseCleaner) cleanOldEpochs(currentEpoch uint32) error {
 		}
 	}
 
-	if wasCleaned {
-		// clean the map only if the directories were removed
-		odc.cleanMap(currentEpoch)
-	}
+	odc.cleanMap(currentEpoch)
 
 	return nil
 }

--- a/storage/disabled/storer.go
+++ b/storage/disabled/storer.go
@@ -2,6 +2,7 @@ package disabled
 
 import (
 	storageCore "github.com/ElrondNetwork/elrond-go-core/storage"
+	"github.com/ElrondNetwork/elrond-go/storage"
 )
 
 type storer struct{}
@@ -67,7 +68,7 @@ func (s *storer) GetBulkFromEpoch(_ [][]byte, _ uint32) ([]storageCore.KeyValueP
 
 // GetOldestEpoch returns 0
 func (s *storer) GetOldestEpoch() (uint32, error) {
-	return 0, nil
+	return 0, storage.ErrOldestEpochNotAvailable
 }
 
 // RangeKeys does nothing

--- a/storage/disabled/storer_test.go
+++ b/storage/disabled/storer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,7 +47,7 @@ func TestStorer_MethodsDoNotPanic(t *testing.T) {
 
 	uintVal, err := s.GetOldestEpoch()
 	assert.Equal(t, uint32(0), uintVal)
-	assert.Nil(t, err)
+	assert.Equal(t, storage.ErrOldestEpochNotAvailable, err)
 
 	s.ClearCache()
 	s.RangeKeys(nil)


### PR DESCRIPTION
## Reasoning behind the pull request 
- oldDatabaseRemover relied on the fact that all storers return the correct oldest epoch and ones that don't have an epoch approach, they would have returned an error. However, a disabled Storer has been introduced recently and returned `0` as that value, with no error
  
## Proposed Changes
- return `0` for the disabled storer

## Testing procedure
- db cleanup
