### PR TITLE
Freeze legacy wasm-vm v1.4

### DIFF
--- a/cmd/assessment/benchmarks/arwenBenchmark.go
+++ b/cmd/assessment/benchmarks/arwenBenchmark.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	arwenConfig "github.com/ElrondNetwork/wasm-vm/config"
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/vm/arwen/arwenvm"
 	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts/defaults"
+	arwenConfig "github.com/ElrondNetwork/wasm-vm-v1_4/config"
 )
 
 // ArgArwenBenchmark is the Arwen type benchmark argument used in constructor

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"testing"
 
-	arwenConfig "github.com/ElrondNetwork/wasm-vm/config"
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
@@ -56,6 +55,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts/defaults"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	vmcommonBuiltInFunctions "github.com/ElrondNetwork/elrond-vm-common/builtInFunctions"
+	arwenConfig "github.com/ElrondNetwork/wasm-vm-v1_4/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/genesis/process/genesisBlockCreator_test.go
+++ b/genesis/process/genesisBlockCreator_test.go
@@ -8,7 +8,6 @@ import (
 	"math/big"
 	"testing"
 
-	arwenConfig "github.com/ElrondNetwork/wasm-vm/config"
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/config"
@@ -34,6 +33,7 @@ import (
 	updateMock "github.com/ElrondNetwork/elrond-go/update/mock"
 	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts/defaults"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	arwenConfig "github.com/ElrondNetwork/wasm-vm-v1_4/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/ElrondNetwork/elrond-go-p2p v1.0.3
 	github.com/ElrondNetwork/elrond-go-storage v1.0.1
 	github.com/ElrondNetwork/elrond-vm-common v1.3.22
-	github.com/ElrondNetwork/wasm-vm v1.4.59
 	github.com/ElrondNetwork/wasm-vm-v1_2 v1.2.42
 	github.com/ElrondNetwork/wasm-vm-v1_3 v1.3.42
+	github.com/ElrondNetwork/wasm-vm-v1_4 v1.4.62
 	github.com/beevik/ntp v0.3.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/elastic/go-elasticsearch/v7 v7.12.0

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/ElrondNetwork/elrond-go-p2p v1.0.3
 	github.com/ElrondNetwork/elrond-go-storage v1.0.1
 	github.com/ElrondNetwork/elrond-vm-common v1.3.22
-	github.com/ElrondNetwork/wasm-vm-v1_2 v1.2.42
-	github.com/ElrondNetwork/wasm-vm-v1_3 v1.3.42
+	github.com/ElrondNetwork/wasm-vm-v1_2 v1.2.44
+	github.com/ElrondNetwork/wasm-vm-v1_3 v1.3.44
 	github.com/ElrondNetwork/wasm-vm-v1_4 v1.4.62
 	github.com/beevik/ntp v0.3.0
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -81,10 +81,10 @@ github.com/ElrondNetwork/go-libp2p-pubsub v0.6.1-rc1 h1:Nu/uwYQg/QbfoQ0uD6GahYTw
 github.com/ElrondNetwork/go-libp2p-pubsub v0.6.1-rc1/go.mod h1:pJfaShe+i5aWZx8NhSkQjvOYQYLoqPztmFUlKjToOzM=
 github.com/ElrondNetwork/protobuf v1.3.2 h1:qoCSYiO+8GtXBEZWEjw0WPcZfM3g7QuuJrwpN+y6Mvg=
 github.com/ElrondNetwork/protobuf v1.3.2/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/ElrondNetwork/wasm-vm-v1_2 v1.2.42 h1:szZcuaxPElmLvYRezR4YayPDqRxDMCWspknhtSHJQyo=
-github.com/ElrondNetwork/wasm-vm-v1_2 v1.2.42/go.mod h1:d1Pirw0GnD4Eh5lhBvX9Bn+N1AHb/FzRVKZSHwWwJLg=
-github.com/ElrondNetwork/wasm-vm-v1_3 v1.3.42 h1:EhLjiR/MnWSuLW3xtWh69oBZ4zAsym/QrhGKsVWwJjw=
-github.com/ElrondNetwork/wasm-vm-v1_3 v1.3.42/go.mod h1:7JeSIgpcCxKiD67iSjnlBQt7qIQf+oSuehtBQp0QgVM=
+github.com/ElrondNetwork/wasm-vm-v1_2 v1.2.44 h1:B1cW2Gvmi88nATPi0kFUGH7Q4AMTiTDcCrdpEZuvPJs=
+github.com/ElrondNetwork/wasm-vm-v1_2 v1.2.44/go.mod h1:d1Pirw0GnD4Eh5lhBvX9Bn+N1AHb/FzRVKZSHwWwJLg=
+github.com/ElrondNetwork/wasm-vm-v1_3 v1.3.44 h1:YKaXYG7Y+7Hy8Pd190B6ZuzYSnZF9vgzdqINFEGO4+4=
+github.com/ElrondNetwork/wasm-vm-v1_3 v1.3.44/go.mod h1:7JeSIgpcCxKiD67iSjnlBQt7qIQf+oSuehtBQp0QgVM=
 github.com/ElrondNetwork/wasm-vm-v1_4 v1.4.62 h1:XZAF3CEMfs9Ct+aXV2IKBtxg7DGl5PMqp8yaBk6NriU=
 github.com/ElrondNetwork/wasm-vm-v1_4 v1.4.62/go.mod h1:BtjngiK7DLyACe/hNM6aHIStmQtYi9eBnvZiFxrys2o=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=

--- a/go.sum
+++ b/go.sum
@@ -81,12 +81,12 @@ github.com/ElrondNetwork/go-libp2p-pubsub v0.6.1-rc1 h1:Nu/uwYQg/QbfoQ0uD6GahYTw
 github.com/ElrondNetwork/go-libp2p-pubsub v0.6.1-rc1/go.mod h1:pJfaShe+i5aWZx8NhSkQjvOYQYLoqPztmFUlKjToOzM=
 github.com/ElrondNetwork/protobuf v1.3.2 h1:qoCSYiO+8GtXBEZWEjw0WPcZfM3g7QuuJrwpN+y6Mvg=
 github.com/ElrondNetwork/protobuf v1.3.2/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/ElrondNetwork/wasm-vm v1.4.59 h1:7TO0R+kpkCU375Pwtw0jBlkcSoakmGSyh2U6+Aob9L0=
-github.com/ElrondNetwork/wasm-vm v1.4.59/go.mod h1:NopwtkceMs1N5esbLzhMU49487XdEMAqaRnVIlQ72QY=
 github.com/ElrondNetwork/wasm-vm-v1_2 v1.2.42 h1:szZcuaxPElmLvYRezR4YayPDqRxDMCWspknhtSHJQyo=
 github.com/ElrondNetwork/wasm-vm-v1_2 v1.2.42/go.mod h1:d1Pirw0GnD4Eh5lhBvX9Bn+N1AHb/FzRVKZSHwWwJLg=
 github.com/ElrondNetwork/wasm-vm-v1_3 v1.3.42 h1:EhLjiR/MnWSuLW3xtWh69oBZ4zAsym/QrhGKsVWwJjw=
 github.com/ElrondNetwork/wasm-vm-v1_3 v1.3.42/go.mod h1:7JeSIgpcCxKiD67iSjnlBQt7qIQf+oSuehtBQp0QgVM=
+github.com/ElrondNetwork/wasm-vm-v1_4 v1.4.62 h1:XZAF3CEMfs9Ct+aXV2IKBtxg7DGl5PMqp8yaBk6NriU=
+github.com/ElrondNetwork/wasm-vm-v1_4 v1.4.62/go.mod h1:BtjngiK7DLyACe/hNM6aHIStmQtYi9eBnvZiFxrys2o=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/integrationTests/multiShard/hardFork/hardFork_test.go
+++ b/integrationTests/multiShard/hardFork/hardFork_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	arwenConfig "github.com/ElrondNetwork/wasm-vm/config"
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
@@ -26,6 +25,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon/genesisMocks"
 	"github.com/ElrondNetwork/elrond-go/update/factory"
 	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts/defaults"
+	arwenConfig "github.com/ElrondNetwork/wasm-vm-v1_4/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/integrationTests/state/stateTrieSync/stateTrieSync_test.go
+++ b/integrationTests/state/stateTrieSync/stateTrieSync_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/trie/statistics"
 	"github.com/ElrondNetwork/elrond-go/trie/storageMarker"
 	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts/defaults"
-	arwenConfig "github.com/ElrondNetwork/wasm-vm/config"
+	arwenConfig "github.com/ElrondNetwork/wasm-vm-v1_4/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	arwenConfig "github.com/ElrondNetwork/wasm-vm/config"
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data"
@@ -66,6 +65,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/vm"
 	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts"
 	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts/defaults"
+	arwenConfig "github.com/ElrondNetwork/wasm-vm-v1_4/config"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -117,7 +117,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts/defaults"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/ElrondNetwork/elrond-vm-common/parsers"
-	arwenConfig "github.com/ElrondNetwork/wasm-vm/config"
+	arwenConfig "github.com/ElrondNetwork/wasm-vm-v1_4/config"
 )
 
 var zero = big.NewInt(0)

--- a/integrationTests/testProcessorNodeWithTestWebServer.go
+++ b/integrationTests/testProcessorNodeWithTestWebServer.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"sync"
 
-	arwenConfig "github.com/ElrondNetwork/wasm-vm/config"
 	dataTransaction "github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/elrond-go/api/groups"
 	"github.com/ElrondNetwork/elrond-go/api/shared"
@@ -28,6 +27,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts/defaults"
 	"github.com/ElrondNetwork/elrond-vm-common/parsers"
 	datafield "github.com/ElrondNetwork/elrond-vm-common/parsers/dataField"
+	arwenConfig "github.com/ElrondNetwork/wasm-vm-v1_4/config"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 )

