### PR TITLE
Fix empty trie root hash

### DIFF
--- a/common/trie.go
+++ b/common/trie.go
@@ -1,0 +1,17 @@
+package common
+
+import "bytes"
+
+// EmptyTrieHash returns the value with empty trie hash
+var EmptyTrieHash = make([]byte, 32)
+
+// IsEmptyTrie returns true if the given root is for an empty trie
+func IsEmptyTrie(root []byte) bool {
+	if len(root) == 0 {
+		return true
+	}
+	if bytes.Equal(root, EmptyTrieHash) {
+		return true
+	}
+	return false
+}

--- a/common/trie_test.go
+++ b/common/trie_test.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsEmptyTrie(t *testing.T) {
+	t.Parallel()
+
+	t.Run("test nil root", func(t *testing.T) {
+		t.Parallel()
+
+		assert.True(t, IsEmptyTrie(nil))
+	})
+	t.Run("test empty root", func(t *testing.T) {
+		t.Parallel()
+
+		assert.True(t, IsEmptyTrie([]byte{}))
+	})
+	t.Run("test empty root hash", func(t *testing.T) {
+		t.Parallel()
+
+		assert.True(t, IsEmptyTrie(EmptyTrieHash))
+	})
+}

--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -1401,7 +1401,7 @@ func (adb *AccountsDB) GetStatsForRootHash(rootHash []byte) (common.TriesStatist
 			continue
 		}
 
