### PR TITLE
FEAT: Use MetaData from outport

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.15
 
 require (
 	github.com/ElrondNetwork/covalent-indexer-go v1.0.7-0.20220922092743-7f3a26b4001a
-	github.com/ElrondNetwork/elastic-indexer-go v1.2.46-0.20221107121020-d2b832565089
-	github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221101091159-7dd46b891266
+	github.com/ElrondNetwork/elastic-indexer-go v1.2.46-0.20221108125017-840d49566319
+	github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221108113024-38dd797ed574
 	github.com/ElrondNetwork/elrond-go-crypto v1.2.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.9
 	github.com/ElrondNetwork/elrond-go-p2p v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/ElrondNetwork/concurrent-map v0.1.3 h1:j2LtPrNJuerannC1cQDE79STvi/P04
 github.com/ElrondNetwork/concurrent-map v0.1.3/go.mod h1:3XwSwn4JHI0lrKxWLZvtp53Emr8BXYTmNQGwcukHJEE=
 github.com/ElrondNetwork/covalent-indexer-go v1.0.7-0.20220922092743-7f3a26b4001a h1:LI6kQSNCnsLkl5g1yMcSILDqfxPGZ2nD+4BiwhjFLaQ=
 github.com/ElrondNetwork/covalent-indexer-go v1.0.7-0.20220922092743-7f3a26b4001a/go.mod h1:JvcH6f+nhhJakiCsg++uyJbp9C9HYKB1fulliw+DiA0=
-github.com/ElrondNetwork/elastic-indexer-go v1.2.46-0.20221107121020-d2b832565089 h1:T4I82+EAgL59WhhUwTi+fW4dh0NnmbMtorJwMUIgvjI=
-github.com/ElrondNetwork/elastic-indexer-go v1.2.46-0.20221107121020-d2b832565089/go.mod h1:icRk6DOPLTeOtywgXvvtLduqQAnp2Uh3bbtDCOoScQI=
+github.com/ElrondNetwork/elastic-indexer-go v1.2.46-0.20221108125017-840d49566319 h1:U3syVrJE1QsULDHq1OciirKnF0Uze0Lcv/uEo9v0xK0=
+github.com/ElrondNetwork/elastic-indexer-go v1.2.46-0.20221108125017-840d49566319/go.mod h1:WFQu99OvIrIeDtNmSxSOxaoV7WoCWGkSas0M6KF/NbA=
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-core v1.1.13/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
@@ -58,9 +58,8 @@ github.com/ElrondNetwork/elrond-go-core v1.1.18/go.mod h1:Yz8JK5sGBctw7+gU8j2mZH
 github.com/ElrondNetwork/elrond-go-core v1.1.19-0.20220729074346-fca5b87ec7c7/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-core v1.1.19/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-core v1.1.20-0.20220915145036-720d0233becd/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
-github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221028092924-4f1c38bae5f9/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
-github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221101091159-7dd46b891266 h1:PEU7GFJtRXeXnnRumf79wSP9HM6d6LzFHPawe1vWXu8=
-github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221101091159-7dd46b891266/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
+github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221108113024-38dd797ed574 h1:XCj1Fo6Xl8EzAFhaIFcCY393Cu2HPppAKeOdxMaTFT4=
+github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221108113024-38dd797ed574/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.0/go.mod h1:DGiR7/j1xv729Xg8SsjYaUzWXL5svMd44REXjWS/gAc=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.1 h1:5wWCBEZp5SMFO2+Nal8UaJNJcG9G9J4PHNNZvQpEeUE=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.1/go.mod h1:UNmpDaJjLTKxfzUcwua2R7Mh9bicw/L3ICJt5V7zqMo=

--- a/outport/process/alteredaccounts/alteredAccountsProvider_test.go
+++ b/outport/process/alteredaccounts/alteredAccountsProvider_test.go
@@ -533,7 +533,7 @@ func testExtractAlteredAccountsFromPoolShouldIncludeNFT(t *testing.T) {
 		Identifier: "token0",
 		Balance:    expectedToken.Value.String(),
 		Nonce:      expectedToken.TokenMetaData.Nonce,
-		MetaData:   expectedToken.TokenMetaData,
+		MetaData:   &outportcore.TokenMetaData{Nonce: expectedToken.TokenMetaData.Nonce},
 	}, res[encodedAddr].Tokens[0])
 }
 
