### PR TITLE
Integrate warm instances

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ElrondNetwork/elrond-go-p2p v1.0.2
 	github.com/ElrondNetwork/elrond-go-storage v1.0.1
 	github.com/ElrondNetwork/elrond-vm-common v1.3.18
-	github.com/ElrondNetwork/wasm-vm v1.4.59
+	github.com/ElrondNetwork/wasm-vm v1.4.61-0.20221004112404-71feea058430
 	github.com/ElrondNetwork/wasm-vm-v1_2 v1.2.42
 	github.com/ElrondNetwork/wasm-vm-v1_3 v1.3.42
 	github.com/beevik/ntp v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/ElrondNetwork/go-libp2p-pubsub v0.6.1-rc1 h1:Nu/uwYQg/QbfoQ0uD6GahYTw
 github.com/ElrondNetwork/go-libp2p-pubsub v0.6.1-rc1/go.mod h1:pJfaShe+i5aWZx8NhSkQjvOYQYLoqPztmFUlKjToOzM=
 github.com/ElrondNetwork/protobuf v1.3.2 h1:qoCSYiO+8GtXBEZWEjw0WPcZfM3g7QuuJrwpN+y6Mvg=
 github.com/ElrondNetwork/protobuf v1.3.2/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/ElrondNetwork/wasm-vm v1.4.59 h1:7TO0R+kpkCU375Pwtw0jBlkcSoakmGSyh2U6+Aob9L0=
-github.com/ElrondNetwork/wasm-vm v1.4.59/go.mod h1:NopwtkceMs1N5esbLzhMU49487XdEMAqaRnVIlQ72QY=
+github.com/ElrondNetwork/wasm-vm v1.4.61-0.20221004112404-71feea058430 h1:7HajGOWw0lqYttYoLGnLuh0y19kDhiNInG3KuXXkh3M=
+github.com/ElrondNetwork/wasm-vm v1.4.61-0.20221004112404-71feea058430/go.mod h1:NopwtkceMs1N5esbLzhMU49487XdEMAqaRnVIlQ72QY=
 github.com/ElrondNetwork/wasm-vm-v1_2 v1.2.42 h1:szZcuaxPElmLvYRezR4YayPDqRxDMCWspknhtSHJQyo=
 github.com/ElrondNetwork/wasm-vm-v1_2 v1.2.42/go.mod h1:d1Pirw0GnD4Eh5lhBvX9Bn+N1AHb/FzRVKZSHwWwJLg=
 github.com/ElrondNetwork/wasm-vm-v1_3 v1.3.42 h1:EhLjiR/MnWSuLW3xtWh69oBZ4zAsym/QrhGKsVWwJjw=


### PR DESCRIPTION
This PR fully enables warm instances, VM-wide.

**Warm instances** are a lower-level of caching. WASM contracts, once instantiated, are kept in memory for future calls, ready to execute. This saves both compilation _and_ instantiation time.

The speed-up potential is immense: once instantiated, contracts are always executed **natively on the CPU** because they are not WASM anymore.