### PR TITLE
fix contributing URL

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 
 ## Pre-requisites
 
-Based on the [Contributing Guidelines](CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
+Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
 - was the PR targeted to the correct branch?
 - if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
 - if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?


### PR DESCRIPTION
## Reasoning behind the pull request
- the reference from PR template to the contributing guidelines was broken
  
## Proposed changes
- use absolute URL instead of relative

## Testing procedure

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
