### PR TITLE
added separate cli flag for db and logs path

### DIFF
--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -249,6 +249,18 @@ var (
 		Usage: "This flag specifies the `directory` where the node will store databases, logs and statistics.",
 		Value: "",
 	}
+	// dbDirectory defines a flag for the path for the db directory.
+	dbDirectory = cli.StringFlag{
+		Name:  "db-path",
+		Usage: "This flag specifies the `directory` where the node will store databases and statistics.",
+		Value: "",
+	}
+	// logsDirectory defines a flag for the path for the logs directory.
+	logsDirectory = cli.StringFlag{
+		Name:  "logs-path",
+		Usage: "This flag specifies the `directory` where the node will store logs.",
+		Value: "",
+	}
 
 	// destinationShardAsObserver defines a flag for the prefered shard to be assigned to as an observer.
 	destinationShardAsObserver = cli.StringFlag{
@@ -405,6 +417,8 @@ func getFlags() []cli.Flag {
 		serializeSnapshots,
 		noKey,
 		p2pKeyPemFile,
+		dbDirectory,
+		logsDirectory,
 	}
 }
 
@@ -413,6 +427,8 @@ func getFlagsConfig(ctx *cli.Context, log logger.Logger) *config.ContextFlagsCon
 
 	workingDir := ctx.GlobalString(workingDirectory.Name)
 	flagsConfig.WorkingDir = getWorkingDir(workingDir, log)
+	flagsConfig.DbDir = getWorkingDir(ctx.GlobalString(dbDirectory.Name), log)
+	flagsConfig.LogsDir = getWorkingDir(ctx.GlobalString(logsDirectory.Name), log)
 	flagsConfig.EnableGops = ctx.GlobalBool(gopsEn.Name)
 	flagsConfig.SaveLogFile = ctx.GlobalBool(logSaveFile.Name)
 	flagsConfig.EnableLogCorrelation = ctx.GlobalBool(logWithCorrelation.Name)

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -247,7 +247,7 @@ func attachFileLogger(log logger.Logger, flagsConfig *config.ContextFlagsConfig)
 	var err error
 	if flagsConfig.SaveLogFile {
 		args := logging.ArgsFileLogging{
-			WorkingDir:      flagsConfig.WorkingDir,
+			WorkingDir:      flagsConfig.LogsDir,
 			DefaultLogsPath: defaultLogsPath,
 			LogFilePrefix:   logFilePrefix,
 		}

--- a/config/contextFlagsConfig.go
+++ b/config/contextFlagsConfig.go
@@ -3,6 +3,8 @@ package config
 // ContextFlagsConfig will keep the values for the cli.Context flags
 type ContextFlagsConfig struct {
 	WorkingDir                   string
+	DbDir                        string
+	LogsDir                      string
 	EnableGops                   bool
 	SaveLogFile                  bool
 	EnableLogCorrelation         bool

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -110,7 +110,7 @@ func (nr *nodeRunner) Start() error {
 
 	log.Info("starting node", "version", flagsConfig.Version, "pid", os.Getpid())
 
-	err = cleanupStorageIfNecessary(flagsConfig.WorkingDir, flagsConfig.CleanupStorage)
+	err = cleanupStorageIfNecessary(flagsConfig.DbDir, flagsConfig.CleanupStorage)
 	if err != nil {
 		return err
 	}
@@ -1145,7 +1145,7 @@ func (nr *nodeRunner) CreateManagedProcessComponents(
 ) (mainFactory.ProcessComponentsHandler, error) {
 	configs := nr.configs
 	configurationPaths := nr.configs.ConfigurationPathsHolder
-	importStartHandler, err := trigger.NewImportStartHandler(filepath.Join(configs.FlagsConfig.WorkingDir, common.DefaultDBPath), configs.FlagsConfig.Version)
+	importStartHandler, err := trigger.NewImportStartHandler(filepath.Join(configs.FlagsConfig.DbDir, common.DefaultDBPath), configs.FlagsConfig.Version)
 	if err != nil {
 		return nil, err
 	}
@@ -1362,7 +1362,7 @@ func (nr *nodeRunner) CreateManagedBootstrapComponents(
 		PrefConfig:        *nr.configs.PreferencesConfig,
 		ImportDbConfig:    *nr.configs.ImportDbConfig,
 		FlagsConfig:       *nr.configs.FlagsConfig,
-		WorkingDir:        nr.configs.FlagsConfig.WorkingDir,
+		WorkingDir:        nr.configs.FlagsConfig.DbDir,
 		CoreComponents:    coreComponents,
 		CryptoComponents:  cryptoComponents,
 		NetworkComponents: networkComponents,
@@ -1444,7 +1444,7 @@ func (nr *nodeRunner) CreateManagedCoreComponents(
 		RatingsConfig:         *nr.configs.RatingsConfig,
 		EconomicsConfig:       *nr.configs.EconomicsConfig,
 		NodesFilename:         nr.configs.ConfigurationPathsHolder.Nodes,
-		WorkingDirectory:      nr.configs.FlagsConfig.WorkingDir,
+		WorkingDirectory:      nr.configs.FlagsConfig.DbDir,
 		ChanStopNodeProcess:   chanStopNodeProcess,
 		StatusHandlersFactory: statusHandlersFactory,
 	}


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- It will be useful to have a separate dir path for logs and db
  
## Proposed Changes
- added separate cli flags for logs and db paths

## Testing procedure
- Standard system test
- Default cli values should work as before, it should be backwards compatible
- Check booting from storage with custom db path
