### PR TITLE
Fix the direct connection processor

### DIFF
--- a/heartbeat/processor/directConnectionsProcessor.go
+++ b/heartbeat/processor/directConnectionsProcessor.go
@@ -163,9 +163,7 @@ func (dcp *directConnectionsProcessor) notifyNewPeers(newPeers []core.PeerID) {
 		errNotCritical := dcp.messenger.SendToConnectedPeer(common.ConnectionTopic, shardValidatorInfoBuff, newPeer)
 		if errNotCritical != nil {
 			log.Trace("directConnectionsProcessor.notifyNewPeers", "pid", newPeer.Pretty(), "error", errNotCritical)
-			continue
 		}
-
 	}
 }
 

--- a/heartbeat/processor/export_test.go
+++ b/heartbeat/processor/export_test.go
@@ -16,9 +16,26 @@ func NewDirectConnectionsProcessorNoGoRoutine(args ArgDirectConnectionsProcessor
 		marshaller:                args.Marshaller,
 		shardCoordinator:          args.ShardCoordinator,
 		delayBetweenNotifications: args.DelayBetweenNotifications,
-		notifiedPeersMap:          make(map[core.PeerID]struct{}),
+		connectedPeersMap:         make(map[core.PeerID]struct{}),
 		nodesCoordinator:          args.NodesCoordinator,
 	}
 
+	err = args.Messenger.AddPeerEventsHandler(dcp)
+	if err != nil {
+		return nil, err
+	}
+
 	return dcp, nil
+}
+
+func (dcp *directConnectionsProcessor) getNewPeers() []core.PeerID {
+	dcp.mutConnectedPeersMap.Lock()
+	defer dcp.mutConnectedPeersMap.Unlock()
+
+	result := make([]core.PeerID, 0, len(dcp.connectedPeersMap))
+	for pid := range dcp.connectedPeersMap {
+		result = append(result, pid)
+	}
+
+	return result
 }

--- a/p2p/errors.go
+++ b/p2p/errors.go
@@ -158,3 +158,6 @@ var ErrNilPeersRatingHandler = errors.New("nil peers rating handler")
 
 // ErrNilCacher signals that a nil cacher has been provided
 var ErrNilCacher = errors.New("nil cacher")
+
+// ErrNilPeerEventsHandler signals that a nil peer events handler was provided
+var ErrNilPeerEventsHandler = errors.New("nil peer events handler")

--- a/p2p/libp2p/discovery/hostWithConnectionManagement.go
+++ b/p2p/libp2p/discovery/hostWithConnectionManagement.go
@@ -49,7 +49,7 @@ func NewHostWithConnectionManagement(args ArgsHostWithConnectionManagement) (*ho
 // Connect tries to connect to the provided address info if the sharder allows it
 func (hwcm *hostWithConnectionManagement) Connect(ctx context.Context, pi peer.AddrInfo) error {
 	addresses := concatenateAddresses(pi.Addrs)
-	hwcm.connectionsWatcher.NewKnownConnection(core.PeerID(pi.ID), addresses)
+	hwcm.connectionsWatcher.Connected(core.PeerID(pi.ID), addresses)
 	err := hwcm.canConnectToPeer(pi.ID)
 	if err != nil {
 		return err

--- a/p2p/libp2p/discovery/hostWithConnectionManagement_test.go
+++ b/p2p/libp2p/discovery/hostWithConnectionManagement_test.go
@@ -98,10 +98,10 @@ func TestHostWithConnectionManagement_ConnectWithSharderNotEvictedShouldCallConn
 			return false
 		},
 	}
-	newKnownConnectionCalled := false
+	connectedCalled := false
 	args.ConnectionsWatcher = &mock.ConnectionsWatcherStub{
-		NewKnownConnectionCalled: func(pid core.PeerID, connection string) {
-			newKnownConnectionCalled = true
+		ConnectedCalled: func(pid core.PeerID, connection string) {
+			connectedCalled = true
 		},
 	}
 	hwcm, _ := discovery.NewHostWithConnectionManagement(args)
@@ -109,7 +109,7 @@ func TestHostWithConnectionManagement_ConnectWithSharderNotEvictedShouldCallConn
 	_ = hwcm.Connect(context.Background(), peer.AddrInfo{})
 
 	assert.True(t, connectCalled)
-	assert.True(t, newKnownConnectionCalled)
+	assert.True(t, connectedCalled)
 }
 
 func TestHostWithConnectionManagement_ConnectWithSharderEvictedShouldNotCallConnect(t *testing.T) {
@@ -134,10 +134,10 @@ func TestHostWithConnectionManagement_ConnectWithSharderEvictedShouldNotCallConn
 			return true
 		},
 	}
