### PR TITLE
Fix link to config scripts in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ ./keygenerator
 
 ### Start the node 
 #### Step 4a: Join Elrond testnet:
-Follow the steps outlined [here](https://docs.elrond.com/validators/testnet/config-scripts/). This is because in order to join the testnet you need a specific node configuration.
+Follow the steps outlined [here](https://docs.elrond.com/validators/elrond-go-scripts/config-scripts/). This is because in order to join the testnet you need a specific node configuration.
 ______
 OR
 ______


### PR DESCRIPTION
## Reasoning behind the pull request
- The Readme included a link that led to a "404 - Page not found"
  
## Proposed changes
- Just fix the link, as the config scripts at the updated link appear to apply also to the Testnet network
