### PR TITLE
fix tx value for altered accounts tx pool

### DIFF
--- a/node/external/blockAPI/baseBlock.go
+++ b/node/external/blockAPI/baseBlock.go
@@ -513,6 +513,10 @@ func (bap *baseAPIBlockProcessor) addTxToPool(tx *transaction.ApiTransactionResu
 	}
 
 	zeroBigInt := big.NewInt(0)
+	txValue, ok := big.NewInt(0).SetString(tx.Value, 10)
+	if !ok {
+		return fmt.Errorf("cannot convert tx value to big int. Value=%s", tx.Value)
+	}
 
 	switch tx.Type {
 	case string(transaction.TxTypeNormal):
@@ -520,6 +524,7 @@ func (bap *baseAPIBlockProcessor) addTxToPool(tx *transaction.ApiTransactionResu
 			&transaction.Transaction{
 				SndAddr: senderBytes,
 				RcvAddr: receiverBytes,
+				Value:   txValue,
 			},
 			0,
 			zeroBigInt,
@@ -529,6 +534,7 @@ func (bap *baseAPIBlockProcessor) addTxToPool(tx *transaction.ApiTransactionResu
 			&smartContractResult.SmartContractResult{
 				SndAddr: senderBytes,
 				RcvAddr: receiverBytes,
+				Value:   txValue,
 			},
 			0,
 			zeroBigInt,
@@ -538,6 +544,7 @@ func (bap *baseAPIBlockProcessor) addTxToPool(tx *transaction.ApiTransactionResu
 			&transaction.Transaction{
 				SndAddr: senderBytes,
 				// do not set the receiver since the cost is only on sender's side in case of invalid txs
+				Value: txValue,
 			},
 			0,
 			zeroBigInt,
@@ -546,6 +553,7 @@ func (bap *baseAPIBlockProcessor) addTxToPool(tx *transaction.ApiTransactionResu
 		pool.Rewards[tx.Hash] = outport.NewTransactionHandlerWithGasAndFee(
 			&rewardTx.RewardTx{
 				RcvAddr: receiverBytes,
+				Value:   txValue,
 			},
 			0,
 			zeroBigInt,

--- a/node/external/blockAPI/baseBlock.go
+++ b/node/external/blockAPI/baseBlock.go
@@ -513,7 +513,11 @@ func (bap *baseAPIBlockProcessor) addTxToPool(tx *transaction.ApiTransactionResu
 	}
 
 	zeroBigInt := big.NewInt(0)
-	txValue, ok := big.NewInt(0).SetString(tx.Value, 10)
+	txValueString := tx.Value
+	if len(txValueString) == 0 {
+		txValueString = "0"
+	}
+	txValue, ok := big.NewInt(0).SetString(txValueString, 10)
 	if !ok {
 		return fmt.Errorf("cannot convert tx value to big int. Value=%s", tx.Value)
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- during the latest changes, altered accounts provider used the tx value, and txs from the pool constructed when querying altered accounts did not have the value set (since it wasn't needed)
  
## Proposed changes
- set tx value

## Testing procedure
- receiver addresses should be returned in altered accounts endpoints

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