--- a/integrationTests/vm/arwen/arwenvm/mandosConverter/mandosConverter.go
+++ b/integrationTests/vm/arwen/arwenvm/mandosConverter/mandosConverter.go
@@ -5,14 +5,14 @@ import (
 	"errors"
 	"math/big"
 
-	mge "github.com/ElrondNetwork/wasm-vm/mandos-go/elrondgo-exporter"
-	mgutil "github.com/ElrondNetwork/wasm-vm/mandos-go/util"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/vm"
 	"github.com/ElrondNetwork/elrond-go/process/factory"
 	"github.com/ElrondNetwork/elrond-go/state"
 	"github.com/ElrondNetwork/elrond-go/testscommon/txDataBuilder"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	mge "github.com/ElrondNetwork/wasm-vm-v1_4/mandos-go/elrondgo-exporter"
+	mgutil "github.com/ElrondNetwork/wasm-vm-v1_4/mandos-go/util"
 )
 
 var errReturnCodeNotOk = errors.New("returnCode is not 0(Ok)")

--- a/integrationTests/vm/arwen/arwenvm/mandosConverter/mandosConverterUtils.go
+++ b/integrationTests/vm/arwen/arwenvm/mandosConverter/mandosConverterUtils.go
@@ -3,9 +3,9 @@ package mandosConverter
 import (
 	"testing"
 
-	mge "github.com/ElrondNetwork/wasm-vm/mandos-go/elrondgo-exporter"
-	mgutil "github.com/ElrondNetwork/wasm-vm/mandos-go/util"
 	"github.com/ElrondNetwork/elrond-go/config"
+	mge "github.com/ElrondNetwork/wasm-vm-v1_4/mandos-go/elrondgo-exporter"
+	mgutil "github.com/ElrondNetwork/wasm-vm-v1_4/mandos-go/util"
 
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	logger "github.com/ElrondNetwork/elrond-go-logger"

--- a/integrationTests/vm/arwen/delegation/delegationSimulation_test.go
+++ b/integrationTests/vm/arwen/delegation/delegationSimulation_test.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 package delegation

--- a/integrationTests/vm/arwen/erc20/erc20_test.go
+++ b/integrationTests/vm/arwen/erc20/erc20_test.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 package erc20

--- a/integrationTests/vm/arwen/upgrades/upgrades_test.go
+++ b/integrationTests/vm/arwen/upgrades/upgrades_test.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 // TODO remove build condition above to allow -race -short, after Arwen fix

--- a/integrationTests/vm/testInitializer.go
+++ b/integrationTests/vm/testInitializer.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"testing"
 
-	arwenConfig "github.com/ElrondNetwork/wasm-vm/config"
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter"
@@ -67,6 +66,7 @@ import (
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	vmcommonBuiltInFunctions "github.com/ElrondNetwork/elrond-vm-common/builtInFunctions"
 	"github.com/ElrondNetwork/elrond-vm-common/parsers"
+	arwenConfig "github.com/ElrondNetwork/wasm-vm-v1_4/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/integrationTests/vm/txsFee/scCalls_test.go
+++ b/integrationTests/vm/txsFee/scCalls_test.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 	"testing"
 
-	arwenConfig "github.com/ElrondNetwork/wasm-vm/config"
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go/config"
@@ -21,6 +20,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon/txDataBuilder"
 	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts/defaults"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	arwenConfig "github.com/ElrondNetwork/wasm-vm-v1_4/config"
 	"github.com/stretchr/testify/require"
 )
 

--- a/process/factory/metachain/vmContainerFactory_test.go
+++ b/process/factory/metachain/vmContainerFactory_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	arwenConfig "github.com/ElrondNetwork/wasm-vm/config"
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go/common"
@@ -19,6 +18,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	stateMock "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	"github.com/ElrondNetwork/elrond-go/vm"
+	arwenConfig "github.com/ElrondNetwork/wasm-vm-v1_4/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/process/factory/shard/vmContainerFactory.go
+++ b/process/factory/shard/vmContainerFactory.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"sort"
 
-	arwen14 "github.com/ElrondNetwork/wasm-vm/arwen"
-	arwenHost14 "github.com/ElrondNetwork/wasm-vm/arwen/host"
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
@@ -21,6 +19,8 @@ import (
 	arwenHost12 "github.com/ElrondNetwork/wasm-vm-v1_2/arwen/host"
 	arwen13 "github.com/ElrondNetwork/wasm-vm-v1_3/arwen"
 	arwenHost13 "github.com/ElrondNetwork/wasm-vm-v1_3/arwen/host"
+	arwen14 "github.com/ElrondNetwork/wasm-vm-v1_4/arwen"
+	arwenHost14 "github.com/ElrondNetwork/wasm-vm-v1_4/arwen/host"
 )
 
 var _ process.VirtualMachinesContainerFactory = (*vmContainerFactory)(nil)

--- a/process/factory/shard/vmContainerFactory_test.go
+++ b/process/factory/shard/vmContainerFactory_test.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 	"testing"
 
-	arwenConfig "github.com/ElrondNetwork/wasm-vm/config"
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go/common/forking"
@@ -17,6 +16,7 @@ import (
 	vmcommonBuiltInFunctions "github.com/ElrondNetwork/elrond-vm-common/builtInFunctions"
 	"github.com/ElrondNetwork/elrond-vm-common/parsers"
 	ipcNodePart1p2 "github.com/ElrondNetwork/wasm-vm-v1_2/ipc/nodepart"
+	arwenConfig "github.com/ElrondNetwork/wasm-vm-v1_4/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/process/smartContract/builtInFunctions/factory_test.go
+++ b/process/smartContract/builtInFunctions/factory_test.go
@@ -24,14 +24,14 @@ func createMockArguments() ArgsCreateBuiltInFunctionContainer {
 
 	gasScheduleNotifier := testscommon.NewGasScheduleNotifierMock(gasMap)
 	args := ArgsCreateBuiltInFunctionContainer{
-		GasSchedule:               gasScheduleNotifier,
-		MapDNSAddresses:           make(map[string]struct{}),
-		EnableUserNameChange:      false,
-		Marshalizer:               &mock.MarshalizerMock{},
-		Accounts:                  &stateMock.AccountsStub{},
-		ShardCoordinator:          mock.NewMultiShardsCoordinatorMock(1),
-		EpochNotifier:             &epochNotifier.EpochNotifierStub{},
-		EnableEpochsHandler:       &testscommon.EnableEpochsHandlerStub{},
+		GasSchedule:          gasScheduleNotifier,
+		MapDNSAddresses:      make(map[string]struct{}),
+		EnableUserNameChange: false,
+		Marshalizer:          &mock.MarshalizerMock{},
+		Accounts:             &stateMock.AccountsStub{},
+		ShardCoordinator:     mock.NewMultiShardsCoordinatorMock(1),
+		EpochNotifier:        &epochNotifier.EpochNotifierStub{},
+		EnableEpochsHandler:  &testscommon.EnableEpochsHandlerStub{},
 		AutomaticCrawlerAddresses: [][]byte{
 			bytes.Repeat([]byte{1}, 32),
 		},

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -42,7 +42,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/trie"
 	trieFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
 	"github.com/ElrondNetwork/elrond-go/trie/hashesHolder"
-	arwenConfig "github.com/ElrondNetwork/wasm-vm/config"
+	arwenConfig "github.com/ElrondNetwork/wasm-vm-v1_4/config"
 	"github.com/stretchr/testify/require"
 )
 

--- a/vm/factory/systemSCFactory_test.go
+++ b/vm/factory/systemSCFactory_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	arwenConfig "github.com/ElrondNetwork/wasm-vm/config"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/config"
@@ -14,6 +13,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/vm"
 	"github.com/ElrondNetwork/elrond-go/vm/mock"
 	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts/defaults"
+	arwenConfig "github.com/ElrondNetwork/wasm-vm-v1_4/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
This PR replaces `wasm-vm` with `wasm-vm-v1_4` and removes the reference to `wasm-vm` entirely.

The `rc/v1.4.0` branch of the must not reference `wasm-vm` without a version suffix just yet (the integration branch for that is work in progress).