-	newKnownConnectionCalled := false
+	connectedCalled := false
 	args.ConnectionsWatcher = &mock.ConnectionsWatcherStub{
-		NewKnownConnectionCalled: func(pid core.PeerID, connection string) {
-			newKnownConnectionCalled = true
+		ConnectedCalled: func(pid core.PeerID, connection string) {
+			connectedCalled = true
 		},
 	}
 	hwcm, _ := discovery.NewHostWithConnectionManagement(args)
@@ -145,5 +145,5 @@ func TestHostWithConnectionManagement_ConnectWithSharderEvictedShouldNotCallConn
 	_ = hwcm.Connect(context.Background(), peer.AddrInfo{})
 
 	assert.False(t, connectCalled)
-	assert.True(t, newKnownConnectionCalled)
+	assert.True(t, connectedCalled)
 }

--- a/p2p/libp2p/metrics/disabledConnectionsWatcher.go
+++ b/p2p/libp2p/metrics/disabledConnectionsWatcher.go
@@ -9,8 +9,11 @@ func NewDisabledConnectionsWatcher() *disabledConnectionsWatcher {
 	return &disabledConnectionsWatcher{}
 }
 
-// NewKnownConnection does nothing
-func (dcw *disabledConnectionsWatcher) NewKnownConnection(_ core.PeerID, _ string) {}
+// Connected does nothing
+func (dcw *disabledConnectionsWatcher) Connected(_ core.PeerID, _ string) {}
+
+// Disconnected does nothing
+func (dcw *disabledConnectionsWatcher) Disconnected(_ core.PeerID) {}
 
 // Close does nothing and returns nil
 func (dcw *disabledConnectionsWatcher) Close() error {

--- a/p2p/libp2p/metrics/disabledConnectionsWatcher_test.go
+++ b/p2p/libp2p/metrics/disabledConnectionsWatcher_test.go
@@ -20,7 +20,8 @@ func TestDisabledConnectionsWatcher_MethodsShouldNotPanic(t *testing.T) {
 
 	dcw := NewDisabledConnectionsWatcher()
 	assert.False(t, check.IfNil(dcw))
-	dcw.NewKnownConnection("", "")
+	dcw.Connected("", "")
+	dcw.Disconnected("")
 	err := dcw.Close()
 	assert.Nil(t, err)
 }

--- a/p2p/libp2p/metrics/printConnectionWatcher_test.go
+++ b/p2p/libp2p/metrics/printConnectionWatcher_test.go
@@ -59,7 +59,7 @@ func TestPrintConnectionsWatcher_Close(t *testing.T) {
 
 }
 
-func TestPrintConnectionsWatcher_NewKnownConnection(t *testing.T) {
+func TestPrintConnectionsWatcher_Connected(t *testing.T) {
 	t.Parallel()
 
 	t.Run("invalid connection", func(t *testing.T) {
@@ -72,7 +72,7 @@ func TestPrintConnectionsWatcher_NewKnownConnection(t *testing.T) {
 		}
 		pcw, _ := NewPrintConnectionsWatcherWithHandler(time.Hour, handler)
 
-		pcw.NewKnownConnection(providedPid, connection)
+		pcw.Connected(providedPid, connection)
 		assert.Equal(t, 0, numCalled)
 	})
 	t.Run("valid connection", func(t *testing.T) {
@@ -87,11 +87,27 @@ func TestPrintConnectionsWatcher_NewKnownConnection(t *testing.T) {
 		}
 		pcw, _ := NewPrintConnectionsWatcherWithHandler(time.Hour, handler)
 
-		pcw.NewKnownConnection(providedPid, connection)
+		pcw.Connected(providedPid, connection)
 		assert.Equal(t, 1, numCalled)
-		pcw.NewKnownConnection(providedPid, connection)
+		pcw.Connected(providedPid, connection)
 		assert.Equal(t, 1, numCalled)
 	})
+}
+
+func TestPrintConnectionsWatcher_DisconnectedShouldNotPanic(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		r := recover()
+		if r != nil {
+			assert.Fail(t, fmt.Sprintf("should have not panic: %v", r))
+		}
+	}()
+
+	pcw, _ := NewPrintConnectionsWatcher(time.Second)
+	pcw.Disconnected("")
+
+	_ = pcw.Close()
 }
 
 func TestLogPrintHandler_shouldNotPanic(t *testing.T) {

--- a/p2p/libp2p/metrics/printConnectionsWatcher.go
+++ b/p2p/libp2p/metrics/printConnectionsWatcher.go
@@ -65,8 +65,8 @@ func (pcw *printConnectionsWatcher) doSweep(ctx context.Context) {
 	}
 }
 
-// NewKnownConnection will add the known connection to the cache, printing it as necessary
-func (pcw *printConnectionsWatcher) NewKnownConnection(pid core.PeerID, connection string) {
+// Connected will add the known connection to the cache, printing it as necessary
+func (pcw *printConnectionsWatcher) Connected(pid core.PeerID, connection string) {
 	conn := strings.Trim(connection, " ")
 	if len(conn) == 0 {
 		return
@@ -83,6 +83,10 @@ func (pcw *printConnectionsWatcher) NewKnownConnection(pid core.PeerID, connecti
 	}
 
 	pcw.printHandler(pid, conn)
+}
+
+// Disconnected does nothing
+func (pcw *printConnectionsWatcher) Disconnected(_ core.PeerID) {
 }
 
 // Close will close any go routines opened by this instance

--- a/p2p/libp2p/mockMessenger.go
+++ b/p2p/libp2p/mockMessenger.go
@@ -36,6 +36,12 @@ func NewMockMessenger(
 		return nil, err
 	}
 
+	p2pNode.peerEventsDriver = NewPeerEventsDriver()
+	err = p2pNode.peerEventsDriver.AddHandler(p2pNode.printConnectionsWatcher)
+	if err != nil {
+		return nil, err
+	}
+
 	err = addComponentsToNode(args, p2pNode, withoutMessageSigning)
 	if err != nil {
 		return nil, err

--- a/p2p/libp2p/peerEventsDriver.go
+++ b/p2p/libp2p/peerEventsDriver.go
@@ -1,0 +1,59 @@
+package libp2p
+
+import (
+	"sync"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go/p2p"
+)
+
+type peerEventsDriver struct {
+	mutHandlers sync.RWMutex
+	handlers    []p2p.PeerEventsHandler
+}
+
+// NewPeerEventsDriver will create a new peer events driver
+func NewPeerEventsDriver() *peerEventsDriver {
+	return &peerEventsDriver{
+		handlers: make([]p2p.PeerEventsHandler, 0),
+	}
+}
+
+// AddHandler will add a new handler to the internal list
+func (driver *peerEventsDriver) AddHandler(handler p2p.PeerEventsHandler) error {
+	if check.IfNil(handler) {
+		return p2p.ErrNilPeerEventsHandler
+	}
+
+	driver.mutHandlers.Lock()
+	driver.handlers = append(driver.handlers, handler)
+	driver.mutHandlers.Unlock()
+
+	return nil
+}
+
+// Connected calls the Connected methods on all registered handlers
+func (driver *peerEventsDriver) Connected(pid core.PeerID, connection string) {
+	driver.mutHandlers.RLock()
+	defer driver.mutHandlers.RUnlock()
+
+	for _, h := range driver.handlers {
+		h.Connected(pid, connection)
+	}
+}
+
+// Disconnected calls the Disconnected methods on all registered handlers
+func (driver *peerEventsDriver) Disconnected(pid core.PeerID) {
+	driver.mutHandlers.RLock()
+	defer driver.mutHandlers.RUnlock()
+
+	for _, h := range driver.handlers {
+		h.Disconnected(pid)
+	}
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (driver *peerEventsDriver) IsInterfaceNil() bool {
+	return driver == nil
+}

--- a/p2p/libp2p/peerEventsDriver_test.go
+++ b/p2p/libp2p/peerEventsDriver_test.go
@@ -1,0 +1,143 @@
+package libp2p_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go/p2p"
+	"github.com/ElrondNetwork/elrond-go/p2p/libp2p"
+	"github.com/ElrondNetwork/elrond-go/p2p/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPeerEventsDriver(t *testing.T) {
+	t.Parallel()
+
+	driver := libp2p.NewPeerEventsDriver()
+	assert.False(t, check.IfNil(driver))
+}
+
+func TestPeerEventsDriver_AddHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil handler should error", func(t *testing.T) {
+		driver := libp2p.NewPeerEventsDriver()
+
+		err := driver.AddHandler(nil)
+		assert.Equal(t, p2p.ErrNilPeerEventsHandler, err)
+	})
+	t.Run("should work", func(t *testing.T) {
+		driver := libp2p.NewPeerEventsDriver()
+		handler := &mock.PeerEventsHandlerStub{}
+
+		err := driver.AddHandler(handler)
+		assert.Nil(t, err)
+
+		assert.Equal(t, 1, len(driver.GetHandlers()))
+		assert.True(t, driver.GetHandlers()[0] == handler) // pointer testing
+
+		t.Run("second element added should be second in the list", func(t *testing.T) {
+			handler2 := &mock.PeerEventsHandlerStub{}
+
+			err = driver.AddHandler(handler2)
+			assert.Nil(t, err)
+
+			assert.Equal(t, 2, len(driver.GetHandlers()))
+			assert.True(t, driver.GetHandlers()[0] == handler)  // pointer testing
+			assert.True(t, driver.GetHandlers()[1] == handler2) // pointer testing
+		})
+	})
+}
+
+func TestConnectionMonitorWrapper_Connected(t *testing.T) {
+	t.Parallel()
+
+	testPid := core.PeerID("pid")
+	testConnection := "connection"
+	t.Run("no handler added should not panic", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			if r != nil {
+				assert.Fail(t, fmt.Sprintf("should have not panicked %v", r))
+			}
+		}()
+
+		driver := libp2p.NewPeerEventsDriver()
+		driver.Connected(testPid, testConnection)
+	})
+	t.Run("2 handlers should work", func(t *testing.T) {
+		driver := libp2p.NewPeerEventsDriver()
+
+		handler1Called := false
+		handler1 := &mock.PeerEventsHandlerStub{
+			ConnectedCalled: func(pid core.PeerID, connection string) {
+				assert.Equal(t, testPid, pid)
+				assert.Equal(t, testConnection, connection)
+				handler1Called = true
+			},
+		}
+
+		handler2Called := false
+		handler2 := &mock.PeerEventsHandlerStub{
+			ConnectedCalled: func(pid core.PeerID, connection string) {
+				assert.Equal(t, testPid, pid)
+				assert.Equal(t, testConnection, connection)
+				handler2Called = true
+			},
+		}
+
+		_ = driver.AddHandler(handler1)
+		_ = driver.AddHandler(handler2)
+
+		driver.Connected(testPid, testConnection)
+
+		assert.True(t, handler1Called)
+		assert.True(t, handler2Called)
+	})
+}
+
+func TestConnectionMonitorWrapper_Disconnected(t *testing.T) {
+	t.Parallel()
+
+	testPid := core.PeerID("pid")
+	t.Run("no handler added should not panic", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			if r != nil {
+				assert.Fail(t, fmt.Sprintf("should have not panicked %v", r))
+			}
+		}()
+
+		driver := libp2p.NewPeerEventsDriver()
+		driver.Disconnected(testPid)
+	})
+	t.Run("2 handlers should work", func(t *testing.T) {
+		driver := libp2p.NewPeerEventsDriver()
+
+		handler1Called := false
+		handler1 := &mock.PeerEventsHandlerStub{
+			DisconnectedCalled: func(pid core.PeerID) {
+				assert.Equal(t, testPid, pid)
+				handler1Called = true
+			},
+		}
+
+		handler2Called := false
+		handler2 := &mock.PeerEventsHandlerStub{
+			DisconnectedCalled: func(pid core.PeerID) {
+				assert.Equal(t, testPid, pid)
+				handler2Called = true
+			},
+		}
+
+		_ = driver.AddHandler(handler1)
+		_ = driver.AddHandler(handler2)
+
+		driver.Disconnected(testPid)
+
+		assert.True(t, handler1Called)
+		assert.True(t, handler2Called)
+	})
+}

