### PR TITLE
Heartbeat v2 monitor better filtering

### DIFF
--- a/heartbeat/monitor/errors.go
+++ b/heartbeat/monitor/errors.go
@@ -1,0 +1,9 @@
+package monitor
+
+import "errors"
+
+var (
+	errEmptyHeartbeatMessagesInstance = errors.New("programming error: empty heartbeatMessages instance")
+	errInconsistentActivePidsList     = errors.New("programming error: inconsistent active pids list")
+	errInconsistentActiveMap          = errors.New("programming error: inconsistent active map")
+)

--- a/heartbeat/monitor/errors.go
+++ b/heartbeat/monitor/errors.go
@@ -4,6 +4,4 @@ import "errors"
 
 var (
 	errEmptyHeartbeatMessagesInstance = errors.New("programming error: empty heartbeatMessages instance")
-	errInconsistentActivePidsList     = errors.New("programming error: inconsistent active pids list")
-	errInconsistentActiveMap          = errors.New("programming error: inconsistent active map")
 )

--- a/heartbeat/monitor/heartbeatMessage.go
+++ b/heartbeat/monitor/heartbeatMessage.go
@@ -1,0 +1,62 @@
+package monitor
+
+import (
+	"sort"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go/heartbeat/data"
+)
+
+type heartbeatMessages struct {
+	activePids         []core.PeerID
+	activeHeartbeats   map[core.PeerID]*data.PubKeyHeartbeat
+	inactiveHeartbeats map[core.PeerID]*data.PubKeyHeartbeat
+}
+
+func newHeartbeatMessages() *heartbeatMessages {
+	return &heartbeatMessages{
+		activePids:         make([]core.PeerID, 0),
+		activeHeartbeats:   make(map[core.PeerID]*data.PubKeyHeartbeat),
+		inactiveHeartbeats: make(map[core.PeerID]*data.PubKeyHeartbeat),
+	}
+}
+
+func (instance *heartbeatMessages) addMessage(pid core.PeerID, message *data.PubKeyHeartbeat) {
+	if message.IsActive {
+		instance.activePids = append(instance.activePids, pid)
+		instance.activeHeartbeats[pid] = message
+
+		return
+	}
+
+	instance.inactiveHeartbeats[pid] = message
+}
+
+func (instance *heartbeatMessages) getHeartbeat() (*data.PubKeyHeartbeat, error) {
+	if len(instance.activeHeartbeats) > 0 {
+		return instance.getFirstActive()
+	}
+	if len(instance.inactiveHeartbeats) > 0 {
+		for _, inactive := range instance.inactiveHeartbeats {
+			return inactive, nil
+		}
+	}
+	return nil, errEmptyHeartbeatMessagesInstance
+}
+
+func (instance *heartbeatMessages) getFirstActive() (*data.PubKeyHeartbeat, error) {
+	sort.Slice(instance.activePids, func(i, j int) bool {
+		return string(instance.activePids[i]) < string(instance.activePids[j])
+	})
+
+	if len(instance.activePids) == 0 {
+		return nil, errInconsistentActivePidsList
+	}
+
+	message, found := instance.activeHeartbeats[instance.activePids[0]]
+	if !found {
+		return nil, errInconsistentActiveMap
+	}
+
+	return message, nil
+}

--- a/heartbeat/monitor/monitor_test.go
+++ b/heartbeat/monitor/monitor_test.go
@@ -331,6 +331,7 @@ func TestHeartbeatV2Monitor_GetHeartbeats(t *testing.T) {
 
 		heartbeats := monitor.GetHeartbeats()
 		assert.Equal(t, 1, len(heartbeats))
+		assert.Equal(t, 1, args.Cache.Len())
 		checkResults(t, providedMessages[2], heartbeats[0], providedStatuses[2], providedPids, 0)
 		assert.Equal(t, 2, len(providedPids)) // 1 inactive was removed from the heartbeat list
 	})