@@ -658,9 +658,7 @@ func testExtractAlteredAccountsFromPoolShouldIncludeDestinationFromTokensLogsTop
 		Identifier: "token0",
 		Balance:    "37",
 		Nonce:      38,
-		MetaData: &esdt.MetaData{
-			Nonce: 38,
-		},
+		MetaData:   &outportcore.TokenMetaData{Nonce: 38},
 	})
 }
 
@@ -855,14 +853,20 @@ func testExtractAlteredAccountsFromPoolAddressHasMultipleNfts(t *testing.T) {
 		Identifier: string(expectedToken1.TokenMetaData.Name),
 		Balance:    expectedToken1.Value.String(),
 		Nonce:      expectedToken1.TokenMetaData.Nonce,
-		MetaData:   expectedToken1.TokenMetaData,
+		MetaData: &outportcore.TokenMetaData{
+			Nonce: expectedToken1.TokenMetaData.Nonce,
+			Name:  string(expectedToken1.TokenMetaData.Name),
+		},
 	})
 
 	require.Contains(t, res[encodedAddr].Tokens, &outportcore.AccountTokenData{
 		Identifier: string(expectedToken2.TokenMetaData.Name),
 		Balance:    expectedToken2.Value.String(),
 		Nonce:      expectedToken2.TokenMetaData.Nonce,
-		MetaData:   expectedToken2.TokenMetaData,
+		MetaData: &outportcore.TokenMetaData{
+			Nonce: expectedToken2.TokenMetaData.Nonce,
+			Name:  string(expectedToken2.TokenMetaData.Name),
+		},
 	})
 
 }

--- a/outport/process/alteredaccounts/alteredAccountsProvider_test.go
+++ b/outport/process/alteredaccounts/alteredAccountsProvider_test.go
@@ -611,7 +611,13 @@ func testExtractAlteredAccountsFromPoolShouldIncludeDestinationFromTokensLogsTop
 	expectedToken := esdt.ESDigitalToken{
 		Value: big.NewInt(37),
 		TokenMetaData: &esdt.MetaData{
-			Nonce: 38,
+			Nonce:      38,
+			Name:       []byte("name"),
+			Creator:    []byte("creator"),
+			Royalties:  1000,
+			Hash:       []byte("hash"),
+			URIs:       [][]byte{[]byte("uri1"), []byte("uri2")},
+			Attributes: []byte("attributes"),
 		},
 	}
 	args := getMockArgs()
@@ -653,12 +659,21 @@ func testExtractAlteredAccountsFromPoolShouldIncludeDestinationFromTokensLogsTop
 	require.Len(t, res, 2)
 
 	mapKeyToSearch := args.AddressConverter.Encode(receiverOnDestination)
+	creator := args.AddressConverter.Encode(expectedToken.TokenMetaData.Creator)
 	require.Len(t, res[mapKeyToSearch].Tokens, 1)
 	require.Equal(t, res[mapKeyToSearch].Tokens[0], &outportcore.AccountTokenData{
 		Identifier: "token0",
 		Balance:    "37",
 		Nonce:      38,
-		MetaData:   &outportcore.TokenMetaData{Nonce: 38},
+		MetaData: &outportcore.TokenMetaData{
+			Nonce:      38,
+			Name:       "name",
+			Creator:    creator,
+			Royalties:  1000,
+			Hash:       []byte("hash"),
+			URIs:       [][]byte{[]byte("uri1"), []byte("uri2")},
+			Attributes: []byte("attributes"),
+		},
 	})
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request
- Within the latest `elrond-go-core` integration, we replaced proto `MetaData` with `TokenMetaData` in altered accounts.

## Proposed changes
- Refactor code to work with the new struct

## Testing procedure
- Unit tests

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