--- a/p2p/mock/connectionsWatcherStub.go
+++ b/p2p/mock/connectionsWatcherStub.go
@@ -4,14 +4,22 @@ import "github.com/ElrondNetwork/elrond-go-core/core"
 
 // ConnectionsWatcherStub -
 type ConnectionsWatcherStub struct {
-	NewKnownConnectionCalled func(pid core.PeerID, connection string)
-	CloseCalled              func() error
+	ConnectedCalled    func(pid core.PeerID, connection string)
+	DisconnectedCalled func(pid core.PeerID)
+	CloseCalled        func() error
 }
 
-// NewKnownConnection -
-func (stub *ConnectionsWatcherStub) NewKnownConnection(pid core.PeerID, connection string) {
-	if stub.NewKnownConnectionCalled != nil {
-		stub.NewKnownConnectionCalled(pid, connection)
+// Connected -
+func (stub *ConnectionsWatcherStub) Connected(pid core.PeerID, connection string) {
+	if stub.ConnectedCalled != nil {
+		stub.ConnectedCalled(pid, connection)
+	}
+}
+
+// Disconnected -
+func (stub *ConnectionsWatcherStub) Disconnected(pid core.PeerID) {
+	if stub.DisconnectedCalled != nil {
+		stub.DisconnectedCalled(pid)
 	}
 }
 

--- a/p2p/mock/peerEventsHandlerStub.go
+++ b/p2p/mock/peerEventsHandlerStub.go
@@ -1,0 +1,28 @@
+package mock
+
+import "github.com/ElrondNetwork/elrond-go-core/core"
+
+// PeerEventsHandlerStub -
+type PeerEventsHandlerStub struct {
+	ConnectedCalled    func(pid core.PeerID, connection string)
+	DisconnectedCalled func(pid core.PeerID)
+}
+
+// Connected -
+func (stub *PeerEventsHandlerStub) Connected(pid core.PeerID, connection string) {
+	if stub.ConnectedCalled != nil {
+		stub.ConnectedCalled(pid, connection)
+	}
+}
+
+// Disconnected -
+func (stub *PeerEventsHandlerStub) Disconnected(pid core.PeerID) {
+	if stub.DisconnectedCalled != nil {
+		stub.DisconnectedCalled(pid)
+	}
+}
+
+// IsInterfaceNil -
+func (stub *PeerEventsHandlerStub) IsInterfaceNil() bool {
+	return stub == nil
+}

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -38,6 +38,13 @@ const (
 	ConnectionWatcherTypeEmpty = ""
 )
 
+// PeerEventsHandler is able to handle peer events such as connection and/or disconnection
+type PeerEventsHandler interface {
+	Connected(pid core.PeerID, connection string)
+	Disconnected(pid core.PeerID)
+	IsInterfaceNil() bool
+}
+
 // MessageProcessor is the interface used to describe what a receive message processor should do
 // All implementations that will be called from Messenger implementation will need to satisfy this interface
 // If the function returns a non nil value, the received message will not be propagated to its connected peers
@@ -165,6 +172,7 @@ type Messenger interface {
 	WaitForConnections(maxWaitingTime time.Duration, minNumOfPeers uint32)
 	Sign(payload []byte) ([]byte, error)
 	Verify(payload []byte, pid core.PeerID, signature []byte) error
+	AddPeerEventsHandler(handler PeerEventsHandler) error
 
 	// IsInterfaceNil returns true if there is no value under the interface
 	IsInterfaceNil() bool
@@ -339,9 +347,8 @@ type SyncTimer interface {
 
 // ConnectionsWatcher represent an entity able to watch new connections
 type ConnectionsWatcher interface {
-	NewKnownConnection(pid core.PeerID, connection string)
+	PeerEventsHandler
 	Close() error
-	IsInterfaceNil() bool
 }
 
 // PeersRatingHandler represent an entity able to handle peers ratings

--- a/testscommon/p2pmocks/messengerStub.go
+++ b/testscommon/p2pmocks/messengerStub.go
@@ -42,6 +42,7 @@ type MessengerStub struct {
 	WaitForConnectionsCalled               func(maxWaitingTime time.Duration, minNumOfPeers uint32)
 	SignCalled                             func(payload []byte) ([]byte, error)
 	VerifyCalled                           func(payload []byte, pid core.PeerID, signature []byte) error
+	AddPeerEventsHandlerCalled             func(handler p2p.PeerEventsHandler) error
 }
 
 // ConnectedFullHistoryPeersOnTopic -
@@ -330,6 +331,15 @@ func (ms *MessengerStub) Sign(payload []byte) ([]byte, error) {
 func (ms *MessengerStub) Verify(payload []byte, pid core.PeerID, signature []byte) error {
 	if ms.VerifyCalled != nil {
 		return ms.VerifyCalled(payload, pid, signature)
+	}
+
+	return nil
+}
+
+// AddPeerEventsHandler -
+func (ms *MessengerStub) AddPeerEventsHandler(handler p2p.PeerEventsHandler) error {
+	if ms.AddPeerEventsHandlerCalled != nil {
+		return ms.AddPeerEventsHandlerCalled(handler)
 	}
 
 	return nil


### PR DESCRIPTION
## Description of the reasoning behind the pull request
- There is an edge case on the p2p connections handling that affects new nodes come to the network. Due to fast connection/disconnection/re-connection patterns, the nodes are unable to reliably send the direct message to provide the current operating shard. This behavior only happens to cross shard connections. For intra shard connections, the heartbeat v2 topic ensures that all nodes from the same shards are known. This will make the connected peers to "think" that they are unknown and treat them accordingly. Since now there are more unknown peers as usual, the newly joined peers (the ones that will normally try to sync the start of epoch metablock & do the trie sync) are unfavored and thus, have less p2p connections. This affects the syncing time & speed.
  
## Proposed Changes
- refactored the directConnectionsProcessor to better "know" about what peer just connected to self and effectively eliminate any edge-case that can appear between the current processor state and the state of the p2p network messenger
- added new peer events handling on network messenger
- refactored the connection watcher in order to better reuse the existing code

## Testing procedure
- standard system test
- large scale test involving hundreds/thousands nodes