-		if len(account.RootHash) == 0 {
+		if common.IsEmptyTrie(account.RootHash) {
 			continue
 		}
 

--- a/trie/depthFirstSync.go
+++ b/trie/depthFirstSync.go
@@ -69,7 +69,7 @@ func NewDepthFirstTrieSyncer(arg ArgTrieSyncer) (*depthFirstTrieSyncer, error) {
 // so this function is treated as a large critical section. This was done so the inner processing can be done without using
 // other mutexes.
 func (d *depthFirstTrieSyncer) StartSyncing(rootHash []byte, ctx context.Context) error {
-	if len(rootHash) == 0 || bytes.Equal(rootHash, EmptyTrieHash) {
+	if len(rootHash) == 0 || bytes.Equal(rootHash, common.EmptyTrieHash) {
 		return nil
 	}
 	if ctx == nil {

--- a/trie/depthFirstSync.go
+++ b/trie/depthFirstSync.go
@@ -1,7 +1,6 @@
 package trie
 
 import (
-	"bytes"
 	"context"
 	"sync"
 	"time"
@@ -69,7 +68,7 @@ func NewDepthFirstTrieSyncer(arg ArgTrieSyncer) (*depthFirstTrieSyncer, error) {
 // so this function is treated as a large critical section. This was done so the inner processing can be done without using
 // other mutexes.
 func (d *depthFirstTrieSyncer) StartSyncing(rootHash []byte, ctx context.Context) error {
-	if len(rootHash) == 0 || bytes.Equal(rootHash, common.EmptyTrieHash) {
+	if common.IsEmptyTrie(rootHash) {
 		return nil
 	}
 	if ctx == nil {

--- a/trie/depthFirstSync_test.go
+++ b/trie/depthFirstSync_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/errors"
 	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/stretchr/testify/assert"
@@ -49,7 +50,7 @@ func TestDepthFirstTrieSyncer_StartSyncingEmptyRootHashShouldReturnNil(t *testin
 
 	arg := createMockArgument(time.Minute)
 	d, _ := NewDepthFirstTrieSyncer(arg)
-	err := d.StartSyncing(EmptyTrieHash, context.Background())
+	err := d.StartSyncing(common.EmptyTrieHash, context.Background())
 
 	assert.Nil(t, err)
 }
@@ -59,7 +60,7 @@ func TestDepthFirstTrieSyncer_StartSyncingNilContextShouldErr(t *testing.T) {
 
 	arg := createMockArgument(time.Minute)
 	d, _ := NewDepthFirstTrieSyncer(arg)
-	err := d.StartSyncing(bytes.Repeat([]byte{1}, len(EmptyTrieHash)), nil)
+	err := d.StartSyncing(bytes.Repeat([]byte{1}, len(common.EmptyTrieHash)), nil)
 
 	assert.Equal(t, ErrNilContext, err)
 }

--- a/trie/doubleListSync.go
+++ b/trie/doubleListSync.go
@@ -1,7 +1,6 @@
 package trie
 
 import (
-	"bytes"
 	"context"
 	"sync"
 	"time"
@@ -84,7 +83,7 @@ func NewDoubleListTrieSyncer(arg ArgTrieSyncer) (*doubleListTrieSyncer, error) {
 // so this function is treated as a large critical section. This was done so the inner processing can be done without using
 // other mutexes.
 func (d *doubleListTrieSyncer) StartSyncing(rootHash []byte, ctx context.Context) error {
-	if len(rootHash) == 0 || bytes.Equal(rootHash, common.EmptyTrieHash) {
+	if common.IsEmptyTrie(rootHash) {
 		return nil
 	}
 	if ctx == nil {

--- a/trie/doubleListSync.go
+++ b/trie/doubleListSync.go
@@ -84,7 +84,7 @@ func NewDoubleListTrieSyncer(arg ArgTrieSyncer) (*doubleListTrieSyncer, error) {
 // so this function is treated as a large critical section. This was done so the inner processing can be done without using
 // other mutexes.
 func (d *doubleListTrieSyncer) StartSyncing(rootHash []byte, ctx context.Context) error {
-	if len(rootHash) == 0 || bytes.Equal(rootHash, EmptyTrieHash) {
+	if len(rootHash) == 0 || bytes.Equal(rootHash, common.EmptyTrieHash) {
 		return nil
 	}
 	if ctx == nil {

--- a/trie/doubleListSync_test.go
+++ b/trie/doubleListSync_test.go
@@ -155,7 +155,7 @@ func TestDoubleListTrieSyncer_StartSyncingEmptyRootHashShouldReturnNil(t *testin
 
 	arg := createMockArgument(time.Minute)
 	d, _ := NewDoubleListTrieSyncer(arg)
-	err := d.StartSyncing(EmptyTrieHash, context.Background())
+	err := d.StartSyncing(common.EmptyTrieHash, context.Background())
 
 	assert.Nil(t, err)
 }
@@ -165,7 +165,7 @@ func TestDoubleListTrieSyncer_StartSyncingNilContextShouldErr(t *testing.T) {
 
 	arg := createMockArgument(time.Minute)
 	d, _ := NewDoubleListTrieSyncer(arg)
-	err := d.StartSyncing(bytes.Repeat([]byte{1}, len(EmptyTrieHash)), nil)
+	err := d.StartSyncing(bytes.Repeat([]byte{1}, len(common.EmptyTrieHash)), nil)
 
 	assert.Equal(t, ErrNilContext, err)
 }

--- a/trie/patriciaMerkleTrie.go
+++ b/trie/patriciaMerkleTrie.go
@@ -29,9 +29,6 @@ const (
 
 const rootDepthLevel = 0
 
-// EmptyTrieHash returns the value with empty trie hash
-var EmptyTrieHash = make([]byte, 32)
-
 type patriciaMerkleTrie struct {
 	root node
 
@@ -199,7 +196,7 @@ func (tr *patriciaMerkleTrie) RootHash() ([]byte, error) {
 
 func (tr *patriciaMerkleTrie) getRootHash() ([]byte, error) {
 	if tr.root == nil {
-		return EmptyTrieHash, nil
+		return common.EmptyTrieHash, nil
 	}
 
 	hash := tr.root.getHash()
@@ -274,7 +271,7 @@ func (tr *patriciaMerkleTrie) RecreateFromEpoch(options common.RootHashHolder) (
 }
 
 func (tr *patriciaMerkleTrie) recreate(root []byte, tsm common.StorageManager) (*patriciaMerkleTrie, error) {
-	if emptyTrie(root) {
+	if common.IsEmptyTrie(root) {
 		return NewTrie(
 			tr.trieStorage,
 			tr.marshalizer,
@@ -318,16 +315,6 @@ func (tr *patriciaMerkleTrie) String() string {
 // IsInterfaceNil returns true if there is no value under the interface
 func (tr *patriciaMerkleTrie) IsInterfaceNil() bool {
 	return tr == nil
-}
-
-func emptyTrie(root []byte) bool {
-	if len(root) == 0 {
-		return true
-	}
-	if bytes.Equal(root, EmptyTrieHash) {
-		return true
-	}
-	return false
 }
 
 // GetObsoleteHashes resets the oldHashes and oldRoot variables and returns the old hashes

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -125,7 +125,7 @@ func checkArguments(arg ArgTrieSyncer) error {
 
 // StartSyncing completes the trie, asking for missing trie nodes on the network
 func (ts *trieSyncer) StartSyncing(rootHash []byte, ctx context.Context) error {
-	if len(rootHash) == 0 || bytes.Equal(rootHash, EmptyTrieHash) {
+	if len(rootHash) == 0 || bytes.Equal(rootHash, common.EmptyTrieHash) {
 		return nil
 	}
 	if ctx == nil {

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -125,7 +125,7 @@ func checkArguments(arg ArgTrieSyncer) error {
 
 // StartSyncing completes the trie, asking for missing trie nodes on the network
 func (ts *trieSyncer) StartSyncing(rootHash []byte, ctx context.Context) error {
-	if len(rootHash) == 0 || bytes.Equal(rootHash, common.EmptyTrieHash) {
+	if common.IsEmptyTrie(rootHash) {
 		return nil
 	}
 	if ctx == nil {

--- a/trie/trieStorageManager.go
+++ b/trie/trieStorageManager.go
@@ -340,7 +340,7 @@ func (tsm *trieStorageManager) TakeSnapshot(
 		return
 	}
 
-	if bytes.Equal(rootHash, EmptyTrieHash) {
+	if bytes.Equal(rootHash, common.EmptyTrieHash) {
 		log.Trace("should not snapshot an empty trie")
 		safelyCloseChan(iteratorChannels.LeavesChan)
 		stats.SnapshotFinished()
@@ -390,7 +390,7 @@ func (tsm *trieStorageManager) SetCheckpoint(
 		return
 	}
 
-	if bytes.Equal(rootHash, EmptyTrieHash) {
+	if bytes.Equal(rootHash, common.EmptyTrieHash) {
 		log.Trace("should not set checkpoint for empty trie")
 		safelyCloseChan(iteratorChannels.LeavesChan)
 		stats.SnapshotFinished()

--- a/update/genesis/import.go
+++ b/update/genesis/import.go
@@ -328,7 +328,7 @@ func (si *stateImport) importDataTrie(identifier string, shID uint32, keys [][]b
 		return err
 	}
 
-	if len(originalRootHash) == 0 || bytes.Equal(originalRootHash, trie.EmptyTrieHash) {
+	if len(originalRootHash) == 0 || bytes.Equal(originalRootHash, common.EmptyTrieHash) {
 		err = dataTrie.Commit()
 		if err != nil {
 			return err
@@ -472,7 +472,7 @@ func (si *stateImport) importState(identifier string, keys [][]byte) error {
 
 	log.Debug("importing state", "shard ID", shId, "root hash", rootHash)
 
-	if len(rootHash) == 0 || bytes.Equal(rootHash, trie.EmptyTrieHash) {
+	if len(rootHash) == 0 || bytes.Equal(rootHash, common.EmptyTrieHash) {
 		return si.saveRootHash(accountsDB, accType, shId, rootHash)
 	}
 

--- a/update/genesis/import.go
+++ b/update/genesis/import.go
@@ -328,7 +328,7 @@ func (si *stateImport) importDataTrie(identifier string, shID uint32, keys [][]b
 		return err
 	}
 
-	if len(originalRootHash) == 0 || bytes.Equal(originalRootHash, common.EmptyTrieHash) {
+	if common.IsEmptyTrie(originalRootHash) {
 		err = dataTrie.Commit()
 		if err != nil {
 			return err
@@ -472,7 +472,7 @@ func (si *stateImport) importState(identifier string, keys [][]byte) error {
 
 	log.Debug("importing state", "shard ID", shId, "root hash", rootHash)
 
-	if len(rootHash) == 0 || bytes.Equal(rootHash, common.EmptyTrieHash) {
+	if common.IsEmptyTrie(rootHash) {
 		return si.saveRootHash(accountsDB, accType, shId, rootHash)
 	}
 


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- There was an error when checking if a trie was empty based on it's root hash
  
## Proposed Changes
- When checking if a trie is empty, also check if the root hash of the trie is equal to the empty trie root hash

## Testing procedure
- Normal testing procedure
