### PR TITLE
fix logs for old db cleaner

### DIFF
--- a/storage/clean/oldDatabaseCleaner.go
+++ b/storage/clean/oldDatabaseCleaner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
+	storageErrors "github.com/ElrondNetwork/elrond-go-storage/common"
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/epochStart/notifier"
 	"github.com/ElrondNetwork/elrond-go/storage"
@@ -166,7 +167,7 @@ func (odc *oldDatabaseCleaner) computeOldestEpochToKeep() (uint32, error) {
 }
 
 func logOldestEpochCompute(err error) {
-	if err != storage.ErrOldestEpochNotAvailable {
+	if err != storageErrors.ErrOldestEpochNotAvailable {
 		log.Debug("cannot compute oldest epoch for storer", "error", err)
 	}
 }

--- a/storage/disabled/storer.go
+++ b/storage/disabled/storer.go
@@ -2,7 +2,7 @@ package disabled
 
 import (
 	storageCore "github.com/ElrondNetwork/elrond-go-core/storage"
-	"github.com/ElrondNetwork/elrond-go/storage"
+	"github.com/ElrondNetwork/elrond-go-storage/common"
 )
 
 type storer struct{}
@@ -68,7 +68,7 @@ func (s *storer) GetBulkFromEpoch(_ [][]byte, _ uint32) ([]storageCore.KeyValueP
 
 // GetOldestEpoch returns 0
 func (s *storer) GetOldestEpoch() (uint32, error) {
-	return 0, storage.ErrOldestEpochNotAvailable
+	return 0, common.ErrOldestEpochNotAvailable
 }
 
 // RangeKeys does nothing

--- a/storage/disabled/storer_test.go
+++ b/storage/disabled/storer_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
-	"github.com/ElrondNetwork/elrond-go/storage"
+	"github.com/ElrondNetwork/elrond-go-storage/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,7 +47,7 @@ func TestStorer_MethodsDoNotPanic(t *testing.T) {
 
 	uintVal, err := s.GetOldestEpoch()
 	assert.Equal(t, uint32(0), uintVal)
-	assert.Equal(t, storage.ErrOldestEpochNotAvailable, err)
+	assert.Equal(t, common.ErrOldestEpochNotAvailable, err)
 
 	s.ClearCache()
 	s.RangeKeys(nil)

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -37,9 +37,6 @@ var ErrNilCustomDatabaseRemover = errors.New("custom database remover")
 // ErrNilStorageListProvider signals that a nil storage list provided has been provided
 var ErrNilStorageListProvider = errors.New("nil storage list provider")
 
-// ErrOldestEpochNotAvailable signals that fetching the oldest epoch is not available
-var ErrOldestEpochNotAvailable = errors.New("oldest epoch not available")
-
 // ErrInvalidNumberOfEpochsToSave signals that an invalid number of epochs to save has been provided
 var ErrInvalidNumberOfEpochsToSave = errors.New("invalid number of epochs to save")
 
@@ -84,9 +81,6 @@ var ErrNotSupportedDBType = storageErrors.ErrNotSupportedDBType
 
 // ErrNotSupportedCacheType is raised when an unsupported cache type is provided
 var ErrNotSupportedCacheType = storageErrors.ErrNotSupportedCacheType
-
-// ErrInvalidCacheExpiry signals that an invalid cache expiry was provided
-var ErrInvalidCacheExpiry = storageErrors.ErrInvalidCacheExpiry
 
 // ErrDBIsClosed is raised when the DB is closed
 var ErrDBIsClosed = storageErrors.ErrDBIsClosed


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- due to the migration of the storage into a separate repository, the `ErrOldestEpochNotAvailable` was present in 2 places, resulting in wrong log printing because on some sides the elrond-go err was used, but on other sides the storage repo err was used
- this didn't affect the functionality, since the only use-case of the error is to print or not the error (since there are storers that don't have the concept of epochs, it is ok that they cannot return the oldest epoch)
  
## Proposed Changes
- use the storage repo variable everywhere and remove the elrond-go one

## Testing procedure
- start a testnet using this branch. after some epochs, on epoch change event, logs like this should not be seen anymore: 
```
DEBUG[2022-10-09 00:12:50.366]   cannot compute oldest epoch for storer   error = oldest epoch not available 
```