@@ -367,6 +368,7 @@ func TestHeartbeatV2Monitor_GetHeartbeats(t *testing.T) {
 
 		heartbeats := monitor.GetHeartbeats()
 		assert.Equal(t, 1, len(heartbeats))
+		assert.Equal(t, 1, args.Cache.Len())
 		checkResults(t, providedMessages[0], heartbeats[0], providedStatuses[0], providedPids, 1)
 		assert.Equal(t, 2, len(providedPids)) // 1 inactive was removed from the heartbeat list
 	})

--- a/heartbeat/monitor/monitor_test.go
+++ b/heartbeat/monitor/monitor_test.go
@@ -144,7 +144,7 @@ func TestHeartbeatV2Monitor_parseMessage(t *testing.T) {
 		monitor, _ := NewHeartbeatV2Monitor(args)
 		assert.False(t, check.IfNil(monitor))
 
-		_, err := monitor.parseMessage("pid", "dummy msg", nil)
+		_, err := monitor.parseMessage("pid", "dummy msg")
 		assert.Equal(t, process.ErrWrongTypeAssertion, err)
 	})
 	t.Run("unmarshal returns error", func(t *testing.T) {
@@ -156,7 +156,7 @@ func TestHeartbeatV2Monitor_parseMessage(t *testing.T) {
 
 		message := createHeartbeatMessage(true, []byte("public key"))
 		message.Payload = []byte("dummy payload")
-		_, err := monitor.parseMessage("pid", message, nil)
+		_, err := monitor.parseMessage("pid", message)
 		assert.NotNil(t, err)
 	})
 	t.Run("skippable message should return error", func(t *testing.T) {
@@ -167,7 +167,7 @@ func TestHeartbeatV2Monitor_parseMessage(t *testing.T) {
 		assert.False(t, check.IfNil(monitor))
 
 		message := createHeartbeatMessage(false, []byte("public key"))
-		_, err := monitor.parseMessage("pid", message, nil)
+		_, err := monitor.parseMessage("pid", message)
 		assert.True(t, errors.Is(err, heartbeat.ErrShouldSkipValidator))
 	})
 	t.Run("should work, peer type provider returns error", func(t *testing.T) {
@@ -184,26 +184,17 @@ func TestHeartbeatV2Monitor_parseMessage(t *testing.T) {
 		monitor, _ := NewHeartbeatV2Monitor(args)
 		assert.False(t, check.IfNil(monitor))
 
-		numInstances := make(map[string]uint64)
 		message := createHeartbeatMessage(true, providedPkBytes)
 		message.Pubkey = providedPkBytesFromMessage
 		providedPid := core.PeerID("pid")
 		providedMap := map[string]struct{}{
 			providedPid.Pretty(): {},
 		}
-		hb, err := monitor.parseMessage(providedPid, message, numInstances)
+		hb, err := monitor.parseMessage(providedPid, message)
 		assert.Nil(t, err)
-		checkResults(t, *message, hb, true, providedMap, 0)
+		checkResults(t, message, *hb, true, providedMap, 0)
 		assert.Equal(t, 0, len(providedMap))
-		pkFromMsg := args.PubKeyConverter.Encode(providedPkBytesFromMessage)
-		entries, ok := numInstances[pkFromMsg]
-		assert.True(t, ok)
-		assert.Equal(t, uint64(1), entries)
 		assert.Equal(t, string(common.ObserverList), hb.PeerType)
-
-		pkFromPSM := args.PubKeyConverter.Encode(providedPkBytes)
-		_, ok = numInstances[pkFromPSM]
-		assert.False(t, ok)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -219,20 +210,15 @@ func TestHeartbeatV2Monitor_parseMessage(t *testing.T) {
 		monitor, _ := NewHeartbeatV2Monitor(args)
 		assert.False(t, check.IfNil(monitor))
 
-		numInstances := make(map[string]uint64)
 		message := createHeartbeatMessage(true, providedPkBytes)
 		providedPid := core.PeerID("pid")
 		providedMap := map[string]struct{}{
 			providedPid.Pretty(): {},
 		}
-		hb, err := monitor.parseMessage(providedPid, message, numInstances)
+		hb, err := monitor.parseMessage(providedPid, message)
 		assert.Nil(t, err)
-		checkResults(t, *message, hb, true, providedMap, 0)
+		checkResults(t, message, *hb, true, providedMap, 0)
 		assert.Equal(t, 0, len(providedMap))
-		pk := args.PubKeyConverter.Encode(providedPkBytes)
-		entries, ok := numInstances[pk]
-		assert.True(t, ok)
-		assert.Equal(t, uint64(1), entries)
 		assert.Equal(t, string(expectedPeerType), hb.PeerType)
 	})
 }
@@ -311,9 +297,91 @@ func TestHeartbeatV2Monitor_GetHeartbeats(t *testing.T) {
 		assert.Equal(t, len(providedStatuses)-1, len(heartbeats))
 		assert.Equal(t, len(providedStatuses)-1, args.Cache.Len()) // faulty message was removed from cache
 		for i := 0; i < len(heartbeats); i++ {
-			checkResults(t, *providedMessages[i], heartbeats[i], providedStatuses[i], providedPids, 1)
+			checkResults(t, providedMessages[i], heartbeats[i], providedStatuses[i], providedPids, 1)
 		}
 		assert.Equal(t, 1, len(providedPids)) // one message is skipped
+	})
+	t.Run("should remove all inactive messages except from the latest message", func(t *testing.T) {
+		t.Parallel()
+		args := createMockHeartbeatV2MonitorArgs()
+		args.HideInactiveValidatorInterval = time.Minute
+		providedStatuses := []bool{false, false, false}
+		numOfMessages := len(providedStatuses)
+		providedPids := make(map[string]struct{}, numOfMessages)
+		providedMessages := make([]*heartbeat.HeartbeatV2, numOfMessages)
+		for i := 0; i < numOfMessages; i++ {
+			pid := core.PeerID(fmt.Sprintf("%s%d", "pid", i))
+			providedPids[pid.Pretty()] = struct{}{}
+			pkBytes := []byte("same pk")
+
+			providedMessages[i] = createHeartbeatMessage(providedStatuses[i], pkBytes)
+			payload := heartbeat.Payload{
+				Timestamp: time.Now().Unix() - 30 + int64(i), // the last message will be the latest, so it will be returned
+			}
+
+			marshaller := testscommon.MarshalizerMock{}
+			payloadBytes, _ := marshaller.Marshal(payload)
+			providedMessages[i].Payload = payloadBytes
+
+			args.Cache.Put(pid.Bytes(), providedMessages[i], providedMessages[i].Size())
+		}
+
+		monitor, _ := NewHeartbeatV2Monitor(args)
+		assert.False(t, check.IfNil(monitor))
+
+		heartbeats := monitor.GetHeartbeats()
+		assert.Equal(t, 1, len(heartbeats))
+		checkResults(t, providedMessages[2], heartbeats[0], providedStatuses[2], providedPids, 0)
+		assert.Equal(t, 2, len(providedPids)) // 1 inactive was removed from the heartbeat list
+	})
+	t.Run("should remove all inactive messages if one is active", func(t *testing.T) {
+		t.Parallel()
+		args := createMockHeartbeatV2MonitorArgs()
+		args.HideInactiveValidatorInterval = time.Minute
+		providedStatuses := []bool{true, false, false}
+		numOfMessages := len(providedStatuses)
+		providedPids := make(map[string]struct{}, numOfMessages)
+		providedMessages := make([]*heartbeat.HeartbeatV2, numOfMessages)
+		for i := 0; i < numOfMessages; i++ {
+			pid := core.PeerID(fmt.Sprintf("%s%d", "pid", i))
+			providedPids[pid.Pretty()] = struct{}{}
+			pkBytes := []byte("same pk")
+
+			providedMessages[i] = createHeartbeatMessage(providedStatuses[i], pkBytes)
+			if i != 0 {
+				// 1, 2 ... are inactive messages
+				payload := heartbeat.Payload{
+					Timestamp: time.Now().Unix() - 30 + int64(i), // the last message will be the latest, so it will be returned
+				}
+
+				marshaller := testscommon.MarshalizerMock{}
+				payloadBytes, _ := marshaller.Marshal(payload)
+				providedMessages[i].Payload = payloadBytes
+			}
+
+			args.Cache.Put(pid.Bytes(), providedMessages[i], providedMessages[i].Size())
+		}
+
+		monitor, _ := NewHeartbeatV2Monitor(args)
+		assert.False(t, check.IfNil(monitor))
+
+		heartbeats := monitor.GetHeartbeats()
+		assert.Equal(t, 1, len(heartbeats))
+		checkResults(t, providedMessages[0], heartbeats[0], providedStatuses[0], providedPids, 1)
+		assert.Equal(t, 2, len(providedPids)) // 1 inactive was removed from the heartbeat list
+	})
+	t.Run("nil message in cache should remove", func(t *testing.T) {
+		t.Parallel()
+		args := createMockHeartbeatV2MonitorArgs()
+		args.HideInactiveValidatorInterval = time.Minute
+		args.Cache.Put([]byte("pid"), nil, 0)
+
+		monitor, _ := NewHeartbeatV2Monitor(args)
+		assert.False(t, check.IfNil(monitor))
+
+		heartbeats := monitor.GetHeartbeats()
+		assert.Equal(t, 0, len(heartbeats))
+		assert.Equal(t, 0, args.Cache.Len())
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -340,19 +408,19 @@ func TestHeartbeatV2Monitor_GetHeartbeats(t *testing.T) {
 		assert.False(t, check.IfNil(monitor))
 
 		heartbeats := monitor.GetHeartbeats()
-		assert.Equal(t, args.Cache.Len(), len(heartbeats))
-		for i := 0; i < numOfMessages; i++ {
+		assert.Equal(t, 2, len(heartbeats)) // 2 have the same pk
+		for i := 0; i < 2; i++ {
 			numInstances := uint64(1)
 			if i > 0 {
 				numInstances = 2
 			}
-			checkResults(t, *providedMessages[i], heartbeats[i], providedStatuses[i], providedPids, numInstances)
+			checkResults(t, providedMessages[i], heartbeats[i], providedStatuses[i], providedPids, numInstances)
 		}
-		assert.Equal(t, 0, len(providedPids))
+		assert.Equal(t, 1, len(providedPids)) // 1 inactive was removed from the heartbeat list
 	})
 }
 
-func checkResults(t *testing.T, message heartbeat.HeartbeatV2, hb data.PubKeyHeartbeat, isActive bool, providedPids map[string]struct{}, numInstances uint64) {
+func checkResults(t *testing.T, message *heartbeat.HeartbeatV2, hb data.PubKeyHeartbeat, isActive bool, providedPids map[string]struct{}, numInstances uint64) {
 	assert.Equal(t, isActive, hb.IsActive)
 	assert.Equal(t, message.VersionNumber, hb.VersionNumber)
 	assert.Equal(t, message.NodeDisplayName, hb.NodeDisplayName)


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- after some **mainnet** node upgrades, the observed heartbeat status response randomly showed active or inactive nodes in the network. This was caused by the fact that the node returned all messages (inactive or active) regardless that the public key is now behind another pid
  
## Proposed Changes
- made the heartbeat v2 monitor struct better filter-out inactive messages by using the following algorithm:

suppose that, for the same BLS public key we got `n` messages from `n` different pids:
1. if all stored messages show inactive nodes, only keep the latest message, remove the older ones, and put the value `0` on the `NumInstances` field from the `data.PubKeyHeartbeat` struct;
2. if all stored messages show only active nodes, sort the messages based on the `pid` (so that the response will be consistent on all requests), take the first active heartbeat message, and set the `NumInstances` field from `data.PubKeyHeartbeat` struct to how many active messages the node has;
3. if some stored messages show inactive nodes and others show active nodes, remove the stored messages that show inactive nodes, and for the rest of the messages that show active nodes, apply point 2. 

## Testing procedure
- standard system test
- mainnet-specific tests that will prove that the new code will better filter-out inactive messages
