### PR TITLE
Add marshaller to data trie tracker

### DIFF
--- a/epochStart/metachain/baseRewards_test.go
+++ b/epochStart/metachain/baseRewards_test.go
@@ -826,7 +826,7 @@ func TestBaseRewardsCreator_isSystemDelegationSC(t *testing.T) {
 	require.False(t, isDelegationSCAddress)
 
 	// peer account
-	peerAccount, err := state.NewPeerAccount([]byte("addressPeer"), &hashingMocks.HasherMock{})
+	peerAccount, err := state.NewPeerAccount([]byte("addressPeer"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	require.Nil(t, err)
 	err = rwd.userAccountsDB.SaveAccount(peerAccount)
 	require.Nil(t, err)
@@ -834,7 +834,7 @@ func TestBaseRewardsCreator_isSystemDelegationSC(t *testing.T) {
 	require.False(t, isDelegationSCAddress)
 
 	// existing user account
-	userAccount, err := state.NewUserAccount([]byte("userAddress"), &hashingMocks.HasherMock{})
+	userAccount, err := state.NewUserAccount([]byte("userAddress"), &hashingMocks.HasherMock{}, &marshal.GogoProtoMarshalizer{})
 	require.Nil(t, err)
 
 	userAccount.SetDataTrie(&trieMock.TrieStub{

--- a/epochStart/metachain/baseRewards_test.go
+++ b/epochStart/metachain/baseRewards_test.go
@@ -834,7 +834,7 @@ func TestBaseRewardsCreator_isSystemDelegationSC(t *testing.T) {
 	require.False(t, isDelegationSCAddress)
 
 	// existing user account
-	userAccount, err := state.NewUserAccount([]byte("userAddress"), &hashingMocks.HasherMock{}, &marshal.GogoProtoMarshalizer{})
+	userAccount, err := state.NewUserAccount([]byte("userAddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	require.Nil(t, err)
 
 	userAccount.SetDataTrie(&trieMock.TrieStub{

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -882,7 +882,7 @@ func (pcf *processComponentsFactory) indexGenesisAccounts() error {
 }
 
 func (pcf *processComponentsFactory) unmarshalUserAccount(address []byte, userAccountsBytes []byte) (state.UserAccountHandler, error) {
-	userAccount, err := state.NewUserAccount(address, pcf.coreData.Hasher())
+	userAccount, err := state.NewUserAccount(address, pcf.coreData.Hasher(), pcf.coreData.InternalMarshalizer())
 	if err != nil {
 		return nil, err
 	}

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -900,7 +900,7 @@ func GenerateAddressJournalAccountAccountsDB() ([]byte, state.UserAccountHandler
 	adr := CreateRandomAddress()
 	trieStorage, _ := CreateTrieStorageManager(CreateMemUnit())
 	adb, _ := CreateAccountsDB(UserAccount, trieStorage)
-	account, _ := state.NewUserAccount(adr, TestHasher)
+	account, _ := state.NewUserAccount(adr, TestHasher, TestMarshaller)
 
 	return adr, account, adb
 }

--- a/integrationTests/vm/systemVM/stakingSC_test.go
+++ b/integrationTests/vm/systemVM/stakingSC_test.go
@@ -412,7 +412,7 @@ func manualSetToInactiveStateStakedPeers(t *testing.T, nodes []*integrationTests
 
 		for index := range nodes {
 			pubKey, _ := hex.DecodeString(generateUniqueKey(index))
-			peerAccount, _ := state.NewPeerAccount(pubKey, integrationTests.TestHasher)
+			peerAccount, _ := state.NewPeerAccount(pubKey, integrationTests.TestHasher, integrationTests.TestMarshaller)
 			peerAccount.List = string(common.InactiveList)
 			peerAccount.BLSPublicKey = pubKey
 			err := node.PeerState.SaveAccount(peerAccount)

--- a/integrationTests/vm/testInitializer.go
+++ b/integrationTests/vm/testInitializer.go
@@ -262,8 +262,8 @@ type accountFactory struct {
 }
 
 // CreateAccount -
-func (af *accountFactory) CreateAccount(address []byte, hasher hashing.Hasher) (vmcommon.AccountHandler, error) {
-	return state.NewUserAccount(address, hasher)
+func (af *accountFactory) CreateAccount(address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (vmcommon.AccountHandler, error) {
+	return state.NewUserAccount(address, hasher, marshaller)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/node/nodeLoadAccounts_test.go
+++ b/node/nodeLoadAccounts_test.go
@@ -25,7 +25,7 @@ import (
 func TestNode_GetAccountWithOptionsShouldWork(t *testing.T) {
 	t.Parallel()
 
-	alice, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{})
+	alice, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	alice.Balance = big.NewInt(100)
 
 	accountsRepostitory := &mockState.AccountsRepositoryStub{}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -69,7 +69,7 @@ func createMockPubkeyConverter() *mock.PubkeyConverterMock {
 func getAccAdapter(balance *big.Int) *stateMock.AccountsStub {
 	accDB := &stateMock.AccountsStub{}
 	accDB.GetExistingAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{})
+		acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 		_ = acc.AddToBalance(balance)
 		acc.IncreaseNonce(1)
 
@@ -195,7 +195,7 @@ func TestGetBalance_AccountNotFoundShouldReturnZeroBalance(t *testing.T) {
 func TestGetBalance(t *testing.T) {
 	t.Parallel()
 
-	testAccount, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{})
+	testAccount, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	testAccount.Balance = big.NewInt(100)
 
 	accountsRepository := &stateMock.AccountsRepositoryStub{
@@ -228,7 +228,7 @@ func TestGetUsername(t *testing.T) {
 
 	expectedUsername := []byte("elrond")
 
-	testAccount, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{})
+	testAccount, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	testAccount.UserName = expectedUsername
 	accountsRepository := &stateMock.AccountsRepositoryStub{
 		GetAccountWithBlockInfoCalled: func(address []byte, options api.AccountQueryOptions) (vmcommon.AccountHandler, common.BlockInfo, error) {
@@ -261,7 +261,7 @@ func TestGetCodeHash(t *testing.T) {
 
 	expectedCodeHash := []byte("hash")
 
-	testAccount, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{})
+	testAccount, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	testAccount.CodeHash = expectedCodeHash
 	accountsRepository := &stateMock.AccountsRepositoryStub{
 		GetAccountWithBlockInfoCalled: func(address []byte, options api.AccountQueryOptions) (vmcommon.AccountHandler, common.BlockInfo, error) {
@@ -292,7 +292,7 @@ func TestGetCodeHash(t *testing.T) {
 func TestNode_GetKeyValuePairs(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	k1, v1 := []byte("key1"), []byte("value1")
 	k2, v2 := []byte("key2"), []byte("value2")
@@ -360,7 +360,7 @@ func TestNode_GetKeyValuePairs(t *testing.T) {
 func TestNode_GetKeyValuePairs_GetAllLeavesShouldFail(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	accDB := &stateMock.AccountsStub{}
 
@@ -415,7 +415,7 @@ func TestNode_GetKeyValuePairs_GetAllLeavesShouldFail(t *testing.T) {
 func TestNode_GetKeyValuePairsContextShouldTimeout(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	accDB := &stateMock.AccountsStub{}
 	acc.SetDataTrie(
@@ -472,7 +472,7 @@ func TestNode_GetKeyValuePairsContextShouldTimeout(t *testing.T) {
 func TestNode_GetValueForKey(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	k1, v1 := []byte("key1"), []byte("value1")
 	_ = acc.SaveKeyValue(k1, v1)
@@ -514,7 +514,7 @@ func TestNode_GetValueForKey(t *testing.T) {
 func TestNode_GetESDTData(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	esdtToken := "newToken"
 
 	esdtData := &esdt.ESDigitalToken{Value: big.NewInt(10)}
@@ -563,7 +563,7 @@ func TestNode_GetESDTData(t *testing.T) {
 func TestNode_GetESDTDataForNFT(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	esdtToken := "newToken"
 	nonce := int64(100)
 
@@ -608,7 +608,7 @@ func TestNode_GetESDTDataForNFT(t *testing.T) {
 func TestNode_GetAllESDTTokens(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	esdtToken := "newToken"
 	esdtKey := []byte(core.ElrondProtectedKeyPrefix + core.ESDTKeyIdentifier + esdtToken)
 
@@ -676,7 +676,7 @@ func TestNode_GetAllESDTTokens(t *testing.T) {
 func TestNode_GetAllESDTTokens_GetAllLeavesShouldFail(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	expectedErr := errors.New("expected error")
 	acc.SetDataTrie(
@@ -732,7 +732,7 @@ func TestNode_GetAllESDTTokens_GetAllLeavesShouldFail(t *testing.T) {
 func TestNode_GetAllESDTTokensContextShouldTimeout(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	acc.SetDataTrie(
 		&trieMock.TrieStub{
@@ -790,7 +790,7 @@ func TestNode_GetAllESDTTokensContextShouldTimeout(t *testing.T) {
 func TestNode_GetAllESDTTokensShouldReturnEsdtAndFormattedNft(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	esdtToken := "TKKR-7q8w9e"
 	esdtKey := []byte(core.ElrondProtectedKeyPrefix + core.ESDTKeyIdentifier + esdtToken)
@@ -886,7 +886,7 @@ func TestNode_GetAllESDTTokensShouldReturnEsdtAndFormattedNft(t *testing.T) {
 func TestNode_GetAllIssuedESDTs(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	esdtToken := []byte("TCK-RANDOM")
 	sftToken := []byte("SFT-RANDOM")
 	nftToken := []byte("NFT-RANDOM")
@@ -983,7 +983,7 @@ func TestNode_GetESDTsWithRole(t *testing.T) {
 	t.Parallel()
 
 	addrBytes := testscommon.TestPubKeyAlice
-	acc, _ := state.NewUserAccount(addrBytes, &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(addrBytes, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	esdtToken := []byte("TCK-RANDOM")
 
 	specialRoles := []*systemSmartContracts.ESDTRoles{
@@ -1063,7 +1063,7 @@ func TestNode_GetESDTsRoles(t *testing.T) {
 	t.Parallel()
 
 	addrBytes := testscommon.TestPubKeyAlice
-	acc, _ := state.NewUserAccount(addrBytes, &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(addrBytes, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	esdtToken := []byte("TCK-RANDOM")
 
 	specialRoles := []*systemSmartContracts.ESDTRoles{
@@ -1135,7 +1135,7 @@ func TestNode_GetNFTTokenIDsRegisteredByAddress(t *testing.T) {
 	t.Parallel()
 
 	addrBytes := testscommon.TestPubKeyAlice
-	acc, _ := state.NewUserAccount(addrBytes, &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(addrBytes, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	esdtToken := []byte("TCK-RANDOM")
 
 	esdtData := &systemSmartContracts.ESDTDataV2{TokenName: []byte("fungible"), TokenType: []byte(core.SemiFungibleESDT), OwnerAddress: addrBytes}
@@ -1200,7 +1200,7 @@ func TestNode_GetNFTTokenIDsRegisteredByAddressContextShouldTimeout(t *testing.T
 	t.Parallel()
 
 	addrBytes := testscommon.TestPubKeyAlice
-	acc, _ := state.NewUserAccount(addrBytes, &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(addrBytes, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	acc.SetDataTrie(
 		&trieMock.TrieStub{
@@ -1371,7 +1371,7 @@ func TestGenerateTransaction_GetAccountReturnsNilShouldWork(t *testing.T) {
 
 	accAdapter := &stateMock.AccountsStub{
 		GetExistingAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
-			return state.NewUserAccount(address, &hashingMocks.HasherMock{})
+			return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 		},
 	}
 	privateKey := getPrivateKey()
@@ -1518,7 +1518,7 @@ func TestGenerateTransaction_ShouldSetCorrectNonce(t *testing.T) {
 	nonce := uint64(7)
 	accAdapter := &stateMock.AccountsStub{
 		GetExistingAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
-			acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{})
+			acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 			_ = acc.AddToBalance(big.NewInt(0))
 			acc.IncreaseNonce(nonce)
 
@@ -2347,7 +2347,7 @@ func TestCreateTransaction_OkValsShouldWork(t *testing.T) {
 	stateComponents := getDefaultStateComponents()
 	stateComponents.AccountsAPI = &stateMock.AccountsStub{
 		GetExistingAccountCalled: func(addressContainer []byte) (vmcommon.AccountHandler, error) {
-			return state.NewUserAccount([]byte("address"), &hashingMocks.HasherMock{})
+			return state.NewUserAccount([]byte("address"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 		},
 	}
 
@@ -2944,7 +2944,7 @@ func TestNode_GetAccountAccountsRepositoryFailsShouldErr(t *testing.T) {
 func TestNode_GetAccountAccountExistsShouldReturn(t *testing.T) {
 	t.Parallel()
 
-	accnt, _ := state.NewUserAccount(testscommon.TestPubKeyBob, &hashingMocks.HasherMock{})
+	accnt, _ := state.NewUserAccount(testscommon.TestPubKeyBob, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	_ = accnt.AddToBalance(big.NewInt(1))
 	accnt.IncreaseNonce(2)
 	accnt.SetRootHash([]byte("root hash"))

--- a/node/trieIterators/delegatedListProcessor_test.go
+++ b/node/trieIterators/delegatedListProcessor_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/node/mock"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/state"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	stateMock "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	trieMock "github.com/ElrondNetwork/elrond-go/testscommon/trie"
@@ -219,7 +220,7 @@ func TestDelegatedListProc_GetDelegatorsListShouldWork(t *testing.T) {
 }
 
 func createDelegationScAccount(address []byte, leaves [][]byte, rootHash []byte, timeSleep time.Duration) state.UserAccountHandler {
-	acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acc.SetDataTrie(&trieMock.TrieStub{
 		RootCalled: func() ([]byte, error) {
 			return rootHash, nil

--- a/node/trieIterators/directStakedListProcessor_test.go
+++ b/node/trieIterators/directStakedListProcessor_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/node/mock"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/state"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	stateMock "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	trieMock "github.com/ElrondNetwork/elrond-go/testscommon/trie"
@@ -149,7 +150,7 @@ func TestDirectStakedListProc_GetDelegatorsListShouldWork(t *testing.T) {
 }
 
 func createValidatorScAccount(address []byte, leaves [][]byte, rootHash []byte, timeSleep time.Duration) state.UserAccountHandler {
-	acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acc.SetDataTrie(&trieMock.TrieStub{
 		RootCalled: func() ([]byte, error) {
 			return rootHash, nil

--- a/node/trieIterators/stakeValuesProcessor_test.go
+++ b/node/trieIterators/stakeValuesProcessor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/node/mock"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/state"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	stateMock "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	trieMock "github.com/ElrondNetwork/elrond-go/testscommon/trie"
@@ -165,7 +166,7 @@ func TestTotalStakedValueProcessor_GetTotalStakedValue_CannotGetRootHash(t *test
 	t.Parallel()
 
 	expectedErr := errors.New("expected error")
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acc.SetDataTrie(&trieMock.TrieStub{
 		RootCalled: func() ([]byte, error) {
 			return nil, expectedErr
@@ -191,7 +192,7 @@ func TestTotalStakedValueProcessor_GetTotalStakedValue_CannotGetRootHash(t *test
 func TestTotalStakedValueProcessor_GetTotalStakedValue_ContextShouldTimeout(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acc.SetDataTrie(&trieMock.TrieStub{
 		GetAllLeavesOnChannelCalled: func(leavesChannels *common.TrieIteratorChannels, _ context.Context, _ []byte, _ common.KeyBuilder) error {
 			time.Sleep(time.Second)
@@ -227,7 +228,7 @@ func TestTotalStakedValueProcessor_GetTotalStakedValue_CannotGetAllLeaves(t *tes
 	t.Parallel()
 
 	expectedErr := errors.New("expected error")
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acc.SetDataTrie(&trieMock.TrieStub{
 		GetAllLeavesOnChannelCalled: func(_ *common.TrieIteratorChannels, _ context.Context, _ []byte, _ common.KeyBuilder) error {
 			return expectedErr
@@ -272,7 +273,7 @@ func TestTotalStakedValueProcessor_GetTotalStakedValue(t *testing.T) {
 	leafKey4 := "0123456783"
 	leafKey5 := "0123456780"
 	leafKey6 := "0123456788"
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acc.SetDataTrie(&trieMock.TrieStub{
 		RootCalled: func() ([]byte, error) {
 			return rootHash, nil

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -1820,7 +1820,7 @@ func unmarshalUserAccount(
 	marshalizer marshal.Marshalizer,
 	hasher hashing.Hasher,
 ) (state.UserAccountHandler, error) {
-	userAccount, err := state.NewUserAccount(address, hasher)
+	userAccount, err := state.NewUserAccount(address, hasher, marshalizer)
 	if err != nil {
 		return nil, err
 	}

--- a/process/dataValidators/txValidator_test.go
+++ b/process/dataValidators/txValidator_test.go
@@ -21,7 +21,7 @@ import (
 func getAccAdapter(nonce uint64, balance *big.Int) *stateMock.AccountsStub {
 	accDB := &stateMock.AccountsStub{}
 	accDB.GetExistingAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{})
+		acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 		acc.Nonce = nonce
 		acc.Balance = balance
 
@@ -331,7 +331,7 @@ func TestTxValidator_CheckTxValidityWrongAccountTypeShouldReturnFalse(t *testing
 
 	accDB := &stateMock.AccountsStub{}
 	accDB.GetExistingAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		return state.NewPeerAccount(address, &hashingMocks.HasherMock{})
+		return state.NewPeerAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	}
 	shardCoordinator := createMockCoordinator("_", 0)
 	maxNonceDeltaAllowed := 100

--- a/process/peer/process_test.go
+++ b/process/peer/process_test.go
@@ -325,7 +325,7 @@ func TestValidatorStatisticsProcessor_SaveInitialStateSetAddressErrors(t *testin
 	t.Parallel()
 
 	saveAccountError := errors.New("save account error")
-	peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{})
+	peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	peerAdapter := &stateMock.AccountsStub{
 		LoadAccountCalled: func(address []byte) (handler vmcommon.AccountHandler, e error) {
 			return peerAccount, nil
@@ -351,7 +351,7 @@ func TestValidatorStatisticsProcessor_SaveInitialStateCommitErrors(t *testing.T)
 	t.Parallel()
 
 	commitError := errors.New("commit error")
-	peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{})
+	peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	peerAdapter := &stateMock.AccountsStub{
 		LoadAccountCalled: func(address []byte) (handler vmcommon.AccountHandler, e error) {
 			return peerAccount, nil
@@ -374,7 +374,7 @@ func TestValidatorStatisticsProcessor_SaveInitialStateCommitErrors(t *testing.T)
 func TestValidatorStatisticsProcessor_SaveInitialStateCommit(t *testing.T) {
 	t.Parallel()
 
-	peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{})
+	peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	peerAdapter := &stateMock.AccountsStub{
 		LoadAccountCalled: func(address []byte) (handler vmcommon.AccountHandler, e error) {
 			return peerAccount, nil
@@ -516,7 +516,7 @@ func TestValidatorStatisticsProcessor_UpdatePeerStateGetHeaderError(t *testing.T
 	marshalizer := &mock.MarshalizerStub{}
 
 	adapter.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		return state.NewPeerAccount(address, &hashingMocks.HasherMock{})
+		return state.NewPeerAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	}
 	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
 
@@ -2487,7 +2487,7 @@ func compare(t *testing.T, peerAccount state.PeerAccountHandler, validatorInfo *
 
 func createPeerAccounts(addrBytes0 []byte, addrBytesMeta []byte) (state.PeerAccountHandler, state.PeerAccountHandler) {
 	addr := addrBytes0
-	pa0, _ := state.NewPeerAccount(addr, &hashingMocks.HasherMock{})
+	pa0, _ := state.NewPeerAccount(addr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	pa0.PeerAccountData = state.PeerAccountData{
 		BLSPublicKey:    []byte("bls0"),
 		RewardAddress:   []byte("reward0"),
@@ -2518,7 +2518,7 @@ func createPeerAccounts(addrBytes0 []byte, addrBytesMeta []byte) (state.PeerAcco
 	}
 
 	addr = addrBytesMeta
-	paMeta, _ := state.NewPeerAccount(addr, &hashingMocks.HasherMock{})
+	paMeta, _ := state.NewPeerAccount(addr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	paMeta.PeerAccountData = state.PeerAccountData{
 		BLSPublicKey:    []byte("blsM"),
 		RewardAddress:   []byte("rewardM"),

--- a/process/rewardTransaction/process_test.go
+++ b/process/rewardTransaction/process_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process/mock"
 	"github.com/ElrondNetwork/elrond-go/process/rewardTransaction"
 	"github.com/ElrondNetwork/elrond-go/state"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	stateMock "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
@@ -187,7 +188,7 @@ func TestRewardTxProcessor_ProcessRewardTransactionShouldWork(t *testing.T) {
 
 	accountsDb := &stateMock.AccountsStub{
 		LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
-			return state.NewUserAccount(address, &hashingMocks.HasherMock{})
+			return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 		},
 		SaveAccountCalled: func(accountHandler vmcommon.AccountHandler) error {
 			saveAccountWasCalled = true
@@ -219,7 +220,7 @@ func TestRewardTxProcessor_ProcessRewardTransactionToASmartContractShouldWork(t 
 	saveAccountWasCalled := false
 
 	address := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6}
-	userAccount, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{})
+	userAccount, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	accountsDb := &stateMock.AccountsStub{
 		LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
 			return userAccount, nil

--- a/process/scToProtocol/stakingToPeer_test.go
+++ b/process/scToProtocol/stakingToPeer_test.go
@@ -240,7 +240,7 @@ func TestStakingToPeer_UpdateProtocolRemoveAccountShouldReturnNil(t *testing.T) 
 
 	peerState := &stateMock.AccountsStub{}
 	peerState.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		peerAcc, _ := state.NewPeerAccount(address, &hashingMocks.HasherMock{})
+		peerAcc, _ := state.NewPeerAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 		_ = peerAcc.SetRewardAddress([]byte("addr"))
 		_ = peerAcc.SetBLSPublicKey([]byte("BlsAddr"))
 
@@ -256,7 +256,7 @@ func TestStakingToPeer_UpdateProtocolRemoveAccountShouldReturnNil(t *testing.T) 
 	}
 
 	arguments := createMockArgumentsNewStakingToPeer()
-	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{})
+	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	baseState := &stateMock.AccountsStub{}
 	baseState.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return userAcc, nil
@@ -299,7 +299,7 @@ func TestStakingToPeer_UpdateProtocolCannotSetRewardAddressShouldErr(t *testing.
 
 	peerState := &stateMock.AccountsStub{}
 	peerState.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		peerAcc, _ := state.NewPeerAccount(address, &hashingMocks.HasherMock{})
+		peerAcc, _ := state.NewPeerAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 		_ = peerAcc.SetRewardAddress([]byte("key"))
 
 		return peerAcc, nil
@@ -310,7 +310,7 @@ func TestStakingToPeer_UpdateProtocolCannotSetRewardAddressShouldErr(t *testing.
 	}
 	marshalizer := &mock.MarshalizerMock{}
 
-	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{})
+	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	baseState := &stateMock.AccountsStub{}
 	baseState.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return userAcc, nil
@@ -356,7 +356,7 @@ func TestStakingToPeer_UpdateProtocolEmptyDataShouldNotAddToTrie(t *testing.T) {
 
 	peerState := &stateMock.AccountsStub{}
 	peerState.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		peerAcc, _ := state.NewPeerAccount(address, &hashingMocks.HasherMock{})
+		peerAcc, _ := state.NewPeerAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 		_ = peerAcc.SetRewardAddress(rwdAddress)
 
 		return peerAcc, nil
@@ -366,7 +366,7 @@ func TestStakingToPeer_UpdateProtocolEmptyDataShouldNotAddToTrie(t *testing.T) {
 		return fmt.Errorf("error")
 	}
 
-	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{})
+	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	baseState := &stateMock.AccountsStub{}
 	baseState.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return userAcc, nil
@@ -422,7 +422,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveAccountShouldErr(t *testing.T) {
 	}
 
 	peerState.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		peerAccount, _ := state.NewPeerAccount(address, &hashingMocks.HasherMock{})
+		peerAccount, _ := state.NewPeerAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 		peerAccount.RewardAddress = address
 		return peerAccount, nil
 	}
@@ -433,7 +433,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveAccountShouldErr(t *testing.T) {
 	}
 	marshalizer := &mock.MarshalizerMock{}
 
-	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{})
+	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	baseState := &stateMock.AccountsStub{}
 	baseState.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return userAcc, nil
@@ -484,7 +484,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveAccountNonceShouldErr(t *testing.
 		},
 	}
 	peerState.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{})
+		peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 		peerAccount.BLSPublicKey = address
 		peerAccount.Nonce = 1
 		return peerAccount, nil
@@ -496,7 +496,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveAccountNonceShouldErr(t *testing.
 	}
 	marshalizer := &mock.MarshalizerMock{}
 
-	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{})
+	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	baseState := &stateMock.AccountsStub{}
 	baseState.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return userAcc, nil
@@ -546,7 +546,7 @@ func TestStakingToPeer_UpdateProtocol(t *testing.T) {
 		},
 	}
 	peerState.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{})
+		peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 		peerAccount.BLSPublicKey = address
 		peerAccount.Nonce = 1
 		return peerAccount, nil
@@ -562,7 +562,7 @@ func TestStakingToPeer_UpdateProtocol(t *testing.T) {
 	arguments.CurrTxs = currTx
 	arguments.PeerState = peerState
 	arguments.Marshalizer = marshalizer
-	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{})
+	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	baseState := &stateMock.AccountsStub{}
 	baseState.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return userAcc, nil
@@ -609,7 +609,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveUnStakedNonceShouldErr(t *testing
 		},
 	}
 	peerState.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{})
+		peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 		peerAccount.BLSPublicKey = address
 		peerAccount.IndexInList = 1
 		return peerAccount, nil
@@ -621,7 +621,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveUnStakedNonceShouldErr(t *testing
 	}
 	marshalizer := &mock.MarshalizerMock{}
 
-	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{})
+	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	baseState := &stateMock.AccountsStub{}
 	baseState.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return userAcc, nil

--- a/process/smartContract/hooks/blockChainHook_test.go
+++ b/process/smartContract/hooks/blockChainHook_test.go
@@ -251,7 +251,7 @@ func TestBlockChainHookImpl_GetCode(t *testing.T) {
 		}
 		bh, _ := hooks.NewBlockChainHookImpl(args)
 
-		account, _ := state.NewUserAccount([]byte("address"), &hashingMocks.HasherMock{})
+		account, _ := state.NewUserAccount([]byte("address"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 		account.SetCodeHash(expectedCodeHash)
 
 		code := bh.GetCode(account)
@@ -311,7 +311,7 @@ func TestBlockChainHookImpl_GetUserAccountWrongTypeShouldErr(t *testing.T) {
 func TestBlockChainHookImpl_GetUserAccount(t *testing.T) {
 	t.Parallel()
 
-	expectedAccount, _ := state.NewUserAccount([]byte("1234"), &hashingMocks.HasherMock{})
+	expectedAccount, _ := state.NewUserAccount([]byte("1234"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	args := createMockBlockChainHookArgs()
 	args.Accounts = &stateMock.AccountsStub{
 		GetExistingAccountCalled: func(address []byte) (handler vmcommon.AccountHandler, e error) {
@@ -421,7 +421,7 @@ func TestBlockChainHookImpl_NewAddressLengthNoGood(t *testing.T) {
 
 	acnts := &stateMock.AccountsStub{}
 	acnts.GetExistingAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
-		return state.NewUserAccount(address, &hashingMocks.HasherMock{})
+		return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	}
 	args := createMockBlockChainHookArgs()
 	args.Accounts = acnts
@@ -445,7 +445,7 @@ func TestBlockChainHookImpl_NewAddressVMTypeTooLong(t *testing.T) {
 
 	acnts := &stateMock.AccountsStub{}
 	acnts.GetExistingAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
-		return state.NewUserAccount(address, &hashingMocks.HasherMock{})
+		return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	}
 	args := createMockBlockChainHookArgs()
 	args.Accounts = acnts
@@ -465,7 +465,7 @@ func TestBlockChainHookImpl_NewAddress(t *testing.T) {
 
 	acnts := &stateMock.AccountsStub{}
 	acnts.GetExistingAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
-		return state.NewUserAccount(address, &hashingMocks.HasherMock{})
+		return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	}
 	args := createMockBlockChainHookArgs()
 	args.Accounts = acnts

--- a/process/transaction/metaProcess_test.go
+++ b/process/transaction/metaProcess_test.go
@@ -154,9 +154,9 @@ func TestMetaTxProcessor_ProcessCheckNotPassShouldErr(t *testing.T) {
 	tx.RcvAddr = []byte("DST")
 	tx.Value = big.NewInt(45)
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	adb := createAccountStub(tx.SndAddr, tx.RcvAddr, acntSrc, acntDst)
@@ -180,9 +180,9 @@ func TestMetaTxProcessor_ProcessMoveBalancesShouldCallProcessIfError(t *testing.
 	tx.RcvAddr = []byte("DST")
 	tx.Value = big.NewInt(0)
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	adb := createAccountStub(tx.SndAddr, tx.RcvAddr, acntSrc, acntDst)
@@ -220,10 +220,10 @@ func TestMetaTxProcessor_ProcessTransactionScTxShouldWork(t *testing.T) {
 	tx.GasPrice = 1
 	tx.GasLimit = 1
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	acntSrc.Balance = big.NewInt(46)
@@ -269,10 +269,10 @@ func TestMetaTxProcessor_ProcessTransactionScTxShouldReturnErrWhenExecutionFails
 	tx.RcvAddr = generateRandomByteSlice(createMockPubkeyConverter().Len())
 	tx.Value = big.NewInt(45)
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 	acntSrc.Balance = big.NewInt(45)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 	acntDst.SetCode([]byte{65})
 
@@ -327,10 +327,10 @@ func TestMetaTxProcessor_ProcessTransactionScTxShouldNotBeCalledWhenAdrDstIsNotI
 		return 0
 	}
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 	acntSrc.Balance = big.NewInt(45)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 	acntDst.SetCode([]byte{65})
 
@@ -391,10 +391,10 @@ func TestMetaTxProcessor_ProcessTransactionBuiltInCallTxShouldWork(t *testing.T)
 	tx.GasPrice = 1
 	tx.GasLimit = 1
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	acntSrc.Balance = big.NewInt(46)

--- a/process/transaction/shardProcess_test.go
+++ b/process/transaction/shardProcess_test.go
@@ -316,8 +316,8 @@ func TestTxProcessor_GetAccountsOkValsSrcShouldWork(t *testing.T) {
 	adr1 := []byte{65}
 	adr2 := []byte{67}
 
-	acnt1, _ := state.NewUserAccount(adr1, &hashingMocks.HasherMock{})
-	acnt2, _ := state.NewUserAccount(adr2, &hashingMocks.HasherMock{})
+	acnt1, _ := state.NewUserAccount(adr1, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acnt2, _ := state.NewUserAccount(adr2, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	adb.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		if bytes.Equal(address, adr1) {
@@ -361,8 +361,8 @@ func TestTxProcessor_GetAccountsOkValsDsthouldWork(t *testing.T) {
 	adr1 := []byte{65}
 	adr2 := []byte{67}
 
-	acnt1, _ := state.NewUserAccount(adr1, &hashingMocks.HasherMock{})
-	acnt2, _ := state.NewUserAccount(adr2, &hashingMocks.HasherMock{})
+	acnt1, _ := state.NewUserAccount(adr1, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acnt2, _ := state.NewUserAccount(adr2, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	adb.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		if bytes.Equal(address, adr1) {
@@ -404,8 +404,8 @@ func TestTxProcessor_GetAccountsOkValsShouldWork(t *testing.T) {
 	adr1 := []byte{65}
 	adr2 := []byte{67}
 
-	acnt1, _ := state.NewUserAccount(adr1, &hashingMocks.HasherMock{})
-	acnt2, _ := state.NewUserAccount(adr2, &hashingMocks.HasherMock{})
+	acnt1, _ := state.NewUserAccount(adr1, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acnt2, _ := state.NewUserAccount(adr2, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	adb := createAccountStub(adr1, adr2, acnt1, acnt2)
 
@@ -425,8 +425,8 @@ func TestTxProcessor_GetSameAccountShouldWork(t *testing.T) {
 	adr1 := []byte{65}
 	adr2 := []byte{65}
 
-	acnt1, _ := state.NewUserAccount(adr1, &hashingMocks.HasherMock{})
-	acnt2, _ := state.NewUserAccount(adr2, &hashingMocks.HasherMock{})
+	acnt1, _ := state.NewUserAccount(adr1, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acnt2, _ := state.NewUserAccount(adr2, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	adb := createAccountStub(adr1, adr2, acnt1, acnt2)
 
@@ -445,7 +445,7 @@ func TestTxProcessor_CheckTxValuesHigherNonceShouldErr(t *testing.T) {
 	t.Parallel()
 
 	adr1 := []byte{65}
-	acnt1, err := state.NewUserAccount(adr1, &hashingMocks.HasherMock{})
+	acnt1, err := state.NewUserAccount(adr1, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	execTx := *createTxProcessor()
@@ -460,7 +460,7 @@ func TestTxProcessor_CheckTxValuesLowerNonceShouldErr(t *testing.T) {
 	t.Parallel()
 
 	adr1 := []byte{65}
-	acnt1, err := state.NewUserAccount(adr1, &hashingMocks.HasherMock{})
+	acnt1, err := state.NewUserAccount(adr1, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	execTx := *createTxProcessor()
@@ -475,7 +475,7 @@ func TestTxProcessor_CheckTxValuesInsufficientFundsShouldErr(t *testing.T) {
 	t.Parallel()
 
 	adr1 := []byte{65}
-	acnt1, err := state.NewUserAccount(adr1, &hashingMocks.HasherMock{})
+	acnt1, err := state.NewUserAccount(adr1, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	execTx := *createTxProcessor()
@@ -490,7 +490,7 @@ func TestTxProcessor_CheckTxValuesMismatchedSenderUsernamesShouldErr(t *testing.
 	t.Parallel()
 
 	adr1 := []byte{65}
-	senderAcc, err := state.NewUserAccount(adr1, &hashingMocks.HasherMock{})
+	senderAcc, err := state.NewUserAccount(adr1, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	assert.Nil(t, err)
 
@@ -512,7 +512,7 @@ func TestTxProcessor_CheckTxValuesMismatchedReceiverUsernamesShouldErr(t *testin
 	t.Parallel()
 
 	adr1 := []byte{65}
-	receiverAcc, err := state.NewUserAccount(adr1, &hashingMocks.HasherMock{})
+	receiverAcc, err := state.NewUserAccount(adr1, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	assert.Nil(t, err)
 
@@ -534,11 +534,11 @@ func TestTxProcessor_CheckTxValuesCorrectUserNamesShouldWork(t *testing.T) {
 	t.Parallel()
 
 	adr1 := []byte{65}
-	senderAcc, err := state.NewUserAccount(adr1, &hashingMocks.HasherMock{})
+	senderAcc, err := state.NewUserAccount(adr1, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	adr2 := []byte{66}
-	recvAcc, err := state.NewUserAccount(adr2, &hashingMocks.HasherMock{})
+	recvAcc, err := state.NewUserAccount(adr2, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	execTx := *createTxProcessor()
@@ -561,7 +561,7 @@ func TestTxProcessor_CheckTxValuesOkValsShouldErr(t *testing.T) {
 	t.Parallel()
 
 	adr1 := []byte{65}
-	acnt1, err := state.NewUserAccount(adr1, &hashingMocks.HasherMock{})
+	acnt1, err := state.NewUserAccount(adr1, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	execTx := *createTxProcessor()
@@ -578,7 +578,7 @@ func TestTxProcessor_IncreaseNonceOkValsShouldWork(t *testing.T) {
 	t.Parallel()
 
 	adrSrc := []byte{65}
-	acntSrc, err := state.NewUserAccount(adrSrc, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(adrSrc, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	execTx := *createTxProcessor()
@@ -629,9 +629,9 @@ func TestTxProcessor_ProcessCheckNotPassShouldErr(t *testing.T) {
 	tx.RcvAddr = []byte("DST")
 	tx.Value = big.NewInt(45)
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	adb := createAccountStub(tx.SndAddr, tx.RcvAddr, acntSrc, acntDst)
@@ -665,9 +665,9 @@ func TestTxProcessor_ProcessWithTxFeeHandlerCheckErrorShouldErr(t *testing.T) {
 	tx.RcvAddr = make([]byte, 32)
 	tx.Value = big.NewInt(0)
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	adb := createAccountStub(tx.SndAddr, tx.RcvAddr, acntSrc, acntDst)
@@ -717,9 +717,9 @@ func TestTxProcessor_ProcessWithTxFeeHandlerInsufficientFeeShouldErr(t *testing.
 	tx.RcvAddr = make([]byte, 32)
 	tx.Value = big.NewInt(0)
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	acntSrc.Balance = big.NewInt(9)
@@ -749,9 +749,9 @@ func TestTxProcessor_ProcessWithInsufficientFundsShouldCreateReceiptErr(t *testi
 	tx.RcvAddr = make([]byte, 32)
 	tx.Value = big.NewInt(0)
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	acntSrc.Balance = big.NewInt(9)
@@ -782,9 +782,9 @@ func TestTxProcessor_ProcessWithUsernameMismatchCreateReceiptErr(t *testing.T) {
 	tx.RcvAddr = make([]byte, 32)
 	tx.Value = big.NewInt(0)
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	acntSrc.Balance = big.NewInt(9)
@@ -814,9 +814,9 @@ func TestTxProcessor_ProcessWithUsernameMismatchAndSCProcessErrorShouldError(t *
 	tx.RcvAddr = make([]byte, 32)
 	tx.Value = big.NewInt(0)
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	acntSrc.Balance = big.NewInt(9)
@@ -861,9 +861,9 @@ func TestTxProcessor_ProcessMoveBalanceToSmartPayableContract(t *testing.T) {
 		return 0
 	}
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	acntDst.CodeMetadata = []byte{0, vmcommon.MetadataPayable}
@@ -902,9 +902,9 @@ func testProcessCheck(t *testing.T, nonce uint64, value *big.Int) {
 		return 0
 	}
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	adb := createAccountStub(tx.SndAddr, tx.RcvAddr, acntSrc, acntDst)
@@ -934,9 +934,9 @@ func TestTxProcessor_ProcessMoveBalancesShouldWork(t *testing.T) {
 	tx.RcvAddr = []byte("DST")
 	tx.Value = big.NewInt(0)
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	adb := createAccountStub(tx.SndAddr, tx.RcvAddr, acntSrc, acntDst)
@@ -965,9 +965,9 @@ func TestTxProcessor_ProcessOkValsShouldWork(t *testing.T) {
 	tx.RcvAddr = []byte("DST")
 	tx.Value = big.NewInt(61)
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	acntSrc.Nonce = 4
@@ -1003,9 +1003,9 @@ func TestTxProcessor_MoveBalanceWithFeesShouldWork(t *testing.T) {
 	tx.GasPrice = 2
 	tx.GasLimit = 2
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	acntSrc.Nonce = 4
@@ -1053,10 +1053,10 @@ func TestTxProcessor_ProcessTransactionScDeployTxShouldWork(t *testing.T) {
 	tx.GasPrice = 1
 	tx.GasLimit = 1
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	acntSrc.Balance = big.NewInt(46)
@@ -1104,10 +1104,10 @@ func TestTxProcessor_ProcessTransactionBuiltInFunctionCallShouldWork(t *testing.
 	tx.GasPrice = 1
 	tx.GasLimit = 1
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	acntSrc.Balance = big.NewInt(46)
@@ -1155,10 +1155,10 @@ func TestTxProcessor_ProcessTransactionScTxShouldWork(t *testing.T) {
 	tx.GasPrice = 1
 	tx.GasLimit = 1
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 
 	acntSrc.Balance = big.NewInt(46)
@@ -1205,10 +1205,10 @@ func TestTxProcessor_ProcessTransactionScTxShouldReturnErrWhenExecutionFails(t *
 	tx.RcvAddr = generateRandomByteSlice(createMockPubkeyConverter().Len())
 	tx.Value = big.NewInt(45)
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 	acntSrc.Balance = big.NewInt(45)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 	acntDst.SetCode([]byte{65})
 
@@ -1262,10 +1262,10 @@ func TestTxProcessor_ProcessTransactionScTxShouldNotBeCalledWhenAdrDstIsNotInNod
 		return 0
 	}
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 	acntSrc.Balance = big.NewInt(45)
-	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, err := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 	acntDst.SetCode([]byte{65})
 
@@ -1533,7 +1533,7 @@ func TestTxProcessor_ProcessTransactionShouldReturnErrForInvalidMetaTx(t *testin
 	tx.GasPrice = 1
 	tx.GasLimit = 1
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 	acntSrc.Balance = big.NewInt(100000000)
 
@@ -1590,7 +1590,7 @@ func TestTxProcessor_ProcessTransactionShouldTreatAsInvalidTxIfTxTypeIsWrong(t *
 	tx.GasPrice = 1
 	tx.GasLimit = 1
 
-	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, err := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 	acntSrc.Balance = big.NewInt(46)
 
@@ -1647,12 +1647,12 @@ func TestTxProcessor_ProcessRelayedTransactionV2NotActiveShouldErr(t *testing.T)
 		"@" +
 		"01a2")
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(10)
 
-	acntFinal, _ := state.NewUserAccount(userTxDest, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTxDest, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(10)
 
 	adb := &stateMock.AccountsStub{}
@@ -1729,12 +1729,12 @@ func TestTxProcessor_ProcessRelayedTransactionV2WithValueShouldErr(t *testing.T)
 		"@" +
 		"01a2")
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(10)
 
-	acntFinal, _ := state.NewUserAccount(userTxDest, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTxDest, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(10)
 
 	adb := &stateMock.AccountsStub{}
@@ -1811,12 +1811,12 @@ func TestTxProcessor_ProcessRelayedTransactionV2ArgsParserShouldErr(t *testing.T
 		"@" +
 		"01a2")
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(10)
 
-	acntFinal, _ := state.NewUserAccount(userTxDest, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTxDest, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(10)
 
 	adb := &stateMock.AccountsStub{}
@@ -1900,12 +1900,12 @@ func TestTxProcessor_ProcessRelayedTransactionV2InvalidParamCountShouldErr(t *te
 		"@" +
 		"1010")
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(10)
 
-	acntFinal, _ := state.NewUserAccount(userTxDest, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTxDest, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(10)
 
 	adb := &stateMock.AccountsStub{}
@@ -1982,12 +1982,12 @@ func TestTxProcessor_ProcessRelayedTransactionV2(t *testing.T) {
 		"@" +
 		"01a2")
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(10)
 
-	acntFinal, _ := state.NewUserAccount(userTxDest, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTxDest, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(10)
 
 	adb := &stateMock.AccountsStub{}
@@ -2063,11 +2063,11 @@ func TestTxProcessor_ProcessRelayedTransaction(t *testing.T) {
 	userTxMarshalled, _ := marshalizer.Marshal(userTx)
 	tx.Data = []byte(core.RelayedTransaction + "@" + hex.EncodeToString(userTxMarshalled))
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(10)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(10)
 
 	adb := &stateMock.AccountsStub{}
@@ -2159,11 +2159,11 @@ func TestTxProcessor_ProcessRelayedTransactionArgsParserErrorShouldError(t *test
 			return "", nil, parseError
 		}}
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(10)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(10)
 
 	adb := &stateMock.AccountsStub{}
@@ -2222,11 +2222,11 @@ func TestTxProcessor_ProcessRelayedTransactionMultipleArgumentsShouldError(t *te
 			return core.RelayedTransaction, [][]byte{[]byte("0"), []byte("1")}, nil
 		}}
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(10)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(10)
 
 	adb := &stateMock.AccountsStub{}
@@ -2285,11 +2285,11 @@ func TestTxProcessor_ProcessRelayedTransactionFailUnMarshalInnerShouldError(t *t
 			return core.RelayedTransaction, [][]byte{[]byte("0")}, nil
 		}}
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(10)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(10)
 
 	adb := &stateMock.AccountsStub{}
@@ -2348,11 +2348,11 @@ func TestTxProcessor_ProcessRelayedTransactionDifferentSenderInInnerTxThanReceiv
 			return core.RelayedTransaction, [][]byte{userTxMarshalled}, nil
 		}}
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(10)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(10)
 
 	adb := &stateMock.AccountsStub{}
@@ -2411,11 +2411,11 @@ func TestTxProcessor_ProcessRelayedTransactionSmallerValueInnerTxShouldError(t *
 			return core.RelayedTransaction, [][]byte{userTxMarshalled}, nil
 		}}
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(10)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(10)
 
 	adb := &stateMock.AccountsStub{}
@@ -2474,11 +2474,11 @@ func TestTxProcessor_ProcessRelayedTransactionGasPriceMismatchShouldError(t *tes
 			return core.RelayedTransaction, [][]byte{userTxMarshalled}, nil
 		}}
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(10)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(10)
 
 	adb := &stateMock.AccountsStub{}
@@ -2537,11 +2537,11 @@ func TestTxProcessor_ProcessRelayedTransactionGasLimitMismatchShouldError(t *tes
 			return core.RelayedTransaction, [][]byte{userTxMarshalled}, nil
 		}}
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(10)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(10)
 
 	adb := &stateMock.AccountsStub{}
@@ -2596,11 +2596,11 @@ func TestTxProcessor_ProcessRelayedTransactionDisabled(t *testing.T) {
 	userTxMarshalled, _ := marshalizer.Marshal(userTx)
 	tx.Data = []byte(core.RelayedTransaction + "@" + hex.EncodeToString(userTxMarshalled))
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(10)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(10)
 
 	adb := &stateMock.AccountsStub{}
@@ -2674,7 +2674,7 @@ func TestTxProcessor_ConsumeMoveBalanceWithUserTx(t *testing.T) {
 	}
 	execTx, _ := txproc.NewTxProcessor(args)
 
-	acntSrc, _ := state.NewUserAccount([]byte("address"), &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount([]byte("address"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
 
 	originalTxHash := []byte("originalTxHash")
@@ -2734,11 +2734,11 @@ func TestTxProcessor_ProcessUserTxOfTypeRelayedShouldError(t *testing.T) {
 			return core.RelayedTransaction, [][]byte{userTxMarshalled}, nil
 		}}
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(100)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(100)
 
 	adb := &stateMock.AccountsStub{}
@@ -2798,11 +2798,11 @@ func TestTxProcessor_ProcessUserTxOfTypeMoveBalanceShouldWork(t *testing.T) {
 			return core.RelayedTransaction, [][]byte{userTxMarshalled}, nil
 		}}
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(100)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(100)
 
 	adb := &stateMock.AccountsStub{}
@@ -2862,11 +2862,11 @@ func TestTxProcessor_ProcessUserTxOfTypeSCDeploymentShouldWork(t *testing.T) {
 			return core.RelayedTransaction, [][]byte{userTxMarshalled}, nil
 		}}
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(100)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(100)
 
 	adb := &stateMock.AccountsStub{}
@@ -2926,11 +2926,11 @@ func TestTxProcessor_ProcessUserTxOfTypeSCInvokingShouldWork(t *testing.T) {
 			return core.RelayedTransaction, [][]byte{userTxMarshalled}, nil
 		}}
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(100)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(100)
 
 	adb := &stateMock.AccountsStub{}
@@ -2990,11 +2990,11 @@ func TestTxProcessor_ProcessUserTxOfTypeBuiltInFunctionCallShouldWork(t *testing
 			return core.RelayedTransaction, [][]byte{userTxMarshalled}, nil
 		}}
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(100)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(100)
 
 	adb := &stateMock.AccountsStub{}
@@ -3058,11 +3058,11 @@ func TestTxProcessor_ProcessUserTxErrNotPayableShouldFailRelayTx(t *testing.T) {
 		return false, process.ErrAccountNotPayable
 	}}
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(100)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(100)
 
 	adb := &stateMock.AccountsStub{}
@@ -3128,11 +3128,11 @@ func TestTxProcessor_ProcessUserTxFailedBuiltInFunctionCall(t *testing.T) {
 		},
 	}
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(100)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(100)
 
 	adb := &stateMock.AccountsStub{}
@@ -3188,11 +3188,11 @@ func TestTxProcessor_ExecuteFailingRelayedTxShouldNotHaveNegativeFee(t *testing.
 
 	args := createArgsForTxProcessor()
 
-	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{})
+	acntSrc, _ := state.NewUserAccount(tx.SndAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntSrc.Balance = big.NewInt(100)
-	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{})
+	acntDst, _ := state.NewUserAccount(tx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntDst.Balance = big.NewInt(100)
-	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{})
+	acntFinal, _ := state.NewUserAccount(userTx.RcvAddr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acntFinal.Balance = big.NewInt(100)
 
 	adb := &stateMock.AccountsStub{}

--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -692,7 +692,7 @@ func (adb *AccountsDB) LoadAccount(address []byte) (vmcommon.AccountHandler, err
 		return nil, err
 	}
 	if check.IfNil(acnt) {
-		return adb.accountFactory.CreateAccount(address, adb.hasher)
+		return adb.accountFactory.CreateAccount(address, adb.hasher, adb.marshaller)
 	}
 
 	baseAcc, ok := acnt.(baseAccountHandler)
@@ -715,7 +715,7 @@ func (adb *AccountsDB) getAccount(address []byte, mainTrie common.Trie) (vmcommo
 		return nil, nil
 	}
 
-	acnt, err := adb.accountFactory.CreateAccount(address, adb.hasher)
+	acnt, err := adb.accountFactory.CreateAccount(address, adb.hasher, adb.marshaller)
 	if err != nil {
 		return nil, err
 	}
@@ -764,7 +764,7 @@ func (adb *AccountsDB) GetAccountFromBytes(address []byte, accountBytes []byte) 
 		return nil, fmt.Errorf("%w in GetAccountFromBytes", ErrNilAddress)
 	}
 
-	acnt, err := adb.accountFactory.CreateAccount(address, adb.hasher)
+	acnt, err := adb.accountFactory.CreateAccount(address, adb.hasher, adb.marshaller)
 	if err != nil {
 		return nil, err
 	}

--- a/state/accountsDBApiWithHistory_test.go
+++ b/state/accountsDBApiWithHistory_test.go
@@ -130,7 +130,7 @@ func TestAccountsDBApiWithHistory_GetAccountWithBlockInfo(t *testing.T) {
 			},
 			GetExistingAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
 				if bytes.Equal(address, testscommon.TestPubKeyAlice) {
-					return state.NewUserAccount(address, &hashingMocks.HasherMock{})
+					return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 				}
 
 				return nil, errors.New("not found")

--- a/state/accountsDBApi_test.go
+++ b/state/accountsDBApi_test.go
@@ -309,7 +309,7 @@ func TestAccountsDBApi_GetExistingAccount(t *testing.T) {
 				return nil
 			},
 			GetExistingAccountCalled: func(addressContainer []byte) (vmcommon.AccountHandler, error) {
-				return state.NewUserAccount(addressContainer, &hashingMocks.HasherMock{})
+				return state.NewUserAccount(addressContainer, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 			},
 		}
 
@@ -353,7 +353,7 @@ func TestAccountsDBApi_GetAccountFromBytes(t *testing.T) {
 				return nil
 			},
 			GetAccountFromBytesCalled: func(address []byte, accountBytes []byte) (vmcommon.AccountHandler, error) {
-				return state.NewUserAccount(address, &hashingMocks.HasherMock{})
+				return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 			},
 		}
 
@@ -397,7 +397,7 @@ func TestAccountsDBApi_LoadAccount(t *testing.T) {
 				return nil
 			},
 			LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
-				return state.NewUserAccount(address, &hashingMocks.HasherMock{})
+				return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 			},
 		}
 

--- a/state/accountsDB_test.go
+++ b/state/accountsDB_test.go
@@ -51,7 +51,7 @@ func createMockAccountsDBArgs() state.ArgsAccountsDB {
 		Hasher:     &hashingMocks.HasherMock{},
 		Marshaller: &testscommon.MarshalizerMock{},
 		AccountFactory: &stateMock.AccountsFactoryStub{
-			CreateAccountCalled: func(address []byte, _ hashing.Hasher) (vmcommon.AccountHandler, error) {
+			CreateAccountCalled: func(address []byte, _ hashing.Hasher, _ marshal.Marshalizer) (vmcommon.AccountHandler, error) {
 				return stateMock.NewAccountWrapMock(address), nil
 			},
 		},
@@ -260,7 +260,7 @@ func TestAccountsDB_SaveAccountNilOldAccount(t *testing.T) {
 		},
 	})
 
-	acc, _ := state.NewUserAccount([]byte("someAddress"), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount([]byte("someAddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	err := adb.SaveAccount(acc)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, adb.JournalLen())
@@ -269,7 +269,7 @@ func TestAccountsDB_SaveAccountNilOldAccount(t *testing.T) {
 func TestAccountsDB_SaveAccountExistingOldAccount(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount([]byte("someAddress"), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount([]byte("someAddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	adb := generateAccountDBFromTrie(&trieMock.TrieStub{
 		GetCalled: func(key []byte) (i []byte, err error) {
@@ -321,7 +321,7 @@ func TestAccountsDB_SaveAccountSavesCodeAndDataTrieForUserAccount(t *testing.T) 
 	})
 
 	accCode := []byte("code")
-	acc, _ := state.NewUserAccount([]byte("someAddress"), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount([]byte("someAddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acc.SetCode(accCode)
 	_ = acc.SaveKeyValue([]byte("key"), []byte("value"))
 
@@ -2421,7 +2421,7 @@ func TestAccountsDB_GetAccountFromBytes(t *testing.T) {
 
 	marshaller := &testscommon.MarshalizerMock{}
 	adr := make([]byte, 32)
-	accountExpected, _ := state.NewUserAccount(adr, &hashingMocks.HasherMock{})
+	accountExpected, _ := state.NewUserAccount(adr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	accountBytes, _ := marshaller.Marshal(accountExpected)
 	_, adb := getDefaultTrieAndAccountsDb()
 

--- a/state/factory/accountCreator.go
+++ b/state/factory/accountCreator.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/state"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
@@ -16,8 +17,8 @@ func NewAccountCreator() state.AccountFactory {
 }
 
 // CreateAccount calls the new Account creator and returns the result
-func (ac *AccountCreator) CreateAccount(address []byte, hasher hashing.Hasher) (vmcommon.AccountHandler, error) {
-	return state.NewUserAccount(address, hasher)
+func (ac *AccountCreator) CreateAccount(address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (vmcommon.AccountHandler, error) {
+	return state.NewUserAccount(address, hasher, marshaller)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/state/factory/accountCreator_test.go
+++ b/state/factory/accountCreator_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go/state"
 	"github.com/ElrondNetwork/elrond-go/state/factory"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	"github.com/stretchr/testify/assert"
 )
@@ -19,7 +20,7 @@ func TestAccountCreator_CreateAccountNilAddress(t *testing.T) {
 	assert.Equal(t, true, ok)
 	assert.False(t, check.IfNil(accF))
 
-	acc, err := accF.CreateAccount(nil, &hashingMocks.HasherMock{})
+	acc, err := accF.CreateAccount(nil, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	assert.Nil(t, acc)
 	assert.Equal(t, err, state.ErrNilAddress)
@@ -33,7 +34,7 @@ func TestAccountCreator_CreateAccountOk(t *testing.T) {
 	_, ok := accF.(*factory.AccountCreator)
 	assert.Equal(t, true, ok)
 
-	acc, err := accF.CreateAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, err := accF.CreateAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	assert.Nil(t, err)
 	assert.False(t, check.IfNil(acc))

--- a/state/factory/peerAccountCreator.go
+++ b/state/factory/peerAccountCreator.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/state"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
@@ -16,8 +17,8 @@ func NewPeerAccountCreator() state.AccountFactory {
 }
 
 // CreateAccount calls the new Account creator and returns the result
-func (pac *PeerAccountCreator) CreateAccount(address []byte, hasher hashing.Hasher) (vmcommon.AccountHandler, error) {
-	return state.NewPeerAccount(address, hasher)
+func (pac *PeerAccountCreator) CreateAccount(address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (vmcommon.AccountHandler, error) {
+	return state.NewPeerAccount(address, hasher, marshaller)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/state/factory/peerAccountCreator_test.go
+++ b/state/factory/peerAccountCreator_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go/state"
 	"github.com/ElrondNetwork/elrond-go/state/factory"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +19,7 @@ func TestPeerAccountCreator_CreateAccountNilAddress(t *testing.T) {
 	_, ok := accF.(*factory.PeerAccountCreator)
 	assert.Equal(t, true, ok)
 
-	acc, err := accF.CreateAccount(nil, &hashingMocks.HasherMock{})
+	acc, err := accF.CreateAccount(nil, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	assert.Nil(t, acc)
 	assert.Equal(t, err, state.ErrNilAddress)
@@ -33,7 +34,7 @@ func TestPeerAccountCreator_CreateAccountOk(t *testing.T) {
 	_, ok := accF.(*factory.PeerAccountCreator)
 	assert.Equal(t, true, ok)
 
-	acc, err := accF.CreateAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, err := accF.CreateAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	assert.NotNil(t, acc)
 	assert.Nil(t, err)

--- a/state/interface.go
+++ b/state/interface.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/data/api"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/common"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
 
 // AccountFactory creates an account of different types
 type AccountFactory interface {
-	CreateAccount(address []byte, hasher hashing.Hasher) (vmcommon.AccountHandler, error)
+	CreateAccount(address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (vmcommon.AccountHandler, error)
 	IsInterfaceNil() bool
 }
 

--- a/state/journalEntries_test.go
+++ b/state/journalEntries_test.go
@@ -185,7 +185,7 @@ func TestNewJournalEntryDataTrieUpdates_EmptyTrieUpdatesShouldErr(t *testing.T) 
 	t.Parallel()
 
 	trieUpdates := make(map[string][]byte)
-	accnt, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	accnt, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	entry, err := state.NewJournalEntryDataTrieUpdates(trieUpdates, accnt)
 
 	assert.True(t, check.IfNil(entry))
@@ -197,7 +197,7 @@ func TestNewJournalEntryDataTrieUpdates_OkValsShouldWork(t *testing.T) {
 
 	trieUpdates := make(map[string][]byte)
 	trieUpdates["a"] = []byte("b")
-	accnt, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	accnt, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	entry, err := state.NewJournalEntryDataTrieUpdates(trieUpdates, accnt)
 
 	assert.Nil(t, err)

--- a/state/peerAccount.go
+++ b/state/peerAccount.go
@@ -2,10 +2,10 @@
 package state
 
 import (
-	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"math/big"
 
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/common"
 )
 

--- a/state/peerAccount.go
+++ b/state/peerAccount.go
@@ -2,6 +2,7 @@
 package state
 
 import (
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"math/big"
 
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
@@ -26,12 +27,12 @@ func NewEmptyPeerAccount() *peerAccount {
 }
 
 // NewPeerAccount creates new simple account wrapper for an PeerAccountContainer (that has just been initialized)
-func NewPeerAccount(address []byte, hasher hashing.Hasher) (*peerAccount, error) {
+func NewPeerAccount(address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (*peerAccount, error) {
 	if len(address) == 0 {
 		return nil, ErrNilAddress
 	}
 
-	tdt, err := NewTrackableDataTrie(address, nil, hasher)
+	tdt, err := NewTrackableDataTrie(address, nil, hasher, marshaller)
 	if err != nil {
 		return nil, err
 	}

--- a/state/peerAccount_test.go
+++ b/state/peerAccount_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go/state"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	"github.com/stretchr/testify/assert"
 )
@@ -22,7 +23,7 @@ func TestNewEmptyPeerAccount(t *testing.T) {
 func TestNewPeerAccount_NilAddressContainerShouldErr(t *testing.T) {
 	t.Parallel()
 
-	acc, err := state.NewPeerAccount(nil, &hashingMocks.HasherMock{})
+	acc, err := state.NewPeerAccount(nil, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.True(t, check.IfNil(acc))
 	assert.Equal(t, state.ErrNilAddress, err)
 }
@@ -30,7 +31,7 @@ func TestNewPeerAccount_NilAddressContainerShouldErr(t *testing.T) {
 func TestNewPeerAccount_OkParamsShouldWork(t *testing.T) {
 	t.Parallel()
 
-	acc, err := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, err := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 	assert.False(t, check.IfNil(acc))
 }
@@ -38,7 +39,7 @@ func TestNewPeerAccount_OkParamsShouldWork(t *testing.T) {
 func TestPeerAccount_SetInvalidBLSPublicKey(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	pubKey := []byte("")
 
 	err := acc.SetBLSPublicKey(pubKey)
@@ -48,7 +49,7 @@ func TestPeerAccount_SetInvalidBLSPublicKey(t *testing.T) {
 func TestPeerAccount_SetAndGetBLSPublicKey(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	pubKey := []byte("BLSpubKey")
 
 	err := acc.SetBLSPublicKey(pubKey)
@@ -59,7 +60,7 @@ func TestPeerAccount_SetAndGetBLSPublicKey(t *testing.T) {
 func TestPeerAccount_SetRewardAddressInvalidAddress(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	err := acc.SetRewardAddress([]byte{})
 	assert.Equal(t, state.ErrEmptyAddress, err)
@@ -68,7 +69,7 @@ func TestPeerAccount_SetRewardAddressInvalidAddress(t *testing.T) {
 func TestPeerAccount_SetAndGetRewardAddress(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	addr := []byte("reward address")
 
 	_ = acc.SetRewardAddress(addr)
@@ -78,7 +79,7 @@ func TestPeerAccount_SetAndGetRewardAddress(t *testing.T) {
 func TestPeerAccount_SetAndGetAccumulatedFees(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	fees := big.NewInt(10)
 
 	acc.AddToAccumulatedFees(fees)
@@ -88,7 +89,7 @@ func TestPeerAccount_SetAndGetAccumulatedFees(t *testing.T) {
 func TestPeerAccount_SetAndGetLeaderSuccessRate(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	increaseVal := uint32(5)
 	decreaseVal := uint32(3)
 
@@ -102,7 +103,7 @@ func TestPeerAccount_SetAndGetLeaderSuccessRate(t *testing.T) {
 func TestPeerAccount_SetAndGetValidatorSuccessRate(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	increaseVal := uint32(5)
 	decreaseVal := uint32(3)
 
@@ -116,7 +117,7 @@ func TestPeerAccount_SetAndGetValidatorSuccessRate(t *testing.T) {
 func TestPeerAccount_IncreaseAndGetSetNumSelectedInSuccessBlocks(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	acc.IncreaseNumSelectedInSuccessBlocks()
 	assert.Equal(t, uint32(1), acc.GetNumSelectedInSuccessBlocks())
@@ -125,7 +126,7 @@ func TestPeerAccount_IncreaseAndGetSetNumSelectedInSuccessBlocks(t *testing.T) {
 func TestPeerAccount_SetAndGetRating(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	rating := uint32(10)
 
 	acc.SetRating(rating)
@@ -135,7 +136,7 @@ func TestPeerAccount_SetAndGetRating(t *testing.T) {
 func TestPeerAccount_SetAndGetTempRating(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	rating := uint32(10)
 
 	acc.SetTempRating(rating)
@@ -145,7 +146,7 @@ func TestPeerAccount_SetAndGetTempRating(t *testing.T) {
 func TestPeerAccount_ResetAtNewEpoch(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	acc.AddToAccumulatedFees(big.NewInt(15))
 	tempRating := uint32(5)
 	acc.SetTempRating(tempRating)
@@ -170,7 +171,7 @@ func TestPeerAccount_ResetAtNewEpoch(t *testing.T) {
 func TestPeerAccount_IncreaseAndGetNonce(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	nonce := uint64(5)
 
 	acc.IncreaseNonce(nonce)

--- a/state/trackableDataTrie.go
+++ b/state/trackableDataTrie.go
@@ -5,28 +5,34 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/common"
 )
 
 // TrackableDataTrie wraps a PatriciaMerkelTrie adding modifying data capabilities
 type trackableDataTrie struct {
-	dirtyData  map[string][]byte
-	tr         common.Trie
-	hasher     hashing.Hasher
-	identifier []byte
+	dirtyData   map[string][]byte
+	tr          common.Trie
+	hasher      hashing.Hasher
+	marshalizer marshal.Marshalizer
+	identifier  []byte
 }
 
 // NewTrackableDataTrie returns an instance of trackableDataTrie
-func NewTrackableDataTrie(identifier []byte, tr common.Trie, hasher hashing.Hasher) (*trackableDataTrie, error) {
+func NewTrackableDataTrie(identifier []byte, tr common.Trie, hasher hashing.Hasher, marshaller marshal.Marshalizer) (*trackableDataTrie, error) {
 	if check.IfNil(hasher) {
 		return nil, ErrNilHasher
 	}
+	if check.IfNil(marshaller) {
+		return nil, ErrNilMarshalizer
+	}
 
 	return &trackableDataTrie{
-		tr:         tr,
-		hasher:     hasher,
-		dirtyData:  make(map[string][]byte),
-		identifier: identifier,
+		tr:          tr,
+		hasher:      hasher,
+		marshalizer: marshaller,
+		dirtyData:   make(map[string][]byte),
+		identifier:  identifier,
 	}, nil
 }
 

--- a/state/trackableDataTrie.go
+++ b/state/trackableDataTrie.go
@@ -11,11 +11,11 @@ import (
 
 // TrackableDataTrie wraps a PatriciaMerkelTrie adding modifying data capabilities
 type trackableDataTrie struct {
-	dirtyData   map[string][]byte
-	tr          common.Trie
-	hasher      hashing.Hasher
-	marshalizer marshal.Marshalizer
-	identifier  []byte
+	dirtyData  map[string][]byte
+	tr         common.Trie
+	hasher     hashing.Hasher
+	marshaller marshal.Marshalizer
+	identifier []byte
 }
 
 // NewTrackableDataTrie returns an instance of trackableDataTrie
@@ -28,11 +28,11 @@ func NewTrackableDataTrie(identifier []byte, tr common.Trie, hasher hashing.Hash
 	}
 
 	return &trackableDataTrie{
-		tr:          tr,
-		hasher:      hasher,
-		marshalizer: marshaller,
-		dirtyData:   make(map[string][]byte),
-		identifier:  identifier,
+		tr:         tr,
+		hasher:     hasher,
+		marshaller: marshaller,
+		dirtyData:  make(map[string][]byte),
+		identifier: identifier,
 	}, nil
 }
 

--- a/state/userAccount.go
+++ b/state/userAccount.go
@@ -3,10 +3,10 @@ package state
 
 import (
 	"bytes"
-	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"math/big"
 
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 )
 
 var _ UserAccountHandler = (*userAccount)(nil)

--- a/state/userAccount.go
+++ b/state/userAccount.go
@@ -3,6 +3,7 @@ package state
 
 import (
 	"bytes"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"math/big"
 
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
@@ -30,12 +31,12 @@ func NewEmptyUserAccount() *userAccount {
 }
 
 // NewUserAccount creates new simple account wrapper for an AccountContainer (that has just been initialized)
-func NewUserAccount(address []byte, hasher hashing.Hasher) (*userAccount, error) {
+func NewUserAccount(address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (*userAccount, error) {
 	if len(address) == 0 {
 		return nil, ErrNilAddress
 	}
 
-	tdt, err := NewTrackableDataTrie(address, nil, hasher)
+	tdt, err := NewTrackableDataTrie(address, nil, hasher, marshaller)
 	if err != nil {
 		return nil, err
 	}

--- a/state/userAccount_test.go
+++ b/state/userAccount_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go/state"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	"github.com/stretchr/testify/assert"
 )
@@ -13,7 +14,7 @@ import (
 func TestNewUserAccount_NilAddressContainerShouldErr(t *testing.T) {
 	t.Parallel()
 
-	acc, err := state.NewUserAccount(nil, &hashingMocks.HasherMock{})
+	acc, err := state.NewUserAccount(nil, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.True(t, check.IfNil(acc))
 	assert.Equal(t, state.ErrNilAddress, err)
 }
@@ -21,7 +22,7 @@ func TestNewUserAccount_NilAddressContainerShouldErr(t *testing.T) {
 func TestNewUserAccount_OkParamsShouldWork(t *testing.T) {
 	t.Parallel()
 
-	acc, err := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, err := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	assert.Nil(t, err)
 	assert.False(t, check.IfNil(acc))
 }
@@ -29,7 +30,7 @@ func TestNewUserAccount_OkParamsShouldWork(t *testing.T) {
 func TestUserAccount_AddToBalanceInsufficientFundsShouldErr(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	value := big.NewInt(-1)
 
 	err := acc.AddToBalance(value)
@@ -39,7 +40,7 @@ func TestUserAccount_AddToBalanceInsufficientFundsShouldErr(t *testing.T) {
 func TestUserAccount_SubFromBalanceInsufficientFundsShouldErr(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	value := big.NewInt(1)
 
 	err := acc.SubFromBalance(value)
@@ -49,7 +50,7 @@ func TestUserAccount_SubFromBalanceInsufficientFundsShouldErr(t *testing.T) {
 func TestUserAccount_GetBalance(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	balance := big.NewInt(100)
 	subFromBalance := big.NewInt(20)
 
@@ -62,7 +63,7 @@ func TestUserAccount_GetBalance(t *testing.T) {
 func TestUserAccount_AddToDeveloperReward(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	reward := big.NewInt(10)
 
 	acc.AddToDeveloperReward(reward)
@@ -72,7 +73,7 @@ func TestUserAccount_AddToDeveloperReward(t *testing.T) {
 func TestUserAccount_ClaimDeveloperRewardsWrongAddressShouldErr(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	val, err := acc.ClaimDeveloperRewards([]byte("wrong address"))
 	assert.Nil(t, val)
 	assert.Equal(t, state.ErrOperationNotPermitted, err)
@@ -81,7 +82,7 @@ func TestUserAccount_ClaimDeveloperRewardsWrongAddressShouldErr(t *testing.T) {
 func TestUserAccount_ClaimDeveloperRewards(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	reward := big.NewInt(10)
 	acc.AddToDeveloperReward(reward)
 
@@ -94,7 +95,7 @@ func TestUserAccount_ClaimDeveloperRewards(t *testing.T) {
 func TestUserAccount_ChangeOwnerAddressWrongAddressShouldErr(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	err := acc.ChangeOwnerAddress([]byte("wrong address"), []byte{})
 	assert.Equal(t, state.ErrOperationNotPermitted, err)
 }
@@ -102,7 +103,7 @@ func TestUserAccount_ChangeOwnerAddressWrongAddressShouldErr(t *testing.T) {
 func TestUserAccount_ChangeOwnerAddressInvalidAddressShouldErr(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	err := acc.ChangeOwnerAddress(acc.OwnerAddress, []byte("new address"))
 	assert.Equal(t, state.ErrInvalidAddressLength, err)
 }
@@ -111,7 +112,7 @@ func TestUserAccount_ChangeOwnerAddress(t *testing.T) {
 	t.Parallel()
 
 	newAddress := make([]byte, 32)
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	err := acc.ChangeOwnerAddress(acc.OwnerAddress, newAddress)
 	assert.Nil(t, err)
@@ -122,7 +123,7 @@ func TestUserAccount_SetOwnerAddress(t *testing.T) {
 	t.Parallel()
 
 	newAddress := []byte("new address")
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	acc.SetOwnerAddress(newAddress)
 	assert.Equal(t, newAddress, acc.GetOwnerAddress())
@@ -131,7 +132,7 @@ func TestUserAccount_SetOwnerAddress(t *testing.T) {
 func TestUserAccount_SetAndGetNonce(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	nonce := uint64(5)
 
 	acc.IncreaseNonce(nonce)
@@ -141,7 +142,7 @@ func TestUserAccount_SetAndGetNonce(t *testing.T) {
 func TestUserAccount_SetAndGetCodeHash(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	codeHash := []byte("code hash")
 
 	acc.SetCodeHash(codeHash)
@@ -151,7 +152,7 @@ func TestUserAccount_SetAndGetCodeHash(t *testing.T) {
 func TestUserAccount_SetAndGetRootHash(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	rootHash := []byte("root hash")
 
 	acc.SetRootHash(rootHash)

--- a/testscommon/state/accountFactoryStub.go
+++ b/testscommon/state/accountFactoryStub.go
@@ -2,17 +2,18 @@ package state
 
 import (
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-vm-common"
 )
 
 // AccountsFactoryStub -
 type AccountsFactoryStub struct {
-	CreateAccountCalled func(address []byte, hasher hashing.Hasher) (vmcommon.AccountHandler, error)
+	CreateAccountCalled func(address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (vmcommon.AccountHandler, error)
 }
 
 // CreateAccount -
-func (afs *AccountsFactoryStub) CreateAccount(address []byte, hasher hashing.Hasher) (vmcommon.AccountHandler, error) {
-	return afs.CreateAccountCalled(address, hasher)
+func (afs *AccountsFactoryStub) CreateAccount(address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (vmcommon.AccountHandler, error) {
+	return afs.CreateAccountCalled(address, hasher, marshaller)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/testscommon/state/accountWrapperMock.go
+++ b/testscommon/state/accountWrapperMock.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/state"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
@@ -31,7 +32,7 @@ type AccountWrapMock struct {
 
 // NewAccountWrapMock -
 func NewAccountWrapMock(adr []byte) *AccountWrapMock {
-	tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), nil, &hashingMocks.HasherMock{})
+	tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), nil, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 
 	return &AccountWrapMock{
 		address:           adr,

--- a/update/genesis/base.go
+++ b/update/genesis/base.go
@@ -3,6 +3,7 @@ package genesis
 import (
 	"encoding/hex"
 	"fmt"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"strconv"
 	"strings"
 
@@ -90,12 +91,12 @@ func NewObject(objType Type) (interface{}, error) {
 }
 
 // NewEmptyAccount returns a new account according to the given type
-func NewEmptyAccount(accType Type, address []byte, hasher hashing.Hasher) (vmcommon.AccountHandler, error) {
+func NewEmptyAccount(accType Type, address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (vmcommon.AccountHandler, error) {
 	switch accType {
 	case UserAccount:
-		return state.NewUserAccount(address, hasher)
+		return state.NewUserAccount(address, hasher, marshaller)
 	case ValidatorAccount:
-		return state.NewPeerAccount(address, hasher)
+		return state.NewPeerAccount(address, hasher, marshaller)
 	case DataTrie:
 		return nil, nil
 	}

--- a/update/genesis/base.go
+++ b/update/genesis/base.go
@@ -3,7 +3,6 @@ package genesis
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"strconv"
 	"strings"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/smartContractResult"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/state"
 	"github.com/ElrondNetwork/elrond-go/update"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"

--- a/update/genesis/import.go
+++ b/update/genesis/import.go
@@ -515,7 +515,7 @@ func (si *stateImport) unMarshalAndSaveAccount(
 	accountsDB state.AccountsDBImporter,
 	mainTrie common.Trie,
 ) error {
-	account, err := NewEmptyAccount(accType, address, si.hasher)
+	account, err := NewEmptyAccount(accType, address, si.hasher, si.marshalizer)
 	if err != nil {
 		return err
 	}

--- a/vm/mock/blockChainHookStub.go
+++ b/vm/mock/blockChainHookStub.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"github.com/ElrondNetwork/elrond-go/state"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
@@ -75,7 +76,7 @@ func (b *BlockChainHookStub) GetUserAccount(address []byte) (vmcommon.UserAccoun
 		return b.GetUserAccountCalled(address)
 	}
 
-	return state.NewUserAccount(address, &hashingMocks.HasherMock{})
+	return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 }
 
 // GetShardOfAddress -

--- a/vm/systemSmartContracts/eei_test.go
+++ b/vm/systemSmartContracts/eei_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/state"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	stateMock "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	"github.com/ElrondNetwork/elrond-go/vm"
@@ -98,7 +99,7 @@ func TestVmContext_GetBalance(t *testing.T) {
 
 	addr := []byte("addr")
 	balance := big.NewInt(10)
-	account, _ := state.NewUserAccount([]byte("123"), &hashingMocks.HasherMock{})
+	account, _ := state.NewUserAccount([]byte("123"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 	_ = account.AddToBalance(balance)
 
 	blockChainHook := &mock.BlockChainHookStub{GetUserAccountCalled: func(address []byte) (a vmcommon.UserAccountHandler, e error) {


### PR DESCRIPTION
## Reasoning behind the pull request
- The trackable data trie needs a marshalizer in order to serialize the data that will be inserted in the trie 
  
## Proposed changes
- Add marshalizer to trackable data trie

## Pre-requisites

Based on the [Contributing Guidelines](CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
