### PR TITLE
Enable epochs handler to data trie

### DIFF
--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -221,7 +221,7 @@
     # FixOldTokenLiquidityEnableEpoch represents the epoch when the fix for old token liquidity is enabled
     FixOldTokenLiquidityEnableEpoch = 1
 
-    # AutoBalanceDataTriesEnableEpoch represents the epoch when the dataTries are automatically balanced by inserting at the hashed key instead of the normal key
+    # AutoBalanceDataTriesEnableEpoch represents the epoch when the data tries are automatically balanced by inserting at the hashed key instead of the normal key
     AutoBalanceDataTriesEnableEpoch = 1
 
     # SetSenderInEeiOutputTransferEnableEpoch represents the epoch when setting the sender in eei output transfers will be enabled

--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -221,6 +221,9 @@
     # FixOldTokenLiquidityEnableEpoch represents the epoch when the fix for old token liquidity is enabled
     FixOldTokenLiquidityEnableEpoch = 1
 
+    # AutoBalanceDataTriesEnableEpoch represents the epoch when the dataTries are automatically balanced by inserting at the hashed key instead of the normal key
+    AutoBalanceDataTriesEnableEpoch = 1
+
     # SetSenderInEeiOutputTransferEnableEpoch represents the epoch when setting the sender in eei output transfers will be enabled
     SetSenderInEeiOutputTransferEnableEpoch = 4
 

--- a/common/enablers/enableEpochsHandler.go
+++ b/common/enablers/enableEpochsHandler.go
@@ -113,6 +113,7 @@ func (handler *enableEpochsHandler) EpochConfirmed(epoch uint32, _ uint64) {
 	handler.setFlagValue(epoch >= handler.enableEpochsConfig.RefactorPeersMiniBlocksEnableEpoch, handler.refactorPeersMiniBlocksFlag, "refactorPeersMiniBlocksFlag")
 	handler.setFlagValue(epoch >= handler.enableEpochsConfig.FixAsyncCallBackArgsListEnableEpoch, handler.fixAsyncCallBackArgsList, "fixAsyncCallBackArgsList")
 	handler.setFlagValue(epoch >= handler.enableEpochsConfig.FixOldTokenLiquidityEnableEpoch, handler.fixOldTokenLiquidity, "fixOldTokenLiquidity")
+	handler.setFlagValue(epoch >= handler.enableEpochsConfig.AutoBalanceDataTriesEnableEpoch, handler.autoBalanceDataTriesFlag, "autoBalanceDataTriesFlag")
 }
 
 func (handler *enableEpochsHandler) setFlagValue(value bool, flag *atomic.Flag, flagName string) {

--- a/common/enablers/enableEpochsHandler_test.go
+++ b/common/enablers/enableEpochsHandler_test.go
@@ -86,6 +86,7 @@ func createEnableEpochsConfig() config.EnableEpochs {
 		CheckExecuteOnReadOnlyEnableEpoch:                 70,
 		FixAsyncCallBackArgsListEnableEpoch:               71,
 		FixOldTokenLiquidityEnableEpoch:                   72,
+		AutoBalanceDataTriesEnableEpoch:                   73,
 	}
 }
 
@@ -204,6 +205,7 @@ func TestNewEnableEpochsHandler_EpochConfirmed(t *testing.T) {
 		assert.True(t, handler.IsCheckExecuteOnReadOnlyFlagEnabled())
 		assert.True(t, handler.IsChangeDelegationOwnerFlagEnabled())
 		assert.True(t, handler.IsFixOldTokenLiquidityEnabled())
+		assert.True(t, handler.IsAutoBalanceDataTriesEnabled())
 	})
 	t.Run("flags with == condition should be set, along with all >=", func(t *testing.T) {
 		t.Parallel()
@@ -299,6 +301,7 @@ func TestNewEnableEpochsHandler_EpochConfirmed(t *testing.T) {
 		assert.True(t, handler.IsChangeDelegationOwnerFlagEnabled())
 		assert.True(t, handler.IsFixAsyncCallBackArgsListFlagEnabled())
 		assert.True(t, handler.IsFixOldTokenLiquidityEnabled())
+		assert.True(t, handler.IsAutoBalanceDataTriesEnabled())
 	})
 	t.Run("flags with < should be set", func(t *testing.T) {
 		t.Parallel()
@@ -389,5 +392,6 @@ func TestNewEnableEpochsHandler_EpochConfirmed(t *testing.T) {
 		assert.False(t, handler.IsChangeDelegationOwnerFlagEnabled())
 		assert.False(t, handler.IsFixAsyncCallBackArgsListFlagEnabled())
 		assert.False(t, handler.IsFixOldTokenLiquidityEnabled())
+		assert.False(t, handler.IsAutoBalanceDataTriesEnabled())
 	})
 }

--- a/common/enablers/epochFlags.go
+++ b/common/enablers/epochFlags.go
@@ -83,6 +83,7 @@ type epochFlagsHolder struct {
 	refactorPeersMiniBlocksFlag                 *atomic.Flag
 	fixAsyncCallBackArgsList                    *atomic.Flag
 	fixOldTokenLiquidity                        *atomic.Flag
+	autoBalanceDataTriesFlag                    *atomic.Flag
 }
 
 func newEpochFlagsHolder() *epochFlagsHolder {
@@ -167,6 +168,7 @@ func newEpochFlagsHolder() *epochFlagsHolder {
 		refactorPeersMiniBlocksFlag:                 &atomic.Flag{},
 		fixAsyncCallBackArgsList:                    &atomic.Flag{},
 		fixOldTokenLiquidity:                        &atomic.Flag{},
+		autoBalanceDataTriesFlag:                    &atomic.Flag{},
 	}
 }
 
@@ -621,4 +623,9 @@ func (holder *epochFlagsHolder) IsFixAsyncCallBackArgsListFlagEnabled() bool {
 // IsFixOldTokenLiquidityEnabled returns true if fixOldTokenLiquidity is enabled
 func (holder *epochFlagsHolder) IsFixOldTokenLiquidityEnabled() bool {
 	return holder.fixOldTokenLiquidity.IsSet()
+}
+
+// IsAutoBalanceDataTriesEnabled returns true if autoBalanceDataTriesFlag is enabled
+func (holder *epochFlagsHolder) IsAutoBalanceDataTriesEnabled() bool {
+	return holder.autoBalanceDataTriesFlag.IsSet()
 }

--- a/common/interface.go
+++ b/common/interface.go
@@ -332,6 +332,7 @@ type EnableEpochsHandler interface {
 	IsRefactorPeersMiniBlocksFlagEnabled() bool
 	IsFixAsyncCallBackArgsListFlagEnabled() bool
 	IsFixOldTokenLiquidityEnabled() bool
+	IsAutoBalanceDataTriesEnabled() bool
 
 	IsInterfaceNil() bool
 }

--- a/config/epochConfig.go
+++ b/config/epochConfig.go
@@ -88,6 +88,7 @@ type EnableEpochs struct {
 	FixOldTokenLiquidityEnableEpoch                   uint32
 	SetSenderInEeiOutputTransferEnableEpoch           uint32
 	RefactorPeersMiniBlocksEnableEpoch                uint32
+	AutoBalanceDataTriesEnableEpoch                   uint32
 	BLSMultiSignerEnableEpoch                         []MultiSignerConfig
 }
 

--- a/epochStart/metachain/baseRewards_test.go
+++ b/epochStart/metachain/baseRewards_test.go
@@ -833,13 +833,13 @@ func TestBaseRewardsCreator_isSystemDelegationSC(t *testing.T) {
 	isDelegationSCAddress = rwd.isSystemDelegationSC(peerAccount.AddressBytes())
 	require.False(t, isDelegationSCAddress)
 
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
 	// existing user account
-	userAccount, err := state.NewUserAccount(
-		[]byte("userAddress"),
-		&hashingMocks.HasherMock{},
-		&testscommon.MarshalizerMock{},
-		&testscommon.EnableEpochsHandlerStub{},
-	)
+	userAccount, err := state.NewUserAccount([]byte("userAddress"), argsAccCreation)
 	require.Nil(t, err)
 
 	userAccount.SetDataTrie(&trieMock.TrieStub{
@@ -1146,7 +1146,12 @@ func getBaseRewardsArguments() BaseRewardsCreatorArgs {
 	storageManagerArgs.Hasher = hasher
 
 	trieFactoryManager, _ := trie.CreateTrieStorageManager(storageManagerArgs, options)
-	accCreator, _ := factory.NewAccountCreator(hasher, marshalizer, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreator := state.ArgsAccountCreation{
+		Hasher:              hasher,
+		Marshaller:          marshalizer,
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	accCreator, _ := factory.NewAccountCreator(argsAccCreator)
 	userAccountsDB := createAccountsDB(hasher, marshalizer, accCreator, trieFactoryManager)
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	shardCoordinator.CurrentShard = core.MetachainShardId

--- a/epochStart/metachain/baseRewards_test.go
+++ b/epochStart/metachain/baseRewards_test.go
@@ -826,7 +826,7 @@ func TestBaseRewardsCreator_isSystemDelegationSC(t *testing.T) {
 	require.False(t, isDelegationSCAddress)
 
 	// peer account
-	peerAccount, err := state.NewPeerAccount([]byte("addressPeer"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	peerAccount, err := state.NewPeerAccount([]byte("addressPeer"))
 	require.Nil(t, err)
 	err = rwd.userAccountsDB.SaveAccount(peerAccount)
 	require.Nil(t, err)
@@ -834,7 +834,12 @@ func TestBaseRewardsCreator_isSystemDelegationSC(t *testing.T) {
 	require.False(t, isDelegationSCAddress)
 
 	// existing user account
-	userAccount, err := state.NewUserAccount([]byte("userAddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	userAccount, err := state.NewUserAccount(
+		[]byte("userAddress"),
+		&hashingMocks.HasherMock{},
+		&testscommon.MarshalizerMock{},
+		&testscommon.EnableEpochsHandlerStub{},
+	)
 	require.Nil(t, err)
 
 	userAccount.SetDataTrie(&trieMock.TrieStub{
@@ -1141,7 +1146,8 @@ func getBaseRewardsArguments() BaseRewardsCreatorArgs {
 	storageManagerArgs.Hasher = hasher
 
 	trieFactoryManager, _ := trie.CreateTrieStorageManager(storageManagerArgs, options)
-	userAccountsDB := createAccountsDB(hasher, marshalizer, factory.NewAccountCreator(), trieFactoryManager)
+	accCreator, _ := factory.NewAccountCreator(hasher, marshalizer, &testscommon.EnableEpochsHandlerStub{})
+	userAccountsDB := createAccountsDB(hasher, marshalizer, accCreator, trieFactoryManager)
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	shardCoordinator.CurrentShard = core.MetachainShardId
 	shardCoordinator.ComputeIdCalled = func(address []byte) uint32 {

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -912,7 +912,12 @@ func createFullArgumentsForSystemSCProcessing(enableEpochsConfig config.EnableEp
 	storageManagerArgs.CheckpointsStorer = trieStorer
 
 	trieFactoryManager, _ := trie.CreateTrieStorageManager(storageManagerArgs, options)
-	accCreator, _ := factory.NewAccountCreator(hasher, marshalizer, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreator := state.ArgsAccountCreation{
+		Hasher:              hasher,
+		Marshaller:          marshalizer,
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	accCreator, _ := factory.NewAccountCreator(argsAccCreator)
 	peerAccCreator := factory.NewPeerAccountCreator()
 	userAccountsDB := createAccountsDB(hasher, marshalizer, accCreator, trieFactoryManager)
 	peerAccountsDB := createAccountsDB(hasher, marshalizer, peerAccCreator, trieFactoryManager)

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -912,8 +912,10 @@ func createFullArgumentsForSystemSCProcessing(enableEpochsConfig config.EnableEp
 	storageManagerArgs.CheckpointsStorer = trieStorer
 
 	trieFactoryManager, _ := trie.CreateTrieStorageManager(storageManagerArgs, options)
-	userAccountsDB := createAccountsDB(hasher, marshalizer, factory.NewAccountCreator(), trieFactoryManager)
-	peerAccountsDB := createAccountsDB(hasher, marshalizer, factory.NewPeerAccountCreator(), trieFactoryManager)
+	accCreator, _ := factory.NewAccountCreator(hasher, marshalizer, &testscommon.EnableEpochsHandlerStub{})
+	peerAccCreator := factory.NewPeerAccountCreator()
+	userAccountsDB := createAccountsDB(hasher, marshalizer, accCreator, trieFactoryManager)
+	peerAccountsDB := createAccountsDB(hasher, marshalizer, peerAccCreator, trieFactoryManager)
 	en := forking.NewGenericEpochNotifier()
 	epochsConfig := &config.EpochConfig{
 		EnableEpochs: enableEpochsConfig,

--- a/factory/processing/blockProcessorCreator_test.go
+++ b/factory/processing/blockProcessorCreator_test.go
@@ -107,10 +107,12 @@ func Test_newBlockProcessorCreatorForMeta(t *testing.T) {
 	trieStorageManagers[trieFactory.UserAccountTrie] = storageManagerUser
 	trieStorageManagers[trieFactory.PeerAccountTrie] = storageManagerPeer
 
+	accCreator, _ := factoryState.NewAccountCreator(coreComponents.Hasher(), coreComponents.InternalMarshalizer(), coreComponents.EnableEpochsHandler())
+
 	accounts, err := createAccountAdapter(
 		&mock.MarshalizerMock{},
 		&hashingMocks.HasherMock{},
-		factoryState.NewAccountCreator(),
+		accCreator,
 		trieStorageManagers[trieFactory.UserAccountTrie],
 	)
 	require.Nil(t, err)

--- a/factory/processing/blockProcessorCreator_test.go
+++ b/factory/processing/blockProcessorCreator_test.go
@@ -107,7 +107,12 @@ func Test_newBlockProcessorCreatorForMeta(t *testing.T) {
 	trieStorageManagers[trieFactory.UserAccountTrie] = storageManagerUser
 	trieStorageManagers[trieFactory.PeerAccountTrie] = storageManagerPeer
 
-	accCreator, _ := factoryState.NewAccountCreator(coreComponents.Hasher(), coreComponents.InternalMarshalizer(), coreComponents.EnableEpochsHandler())
+	argsAccCreator := state.ArgsAccountCreation{
+		Hasher:              coreComponents.Hasher(),
+		Marshaller:          coreComponents.InternalMarshalizer(),
+		EnableEpochsHandler: coreComponents.EnableEpochsHandler(),
+	}
+	accCreator, _ := factoryState.NewAccountCreator(argsAccCreator)
 
 	accounts, err := createAccountAdapter(
 		&mock.MarshalizerMock{},

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -882,12 +882,12 @@ func (pcf *processComponentsFactory) indexGenesisAccounts() error {
 }
 
 func (pcf *processComponentsFactory) unmarshalUserAccount(address []byte, userAccountsBytes []byte) (state.UserAccountHandler, error) {
-	userAccount, err := state.NewUserAccount(
-		address,
-		pcf.coreData.Hasher(),
-		pcf.coreData.InternalMarshalizer(),
-		pcf.coreData.EnableEpochsHandler(),
-	)
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              pcf.coreData.Hasher(),
+		Marshaller:          pcf.coreData.InternalMarshalizer(),
+		EnableEpochsHandler: pcf.coreData.EnableEpochsHandler(),
+	}
+	userAccount, err := state.NewUserAccount(address, argsAccCreation)
 	if err != nil {
 		return nil, err
 	}

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -882,7 +882,12 @@ func (pcf *processComponentsFactory) indexGenesisAccounts() error {
 }
 
 func (pcf *processComponentsFactory) unmarshalUserAccount(address []byte, userAccountsBytes []byte) (state.UserAccountHandler, error) {
-	userAccount, err := state.NewUserAccount(address, pcf.coreData.Hasher(), pcf.coreData.InternalMarshalizer())
+	userAccount, err := state.NewUserAccount(
+		address,
+		pcf.coreData.Hasher(),
+		pcf.coreData.InternalMarshalizer(),
+		pcf.coreData.EnableEpochsHandler(),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/factory/state/stateComponents.go
+++ b/factory/state/stateComponents.go
@@ -118,7 +118,12 @@ func (scf *stateComponentsFactory) Create() (*stateComponents, error) {
 }
 
 func (scf *stateComponentsFactory) createAccountsAdapters(triesContainer common.TriesHolder) (state.AccountsAdapter, state.AccountsAdapter, state.AccountsRepository, error) {
-	accountFactory, err := factoryState.NewAccountCreator(scf.core.Hasher(), scf.core.InternalMarshalizer(), scf.core.EnableEpochsHandler())
+	argsAccCreator := state.ArgsAccountCreation{
+		Hasher:              scf.core.Hasher(),
+		Marshaller:          scf.core.InternalMarshalizer(),
+		EnableEpochsHandler: scf.core.EnableEpochsHandler(),
+	}
+	accountFactory, err := factoryState.NewAccountCreator(argsAccCreator)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/factory/state/stateComponents.go
+++ b/factory/state/stateComponents.go
@@ -118,7 +118,11 @@ func (scf *stateComponentsFactory) Create() (*stateComponents, error) {
 }
 
 func (scf *stateComponentsFactory) createAccountsAdapters(triesContainer common.TriesHolder) (state.AccountsAdapter, state.AccountsAdapter, state.AccountsRepository, error) {
-	accountFactory := factoryState.NewAccountCreator()
+	accountFactory, err := factoryState.NewAccountCreator(scf.core.Hasher(), scf.core.InternalMarshalizer(), scf.core.EnableEpochsHandler())
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	merkleTrie := triesContainer.Get([]byte(trieFactory.UserAccountTrie))
 	storagePruning, err := scf.newStoragePruningManager()
 	if err != nil {

--- a/genesis/process/genesisBlockCreator.go
+++ b/genesis/process/genesisBlockCreator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/process/smartContract/hooks"
 	"github.com/ElrondNetwork/elrond-go/sharding"
+	"github.com/ElrondNetwork/elrond-go/state"
 	factoryState "github.com/ElrondNetwork/elrond-go/state/factory"
 	"github.com/ElrondNetwork/elrond-go/statusHandler"
 	"github.com/ElrondNetwork/elrond-go/storage"
@@ -478,7 +479,12 @@ func (gbc *genesisBlockCreator) getNewArgForShard(shardID uint32) (ArgsGenesisBl
 	}
 	newArgument := gbc.arg // copy the arguments
 
-	accCreator, err := factoryState.NewAccountCreator(newArgument.Core.Hasher(), newArgument.Core.InternalMarshalizer(), newArgument.Core.EnableEpochsHandler())
+	argsAccCreator := state.ArgsAccountCreation{
+		Hasher:              newArgument.Core.Hasher(),
+		Marshaller:          newArgument.Core.InternalMarshalizer(),
+		EnableEpochsHandler: newArgument.Core.EnableEpochsHandler(),
+	}
+	accCreator, err := factoryState.NewAccountCreator(argsAccCreator)
 	if err != nil {
 		return ArgsGenesisBlockCreator{}, err
 	}

--- a/genesis/process/genesisBlockCreator.go
+++ b/genesis/process/genesisBlockCreator.go
@@ -114,6 +114,7 @@ func (gbc *genesisBlockCreator) createHardForkImportHandler() error {
 		ShardID:             gbc.arg.ShardCoordinator.SelfId(),
 		StorageConfig:       gbc.arg.HardForkConfig.ImportStateStorageConfig,
 		TrieStorageManagers: gbc.arg.TrieStorageManagers,
+		EnableEpochsHandler: gbc.arg.Core.EnableEpochsHandler(),
 	}
 	importHandler, err := hardfork.NewStateImport(argsHardForkImport)
 	if err != nil {
@@ -475,12 +476,17 @@ func (gbc *genesisBlockCreator) getNewArgForShard(shardID uint32) (ArgsGenesisBl
 		newArgument.Data = newArgument.Data.Clone().(dataComponentsHandler)
 		return newArgument, nil
 	}
-
 	newArgument := gbc.arg // copy the arguments
+
+	accCreator, err := factoryState.NewAccountCreator(newArgument.Core.Hasher(), newArgument.Core.InternalMarshalizer(), newArgument.Core.EnableEpochsHandler())
+	if err != nil {
+		return ArgsGenesisBlockCreator{}, err
+	}
+
 	newArgument.Accounts, err = createAccountAdapter(
 		newArgument.Core.InternalMarshalizer(),
 		newArgument.Core.Hasher(),
-		factoryState.NewAccountCreator(),
+		accCreator,
 		gbc.arg.TrieStorageManagers[triesFactory.UserAccountTrie],
 	)
 	if err != nil {

--- a/genesis/process/genesisBlockCreator_test.go
+++ b/genesis/process/genesisBlockCreator_test.go
@@ -141,7 +141,12 @@ func createMockArgument(
 		SelfShardId: 0,
 	}
 
-	accCreator, err := factoryState.NewAccountCreator(&hashingMocks.HasherMock{}, &mock.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreator := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &mock.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	accCreator, err := factoryState.NewAccountCreator(argsAccCreator)
 	require.Nil(t, err)
 
 	arg.Accounts, err = createAccountAdapter(

--- a/genesis/process/genesisBlockCreator_test.go
+++ b/genesis/process/genesisBlockCreator_test.go
@@ -141,11 +141,13 @@ func createMockArgument(
 		SelfShardId: 0,
 	}
 
-	var err error
+	accCreator, err := factoryState.NewAccountCreator(&hashingMocks.HasherMock{}, &mock.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	require.Nil(t, err)
+
 	arg.Accounts, err = createAccountAdapter(
 		&mock.MarshalizerMock{},
 		&hashingMocks.HasherMock{},
-		factoryState.NewAccountCreator(),
+		accCreator,
 		trieStorageManagers[factory.UserAccountTrie],
 	)
 	require.Nil(t, err)

--- a/integrationTests/state/stateTrie/stateTrie_test.go
+++ b/integrationTests/state/stateTrie/stateTrie_test.go
@@ -1057,7 +1057,12 @@ func createAccounts(
 	maxTrieLevelInMemory := uint(5)
 	tr, _ := trie.NewTrie(trieStorage, integrationTests.TestMarshalizer, integrationTests.TestHasher, maxTrieLevelInMemory)
 	spm, _ := storagePruningManager.NewStoragePruningManager(ewl, 10)
-	accCreator, _ := factory.NewAccountCreator(integrationTests.TestHasher, integrationTests.TestMarshalizer, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreator := state.ArgsAccountCreation{
+		Hasher:              integrationTests.TestHasher,
+		Marshaller:          integrationTests.TestMarshalizer,
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	accCreator, _ := factory.NewAccountCreator(argsAccCreator)
 	argsAccountsDB := state.ArgsAccountsDB{
 		Trie:                  tr,
 		Hasher:                integrationTests.TestHasher,
@@ -2401,7 +2406,12 @@ func createAccountsDBTestSetup() *state.AccountsDB {
 	maxTrieLevelInMemory := uint(5)
 	tr, _ := trie.NewTrie(trieStorage, integrationTests.TestMarshalizer, integrationTests.TestHasher, maxTrieLevelInMemory)
 	spm, _ := storagePruningManager.NewStoragePruningManager(ewl, 10)
-	accCreator, _ := factory.NewAccountCreator(integrationTests.TestHasher, integrationTests.TestMarshalizer, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreator := state.ArgsAccountCreation{
+		Hasher:              integrationTests.TestHasher,
+		Marshaller:          integrationTests.TestMarshalizer,
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	accCreator, _ := factory.NewAccountCreator(argsAccCreator)
 
 	argsAccountsDB := state.ArgsAccountsDB{
 		Trie:                  tr,

--- a/integrationTests/state/stateTrie/stateTrie_test.go
+++ b/integrationTests/state/stateTrie/stateTrie_test.go
@@ -1057,12 +1057,12 @@ func createAccounts(
 	maxTrieLevelInMemory := uint(5)
 	tr, _ := trie.NewTrie(trieStorage, integrationTests.TestMarshalizer, integrationTests.TestHasher, maxTrieLevelInMemory)
 	spm, _ := storagePruningManager.NewStoragePruningManager(ewl, 10)
-
+	accCreator, _ := factory.NewAccountCreator(integrationTests.TestHasher, integrationTests.TestMarshalizer, &testscommon.EnableEpochsHandlerStub{})
 	argsAccountsDB := state.ArgsAccountsDB{
 		Trie:                  tr,
 		Hasher:                integrationTests.TestHasher,
 		Marshaller:            integrationTests.TestMarshalizer,
-		AccountFactory:        factory.NewAccountCreator(),
+		AccountFactory:        accCreator,
 		StoragePruningManager: spm,
 		ProcessingMode:        common.Normal,
 		ProcessStatusHandler:  &testscommon.ProcessStatusHandlerStub{},
@@ -2401,12 +2401,13 @@ func createAccountsDBTestSetup() *state.AccountsDB {
 	maxTrieLevelInMemory := uint(5)
 	tr, _ := trie.NewTrie(trieStorage, integrationTests.TestMarshalizer, integrationTests.TestHasher, maxTrieLevelInMemory)
 	spm, _ := storagePruningManager.NewStoragePruningManager(ewl, 10)
+	accCreator, _ := factory.NewAccountCreator(integrationTests.TestHasher, integrationTests.TestMarshalizer, &testscommon.EnableEpochsHandlerStub{})
 
 	argsAccountsDB := state.ArgsAccountsDB{
 		Trie:                  tr,
 		Hasher:                integrationTests.TestHasher,
 		Marshaller:            integrationTests.TestMarshalizer,
-		AccountFactory:        factory.NewAccountCreator(),
+		AccountFactory:        accCreator,
 		StoragePruningManager: spm,
 		ProcessingMode:        common.Normal,
 		ProcessStatusHandler:  &testscommon.ProcessStatusHandlerStub{},

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -469,7 +469,12 @@ func CreateAccountsDBWithEnableEpochsHandler(
 func getAccountFactory(accountType Type, enableEpochsHandler common.EnableEpochsHandler) (state.AccountFactory, error) {
 	switch accountType {
 	case UserAccount:
-		return factory.NewAccountCreator(sha256.NewSha256(), TestMarshalizer, enableEpochsHandler)
+		argsAccCreator := state.ArgsAccountCreation{
+			Hasher:              TestHasher,
+			Marshaller:          TestMarshalizer,
+			EnableEpochsHandler: enableEpochsHandler,
+		}
+		return factory.NewAccountCreator(argsAccCreator)
 	case ValidatorAccount:
 		return factory.NewPeerAccountCreator(), nil
 	default:
@@ -909,12 +914,12 @@ func GenerateAddressJournalAccountAccountsDB() ([]byte, state.UserAccountHandler
 	adr := CreateRandomAddress()
 	trieStorage, _ := CreateTrieStorageManager(CreateMemUnit())
 	adb, _ := CreateAccountsDB(UserAccount, trieStorage)
-	account, _ := state.NewUserAccount(
-		adr,
-		TestHasher,
-		TestMarshaller,
-		&testscommon.EnableEpochsHandlerStub{},
-	)
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              TestHasher,
+		Marshaller:          TestMarshaller,
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	account, _ := state.NewUserAccount(adr, argsAccCreation)
 
 	return adr, account, adb
 }

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -437,10 +437,19 @@ func CreateAccountsDB(
 	accountType Type,
 	trieStorageManager common.StorageManager,
 ) (*state.AccountsDB, common.Trie) {
+	return CreateAccountsDBWithEnableEpochsHandler(accountType, trieStorageManager, &testscommon.EnableEpochsHandlerStub{})
+}
+
+// CreateAccountsDBWithEnableEpochsHandler creates a new AccountsDb with the given enableEpochsHandler
+func CreateAccountsDBWithEnableEpochsHandler(
+	accountType Type,
+	trieStorageManager common.StorageManager,
+	enableEpochsHandler common.EnableEpochsHandler,
+) (*state.AccountsDB, common.Trie) {
 	tr, _ := trie.NewTrie(trieStorageManager, TestMarshalizer, TestHasher, maxTrieLevelInMemory)
 
 	ewl, _ := evictionWaitingList.NewEvictionWaitingList(100, database.NewMemDB(), TestMarshalizer)
-	accountFactory := getAccountFactory(accountType)
+	accountFactory, _ := getAccountFactory(accountType, enableEpochsHandler)
 	spm, _ := storagePruningManager.NewStoragePruningManager(ewl, 10)
 	args := state.ArgsAccountsDB{
 		Trie:                  tr,
@@ -457,14 +466,14 @@ func CreateAccountsDB(
 	return adb, tr
 }
 
-func getAccountFactory(accountType Type) state.AccountFactory {
+func getAccountFactory(accountType Type, enableEpochsHandler common.EnableEpochsHandler) (state.AccountFactory, error) {
 	switch accountType {
 	case UserAccount:
-		return factory.NewAccountCreator()
+		return factory.NewAccountCreator(sha256.NewSha256(), TestMarshalizer, enableEpochsHandler)
 	case ValidatorAccount:
-		return factory.NewPeerAccountCreator()
+		return factory.NewPeerAccountCreator(), nil
 	default:
-		return nil
+		return nil, fmt.Errorf("invalid account type provided")
 	}
 }
 
@@ -803,7 +812,7 @@ func CreateGenesisMetaBlock(
 
 		newBlkc, _ := blockchain.NewMetaChain(&statusHandlerMock.AppStatusHandlerStub{})
 		trieStorage, _ := CreateTrieStorageManager(CreateMemUnit())
-		newAccounts, _ := CreateAccountsDB(UserAccount, trieStorage)
+		newAccounts, _ := CreateAccountsDBWithEnableEpochsHandler(UserAccount, trieStorage, coreComponents.EnableEpochsHandler())
 
 		argsMetaGenesis.ShardCoordinator = newShardCoordinator
 		argsMetaGenesis.Accounts = newAccounts
@@ -900,7 +909,12 @@ func GenerateAddressJournalAccountAccountsDB() ([]byte, state.UserAccountHandler
 	adr := CreateRandomAddress()
 	trieStorage, _ := CreateTrieStorageManager(CreateMemUnit())
 	adb, _ := CreateAccountsDB(UserAccount, trieStorage)
-	account, _ := state.NewUserAccount(adr, TestHasher, TestMarshaller)
+	account, _ := state.NewUserAccount(
+		adr,
+		TestHasher,
+		TestMarshaller,
+		&testscommon.EnableEpochsHandlerStub{},
+	)
 
 	return adr, account, adb
 }

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -522,11 +522,11 @@ func (tpn *TestProcessorNode) initAccountDBsWithPruningStorer() {
 	trieStorageManager := CreateTrieStorageManagerWithPruningStorer(tpn.ShardCoordinator, tpn.EpochStartNotifier)
 	tpn.TrieContainer = state.NewDataTriesHolder()
 	var stateTrie common.Trie
-	tpn.AccntState, stateTrie = CreateAccountsDB(UserAccount, trieStorageManager)
+	tpn.AccntState, stateTrie = CreateAccountsDBWithEnableEpochsHandler(UserAccount, trieStorageManager, tpn.EnableEpochsHandler)
 	tpn.TrieContainer.Put([]byte(trieFactory.UserAccountTrie), stateTrie)
 
 	var peerTrie common.Trie
-	tpn.PeerState, peerTrie = CreateAccountsDB(ValidatorAccount, trieStorageManager)
+	tpn.PeerState, peerTrie = CreateAccountsDBWithEnableEpochsHandler(ValidatorAccount, trieStorageManager, tpn.EnableEpochsHandler)
 	tpn.TrieContainer.Put([]byte(trieFactory.PeerAccountTrie), peerTrie)
 
 	tpn.TrieStorageManagers = make(map[string]common.StorageManager)
@@ -538,11 +538,11 @@ func (tpn *TestProcessorNode) initAccountDBs(store storage.Storer) {
 	trieStorageManager, _ := CreateTrieStorageManager(store)
 	tpn.TrieContainer = state.NewDataTriesHolder()
 	var stateTrie common.Trie
-	tpn.AccntState, stateTrie = CreateAccountsDB(UserAccount, trieStorageManager)
+	tpn.AccntState, stateTrie = CreateAccountsDBWithEnableEpochsHandler(UserAccount, trieStorageManager, tpn.EnableEpochsHandler)
 	tpn.TrieContainer.Put([]byte(trieFactory.UserAccountTrie), stateTrie)
 
 	var peerTrie common.Trie
-	tpn.PeerState, peerTrie = CreateAccountsDB(ValidatorAccount, trieStorageManager)
+	tpn.PeerState, peerTrie = CreateAccountsDBWithEnableEpochsHandler(ValidatorAccount, trieStorageManager, tpn.EnableEpochsHandler)
 	tpn.TrieContainer.Put([]byte(trieFactory.PeerAccountTrie), peerTrie)
 
 	tpn.TrieStorageManagers = make(map[string]common.StorageManager)

--- a/integrationTests/vm/systemVM/stakingSC_test.go
+++ b/integrationTests/vm/systemVM/stakingSC_test.go
@@ -412,7 +412,7 @@ func manualSetToInactiveStateStakedPeers(t *testing.T, nodes []*integrationTests
 
 		for index := range nodes {
 			pubKey, _ := hex.DecodeString(generateUniqueKey(index))
-			peerAccount, _ := state.NewPeerAccount(pubKey, integrationTests.TestHasher, integrationTests.TestMarshaller)
+			peerAccount, _ := state.NewPeerAccount(pubKey)
 			peerAccount.List = string(common.InactiveList)
 			peerAccount.BLSPublicKey = pubKey
 			err := node.PeerState.SaveAccount(peerAccount)

--- a/integrationTests/vm/testInitializer.go
+++ b/integrationTests/vm/testInitializer.go
@@ -265,11 +265,12 @@ type accountFactory struct {
 
 // CreateAccount -
 func (af *accountFactory) CreateAccount(address []byte) (vmcommon.AccountHandler, error) {
-	return state.NewUserAccount(address,
-		af.hasher,
-		af.marshaller,
-		&testscommon.EnableEpochsHandlerStub{},
-	)
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              af.hasher,
+		Marshaller:          af.marshaller,
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	return state.NewUserAccount(address, argsAccCreation)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/integrationTests/vm/testInitializer.go
+++ b/integrationTests/vm/testInitializer.go
@@ -259,11 +259,17 @@ func (vmTestContext *VMTestContext) GetVMOutputWithTransientVM(funcName string, 
 }
 
 type accountFactory struct {
+	hasher     hashing.Hasher
+	marshaller marshal.Marshalizer
 }
 
 // CreateAccount -
-func (af *accountFactory) CreateAccount(address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (vmcommon.AccountHandler, error) {
-	return state.NewUserAccount(address, hasher, marshaller)
+func (af *accountFactory) CreateAccount(address []byte) (vmcommon.AccountHandler, error) {
+	return state.NewUserAccount(address,
+		af.hasher,
+		af.marshaller,
+		&testscommon.EnableEpochsHandlerStub{},
+	)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface
@@ -313,10 +319,13 @@ func CreateInMemoryShardAccountsDB() *state.AccountsDB {
 	spm, _ := storagePruningManager.NewStoragePruningManager(ewl, 10)
 
 	argsAccountsDB := state.ArgsAccountsDB{
-		Trie:                  tr,
-		Hasher:                testHasher,
-		Marshaller:            marshaller,
-		AccountFactory:        &accountFactory{},
+		Trie:       tr,
+		Hasher:     testHasher,
+		Marshaller: marshaller,
+		AccountFactory: &accountFactory{
+			hasher:     testHasher,
+			marshaller: testMarshalizer,
+		},
 		StoragePruningManager: spm,
 		ProcessingMode:        common.Normal,
 		ProcessStatusHandler:  &testscommon.ProcessStatusHandlerStub{},

--- a/node/nodeLoadAccounts_test.go
+++ b/node/nodeLoadAccounts_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/dblookupext"
 	"github.com/ElrondNetwork/elrond-go/testscommon/genericMocks"
-	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	mockState "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/stretchr/testify/require"
@@ -25,8 +24,8 @@ import (
 func TestNode_GetAccountWithOptionsShouldWork(t *testing.T) {
 	t.Parallel()
 
-	alice, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
-	alice.Balance = big.NewInt(100)
+	alice := createAcc(testscommon.TestPubKeyAlice)
+	_ = alice.AddToBalance(big.NewInt(100))
 
 	accountsRepostitory := &mockState.AccountsRepositoryStub{}
 	accountsRepostitory.GetAccountWithBlockInfoCalled = func(pubkey []byte, options api.AccountQueryOptions) (vmcommon.AccountHandler, common.BlockInfo, error) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -67,12 +67,12 @@ func createMockPubkeyConverter() *mock.PubkeyConverterMock {
 }
 
 func createAcc(address []byte) state.UserAccountHandler {
-	acc, _ := state.NewUserAccount(
-		address,
-		&hashingMocks.HasherMock{},
-		&testscommon.MarshalizerMock{},
-		&testscommon.EnableEpochsHandlerStub{},
-	)
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	acc, _ := state.NewUserAccount(address, argsAccCreation)
 
 	return acc
 }
@@ -206,12 +206,12 @@ func TestGetBalance_AccountNotFoundShouldReturnZeroBalance(t *testing.T) {
 func TestGetBalance(t *testing.T) {
 	t.Parallel()
 
-	testAccount, _ := state.NewUserAccount(
-		testscommon.TestPubKeyAlice,
-		&hashingMocks.HasherMock{},
-		&testscommon.MarshalizerMock{},
-		&testscommon.EnableEpochsHandlerStub{},
-	)
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	testAccount, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, argsAccCreation)
 	testAccount.Balance = big.NewInt(100)
 
 	accountsRepository := &stateMock.AccountsRepositoryStub{
@@ -244,12 +244,12 @@ func TestGetUsername(t *testing.T) {
 
 	expectedUsername := []byte("elrond")
 
-	testAccount, _ := state.NewUserAccount(
-		testscommon.TestPubKeyAlice,
-		&hashingMocks.HasherMock{},
-		&testscommon.MarshalizerMock{},
-		&testscommon.EnableEpochsHandlerStub{},
-	)
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	testAccount, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, argsAccCreation)
 	testAccount.UserName = expectedUsername
 	accountsRepository := &stateMock.AccountsRepositoryStub{
 		GetAccountWithBlockInfoCalled: func(address []byte, options api.AccountQueryOptions) (vmcommon.AccountHandler, common.BlockInfo, error) {
@@ -282,12 +282,12 @@ func TestGetCodeHash(t *testing.T) {
 
 	expectedCodeHash := []byte("hash")
 
-	testAccount, _ := state.NewUserAccount(
-		testscommon.TestPubKeyAlice,
-		&hashingMocks.HasherMock{},
-		&testscommon.MarshalizerMock{},
-		&testscommon.EnableEpochsHandlerStub{},
-	)
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	testAccount, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, argsAccCreation)
 	testAccount.CodeHash = expectedCodeHash
 	accountsRepository := &stateMock.AccountsRepositoryStub{
 		GetAccountWithBlockInfoCalled: func(address []byte, options api.AccountQueryOptions) (vmcommon.AccountHandler, common.BlockInfo, error) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -66,10 +66,21 @@ func createMockPubkeyConverter() *mock.PubkeyConverterMock {
 	return mock.NewPubkeyConverterMock(32)
 }
 
+func createAcc(address []byte) state.UserAccountHandler {
+	acc, _ := state.NewUserAccount(
+		address,
+		&hashingMocks.HasherMock{},
+		&testscommon.MarshalizerMock{},
+		&testscommon.EnableEpochsHandlerStub{},
+	)
+
+	return acc
+}
+
 func getAccAdapter(balance *big.Int) *stateMock.AccountsStub {
 	accDB := &stateMock.AccountsStub{}
 	accDB.GetExistingAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+		acc := createAcc(address)
 		_ = acc.AddToBalance(balance)
 		acc.IncreaseNonce(1)
 
@@ -195,7 +206,12 @@ func TestGetBalance_AccountNotFoundShouldReturnZeroBalance(t *testing.T) {
 func TestGetBalance(t *testing.T) {
 	t.Parallel()
 
-	testAccount, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	testAccount, _ := state.NewUserAccount(
+		testscommon.TestPubKeyAlice,
+		&hashingMocks.HasherMock{},
+		&testscommon.MarshalizerMock{},
+		&testscommon.EnableEpochsHandlerStub{},
+	)
 	testAccount.Balance = big.NewInt(100)
 
 	accountsRepository := &stateMock.AccountsRepositoryStub{
@@ -228,7 +244,12 @@ func TestGetUsername(t *testing.T) {
 
 	expectedUsername := []byte("elrond")
 
-	testAccount, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	testAccount, _ := state.NewUserAccount(
+		testscommon.TestPubKeyAlice,
+		&hashingMocks.HasherMock{},
+		&testscommon.MarshalizerMock{},
+		&testscommon.EnableEpochsHandlerStub{},
+	)
 	testAccount.UserName = expectedUsername
 	accountsRepository := &stateMock.AccountsRepositoryStub{
 		GetAccountWithBlockInfoCalled: func(address []byte, options api.AccountQueryOptions) (vmcommon.AccountHandler, common.BlockInfo, error) {
@@ -261,7 +282,12 @@ func TestGetCodeHash(t *testing.T) {
 
 	expectedCodeHash := []byte("hash")
 
-	testAccount, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	testAccount, _ := state.NewUserAccount(
+		testscommon.TestPubKeyAlice,
+		&hashingMocks.HasherMock{},
+		&testscommon.MarshalizerMock{},
+		&testscommon.EnableEpochsHandlerStub{},
+	)
 	testAccount.CodeHash = expectedCodeHash
 	accountsRepository := &stateMock.AccountsRepositoryStub{
 		GetAccountWithBlockInfoCalled: func(address []byte, options api.AccountQueryOptions) (vmcommon.AccountHandler, common.BlockInfo, error) {
@@ -292,7 +318,7 @@ func TestGetCodeHash(t *testing.T) {
 func TestNode_GetKeyValuePairs(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc := createAcc([]byte("newaddress"))
 
 	k1, v1 := []byte("key1"), []byte("value1")
 	k2, v2 := []byte("key2"), []byte("value2")
@@ -360,7 +386,7 @@ func TestNode_GetKeyValuePairs(t *testing.T) {
 func TestNode_GetKeyValuePairs_GetAllLeavesShouldFail(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc := createAcc([]byte("newaddress"))
 
 	accDB := &stateMock.AccountsStub{}
 
@@ -415,7 +441,7 @@ func TestNode_GetKeyValuePairs_GetAllLeavesShouldFail(t *testing.T) {
 func TestNode_GetKeyValuePairsContextShouldTimeout(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc := createAcc([]byte("newaddress"))
 
 	accDB := &stateMock.AccountsStub{}
 	acc.SetDataTrie(
@@ -472,7 +498,7 @@ func TestNode_GetKeyValuePairsContextShouldTimeout(t *testing.T) {
 func TestNode_GetValueForKey(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc := createAcc([]byte("newaddress"))
 
 	k1, v1 := []byte("key1"), []byte("value1")
 	_ = acc.SaveKeyValue(k1, v1)
@@ -514,7 +540,7 @@ func TestNode_GetValueForKey(t *testing.T) {
 func TestNode_GetESDTData(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc := createAcc(testscommon.TestPubKeyAlice)
 	esdtToken := "newToken"
 
 	esdtData := &esdt.ESDigitalToken{Value: big.NewInt(10)}
@@ -563,7 +589,7 @@ func TestNode_GetESDTData(t *testing.T) {
 func TestNode_GetESDTDataForNFT(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc := createAcc(testscommon.TestPubKeyAlice)
 	esdtToken := "newToken"
 	nonce := int64(100)
 
@@ -608,7 +634,7 @@ func TestNode_GetESDTDataForNFT(t *testing.T) {
 func TestNode_GetAllESDTTokens(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc := createAcc(testscommon.TestPubKeyAlice)
 	esdtToken := "newToken"
 	esdtKey := []byte(core.ElrondProtectedKeyPrefix + core.ESDTKeyIdentifier + esdtToken)
 
@@ -676,7 +702,7 @@ func TestNode_GetAllESDTTokens(t *testing.T) {
 func TestNode_GetAllESDTTokens_GetAllLeavesShouldFail(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc := createAcc(testscommon.TestPubKeyAlice)
 
 	expectedErr := errors.New("expected error")
 	acc.SetDataTrie(
@@ -732,7 +758,7 @@ func TestNode_GetAllESDTTokens_GetAllLeavesShouldFail(t *testing.T) {
 func TestNode_GetAllESDTTokensContextShouldTimeout(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc := createAcc(testscommon.TestPubKeyAlice)
 
 	acc.SetDataTrie(
 		&trieMock.TrieStub{
@@ -790,7 +816,7 @@ func TestNode_GetAllESDTTokensContextShouldTimeout(t *testing.T) {
 func TestNode_GetAllESDTTokensShouldReturnEsdtAndFormattedNft(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(testscommon.TestPubKeyAlice, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc := createAcc(testscommon.TestPubKeyAlice)
 
 	esdtToken := "TKKR-7q8w9e"
 	esdtKey := []byte(core.ElrondProtectedKeyPrefix + core.ESDTKeyIdentifier + esdtToken)
@@ -886,7 +912,7 @@ func TestNode_GetAllESDTTokensShouldReturnEsdtAndFormattedNft(t *testing.T) {
 func TestNode_GetAllIssuedESDTs(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc := createAcc([]byte("newaddress"))
 	esdtToken := []byte("TCK-RANDOM")
 	sftToken := []byte("SFT-RANDOM")
 	nftToken := []byte("NFT-RANDOM")
@@ -983,7 +1009,7 @@ func TestNode_GetESDTsWithRole(t *testing.T) {
 	t.Parallel()
 
 	addrBytes := testscommon.TestPubKeyAlice
-	acc, _ := state.NewUserAccount(addrBytes, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc := createAcc(addrBytes)
 	esdtToken := []byte("TCK-RANDOM")
 
 	specialRoles := []*systemSmartContracts.ESDTRoles{
@@ -1063,7 +1089,7 @@ func TestNode_GetESDTsRoles(t *testing.T) {
 	t.Parallel()
 
 	addrBytes := testscommon.TestPubKeyAlice
-	acc, _ := state.NewUserAccount(addrBytes, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc := createAcc(addrBytes)
 	esdtToken := []byte("TCK-RANDOM")
 
 	specialRoles := []*systemSmartContracts.ESDTRoles{
@@ -1135,7 +1161,7 @@ func TestNode_GetNFTTokenIDsRegisteredByAddress(t *testing.T) {
 	t.Parallel()
 
 	addrBytes := testscommon.TestPubKeyAlice
-	acc, _ := state.NewUserAccount(addrBytes, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc := createAcc(addrBytes)
 	esdtToken := []byte("TCK-RANDOM")
 
 	esdtData := &systemSmartContracts.ESDTDataV2{TokenName: []byte("fungible"), TokenType: []byte(core.SemiFungibleESDT), OwnerAddress: addrBytes}
@@ -1200,7 +1226,7 @@ func TestNode_GetNFTTokenIDsRegisteredByAddressContextShouldTimeout(t *testing.T
 	t.Parallel()
 
 	addrBytes := testscommon.TestPubKeyAlice
-	acc, _ := state.NewUserAccount(addrBytes, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc := createAcc(addrBytes)
 
 	acc.SetDataTrie(
 		&trieMock.TrieStub{
@@ -1371,7 +1397,7 @@ func TestGenerateTransaction_GetAccountReturnsNilShouldWork(t *testing.T) {
 
 	accAdapter := &stateMock.AccountsStub{
 		GetExistingAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
-			return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+			return createAcc(address), nil
 		},
 	}
 	privateKey := getPrivateKey()
@@ -1518,7 +1544,7 @@ func TestGenerateTransaction_ShouldSetCorrectNonce(t *testing.T) {
 	nonce := uint64(7)
 	accAdapter := &stateMock.AccountsStub{
 		GetExistingAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
-			acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+			acc := createAcc(address)
 			_ = acc.AddToBalance(big.NewInt(0))
 			acc.IncreaseNonce(nonce)
 
@@ -2347,7 +2373,7 @@ func TestCreateTransaction_OkValsShouldWork(t *testing.T) {
 	stateComponents := getDefaultStateComponents()
 	stateComponents.AccountsAPI = &stateMock.AccountsStub{
 		GetExistingAccountCalled: func(addressContainer []byte) (vmcommon.AccountHandler, error) {
-			return state.NewUserAccount([]byte("address"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+			return createAcc([]byte("address")), nil
 		},
 	}
 
@@ -2944,7 +2970,7 @@ func TestNode_GetAccountAccountsRepositoryFailsShouldErr(t *testing.T) {
 func TestNode_GetAccountAccountExistsShouldReturn(t *testing.T) {
 	t.Parallel()
 
-	accnt, _ := state.NewUserAccount(testscommon.TestPubKeyBob, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	accnt := createAcc(testscommon.TestPubKeyBob)
 	_ = accnt.AddToBalance(big.NewInt(1))
 	accnt.IncreaseNonce(2)
 	accnt.SetRootHash([]byte("root hash"))

--- a/node/trieIterators/directStakedListProcessor_test.go
+++ b/node/trieIterators/directStakedListProcessor_test.go
@@ -77,7 +77,7 @@ func TestDirectStakedListProc_GetDelegatorsListContextShouldTimeout(t *testing.T
 	}
 	arg.Accounts.AccountsAdapter = &stateMock.AccountsStub{
 		GetExistingAccountCalled: func(addressContainer []byte) (vmcommon.AccountHandler, error) {
-			return createValidatorScAccount(addressContainer, validators, addressContainer, time.Second), nil
+			return createScAccount(addressContainer, validators, addressContainer, time.Second), nil
 		},
 		RecreateTrieCalled: func(rootHash []byte) error {
 			return nil
@@ -121,7 +121,7 @@ func TestDirectStakedListProc_GetDelegatorsListShouldWork(t *testing.T) {
 	}
 	arg.Accounts.AccountsAdapter = &stateMock.AccountsStub{
 		GetExistingAccountCalled: func(addressContainer []byte) (vmcommon.AccountHandler, error) {
-			return createValidatorScAccount(addressContainer, validators, addressContainer, 0), nil
+			return createScAccount(addressContainer, validators, addressContainer, 0), nil
 		},
 		RecreateTrieCalled: func(rootHash []byte) error {
 			return nil
@@ -149,8 +149,8 @@ func TestDirectStakedListProc_GetDelegatorsListShouldWork(t *testing.T) {
 	assert.Equal(t, []*api.DirectStakedValue{&expectedDirectStake1, &expectedDirectStake2}, directStakedList)
 }
 
-func createValidatorScAccount(address []byte, leaves [][]byte, rootHash []byte, timeSleep time.Duration) state.UserAccountHandler {
-	acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+func createScAccount(address []byte, leaves [][]byte, rootHash []byte, timeSleep time.Duration) state.UserAccountHandler {
+	acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	acc.SetDataTrie(&trieMock.TrieStub{
 		RootCalled: func() ([]byte, error) {
 			return rootHash, nil

--- a/node/trieIterators/directStakedListProcessor_test.go
+++ b/node/trieIterators/directStakedListProcessor_test.go
@@ -150,7 +150,12 @@ func TestDirectStakedListProc_GetDelegatorsListShouldWork(t *testing.T) {
 }
 
 func createScAccount(address []byte, leaves [][]byte, rootHash []byte, timeSleep time.Duration) state.UserAccountHandler {
-	acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	acc, _ := state.NewUserAccount(address, argsAccCreation)
 	acc.SetDataTrie(&trieMock.TrieStub{
 		RootCalled: func() ([]byte, error) {
 			return rootHash, nil

--- a/node/trieIterators/stakeValuesProcessor_test.go
+++ b/node/trieIterators/stakeValuesProcessor_test.go
@@ -166,7 +166,12 @@ func TestTotalStakedValueProcessor_GetTotalStakedValue_CannotGetRootHash(t *test
 	t.Parallel()
 
 	expectedErr := errors.New("expected error")
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	acc, _ := state.NewUserAccount([]byte("newaddress"), argsAccCreation)
 	acc.SetDataTrie(&trieMock.TrieStub{
 		RootCalled: func() ([]byte, error) {
 			return nil, expectedErr
@@ -192,7 +197,12 @@ func TestTotalStakedValueProcessor_GetTotalStakedValue_CannotGetRootHash(t *test
 func TestTotalStakedValueProcessor_GetTotalStakedValue_ContextShouldTimeout(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	acc, _ := state.NewUserAccount([]byte("newaddress"), argsAccCreation)
 	acc.SetDataTrie(&trieMock.TrieStub{
 		GetAllLeavesOnChannelCalled: func(leavesChannels *common.TrieIteratorChannels, _ context.Context, _ []byte, _ common.KeyBuilder) error {
 			time.Sleep(time.Second)
@@ -228,7 +238,12 @@ func TestTotalStakedValueProcessor_GetTotalStakedValue_CannotGetAllLeaves(t *tes
 	t.Parallel()
 
 	expectedErr := errors.New("expected error")
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	acc, _ := state.NewUserAccount([]byte("newaddress"), argsAccCreation)
 	acc.SetDataTrie(&trieMock.TrieStub{
 		GetAllLeavesOnChannelCalled: func(_ *common.TrieIteratorChannels, _ context.Context, _ []byte, _ common.KeyBuilder) error {
 			return expectedErr
@@ -273,7 +288,12 @@ func TestTotalStakedValueProcessor_GetTotalStakedValue(t *testing.T) {
 	leafKey4 := "0123456783"
 	leafKey5 := "0123456780"
 	leafKey6 := "0123456788"
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	acc, _ := state.NewUserAccount([]byte("newaddress"), argsAccCreation)
 	acc.SetDataTrie(&trieMock.TrieStub{
 		RootCalled: func() ([]byte, error) {
 			return rootHash, nil

--- a/node/trieIterators/stakeValuesProcessor_test.go
+++ b/node/trieIterators/stakeValuesProcessor_test.go
@@ -166,7 +166,7 @@ func TestTotalStakedValueProcessor_GetTotalStakedValue_CannotGetRootHash(t *test
 	t.Parallel()
 
 	expectedErr := errors.New("expected error")
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	acc.SetDataTrie(&trieMock.TrieStub{
 		RootCalled: func() ([]byte, error) {
 			return nil, expectedErr
@@ -192,7 +192,7 @@ func TestTotalStakedValueProcessor_GetTotalStakedValue_CannotGetRootHash(t *test
 func TestTotalStakedValueProcessor_GetTotalStakedValue_ContextShouldTimeout(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	acc.SetDataTrie(&trieMock.TrieStub{
 		GetAllLeavesOnChannelCalled: func(leavesChannels *common.TrieIteratorChannels, _ context.Context, _ []byte, _ common.KeyBuilder) error {
 			time.Sleep(time.Second)
@@ -228,7 +228,7 @@ func TestTotalStakedValueProcessor_GetTotalStakedValue_CannotGetAllLeaves(t *tes
 	t.Parallel()
 
 	expectedErr := errors.New("expected error")
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	acc.SetDataTrie(&trieMock.TrieStub{
 		GetAllLeavesOnChannelCalled: func(_ *common.TrieIteratorChannels, _ context.Context, _ []byte, _ common.KeyBuilder) error {
 			return expectedErr
@@ -273,7 +273,7 @@ func TestTotalStakedValueProcessor_GetTotalStakedValue(t *testing.T) {
 	leafKey4 := "0123456783"
 	leafKey5 := "0123456780"
 	leafKey6 := "0123456788"
-	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount([]byte("newaddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	acc.SetDataTrie(&trieMock.TrieStub{
 		RootCalled: func() ([]byte, error) {
 			return rootHash, nil

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -1744,7 +1744,7 @@ func (bp *baseProcessor) commitTrieEpochRootHashIfNeeded(metaBlock *block.MetaBl
 	totalSizeAccountsDataTries := 0
 	totalSizeCodeLeaves := 0
 	for leaf := range iteratorChannels.LeavesChan {
-		userAccount, errUnmarshal := unmarshalUserAccount(leaf.Key(), leaf.Value(), bp.marshalizer, bp.hasher)
+		userAccount, errUnmarshal := bp.unmarshalUserAccount(leaf.Key(), leaf.Value())
 		if errUnmarshal != nil {
 			numCodeLeaves++
 			totalSizeCodeLeaves += len(leaf.Value())
@@ -1814,17 +1814,15 @@ func (bp *baseProcessor) commitTrieEpochRootHashIfNeeded(metaBlock *block.MetaBl
 	return nil
 }
 
-func unmarshalUserAccount(
+func (bp *baseProcessor) unmarshalUserAccount(
 	address []byte,
 	userAccountsBytes []byte,
-	marshalizer marshal.Marshalizer,
-	hasher hashing.Hasher,
 ) (state.UserAccountHandler, error) {
-	userAccount, err := state.NewUserAccount(address, hasher, marshalizer)
+	userAccount, err := state.NewUserAccount(address, bp.hasher, bp.marshalizer, bp.enableEpochsHandler)
 	if err != nil {
 		return nil, err
 	}
-	err = marshalizer.Unmarshal(userAccount, userAccountsBytes)
+	err = bp.marshalizer.Unmarshal(userAccount, userAccountsBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -1818,7 +1818,12 @@ func (bp *baseProcessor) unmarshalUserAccount(
 	address []byte,
 	userAccountsBytes []byte,
 ) (state.UserAccountHandler, error) {
-	userAccount, err := state.NewUserAccount(address, bp.hasher, bp.marshalizer, bp.enableEpochsHandler)
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              bp.hasher,
+		Marshaller:          bp.marshalizer,
+		EnableEpochsHandler: bp.enableEpochsHandler,
+	}
+	userAccount, err := state.NewUserAccount(address, argsAccCreation)
 	if err != nil {
 		return nil, err
 	}

--- a/process/dataValidators/txValidator_test.go
+++ b/process/dataValidators/txValidator_test.go
@@ -21,7 +21,7 @@ import (
 func getAccAdapter(nonce uint64, balance *big.Int) *stateMock.AccountsStub {
 	accDB := &stateMock.AccountsStub{}
 	accDB.GetExistingAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+		acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 		acc.Nonce = nonce
 		acc.Balance = balance
 
@@ -331,7 +331,7 @@ func TestTxValidator_CheckTxValidityWrongAccountTypeShouldReturnFalse(t *testing
 
 	accDB := &stateMock.AccountsStub{}
 	accDB.GetExistingAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		return state.NewPeerAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+		return state.NewPeerAccount(address)
 	}
 	shardCoordinator := createMockCoordinator("_", 0)
 	maxNonceDeltaAllowed := 100

--- a/process/dataValidators/txValidator_test.go
+++ b/process/dataValidators/txValidator_test.go
@@ -21,7 +21,12 @@ import (
 func getAccAdapter(nonce uint64, balance *big.Int) *stateMock.AccountsStub {
 	accDB := &stateMock.AccountsStub{}
 	accDB.GetExistingAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		acc, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+		argsAccCreation := state.ArgsAccountCreation{
+			Hasher:              &hashingMocks.HasherMock{},
+			Marshaller:          &testscommon.MarshalizerMock{},
+			EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+		}
+		acc, _ := state.NewUserAccount(address, argsAccCreation)
 		acc.Nonce = nonce
 		acc.Balance = balance
 

--- a/process/peer/process_test.go
+++ b/process/peer/process_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 	dataRetrieverMock "github.com/ElrondNetwork/elrond-go/testscommon/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/testscommon/epochNotifier"
-	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	"github.com/ElrondNetwork/elrond-go/testscommon/shardingMocks"
 	stateMock "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	storageStubs "github.com/ElrondNetwork/elrond-go/testscommon/storage"
@@ -325,7 +324,7 @@ func TestValidatorStatisticsProcessor_SaveInitialStateSetAddressErrors(t *testin
 	t.Parallel()
 
 	saveAccountError := errors.New("save account error")
-	peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	peerAccount, _ := state.NewPeerAccount([]byte("1234"))
 	peerAdapter := &stateMock.AccountsStub{
 		LoadAccountCalled: func(address []byte) (handler vmcommon.AccountHandler, e error) {
 			return peerAccount, nil
@@ -351,7 +350,7 @@ func TestValidatorStatisticsProcessor_SaveInitialStateCommitErrors(t *testing.T)
 	t.Parallel()
 
 	commitError := errors.New("commit error")
-	peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	peerAccount, _ := state.NewPeerAccount([]byte("1234"))
 	peerAdapter := &stateMock.AccountsStub{
 		LoadAccountCalled: func(address []byte) (handler vmcommon.AccountHandler, e error) {
 			return peerAccount, nil
@@ -374,7 +373,7 @@ func TestValidatorStatisticsProcessor_SaveInitialStateCommitErrors(t *testing.T)
 func TestValidatorStatisticsProcessor_SaveInitialStateCommit(t *testing.T) {
 	t.Parallel()
 
-	peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	peerAccount, _ := state.NewPeerAccount([]byte("1234"))
 	peerAdapter := &stateMock.AccountsStub{
 		LoadAccountCalled: func(address []byte) (handler vmcommon.AccountHandler, e error) {
 			return peerAccount, nil
@@ -516,7 +515,7 @@ func TestValidatorStatisticsProcessor_UpdatePeerStateGetHeaderError(t *testing.T
 	marshalizer := &mock.MarshalizerStub{}
 
 	adapter.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		return state.NewPeerAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+		return state.NewPeerAccount(address)
 	}
 	shardCoordinatorMock := mock.NewOneShardCoordinatorMock()
 
@@ -2487,7 +2486,7 @@ func compare(t *testing.T, peerAccount state.PeerAccountHandler, validatorInfo *
 
 func createPeerAccounts(addrBytes0 []byte, addrBytesMeta []byte) (state.PeerAccountHandler, state.PeerAccountHandler) {
 	addr := addrBytes0
-	pa0, _ := state.NewPeerAccount(addr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	pa0, _ := state.NewPeerAccount(addr)
 	pa0.PeerAccountData = state.PeerAccountData{
 		BLSPublicKey:    []byte("bls0"),
 		RewardAddress:   []byte("reward0"),
@@ -2518,7 +2517,7 @@ func createPeerAccounts(addrBytes0 []byte, addrBytesMeta []byte) (state.PeerAcco
 	}
 
 	addr = addrBytesMeta
-	paMeta, _ := state.NewPeerAccount(addr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	paMeta, _ := state.NewPeerAccount(addr)
 	paMeta.PeerAccountData = state.PeerAccountData{
 		BLSPublicKey:    []byte("blsM"),
 		RewardAddress:   []byte("rewardM"),

--- a/process/rewardTransaction/process_test.go
+++ b/process/rewardTransaction/process_test.go
@@ -188,7 +188,12 @@ func TestRewardTxProcessor_ProcessRewardTransactionShouldWork(t *testing.T) {
 
 	accountsDb := &stateMock.AccountsStub{
 		LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
-			return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+			argsAccCreation := state.ArgsAccountCreation{
+				Hasher:              &hashingMocks.HasherMock{},
+				Marshaller:          &testscommon.MarshalizerMock{},
+				EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+			}
+			return state.NewUserAccount(address, argsAccCreation)
 		},
 		SaveAccountCalled: func(accountHandler vmcommon.AccountHandler) error {
 			saveAccountWasCalled = true
@@ -220,7 +225,12 @@ func TestRewardTxProcessor_ProcessRewardTransactionToASmartContractShouldWork(t 
 	saveAccountWasCalled := false
 
 	address := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6}
-	userAccount, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	userAccount, _ := state.NewUserAccount(address, argsAccCreation)
 	accountsDb := &stateMock.AccountsStub{
 		LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
 			return userAccount, nil

--- a/process/rewardTransaction/process_test.go
+++ b/process/rewardTransaction/process_test.go
@@ -188,7 +188,7 @@ func TestRewardTxProcessor_ProcessRewardTransactionShouldWork(t *testing.T) {
 
 	accountsDb := &stateMock.AccountsStub{
 		LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
-			return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+			return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 		},
 		SaveAccountCalled: func(accountHandler vmcommon.AccountHandler) error {
 			saveAccountWasCalled = true
@@ -220,7 +220,7 @@ func TestRewardTxProcessor_ProcessRewardTransactionToASmartContractShouldWork(t 
 	saveAccountWasCalled := false
 
 	address := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6}
-	userAccount, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	userAccount, _ := state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	accountsDb := &stateMock.AccountsStub{
 		LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
 			return userAccount, nil

--- a/process/scToProtocol/stakingToPeer_test.go
+++ b/process/scToProtocol/stakingToPeer_test.go
@@ -57,6 +57,16 @@ func createBlockBody() *block.Body {
 	}
 }
 
+func createStakingScAccount() state.UserAccountHandler {
+	userAcc, _ := state.NewUserAccount(
+		vm.StakingSCAddress,
+		&hashingMocks.HasherMock{},
+		&testscommon.MarshalizerMock{},
+		&testscommon.EnableEpochsHandlerStub{},
+	)
+	return userAcc
+}
+
 func TestNewStakingToPeerNilAddrConverterShouldErr(t *testing.T) {
 	t.Parallel()
 
@@ -240,7 +250,7 @@ func TestStakingToPeer_UpdateProtocolRemoveAccountShouldReturnNil(t *testing.T) 
 
 	peerState := &stateMock.AccountsStub{}
 	peerState.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		peerAcc, _ := state.NewPeerAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+		peerAcc, _ := state.NewPeerAccount(address)
 		_ = peerAcc.SetRewardAddress([]byte("addr"))
 		_ = peerAcc.SetBLSPublicKey([]byte("BlsAddr"))
 
@@ -256,7 +266,7 @@ func TestStakingToPeer_UpdateProtocolRemoveAccountShouldReturnNil(t *testing.T) 
 	}
 
 	arguments := createMockArgumentsNewStakingToPeer()
-	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	userAcc := createStakingScAccount()
 	baseState := &stateMock.AccountsStub{}
 	baseState.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return userAcc, nil
@@ -299,7 +309,7 @@ func TestStakingToPeer_UpdateProtocolCannotSetRewardAddressShouldErr(t *testing.
 
 	peerState := &stateMock.AccountsStub{}
 	peerState.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		peerAcc, _ := state.NewPeerAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+		peerAcc, _ := state.NewPeerAccount(address)
 		_ = peerAcc.SetRewardAddress([]byte("key"))
 
 		return peerAcc, nil
@@ -310,7 +320,7 @@ func TestStakingToPeer_UpdateProtocolCannotSetRewardAddressShouldErr(t *testing.
 	}
 	marshalizer := &mock.MarshalizerMock{}
 
-	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	userAcc := createStakingScAccount()
 	baseState := &stateMock.AccountsStub{}
 	baseState.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return userAcc, nil
@@ -356,7 +366,7 @@ func TestStakingToPeer_UpdateProtocolEmptyDataShouldNotAddToTrie(t *testing.T) {
 
 	peerState := &stateMock.AccountsStub{}
 	peerState.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		peerAcc, _ := state.NewPeerAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+		peerAcc, _ := state.NewPeerAccount(address)
 		_ = peerAcc.SetRewardAddress(rwdAddress)
 
 		return peerAcc, nil
@@ -366,7 +376,7 @@ func TestStakingToPeer_UpdateProtocolEmptyDataShouldNotAddToTrie(t *testing.T) {
 		return fmt.Errorf("error")
 	}
 
-	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	userAcc := createStakingScAccount()
 	baseState := &stateMock.AccountsStub{}
 	baseState.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return userAcc, nil
@@ -422,7 +432,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveAccountShouldErr(t *testing.T) {
 	}
 
 	peerState.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		peerAccount, _ := state.NewPeerAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+		peerAccount, _ := state.NewPeerAccount(address)
 		peerAccount.RewardAddress = address
 		return peerAccount, nil
 	}
@@ -433,7 +443,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveAccountShouldErr(t *testing.T) {
 	}
 	marshalizer := &mock.MarshalizerMock{}
 
-	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	userAcc := createStakingScAccount()
 	baseState := &stateMock.AccountsStub{}
 	baseState.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return userAcc, nil
@@ -484,7 +494,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveAccountNonceShouldErr(t *testing.
 		},
 	}
 	peerState.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+		peerAccount, _ := state.NewPeerAccount([]byte("1234"))
 		peerAccount.BLSPublicKey = address
 		peerAccount.Nonce = 1
 		return peerAccount, nil
@@ -496,7 +506,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveAccountNonceShouldErr(t *testing.
 	}
 	marshalizer := &mock.MarshalizerMock{}
 
-	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	userAcc := createStakingScAccount()
 	baseState := &stateMock.AccountsStub{}
 	baseState.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return userAcc, nil
@@ -546,7 +556,7 @@ func TestStakingToPeer_UpdateProtocol(t *testing.T) {
 		},
 	}
 	peerState.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+		peerAccount, _ := state.NewPeerAccount([]byte("1234"))
 		peerAccount.BLSPublicKey = address
 		peerAccount.Nonce = 1
 		return peerAccount, nil
@@ -562,7 +572,7 @@ func TestStakingToPeer_UpdateProtocol(t *testing.T) {
 	arguments.CurrTxs = currTx
 	arguments.PeerState = peerState
 	arguments.Marshalizer = marshalizer
-	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	userAcc := createStakingScAccount()
 	baseState := &stateMock.AccountsStub{}
 	baseState.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return userAcc, nil
@@ -609,7 +619,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveUnStakedNonceShouldErr(t *testing
 		},
 	}
 	peerState.LoadAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
-		peerAccount, _ := state.NewPeerAccount([]byte("1234"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+		peerAccount, _ := state.NewPeerAccount([]byte("1234"))
 		peerAccount.BLSPublicKey = address
 		peerAccount.IndexInList = 1
 		return peerAccount, nil
@@ -621,7 +631,7 @@ func TestStakingToPeer_UpdateProtocolCannotSaveUnStakedNonceShouldErr(t *testing
 	}
 	marshalizer := &mock.MarshalizerMock{}
 
-	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	userAcc := createStakingScAccount()
 	baseState := &stateMock.AccountsStub{}
 	baseState.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return userAcc, nil

--- a/process/scToProtocol/stakingToPeer_test.go
+++ b/process/scToProtocol/stakingToPeer_test.go
@@ -58,12 +58,12 @@ func createBlockBody() *block.Body {
 }
 
 func createStakingScAccount() state.UserAccountHandler {
-	userAcc, _ := state.NewUserAccount(
-		vm.StakingSCAddress,
-		&hashingMocks.HasherMock{},
-		&testscommon.MarshalizerMock{},
-		&testscommon.EnableEpochsHandlerStub{},
-	)
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	userAcc, _ := state.NewUserAccount(vm.StakingSCAddress, argsAccCreation)
 	return userAcc
 }
 

--- a/process/smartContract/hooks/blockChainHook_test.go
+++ b/process/smartContract/hooks/blockChainHook_test.go
@@ -77,6 +77,16 @@ func createContractCallInput(function string, sender, receiver []byte) *vmcommon
 	}
 }
 
+func createAccount(address []byte) state.UserAccountHandler {
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	account, _ := state.NewUserAccount(address, argsAccCreation)
+	return account
+}
+
 func TestNewBlockChainHookImpl(t *testing.T) {
 	t.Parallel()
 
@@ -251,15 +261,10 @@ func TestBlockChainHookImpl_GetCode(t *testing.T) {
 		}
 		bh, _ := hooks.NewBlockChainHookImpl(args)
 
-		account, _ := state.NewUserAccount(
-			[]byte("address"),
-			&hashingMocks.HasherMock{},
-			&testscommon.MarshalizerMock{},
-			&testscommon.EnableEpochsHandlerStub{},
-		)
+		account := createAccount([]byte("address"))
 		account.SetCodeHash(expectedCodeHash)
 
-		code := bh.GetCode(account)
+		code := bh.GetCode(account.(vmcommon.UserAccountHandler))
 		require.Equal(t, expectedCode, code)
 	})
 }
@@ -316,12 +321,7 @@ func TestBlockChainHookImpl_GetUserAccountWrongTypeShouldErr(t *testing.T) {
 func TestBlockChainHookImpl_GetUserAccount(t *testing.T) {
 	t.Parallel()
 
-	expectedAccount, _ := state.NewUserAccount(
-		[]byte("1234"),
-		&hashingMocks.HasherMock{},
-		&testscommon.MarshalizerMock{},
-		&testscommon.EnableEpochsHandlerStub{},
-	)
+	expectedAccount := createAccount([]byte("1234"))
 	args := createMockBlockChainHookArgs()
 	args.Accounts = &stateMock.AccountsStub{
 		GetExistingAccountCalled: func(address []byte) (handler vmcommon.AccountHandler, e error) {
@@ -329,7 +329,7 @@ func TestBlockChainHookImpl_GetUserAccount(t *testing.T) {
 		},
 	}
 	bh, _ := hooks.NewBlockChainHookImpl(args)
-	acc, err := bh.GetUserAccount(expectedAccount.Address)
+	acc, err := bh.GetUserAccount(expectedAccount.AddressBytes())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedAccount, acc)
@@ -431,12 +431,7 @@ func TestBlockChainHookImpl_NewAddressLengthNoGood(t *testing.T) {
 
 	acnts := &stateMock.AccountsStub{}
 	acnts.GetExistingAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
-		return state.NewUserAccount(
-			address,
-			&hashingMocks.HasherMock{},
-			&testscommon.MarshalizerMock{},
-			&testscommon.EnableEpochsHandlerStub{},
-		)
+		return createAccount(address).(vmcommon.AccountHandler), nil
 	}
 	args := createMockBlockChainHookArgs()
 	args.Accounts = acnts
@@ -460,12 +455,7 @@ func TestBlockChainHookImpl_NewAddressVMTypeTooLong(t *testing.T) {
 
 	acnts := &stateMock.AccountsStub{}
 	acnts.GetExistingAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
-		return state.NewUserAccount(
-			address,
-			&hashingMocks.HasherMock{},
-			&testscommon.MarshalizerMock{},
-			&testscommon.EnableEpochsHandlerStub{},
-		)
+		return createAccount(address).(vmcommon.AccountHandler), nil
 	}
 	args := createMockBlockChainHookArgs()
 	args.Accounts = acnts
@@ -485,12 +475,7 @@ func TestBlockChainHookImpl_NewAddress(t *testing.T) {
 
 	acnts := &stateMock.AccountsStub{}
 	acnts.GetExistingAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
-		return state.NewUserAccount(
-			address,
-			&hashingMocks.HasherMock{},
-			&testscommon.MarshalizerMock{},
-			&testscommon.EnableEpochsHandlerStub{},
-		)
+		return createAccount(address).(vmcommon.AccountHandler), nil
 	}
 	args := createMockBlockChainHookArgs()
 	args.Accounts = acnts

--- a/process/smartContract/hooks/blockChainHook_test.go
+++ b/process/smartContract/hooks/blockChainHook_test.go
@@ -251,7 +251,12 @@ func TestBlockChainHookImpl_GetCode(t *testing.T) {
 		}
 		bh, _ := hooks.NewBlockChainHookImpl(args)
 
-		account, _ := state.NewUserAccount([]byte("address"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+		account, _ := state.NewUserAccount(
+			[]byte("address"),
+			&hashingMocks.HasherMock{},
+			&testscommon.MarshalizerMock{},
+			&testscommon.EnableEpochsHandlerStub{},
+		)
 		account.SetCodeHash(expectedCodeHash)
 
 		code := bh.GetCode(account)
@@ -311,7 +316,12 @@ func TestBlockChainHookImpl_GetUserAccountWrongTypeShouldErr(t *testing.T) {
 func TestBlockChainHookImpl_GetUserAccount(t *testing.T) {
 	t.Parallel()
 
-	expectedAccount, _ := state.NewUserAccount([]byte("1234"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	expectedAccount, _ := state.NewUserAccount(
+		[]byte("1234"),
+		&hashingMocks.HasherMock{},
+		&testscommon.MarshalizerMock{},
+		&testscommon.EnableEpochsHandlerStub{},
+	)
 	args := createMockBlockChainHookArgs()
 	args.Accounts = &stateMock.AccountsStub{
 		GetExistingAccountCalled: func(address []byte) (handler vmcommon.AccountHandler, e error) {
@@ -421,7 +431,12 @@ func TestBlockChainHookImpl_NewAddressLengthNoGood(t *testing.T) {
 
 	acnts := &stateMock.AccountsStub{}
 	acnts.GetExistingAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
-		return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+		return state.NewUserAccount(
+			address,
+			&hashingMocks.HasherMock{},
+			&testscommon.MarshalizerMock{},
+			&testscommon.EnableEpochsHandlerStub{},
+		)
 	}
 	args := createMockBlockChainHookArgs()
 	args.Accounts = acnts
@@ -445,7 +460,12 @@ func TestBlockChainHookImpl_NewAddressVMTypeTooLong(t *testing.T) {
 
 	acnts := &stateMock.AccountsStub{}
 	acnts.GetExistingAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
-		return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+		return state.NewUserAccount(
+			address,
+			&hashingMocks.HasherMock{},
+			&testscommon.MarshalizerMock{},
+			&testscommon.EnableEpochsHandlerStub{},
+		)
 	}
 	args := createMockBlockChainHookArgs()
 	args.Accounts = acnts
@@ -465,7 +485,12 @@ func TestBlockChainHookImpl_NewAddress(t *testing.T) {
 
 	acnts := &stateMock.AccountsStub{}
 	acnts.GetExistingAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
-		return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+		return state.NewUserAccount(
+			address,
+			&hashingMocks.HasherMock{},
+			&testscommon.MarshalizerMock{},
+			&testscommon.EnableEpochsHandlerStub{},
+		)
 	}
 	args := createMockBlockChainHookArgs()
 	args.Accounts = acnts

--- a/process/smartContract/process_test.go
+++ b/process/smartContract/process_test.go
@@ -49,12 +49,12 @@ func createMockPubkeyConverter() *mock.PubkeyConverterMock {
 }
 
 func createAccount(address []byte) state.UserAccountHandler {
-	acc, _ := state.NewUserAccount(
-		address,
-		&hashingMocks.HasherMock{},
-		&testscommon.MarshalizerMock{},
-		&testscommon.EnableEpochsHandlerStub{},
-	)
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	acc, _ := state.NewUserAccount(address, argsAccCreation)
 	return acc
 }
 

--- a/process/transaction/metaProcess_test.go
+++ b/process/transaction/metaProcess_test.go
@@ -37,12 +37,12 @@ func createMockNewMetaTxArgs() txproc.ArgsNewMetaTxProcessor {
 }
 
 func createUserAcc(address []byte) state.UserAccountHandler {
-	acc, _ := state.NewUserAccount(
-		address,
-		&hashingMocks.HasherMock{},
-		&testscommon.MarshalizerMock{},
-		&testscommon.EnableEpochsHandlerStub{},
-	)
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	acc, _ := state.NewUserAccount(address, argsAccCreation)
 	return acc
 }
 

--- a/sharding/mock/enableEpochsHandlerMock.go
+++ b/sharding/mock/enableEpochsHandlerMock.go
@@ -541,6 +541,11 @@ func (mock *EnableEpochsHandlerMock) IsFixOldTokenLiquidityEnabled() bool {
 	return false
 }
 
+// IsAutoBalanceDataTriesEnabled -
+func (mock *EnableEpochsHandlerMock) IsAutoBalanceDataTriesEnabled() bool {
+	return false
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (mock *EnableEpochsHandlerMock) IsInterfaceNil() bool {
 	return mock == nil

--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -692,7 +692,7 @@ func (adb *AccountsDB) LoadAccount(address []byte) (vmcommon.AccountHandler, err
 		return nil, err
 	}
 	if check.IfNil(acnt) {
-		return adb.accountFactory.CreateAccount(address, adb.hasher, adb.marshaller)
+		return adb.accountFactory.CreateAccount(address)
 	}
 
 	baseAcc, ok := acnt.(baseAccountHandler)
@@ -715,7 +715,7 @@ func (adb *AccountsDB) getAccount(address []byte, mainTrie common.Trie) (vmcommo
 		return nil, nil
 	}
 
-	acnt, err := adb.accountFactory.CreateAccount(address, adb.hasher, adb.marshaller)
+	acnt, err := adb.accountFactory.CreateAccount(address)
 	if err != nil {
 		return nil, err
 	}
@@ -764,7 +764,7 @@ func (adb *AccountsDB) GetAccountFromBytes(address []byte, accountBytes []byte) 
 		return nil, fmt.Errorf("%w in GetAccountFromBytes", ErrNilAddress)
 	}
 
-	acnt, err := adb.accountFactory.CreateAccount(address, adb.hasher, adb.marshaller)
+	acnt, err := adb.accountFactory.CreateAccount(address)
 	if err != nil {
 		return nil, err
 	}

--- a/state/accountsDBApiWithHistory_test.go
+++ b/state/accountsDBApiWithHistory_test.go
@@ -130,7 +130,7 @@ func TestAccountsDBApiWithHistory_GetAccountWithBlockInfo(t *testing.T) {
 			},
 			GetExistingAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
 				if bytes.Equal(address, testscommon.TestPubKeyAlice) {
-					return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+					return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 				}
 
 				return nil, errors.New("not found")

--- a/state/accountsDBApiWithHistory_test.go
+++ b/state/accountsDBApiWithHistory_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/common/holders"
 	"github.com/ElrondNetwork/elrond-go/state"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
-	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	mockState "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/stretchr/testify/assert"
@@ -130,7 +129,7 @@ func TestAccountsDBApiWithHistory_GetAccountWithBlockInfo(t *testing.T) {
 			},
 			GetExistingAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
 				if bytes.Equal(address, testscommon.TestPubKeyAlice) {
-					return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+					return createUserAcc(address), nil
 				}
 
 				return nil, errors.New("not found")

--- a/state/accountsDBApi_test.go
+++ b/state/accountsDBApi_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/common/holders"
 	"github.com/ElrondNetwork/elrond-go/state"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
-	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	mockState "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	"github.com/ElrondNetwork/elrond-go/testscommon/trie"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
@@ -309,7 +308,7 @@ func TestAccountsDBApi_GetExistingAccount(t *testing.T) {
 				return nil
 			},
 			GetExistingAccountCalled: func(addressContainer []byte) (vmcommon.AccountHandler, error) {
-				return state.NewUserAccount(addressContainer, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+				return createUserAcc(addressContainer), nil
 			},
 		}
 
@@ -353,7 +352,7 @@ func TestAccountsDBApi_GetAccountFromBytes(t *testing.T) {
 				return nil
 			},
 			GetAccountFromBytesCalled: func(address []byte, accountBytes []byte) (vmcommon.AccountHandler, error) {
-				return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+				return createUserAcc(address), nil
 			},
 		}
 
@@ -397,7 +396,7 @@ func TestAccountsDBApi_LoadAccount(t *testing.T) {
 				return nil
 			},
 			LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
-				return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+				return createUserAcc(address), nil
 			},
 		}
 

--- a/state/accountsDBApi_test.go
+++ b/state/accountsDBApi_test.go
@@ -309,7 +309,7 @@ func TestAccountsDBApi_GetExistingAccount(t *testing.T) {
 				return nil
 			},
 			GetExistingAccountCalled: func(addressContainer []byte) (vmcommon.AccountHandler, error) {
-				return state.NewUserAccount(addressContainer, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+				return state.NewUserAccount(addressContainer, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 			},
 		}
 
@@ -353,7 +353,7 @@ func TestAccountsDBApi_GetAccountFromBytes(t *testing.T) {
 				return nil
 			},
 			GetAccountFromBytesCalled: func(address []byte, accountBytes []byte) (vmcommon.AccountHandler, error) {
-				return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+				return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 			},
 		}
 
@@ -397,7 +397,7 @@ func TestAccountsDBApi_LoadAccount(t *testing.T) {
 				return nil
 			},
 			LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
-				return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+				return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 			},
 		}
 

--- a/state/accountsDB_test.go
+++ b/state/accountsDB_test.go
@@ -62,6 +62,19 @@ func createMockAccountsDBArgs() state.ArgsAccountsDB {
 	}
 }
 
+func getDefaultArgsAccountCreation() state.ArgsAccountCreation {
+	return state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+}
+
+func createUserAcc(address []byte) state.UserAccountHandler {
+	acc, _ := state.NewUserAccount(address, getDefaultArgsAccountCreation())
+	return acc
+}
+
 func generateAccountDBFromTrie(trie common.Trie) *state.AccountsDB {
 	args := createMockAccountsDBArgs()
 	args.Trie = trie
@@ -113,7 +126,12 @@ func getDefaultStateComponents(
 	tr, _ := trie.NewTrie(trieStorage, marshaller, hasher, 5)
 	ewl, _ := evictionWaitingList.NewEvictionWaitingList(100, testscommon.NewMemDbMock(), marshaller)
 	spm, _ := storagePruningManager.NewStoragePruningManager(ewl, generalCfg.PruningBufferLen)
-	accCreator, _ := factory.NewAccountCreator(hasher, marshaller, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreator := state.ArgsAccountCreation{
+		Hasher:              hasher,
+		Marshaller:          marshaller,
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	accCreator, _ := factory.NewAccountCreator(argsAccCreator)
 
 	argsAccountsDB := state.ArgsAccountsDB{
 		Trie:                  tr,
@@ -261,7 +279,7 @@ func TestAccountsDB_SaveAccountNilOldAccount(t *testing.T) {
 		},
 	})
 
-	acc, _ := state.NewUserAccount([]byte("someAddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	acc := createUserAcc([]byte("someAddress"))
 	err := adb.SaveAccount(acc)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, adb.JournalLen())
@@ -270,8 +288,7 @@ func TestAccountsDB_SaveAccountNilOldAccount(t *testing.T) {
 func TestAccountsDB_SaveAccountExistingOldAccount(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount([]byte("someAddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
-
+	acc := createUserAcc([]byte("someAddress"))
 	adb := generateAccountDBFromTrie(&trieMock.TrieStub{
 		GetCalled: func(_ []byte) ([]byte, uint32, error) {
 			serializedAcc, err := (&testscommon.MarshalizerMock{}).Marshal(acc)
@@ -323,7 +340,7 @@ func TestAccountsDB_SaveAccountSavesCodeAndDataTrieForUserAccount(t *testing.T) 
 	})
 
 	accCode := []byte("code")
-	acc, _ := state.NewUserAccount([]byte("someAddress"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	acc := createUserAcc([]byte("someAddress"))
 	acc.SetCode(accCode)
 	_ = acc.SaveKeyValue([]byte("key"), []byte("value"))
 
@@ -1748,7 +1765,12 @@ func TestAccountsDB_MainTrieAutomaticallyMarksCodeUpdatesForEviction(t *testing.
 	argsAccountsDB.Trie = tr
 	argsAccountsDB.Hasher = hasher
 	argsAccountsDB.Marshaller = marshaller
-	argsAccountsDB.AccountFactory, _ = factory.NewAccountCreator(hasher, marshaller, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreator := state.ArgsAccountCreation{
+		Hasher:              hasher,
+		Marshaller:          marshaller,
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	argsAccountsDB.AccountFactory, _ = factory.NewAccountCreator(argsAccCreator)
 	argsAccountsDB.StoragePruningManager = spm
 
 	adb, _ := state.NewAccountsDB(argsAccountsDB)
@@ -1832,7 +1854,12 @@ func TestAccountsDB_RemoveAccountMarksObsoleteHashesForEviction(t *testing.T) {
 	argsAccountsDB.Trie = tr
 	argsAccountsDB.Hasher = hasher
 	argsAccountsDB.Marshaller = marshaller
-	argsAccountsDB.AccountFactory, _ = factory.NewAccountCreator(hasher, marshaller, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreator := state.ArgsAccountCreation{
+		Hasher:              hasher,
+		Marshaller:          marshaller,
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	argsAccountsDB.AccountFactory, _ = factory.NewAccountCreator(argsAccCreator)
 	argsAccountsDB.StoragePruningManager = spm
 
 	adb, _ := state.NewAccountsDB(argsAccountsDB)
@@ -2259,7 +2286,12 @@ func TestAccountsDB_GetCode(t *testing.T) {
 	argsAccountsDB.Trie = tr
 	argsAccountsDB.Hasher = hasher
 	argsAccountsDB.Marshaller = marshaller
-	argsAccountsDB.AccountFactory, _ = factory.NewAccountCreator(hasher, marshaller, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreator := state.ArgsAccountCreation{
+		Hasher:              hasher,
+		Marshaller:          marshaller,
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	argsAccountsDB.AccountFactory, _ = factory.NewAccountCreator(argsAccCreator)
 	argsAccountsDB.StoragePruningManager = spm
 
 	adb, _ := state.NewAccountsDB(argsAccountsDB)
@@ -2411,7 +2443,12 @@ func TestAccountsDB_Close(t *testing.T) {
 	argsAccountsDB.Trie = tr
 	argsAccountsDB.Hasher = hasher
 	argsAccountsDB.Marshaller = marshaller
-	argsAccountsDB.AccountFactory, _ = factory.NewAccountCreator(hasher, marshaller, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreator := state.ArgsAccountCreation{
+		Hasher:              hasher,
+		Marshaller:          marshaller,
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	argsAccountsDB.AccountFactory, _ = factory.NewAccountCreator(argsAccCreator)
 	argsAccountsDB.StoragePruningManager = spm
 
 	adb, _ := state.NewAccountsDB(argsAccountsDB)
@@ -2437,7 +2474,7 @@ func TestAccountsDB_GetAccountFromBytes(t *testing.T) {
 
 	marshaller := &testscommon.MarshalizerMock{}
 	adr := make([]byte, 32)
-	accountExpected, _ := state.NewUserAccount(adr, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	accountExpected := createUserAcc(adr)
 	accountBytes, _ := marshaller.Marshal(accountExpected)
 	_, adb := getDefaultTrieAndAccountsDb()
 
@@ -2646,7 +2683,12 @@ func BenchmarkAccountsDb_GetCodeEntry(b *testing.B) {
 	argsAccountsDB.Trie = tr
 	argsAccountsDB.Hasher = hasher
 	argsAccountsDB.Marshaller = marshaller
-	argsAccountsDB.AccountFactory, _ = factory.NewAccountCreator(hasher, marshaller, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreator := state.ArgsAccountCreation{
+		Hasher:              hasher,
+		Marshaller:          marshaller,
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	argsAccountsDB.AccountFactory, _ = factory.NewAccountCreator(argsAccCreator)
 	argsAccountsDB.StoragePruningManager = spm
 
 	adb, _ := state.NewAccountsDB(argsAccountsDB)

--- a/state/disabled/disabledDataTrieHandler.go
+++ b/state/disabled/disabledDataTrieHandler.go
@@ -1,0 +1,39 @@
+package disabled
+
+import (
+	"context"
+
+	"github.com/ElrondNetwork/elrond-go/common"
+)
+
+type disabledDataTrieHandler struct {
+}
+
+// NewDisabledDataTrieHandler returns a new instance of disabledDataTrieHandler
+func NewDisabledDataTrieHandler() *disabledDataTrieHandler {
+	return &disabledDataTrieHandler{}
+}
+
+// RootHash returns an empty byte array
+func (ddth *disabledDataTrieHandler) RootHash() ([]byte, error) {
+	return []byte{}, nil
+}
+
+// GetAllLeavesOnChannel does nothing for this implementation
+func (ddth *disabledDataTrieHandler) GetAllLeavesOnChannel(
+	leavesChannels *common.TrieIteratorChannels,
+	_ context.Context,
+	_ []byte,
+	_ common.KeyBuilder,
+) error {
+	if leavesChannels.LeavesChan != nil {
+		close(leavesChannels.LeavesChan)
+	}
+
+	return nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (ddth *disabledDataTrieHandler) IsInterfaceNil() bool {
+	return ddth == nil
+}

--- a/state/disabled/disabledDataTrieHandler.go
+++ b/state/disabled/disabledDataTrieHandler.go
@@ -29,6 +29,9 @@ func (ddth *disabledDataTrieHandler) GetAllLeavesOnChannel(
 	if leavesChannels.LeavesChan != nil {
 		close(leavesChannels.LeavesChan)
 	}
+	if leavesChannels.ErrChan != nil {
+		close(leavesChannels.ErrChan)
+	}
 
 	return nil
 }

--- a/state/disabled/disabledDataTrieHandler_test.go
+++ b/state/disabled/disabledDataTrieHandler_test.go
@@ -1,0 +1,46 @@
+package disabled
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDisabledDataTrieHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("new disabledDataTrieHandler", func(t *testing.T) {
+		t.Parallel()
+
+		assert.False(t, check.IfNil(NewDisabledDataTrieHandler()))
+	})
+
+	t.Run("root hash", func(t *testing.T) {
+		t.Parallel()
+
+		ddth := NewDisabledDataTrieHandler()
+
+		rootHash, err := ddth.RootHash()
+		assert.Equal(t, 0, len(rootHash))
+		assert.Nil(t, err)
+	})
+
+	t.Run("get all leaves on channel", func(t *testing.T) {
+		t.Parallel()
+
+		ddth := NewDisabledDataTrieHandler()
+
+		chans := &common.TrieIteratorChannels{
+			LeavesChan: make(chan core.KeyValueHolder, 1),
+			ErrChan:    nil,
+		}
+
+		err := ddth.GetAllLeavesOnChannel(chans, nil, nil, nil)
+		assert.Nil(t, err)
+		_, ok := <-chans.LeavesChan
+		assert.False(t, ok)
+	})
+}

--- a/state/disabled/disabledDataTrieHandler_test.go
+++ b/state/disabled/disabledDataTrieHandler_test.go
@@ -35,12 +35,14 @@ func TestNewDisabledDataTrieHandler(t *testing.T) {
 
 		chans := &common.TrieIteratorChannels{
 			LeavesChan: make(chan core.KeyValueHolder, 1),
-			ErrChan:    nil,
+			ErrChan:    make(chan error),
 		}
 
 		err := ddth.GetAllLeavesOnChannel(chans, nil, nil, nil)
 		assert.Nil(t, err)
 		_, ok := <-chans.LeavesChan
+		assert.False(t, ok)
+		_, ok = <-chans.ErrChan
 		assert.False(t, ok)
 	})
 }

--- a/state/disabled/disabledTrackableDataTrie.go
+++ b/state/disabled/disabledTrackableDataTrie.go
@@ -1,0 +1,40 @@
+package disabled
+
+import "github.com/ElrondNetwork/elrond-go/common"
+
+type disabledTrackableDataTrie struct {
+}
+
+// NewDisabledTrackableDataTrie returns a new instance of disabledTrackableDataTrie
+func NewDisabledTrackableDataTrie() *disabledTrackableDataTrie {
+	return &disabledTrackableDataTrie{}
+}
+
+// RetrieveValue returns an empty byte array
+func (dtdt *disabledTrackableDataTrie) RetrieveValue(_ []byte) ([]byte, uint32, error) {
+	return []byte{}, 0, nil
+}
+
+// SaveKeyValue does nothing for this implementation
+func (dtdt *disabledTrackableDataTrie) SaveKeyValue(_ []byte, _ []byte) error {
+	return nil
+}
+
+// SetDataTrie does nothing for this implementation
+func (dtdt *disabledTrackableDataTrie) SetDataTrie(_ common.Trie) {
+}
+
+// DataTrie returns a new disabledDataTrieHandler
+func (dtdt *disabledTrackableDataTrie) DataTrie() common.DataTrieHandler {
+	return NewDisabledDataTrieHandler()
+}
+
+// SaveDirtyData does nothing for this implementation
+func (dtdt *disabledTrackableDataTrie) SaveDirtyData(_ common.Trie) (map[string][]byte, error) {
+	return map[string][]byte{}, nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (dtdt *disabledTrackableDataTrie) IsInterfaceNil() bool {
+	return dtdt == nil
+}

--- a/state/disabled/disabledTrackableDataTrie_test.go
+++ b/state/disabled/disabledTrackableDataTrie_test.go
@@ -1,0 +1,65 @@
+package disabled
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDisabledTrackableDataTrie(t *testing.T) {
+	t.Parallel()
+
+	t.Run("new disabledTrackableDataTrie", func(t *testing.T) {
+		t.Parallel()
+
+		assert.False(t, check.IfNil(NewDisabledTrackableDataTrie()))
+	})
+
+	t.Run("retrieve value", func(t *testing.T) {
+		t.Parallel()
+
+		dtdt := NewDisabledTrackableDataTrie()
+
+		val, depth, err := dtdt.RetrieveValue(nil)
+		assert.Nil(t, err)
+		assert.Equal(t, uint32(0), depth)
+		assert.Equal(t, 0, len(val))
+	})
+
+	t.Run("saveKeyValue", func(t *testing.T) {
+		t.Parallel()
+
+		dtdt := NewDisabledTrackableDataTrie()
+
+		err := dtdt.SaveKeyValue(nil, nil)
+		assert.Nil(t, err)
+	})
+
+	t.Run("set and get data trie", func(t *testing.T) {
+		t.Parallel()
+
+		dtdt := NewDisabledTrackableDataTrie()
+		isDisabledDataTrieHandler := false
+		dtdt.SetDataTrie(nil)
+		tr := dtdt.DataTrie()
+
+		switch tr.(type) {
+		case *disabledDataTrieHandler:
+			isDisabledDataTrieHandler = true
+		default:
+			assert.Fail(t, "this should not have been called")
+		}
+		assert.True(t, isDisabledDataTrieHandler)
+	})
+
+	t.Run("save dirty data", func(t *testing.T) {
+		t.Parallel()
+
+		dtdt := NewDisabledTrackableDataTrie()
+
+		oldValues, err := dtdt.SaveDirtyData(nil)
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(oldValues))
+	})
+}

--- a/state/disabled/disabledTrackableDataTrie_test.go
+++ b/state/disabled/disabledTrackableDataTrie_test.go
@@ -10,56 +10,52 @@ import (
 func TestNewDisabledTrackableDataTrie(t *testing.T) {
 	t.Parallel()
 
-	t.Run("new disabledTrackableDataTrie", func(t *testing.T) {
-		t.Parallel()
+	assert.False(t, check.IfNil(NewDisabledTrackableDataTrie()))
+}
 
-		assert.False(t, check.IfNil(NewDisabledTrackableDataTrie()))
-	})
+func TestDisabledTrackableDataTrie_RetrieveValue(t *testing.T) {
+	t.Parallel()
 
-	t.Run("retrieve value", func(t *testing.T) {
-		t.Parallel()
+	dtdt := NewDisabledTrackableDataTrie()
 
-		dtdt := NewDisabledTrackableDataTrie()
+	val, depth, err := dtdt.RetrieveValue(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, uint32(0), depth)
+	assert.Equal(t, 0, len(val))
+}
 
-		val, depth, err := dtdt.RetrieveValue(nil)
-		assert.Nil(t, err)
-		assert.Equal(t, uint32(0), depth)
-		assert.Equal(t, 0, len(val))
-	})
+func TestDisabledTrackableDataTrie_SaveKeyValue(t *testing.T) {
+	t.Parallel()
 
-	t.Run("saveKeyValue", func(t *testing.T) {
-		t.Parallel()
+	dtdt := NewDisabledTrackableDataTrie()
 
-		dtdt := NewDisabledTrackableDataTrie()
+	err := dtdt.SaveKeyValue(nil, nil)
+	assert.Nil(t, err)
+}
 
-		err := dtdt.SaveKeyValue(nil, nil)
-		assert.Nil(t, err)
-	})
+func TestDisabledTrackableDataTrie_SetAndGetDataTrie(t *testing.T) {
+	t.Parallel()
 
-	t.Run("set and get data trie", func(t *testing.T) {
-		t.Parallel()
+	dtdt := NewDisabledTrackableDataTrie()
+	isDisabledDataTrieHandler := false
+	dtdt.SetDataTrie(nil)
+	tr := dtdt.DataTrie()
 
-		dtdt := NewDisabledTrackableDataTrie()
-		isDisabledDataTrieHandler := false
-		dtdt.SetDataTrie(nil)
-		tr := dtdt.DataTrie()
+	switch tr.(type) {
+	case *disabledDataTrieHandler:
+		isDisabledDataTrieHandler = true
+	default:
+		assert.Fail(t, "this should not have been called")
+	}
+	assert.True(t, isDisabledDataTrieHandler)
+}
 
-		switch tr.(type) {
-		case *disabledDataTrieHandler:
-			isDisabledDataTrieHandler = true
-		default:
-			assert.Fail(t, "this should not have been called")
-		}
-		assert.True(t, isDisabledDataTrieHandler)
-	})
+func TestDisabledTrackableDataTrie_SaveDirtyData(t *testing.T) {
+	t.Parallel()
 
-	t.Run("save dirty data", func(t *testing.T) {
-		t.Parallel()
+	dtdt := NewDisabledTrackableDataTrie()
 
-		dtdt := NewDisabledTrackableDataTrie()
-
-		oldValues, err := dtdt.SaveDirtyData(nil)
-		assert.Nil(t, err)
-		assert.Equal(t, 0, len(oldValues))
-	})
+	oldValues, err := dtdt.SaveDirtyData(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(oldValues))
 }

--- a/state/errors.go
+++ b/state/errors.go
@@ -161,3 +161,6 @@ var ErrNilTrieSyncer = errors.New("trie syncer is nil")
 
 // ErrNilSyncStatisticsHandler signals that a nil sync statistics handler was provided
 var ErrNilSyncStatisticsHandler = errors.New("nil sync statistics handler")
+
+// ErrNilEnableEpochsHandler signals that a nil enable epochs handler has been provided
+var ErrNilEnableEpochsHandler = errors.New("nil enable epochs handler")

--- a/state/factory/accountCreator.go
+++ b/state/factory/accountCreator.go
@@ -1,24 +1,44 @@
 package factory
 
 import (
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
+	"github.com/ElrondNetwork/elrond-go/common"
+	"github.com/ElrondNetwork/elrond-go/errors"
 	"github.com/ElrondNetwork/elrond-go/state"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
 
 // AccountCreator has method to create a new account
 type AccountCreator struct {
+	hasher              hashing.Hasher
+	marshaller          marshal.Marshalizer
+	enableEpochsHandler common.EnableEpochsHandler
 }
 
 // NewAccountCreator creates an account creator
-func NewAccountCreator() state.AccountFactory {
-	return &AccountCreator{}
+func NewAccountCreator(hasher hashing.Hasher, marshaller marshal.Marshalizer, enableEpochsHandler common.EnableEpochsHandler) (state.AccountFactory, error) {
+	if check.IfNil(hasher) {
+		return nil, errors.ErrNilHasher
+	}
+	if check.IfNil(marshaller) {
+		return nil, errors.ErrNilMarshalizer
+	}
+	if check.IfNil(enableEpochsHandler) {
+		return nil, errors.ErrNilEnableEpochsHandler
+	}
+
+	return &AccountCreator{
+		hasher:              hasher,
+		marshaller:          marshaller,
+		enableEpochsHandler: enableEpochsHandler,
+	}, nil
 }
 
 // CreateAccount calls the new Account creator and returns the result
-func (ac *AccountCreator) CreateAccount(address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (vmcommon.AccountHandler, error) {
-	return state.NewUserAccount(address, hasher, marshaller)
+func (ac *AccountCreator) CreateAccount(address []byte) (vmcommon.AccountHandler, error) {
+	return state.NewUserAccount(address, ac.hasher, ac.marshaller, ac.enableEpochsHandler)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/state/factory/accountCreator.go
+++ b/state/factory/accountCreator.go
@@ -2,9 +2,6 @@ package factory
 
 import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
-	"github.com/ElrondNetwork/elrond-go-core/hashing"
-	"github.com/ElrondNetwork/elrond-go-core/marshal"
-	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/errors"
 	"github.com/ElrondNetwork/elrond-go/state"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
@@ -12,33 +9,29 @@ import (
 
 // AccountCreator has method to create a new account
 type AccountCreator struct {
-	hasher              hashing.Hasher
-	marshaller          marshal.Marshalizer
-	enableEpochsHandler common.EnableEpochsHandler
+	accountArgs state.ArgsAccountCreation
 }
 
-// NewAccountCreator creates an account creator
-func NewAccountCreator(hasher hashing.Hasher, marshaller marshal.Marshalizer, enableEpochsHandler common.EnableEpochsHandler) (state.AccountFactory, error) {
-	if check.IfNil(hasher) {
+// NewAccountCreator creates a new instance of AccountCreator
+func NewAccountCreator(args state.ArgsAccountCreation) (state.AccountFactory, error) {
+	if check.IfNil(args.Hasher) {
 		return nil, errors.ErrNilHasher
 	}
-	if check.IfNil(marshaller) {
+	if check.IfNil(args.Marshaller) {
 		return nil, errors.ErrNilMarshalizer
 	}
-	if check.IfNil(enableEpochsHandler) {
+	if check.IfNil(args.EnableEpochsHandler) {
 		return nil, errors.ErrNilEnableEpochsHandler
 	}
 
 	return &AccountCreator{
-		hasher:              hasher,
-		marshaller:          marshaller,
-		enableEpochsHandler: enableEpochsHandler,
+		accountArgs: args,
 	}, nil
 }
 
 // CreateAccount calls the new Account creator and returns the result
 func (ac *AccountCreator) CreateAccount(address []byte) (vmcommon.AccountHandler, error) {
-	return state.NewUserAccount(address, ac.hasher, ac.marshaller, ac.enableEpochsHandler)
+	return state.NewUserAccount(address, ac.accountArgs)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/state/factory/accountCreator_test.go
+++ b/state/factory/accountCreator_test.go
@@ -12,34 +12,48 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func getDefaultArgs() state.ArgsAccountCreation {
+	return state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+}
+
 func TestNewAccountCreator(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil hasher", func(t *testing.T) {
 		t.Parallel()
 
-		accF, err := factory.NewAccountCreator(nil, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+		args := getDefaultArgs()
+		args.Hasher = nil
+		accF, err := factory.NewAccountCreator(args)
 		assert.True(t, check.IfNil(accF))
 		assert.Equal(t, errors.ErrNilHasher, err)
 	})
 	t.Run("nil marshalizer", func(t *testing.T) {
 		t.Parallel()
 
-		accF, err := factory.NewAccountCreator(&hashingMocks.HasherMock{}, nil, &testscommon.EnableEpochsHandlerStub{})
+		args := getDefaultArgs()
+		args.Marshaller = nil
+		accF, err := factory.NewAccountCreator(args)
 		assert.True(t, check.IfNil(accF))
 		assert.Equal(t, errors.ErrNilMarshalizer, err)
 	})
 	t.Run("nil enableEpochsHandler", func(t *testing.T) {
 		t.Parallel()
 
-		accF, err := factory.NewAccountCreator(&hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, nil)
+		args := getDefaultArgs()
+		args.EnableEpochsHandler = nil
+		accF, err := factory.NewAccountCreator(args)
 		assert.True(t, check.IfNil(accF))
 		assert.Equal(t, errors.ErrNilEnableEpochsHandler, err)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		accF, err := factory.NewAccountCreator(&hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+		accF, err := factory.NewAccountCreator(getDefaultArgs())
 		assert.False(t, check.IfNil(accF))
 		assert.Nil(t, err)
 	})
@@ -48,7 +62,7 @@ func TestNewAccountCreator(t *testing.T) {
 func TestAccountCreator_CreateAccountNilAddress(t *testing.T) {
 	t.Parallel()
 
-	accF, _ := factory.NewAccountCreator(&hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	accF, _ := factory.NewAccountCreator(getDefaultArgs())
 
 	_, ok := accF.(*factory.AccountCreator)
 	assert.Equal(t, true, ok)
@@ -63,7 +77,7 @@ func TestAccountCreator_CreateAccountNilAddress(t *testing.T) {
 func TestAccountCreator_CreateAccountOk(t *testing.T) {
 	t.Parallel()
 
-	accF, _ := factory.NewAccountCreator(&hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	accF, _ := factory.NewAccountCreator(getDefaultArgs())
 
 	_, ok := accF.(*factory.AccountCreator)
 	assert.Equal(t, true, ok)

--- a/state/factory/accountCreator_test.go
+++ b/state/factory/accountCreator_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go/errors"
 	"github.com/ElrondNetwork/elrond-go/state"
 	"github.com/ElrondNetwork/elrond-go/state/factory"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
@@ -11,16 +12,49 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNewAccountCreator(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil hasher", func(t *testing.T) {
+		t.Parallel()
+
+		accF, err := factory.NewAccountCreator(nil, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+		assert.True(t, check.IfNil(accF))
+		assert.Equal(t, errors.ErrNilHasher, err)
+	})
+	t.Run("nil marshalizer", func(t *testing.T) {
+		t.Parallel()
+
+		accF, err := factory.NewAccountCreator(&hashingMocks.HasherMock{}, nil, &testscommon.EnableEpochsHandlerStub{})
+		assert.True(t, check.IfNil(accF))
+		assert.Equal(t, errors.ErrNilMarshalizer, err)
+	})
+	t.Run("nil enableEpochsHandler", func(t *testing.T) {
+		t.Parallel()
+
+		accF, err := factory.NewAccountCreator(&hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, nil)
+		assert.True(t, check.IfNil(accF))
+		assert.Equal(t, errors.ErrNilEnableEpochsHandler, err)
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		accF, err := factory.NewAccountCreator(&hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+		assert.False(t, check.IfNil(accF))
+		assert.Nil(t, err)
+	})
+}
+
 func TestAccountCreator_CreateAccountNilAddress(t *testing.T) {
 	t.Parallel()
 
-	accF := factory.NewAccountCreator()
+	accF, _ := factory.NewAccountCreator(&hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 
 	_, ok := accF.(*factory.AccountCreator)
 	assert.Equal(t, true, ok)
 	assert.False(t, check.IfNil(accF))
 
-	acc, err := accF.CreateAccount(nil, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, err := accF.CreateAccount(nil)
 
 	assert.Nil(t, acc)
 	assert.Equal(t, err, state.ErrNilAddress)
@@ -29,12 +63,12 @@ func TestAccountCreator_CreateAccountNilAddress(t *testing.T) {
 func TestAccountCreator_CreateAccountOk(t *testing.T) {
 	t.Parallel()
 
-	accF := factory.NewAccountCreator()
+	accF, _ := factory.NewAccountCreator(&hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 
 	_, ok := accF.(*factory.AccountCreator)
 	assert.Equal(t, true, ok)
 
-	acc, err := accF.CreateAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, err := accF.CreateAccount(make([]byte, 32))
 
 	assert.Nil(t, err)
 	assert.False(t, check.IfNil(acc))

--- a/state/factory/peerAccountCreator.go
+++ b/state/factory/peerAccountCreator.go
@@ -1,8 +1,6 @@
 package factory
 
 import (
-	"github.com/ElrondNetwork/elrond-go-core/hashing"
-	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/state"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
@@ -17,8 +15,8 @@ func NewPeerAccountCreator() state.AccountFactory {
 }
 
 // CreateAccount calls the new Account creator and returns the result
-func (pac *PeerAccountCreator) CreateAccount(address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (vmcommon.AccountHandler, error) {
-	return state.NewPeerAccount(address, hasher, marshaller)
+func (pac *PeerAccountCreator) CreateAccount(address []byte) (vmcommon.AccountHandler, error) {
+	return state.NewPeerAccount(address)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/state/factory/peerAccountCreator_test.go
+++ b/state/factory/peerAccountCreator_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go/state"
 	"github.com/ElrondNetwork/elrond-go/state/factory"
-	"github.com/ElrondNetwork/elrond-go/testscommon"
-	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,7 +17,7 @@ func TestPeerAccountCreator_CreateAccountNilAddress(t *testing.T) {
 	_, ok := accF.(*factory.PeerAccountCreator)
 	assert.Equal(t, true, ok)
 
-	acc, err := accF.CreateAccount(nil, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, err := accF.CreateAccount(nil)
 
 	assert.Nil(t, acc)
 	assert.Equal(t, err, state.ErrNilAddress)
@@ -34,7 +32,7 @@ func TestPeerAccountCreator_CreateAccountOk(t *testing.T) {
 	_, ok := accF.(*factory.PeerAccountCreator)
 	assert.Equal(t, true, ok)
 
-	acc, err := accF.CreateAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, err := accF.CreateAccount(make([]byte, 32))
 
 	assert.NotNil(t, acc)
 	assert.Nil(t, err)

--- a/state/interface.go
+++ b/state/interface.go
@@ -5,15 +5,13 @@ import (
 	"math/big"
 
 	"github.com/ElrondNetwork/elrond-go-core/data/api"
-	"github.com/ElrondNetwork/elrond-go-core/hashing"
-	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/common"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
 
 // AccountFactory creates an account of different types
 type AccountFactory interface {
-	CreateAccount(address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (vmcommon.AccountHandler, error)
+	CreateAccount(address []byte) (vmcommon.AccountHandler, error)
 	IsInterfaceNil() bool
 }
 

--- a/state/journalEntries_test.go
+++ b/state/journalEntries_test.go
@@ -186,7 +186,12 @@ func TestNewJournalEntryDataTrieUpdates_EmptyTrieUpdatesShouldErr(t *testing.T) 
 	t.Parallel()
 
 	trieUpdates := make(map[string][]byte)
-	accnt, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	args := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	accnt, _ := state.NewUserAccount(make([]byte, 32), args)
 	entry, err := state.NewJournalEntryDataTrieUpdates(trieUpdates, accnt)
 
 	assert.True(t, check.IfNil(entry))
@@ -198,7 +203,12 @@ func TestNewJournalEntryDataTrieUpdates_OkValsShouldWork(t *testing.T) {
 
 	trieUpdates := make(map[string][]byte)
 	trieUpdates["a"] = []byte("b")
-	accnt, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	args := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	accnt, _ := state.NewUserAccount(make([]byte, 32), args)
 	entry, err := state.NewJournalEntryDataTrieUpdates(trieUpdates, accnt)
 
 	assert.Nil(t, err)

--- a/state/journalEntries_test.go
+++ b/state/journalEntries_test.go
@@ -186,7 +186,7 @@ func TestNewJournalEntryDataTrieUpdates_EmptyTrieUpdatesShouldErr(t *testing.T) 
 	t.Parallel()
 
 	trieUpdates := make(map[string][]byte)
-	accnt, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	accnt, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	entry, err := state.NewJournalEntryDataTrieUpdates(trieUpdates, accnt)
 
 	assert.True(t, check.IfNil(entry))
@@ -198,7 +198,7 @@ func TestNewJournalEntryDataTrieUpdates_OkValsShouldWork(t *testing.T) {
 
 	trieUpdates := make(map[string][]byte)
 	trieUpdates["a"] = []byte("b")
-	accnt, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	accnt, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	entry, err := state.NewJournalEntryDataTrieUpdates(trieUpdates, accnt)
 
 	assert.Nil(t, err)

--- a/state/peerAccount.go
+++ b/state/peerAccount.go
@@ -10,6 +10,7 @@ import (
 
 // PeerAccount is the struct used in serialization/deserialization
 type peerAccount struct {
+	//TODO investigate if *baseAccount is needed in peerAccount, and remove if not
 	*baseAccount
 	PeerAccountData
 }

--- a/state/peerAccount.go
+++ b/state/peerAccount.go
@@ -26,7 +26,7 @@ func NewEmptyPeerAccount() *peerAccount {
 	}
 }
 
-// NewPeerAccount creates new simple account wrapper for an PeerAccountContainer (that has just been initialized)
+// NewPeerAccount creates a new instance of peerAccount
 func NewPeerAccount(address []byte) (*peerAccount, error) {
 	if len(address) == 0 {
 		return nil, ErrNilAddress

--- a/state/peerAccount.go
+++ b/state/peerAccount.go
@@ -4,9 +4,8 @@ package state
 import (
 	"math/big"
 
-	"github.com/ElrondNetwork/elrond-go-core/hashing"
-	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/common"
+	"github.com/ElrondNetwork/elrond-go/state/disabled"
 )
 
 // PeerAccount is the struct used in serialization/deserialization
@@ -27,20 +26,15 @@ func NewEmptyPeerAccount() *peerAccount {
 }
 
 // NewPeerAccount creates new simple account wrapper for an PeerAccountContainer (that has just been initialized)
-func NewPeerAccount(address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (*peerAccount, error) {
+func NewPeerAccount(address []byte) (*peerAccount, error) {
 	if len(address) == 0 {
 		return nil, ErrNilAddress
-	}
-
-	tdt, err := NewTrackableDataTrie(address, nil, hasher, marshaller)
-	if err != nil {
-		return nil, err
 	}
 
 	return &peerAccount{
 		baseAccount: &baseAccount{
 			address:         address,
-			dataTrieTracker: tdt,
+			dataTrieTracker: disabled.NewDisabledTrackableDataTrie(),
 		},
 		PeerAccountData: PeerAccountData{
 			AccumulatedFees: big.NewInt(0),

--- a/state/peerAccount_test.go
+++ b/state/peerAccount_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go/state"
-	"github.com/ElrondNetwork/elrond-go/testscommon"
-	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,7 +21,7 @@ func TestNewEmptyPeerAccount(t *testing.T) {
 func TestNewPeerAccount_NilAddressContainerShouldErr(t *testing.T) {
 	t.Parallel()
 
-	acc, err := state.NewPeerAccount(nil, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, err := state.NewPeerAccount(nil)
 	assert.True(t, check.IfNil(acc))
 	assert.Equal(t, state.ErrNilAddress, err)
 }
@@ -31,7 +29,7 @@ func TestNewPeerAccount_NilAddressContainerShouldErr(t *testing.T) {
 func TestNewPeerAccount_OkParamsShouldWork(t *testing.T) {
 	t.Parallel()
 
-	acc, err := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, err := state.NewPeerAccount(make([]byte, 32))
 	assert.Nil(t, err)
 	assert.False(t, check.IfNil(acc))
 }
@@ -39,7 +37,7 @@ func TestNewPeerAccount_OkParamsShouldWork(t *testing.T) {
 func TestPeerAccount_SetInvalidBLSPublicKey(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32))
 	pubKey := []byte("")
 
 	err := acc.SetBLSPublicKey(pubKey)
@@ -49,7 +47,7 @@ func TestPeerAccount_SetInvalidBLSPublicKey(t *testing.T) {
 func TestPeerAccount_SetAndGetBLSPublicKey(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32))
 	pubKey := []byte("BLSpubKey")
 
 	err := acc.SetBLSPublicKey(pubKey)
@@ -60,7 +58,7 @@ func TestPeerAccount_SetAndGetBLSPublicKey(t *testing.T) {
 func TestPeerAccount_SetRewardAddressInvalidAddress(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32))
 
 	err := acc.SetRewardAddress([]byte{})
 	assert.Equal(t, state.ErrEmptyAddress, err)
@@ -69,7 +67,7 @@ func TestPeerAccount_SetRewardAddressInvalidAddress(t *testing.T) {
 func TestPeerAccount_SetAndGetRewardAddress(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32))
 	addr := []byte("reward address")
 
 	_ = acc.SetRewardAddress(addr)
@@ -79,7 +77,7 @@ func TestPeerAccount_SetAndGetRewardAddress(t *testing.T) {
 func TestPeerAccount_SetAndGetAccumulatedFees(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32))
 	fees := big.NewInt(10)
 
 	acc.AddToAccumulatedFees(fees)
@@ -89,7 +87,7 @@ func TestPeerAccount_SetAndGetAccumulatedFees(t *testing.T) {
 func TestPeerAccount_SetAndGetLeaderSuccessRate(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32))
 	increaseVal := uint32(5)
 	decreaseVal := uint32(3)
 
@@ -103,7 +101,7 @@ func TestPeerAccount_SetAndGetLeaderSuccessRate(t *testing.T) {
 func TestPeerAccount_SetAndGetValidatorSuccessRate(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32))
 	increaseVal := uint32(5)
 	decreaseVal := uint32(3)
 
@@ -117,7 +115,7 @@ func TestPeerAccount_SetAndGetValidatorSuccessRate(t *testing.T) {
 func TestPeerAccount_IncreaseAndGetSetNumSelectedInSuccessBlocks(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32))
 
 	acc.IncreaseNumSelectedInSuccessBlocks()
 	assert.Equal(t, uint32(1), acc.GetNumSelectedInSuccessBlocks())
@@ -126,7 +124,7 @@ func TestPeerAccount_IncreaseAndGetSetNumSelectedInSuccessBlocks(t *testing.T) {
 func TestPeerAccount_SetAndGetRating(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32))
 	rating := uint32(10)
 
 	acc.SetRating(rating)
@@ -136,7 +134,7 @@ func TestPeerAccount_SetAndGetRating(t *testing.T) {
 func TestPeerAccount_SetAndGetTempRating(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32))
 	rating := uint32(10)
 
 	acc.SetTempRating(rating)
@@ -146,7 +144,7 @@ func TestPeerAccount_SetAndGetTempRating(t *testing.T) {
 func TestPeerAccount_ResetAtNewEpoch(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32))
 	acc.AddToAccumulatedFees(big.NewInt(15))
 	tempRating := uint32(5)
 	acc.SetTempRating(tempRating)
@@ -171,7 +169,7 @@ func TestPeerAccount_ResetAtNewEpoch(t *testing.T) {
 func TestPeerAccount_IncreaseAndGetNonce(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewPeerAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewPeerAccount(make([]byte, 32))
 	nonce := uint64(5)
 
 	acc.IncreaseNonce(nonce)

--- a/state/storagePruningManager/storagePruningManager_test.go
+++ b/state/storagePruningManager/storagePruningManager_test.go
@@ -37,12 +37,13 @@ func getDefaultTrieAndAccountsDbAndStoragePruningManager() (common.Trie, *state.
 	tr, _ := trie.NewTrie(trieStorage, marshaller, hasher, 5)
 	ewl, _ := evictionWaitingList.NewEvictionWaitingList(100, testscommon.NewMemDbMock(), marshaller)
 	spm, _ := NewStoragePruningManager(ewl, generalCfg.PruningBufferLen)
+	accCreator, _ := factory.NewAccountCreator(hasher, marshaller, &testscommon.EnableEpochsHandlerStub{})
 
 	argsAccountsDB := state.ArgsAccountsDB{
 		Trie:                  tr,
 		Hasher:                hasher,
 		Marshaller:            marshaller,
-		AccountFactory:        factory.NewAccountCreator(),
+		AccountFactory:        accCreator,
 		StoragePruningManager: spm,
 		ProcessingMode:        common.Normal,
 		ProcessStatusHandler:  &testscommon.ProcessStatusHandlerStub{},

--- a/state/storagePruningManager/storagePruningManager_test.go
+++ b/state/storagePruningManager/storagePruningManager_test.go
@@ -37,7 +37,12 @@ func getDefaultTrieAndAccountsDbAndStoragePruningManager() (common.Trie, *state.
 	tr, _ := trie.NewTrie(trieStorage, marshaller, hasher, 5)
 	ewl, _ := evictionWaitingList.NewEvictionWaitingList(100, testscommon.NewMemDbMock(), marshaller)
 	spm, _ := NewStoragePruningManager(ewl, generalCfg.PruningBufferLen)
-	accCreator, _ := factory.NewAccountCreator(hasher, marshaller, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreator := state.ArgsAccountCreation{
+		Hasher:              hasher,
+		Marshaller:          marshaller,
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	accCreator, _ := factory.NewAccountCreator(argsAccCreator)
 
 	argsAccountsDB := state.ArgsAccountsDB{
 		Trie:                  tr,

--- a/state/userAccount.go
+++ b/state/userAccount.go
@@ -5,8 +5,10 @@ import (
 	"bytes"
 	"math/big"
 
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
+	"github.com/ElrondNetwork/elrond-go/common"
 )
 
 var _ UserAccountHandler = (*userAccount)(nil)
@@ -31,9 +33,20 @@ func NewEmptyUserAccount() *userAccount {
 }
 
 // NewUserAccount creates new simple account wrapper for an AccountContainer (that has just been initialized)
-func NewUserAccount(address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (*userAccount, error) {
+func NewUserAccount(
+	address []byte,
+	hasher hashing.Hasher,
+	marshaller marshal.Marshalizer,
+	enableEpochsHandler common.EnableEpochsHandler,
+) (*userAccount, error) {
 	if len(address) == 0 {
 		return nil, ErrNilAddress
+	}
+	if check.IfNil(marshaller) {
+		return nil, ErrNilMarshalizer
+	}
+	if check.IfNil(enableEpochsHandler) {
+		return nil, ErrNilEnableEpochsHandler
 	}
 
 	tdt, err := NewTrackableDataTrie(address, nil, hasher, marshaller)

--- a/state/userAccount.go
+++ b/state/userAccount.go
@@ -21,7 +21,7 @@ type userAccount struct {
 
 var zero = big.NewInt(0)
 
-// NewEmptyUserAccount creates new simple account wrapper for an AccountContainer (that has just been initialized)
+// NewEmptyUserAccount creates a new empty instance of userAccount
 func NewEmptyUserAccount() *userAccount {
 	return &userAccount{
 		baseAccount: &baseAccount{},
@@ -32,24 +32,32 @@ func NewEmptyUserAccount() *userAccount {
 	}
 }
 
-// NewUserAccount creates new simple account wrapper for an AccountContainer (that has just been initialized)
+// ArgsAccountCreation holds the arguments needed to create a new instance of userAccount
+type ArgsAccountCreation struct {
+	Hasher              hashing.Hasher
+	Marshaller          marshal.Marshalizer
+	EnableEpochsHandler common.EnableEpochsHandler
+}
+
+// NewUserAccount creates a new instance of userAccount
 func NewUserAccount(
 	address []byte,
-	hasher hashing.Hasher,
-	marshaller marshal.Marshalizer,
-	enableEpochsHandler common.EnableEpochsHandler,
+	args ArgsAccountCreation,
 ) (*userAccount, error) {
 	if len(address) == 0 {
 		return nil, ErrNilAddress
 	}
-	if check.IfNil(marshaller) {
+	if check.IfNil(args.Marshaller) {
 		return nil, ErrNilMarshalizer
 	}
-	if check.IfNil(enableEpochsHandler) {
+	if check.IfNil(args.Hasher) {
+		return nil, ErrNilHasher
+	}
+	if check.IfNil(args.EnableEpochsHandler) {
 		return nil, ErrNilEnableEpochsHandler
 	}
 
-	tdt, err := NewTrackableDataTrie(address, nil, hasher, marshaller)
+	tdt, err := NewTrackableDataTrie(address, nil, args.Hasher, args.Marshaller)
 	if err != nil {
 		return nil, err
 	}

--- a/state/userAccount_test.go
+++ b/state/userAccount_test.go
@@ -14,7 +14,7 @@ import (
 func TestNewUserAccount_NilAddressContainerShouldErr(t *testing.T) {
 	t.Parallel()
 
-	acc, err := state.NewUserAccount(nil, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, err := state.NewUserAccount(nil, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	assert.True(t, check.IfNil(acc))
 	assert.Equal(t, state.ErrNilAddress, err)
 }
@@ -22,7 +22,7 @@ func TestNewUserAccount_NilAddressContainerShouldErr(t *testing.T) {
 func TestNewUserAccount_OkParamsShouldWork(t *testing.T) {
 	t.Parallel()
 
-	acc, err := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, err := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	assert.Nil(t, err)
 	assert.False(t, check.IfNil(acc))
 }
@@ -30,7 +30,7 @@ func TestNewUserAccount_OkParamsShouldWork(t *testing.T) {
 func TestUserAccount_AddToBalanceInsufficientFundsShouldErr(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	value := big.NewInt(-1)
 
 	err := acc.AddToBalance(value)
@@ -40,7 +40,7 @@ func TestUserAccount_AddToBalanceInsufficientFundsShouldErr(t *testing.T) {
 func TestUserAccount_SubFromBalanceInsufficientFundsShouldErr(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	value := big.NewInt(1)
 
 	err := acc.SubFromBalance(value)
@@ -50,7 +50,7 @@ func TestUserAccount_SubFromBalanceInsufficientFundsShouldErr(t *testing.T) {
 func TestUserAccount_GetBalance(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	balance := big.NewInt(100)
 	subFromBalance := big.NewInt(20)
 
@@ -63,7 +63,7 @@ func TestUserAccount_GetBalance(t *testing.T) {
 func TestUserAccount_AddToDeveloperReward(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	reward := big.NewInt(10)
 
 	acc.AddToDeveloperReward(reward)
@@ -73,7 +73,7 @@ func TestUserAccount_AddToDeveloperReward(t *testing.T) {
 func TestUserAccount_ClaimDeveloperRewardsWrongAddressShouldErr(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	val, err := acc.ClaimDeveloperRewards([]byte("wrong address"))
 	assert.Nil(t, val)
 	assert.Equal(t, state.ErrOperationNotPermitted, err)
@@ -82,7 +82,7 @@ func TestUserAccount_ClaimDeveloperRewardsWrongAddressShouldErr(t *testing.T) {
 func TestUserAccount_ClaimDeveloperRewards(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	reward := big.NewInt(10)
 	acc.AddToDeveloperReward(reward)
 
@@ -95,7 +95,7 @@ func TestUserAccount_ClaimDeveloperRewards(t *testing.T) {
 func TestUserAccount_ChangeOwnerAddressWrongAddressShouldErr(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	err := acc.ChangeOwnerAddress([]byte("wrong address"), []byte{})
 	assert.Equal(t, state.ErrOperationNotPermitted, err)
 }
@@ -103,7 +103,7 @@ func TestUserAccount_ChangeOwnerAddressWrongAddressShouldErr(t *testing.T) {
 func TestUserAccount_ChangeOwnerAddressInvalidAddressShouldErr(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	err := acc.ChangeOwnerAddress(acc.OwnerAddress, []byte("new address"))
 	assert.Equal(t, state.ErrInvalidAddressLength, err)
 }
@@ -112,7 +112,7 @@ func TestUserAccount_ChangeOwnerAddress(t *testing.T) {
 	t.Parallel()
 
 	newAddress := make([]byte, 32)
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 
 	err := acc.ChangeOwnerAddress(acc.OwnerAddress, newAddress)
 	assert.Nil(t, err)
@@ -123,7 +123,7 @@ func TestUserAccount_SetOwnerAddress(t *testing.T) {
 	t.Parallel()
 
 	newAddress := []byte("new address")
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 
 	acc.SetOwnerAddress(newAddress)
 	assert.Equal(t, newAddress, acc.GetOwnerAddress())
@@ -132,7 +132,7 @@ func TestUserAccount_SetOwnerAddress(t *testing.T) {
 func TestUserAccount_SetAndGetNonce(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	nonce := uint64(5)
 
 	acc.IncreaseNonce(nonce)
@@ -142,7 +142,7 @@ func TestUserAccount_SetAndGetNonce(t *testing.T) {
 func TestUserAccount_SetAndGetCodeHash(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	codeHash := []byte("code hash")
 
 	acc.SetCodeHash(codeHash)
@@ -152,7 +152,7 @@ func TestUserAccount_SetAndGetCodeHash(t *testing.T) {
 func TestUserAccount_SetAndGetRootHash(t *testing.T) {
 	t.Parallel()
 
-	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	acc, _ := state.NewUserAccount(make([]byte, 32), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	rootHash := []byte("root hash")
 
 	acc.SetRootHash(rootHash)

--- a/testscommon/enableEpochsHandlerStub.go
+++ b/testscommon/enableEpochsHandlerStub.go
@@ -112,6 +112,7 @@ type EnableEpochsHandlerStub struct {
 	IsRefactorPeersMiniBlocksFlagEnabledField                    bool
 	IsFixAsyncCallBackArgsListFlagEnabledField                   bool
 	IsFixOldTokenLiquidityEnabledField                           bool
+	IsAutoBalanceDataTriesEnabledField                           bool
 }
 
 // ResetPenalizedTooMuchGasFlag -
@@ -967,6 +968,14 @@ func (stub *EnableEpochsHandlerStub) IsFixOldTokenLiquidityEnabled() bool {
 	defer stub.RUnlock()
 
 	return stub.IsFixOldTokenLiquidityEnabledField
+}
+
+// IsAutoBalanceDataTriesEnabled -
+func (stub *EnableEpochsHandlerStub) IsAutoBalanceDataTriesEnabled() bool {
+	stub.RLock()
+	defer stub.RUnlock()
+
+	return stub.IsAutoBalanceDataTriesEnabledField
 }
 
 // IsInterfaceNil -

--- a/testscommon/state/accountFactoryStub.go
+++ b/testscommon/state/accountFactoryStub.go
@@ -3,6 +3,8 @@ package state
 import (
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
 	"github.com/ElrondNetwork/elrond-vm-common"
 )
 
@@ -12,8 +14,8 @@ type AccountsFactoryStub struct {
 }
 
 // CreateAccount -
-func (afs *AccountsFactoryStub) CreateAccount(address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (vmcommon.AccountHandler, error) {
-	return afs.CreateAccountCalled(address, hasher, marshaller)
+func (afs *AccountsFactoryStub) CreateAccount(address []byte) (vmcommon.AccountHandler, error) {
+	return afs.CreateAccountCalled(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/update/genesis/base.go
+++ b/update/genesis/base.go
@@ -101,7 +101,12 @@ func NewEmptyAccount(
 ) (vmcommon.AccountHandler, error) {
 	switch accType {
 	case UserAccount:
-		return state.NewUserAccount(address, hasher, marshaller, enableEpochsHandler)
+		argsAccCreation := state.ArgsAccountCreation{
+			Hasher:              hasher,
+			Marshaller:          marshaller,
+			EnableEpochsHandler: enableEpochsHandler,
+		}
+		return state.NewUserAccount(address, argsAccCreation)
 	case ValidatorAccount:
 		return state.NewPeerAccount(address)
 	case DataTrie:

--- a/update/genesis/base.go
+++ b/update/genesis/base.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/state"
 	"github.com/ElrondNetwork/elrond-go/update"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
@@ -91,12 +92,18 @@ func NewObject(objType Type) (interface{}, error) {
 }
 
 // NewEmptyAccount returns a new account according to the given type
-func NewEmptyAccount(accType Type, address []byte, hasher hashing.Hasher, marshaller marshal.Marshalizer) (vmcommon.AccountHandler, error) {
+func NewEmptyAccount(
+	accType Type,
+	address []byte,
+	hasher hashing.Hasher,
+	marshaller marshal.Marshalizer,
+	enableEpochsHandler common.EnableEpochsHandler,
+) (vmcommon.AccountHandler, error) {
 	switch accType {
 	case UserAccount:
-		return state.NewUserAccount(address, hasher, marshaller)
+		return state.NewUserAccount(address, hasher, marshaller, enableEpochsHandler)
 	case ValidatorAccount:
-		return state.NewPeerAccount(address, hasher, marshaller)
+		return state.NewPeerAccount(address)
 	case DataTrie:
 		return nil, nil
 	}

--- a/update/genesis/import.go
+++ b/update/genesis/import.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/common"
 	commonDisabled "github.com/ElrondNetwork/elrond-go/common/disabled"
 	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/errors"
 	"github.com/ElrondNetwork/elrond-go/state"
 	"github.com/ElrondNetwork/elrond-go/state/factory"
 	"github.com/ElrondNetwork/elrond-go/state/storagePruningManager/disabled"
@@ -36,6 +37,7 @@ type ArgsNewStateImport struct {
 	StorageConfig       config.StorageConfig
 	TrieStorageManagers map[string]common.StorageManager
 	HardforkStorer      update.HardforkStorer
+	EnableEpochsHandler common.EnableEpochsHandler
 }
 
 type stateImport struct {
@@ -54,6 +56,7 @@ type stateImport struct {
 	shardID             uint32
 	storageConfig       config.StorageConfig
 	trieStorageManagers map[string]common.StorageManager
+	enableEpochsHandler common.EnableEpochsHandler
 }
 
 // NewStateImport creates an importer which reads all the files for a new start
@@ -70,6 +73,9 @@ func NewStateImport(args ArgsNewStateImport) (*stateImport, error) {
 	if check.IfNil(args.HardforkStorer) {
 		return nil, update.ErrNilHardforkStorer
 	}
+	if check.IfNil(args.EnableEpochsHandler) {
+		return nil, errors.ErrNilEnableEpochsHandler
+	}
 
 	st := &stateImport{
 		genesisHeaders:               make(map[uint32]data.HeaderHandler),
@@ -85,6 +91,7 @@ func NewStateImport(args ArgsNewStateImport) (*stateImport, error) {
 		storageConfig:                args.StorageConfig,
 		shardID:                      args.ShardID,
 		hardforkStorer:               args.HardforkStorer,
+		enableEpochsHandler:          args.EnableEpochsHandler,
 	}
 
 	return st, nil
@@ -265,10 +272,15 @@ func (si *stateImport) importMiniBlocks(identifier string, keys [][]byte) error 
 	return nil
 }
 
-func newAccountCreator(accType Type) (state.AccountFactory, error) {
+func newAccountCreator(
+	accType Type,
+	hasher hashing.Hasher,
+	marshaller marshal.Marshalizer,
+	handler common.EnableEpochsHandler,
+) (state.AccountFactory, error) {
 	switch accType {
 	case UserAccount:
-		return factory.NewAccountCreator(), nil
+		return factory.NewAccountCreator(hasher, marshaller, handler)
 	case ValidatorAccount:
 		return factory.NewPeerAccountCreator(), nil
 	}
@@ -382,7 +394,7 @@ func (si *stateImport) importDataTrie(identifier string, shID uint32, keys [][]b
 }
 
 func (si *stateImport) getAccountsDB(accType Type, shardID uint32) (state.AccountsDBImporter, common.Trie, error) {
-	accountFactory, err := newAccountCreator(accType)
+	accountFactory, err := newAccountCreator(accType, si.hasher, si.marshalizer, si.enableEpochsHandler)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -515,7 +527,7 @@ func (si *stateImport) unMarshalAndSaveAccount(
 	accountsDB state.AccountsDBImporter,
 	mainTrie common.Trie,
 ) error {
-	account, err := NewEmptyAccount(accType, address, si.hasher, si.marshalizer)
+	account, err := NewEmptyAccount(accType, address, si.hasher, si.marshalizer, si.enableEpochsHandler)
 	if err != nil {
 		return err
 	}

--- a/update/genesis/import.go
+++ b/update/genesis/import.go
@@ -280,7 +280,12 @@ func newAccountCreator(
 ) (state.AccountFactory, error) {
 	switch accType {
 	case UserAccount:
-		return factory.NewAccountCreator(hasher, marshaller, handler)
+		args := state.ArgsAccountCreation{
+			Hasher:              hasher,
+			Marshaller:          marshaller,
+			EnableEpochsHandler: handler,
+		}
+		return factory.NewAccountCreator(args)
 	case ValidatorAccount:
 		return factory.NewPeerAccountCreator(), nil
 	}

--- a/update/genesis/import_test.go
+++ b/update/genesis/import_test.go
@@ -66,6 +66,7 @@ func TestNewStateImport(t *testing.T) {
 				Marshalizer:         &mock.MarshalizerMock{},
 				Hasher:              &mock.HasherStub{},
 				TrieStorageManagers: trieStorageManagers,
+				EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
 			},
 			exError: nil,
 		},
@@ -92,6 +93,7 @@ func TestImportAll(t *testing.T) {
 		TrieStorageManagers: trieStorageManagers,
 		ShardID:             0,
 		StorageConfig:       config.StorageConfig{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
 	}
 
 	importState, _ := NewStateImport(args)
@@ -126,6 +128,7 @@ func TestStateImport_ImportUnFinishedMetaBlocksShouldWork(t *testing.T) {
 		TrieStorageManagers: trieStorageManagers,
 		ShardID:             0,
 		StorageConfig:       config.StorageConfig{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
 	}
 
 	importState, _ := NewStateImport(args)

--- a/vm/mock/blockChainHookStub.go
+++ b/vm/mock/blockChainHookStub.go
@@ -76,7 +76,7 @@ func (b *BlockChainHookStub) GetUserAccount(address []byte) (vmcommon.UserAccoun
 		return b.GetUserAccountCalled(address)
 	}
 
-	return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 }
 
 // GetShardOfAddress -

--- a/vm/mock/blockChainHookStub.go
+++ b/vm/mock/blockChainHookStub.go
@@ -76,7 +76,12 @@ func (b *BlockChainHookStub) GetUserAccount(address []byte) (vmcommon.UserAccoun
 		return b.GetUserAccountCalled(address)
 	}
 
-	return state.NewUserAccount(address, &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	return state.NewUserAccount(address, argsAccCreation)
 }
 
 // GetShardOfAddress -

--- a/vm/systemSmartContracts/eei_test.go
+++ b/vm/systemSmartContracts/eei_test.go
@@ -99,7 +99,12 @@ func TestVmContext_GetBalance(t *testing.T) {
 
 	addr := []byte("addr")
 	balance := big.NewInt(10)
-	account, _ := state.NewUserAccount([]byte("123"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
+	argsAccCreation := state.ArgsAccountCreation{
+		Hasher:              &hashingMocks.HasherMock{},
+		Marshaller:          &testscommon.MarshalizerMock{},
+		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+	}
+	account, _ := state.NewUserAccount([]byte("123"), argsAccCreation)
 	_ = account.AddToBalance(balance)
 
 	blockChainHook := &mock.BlockChainHookStub{GetUserAccountCalled: func(address []byte) (a vmcommon.UserAccountHandler, e error) {

--- a/vm/systemSmartContracts/eei_test.go
+++ b/vm/systemSmartContracts/eei_test.go
@@ -99,7 +99,7 @@ func TestVmContext_GetBalance(t *testing.T) {
 
 	addr := []byte("addr")
 	balance := big.NewInt(10)
-	account, _ := state.NewUserAccount([]byte("123"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{})
+	account, _ := state.NewUserAccount([]byte("123"), &hashingMocks.HasherMock{}, &testscommon.MarshalizerMock{}, &testscommon.EnableEpochsHandlerStub{})
 	_ = account.AddToBalance(balance)
 
 	blockChainHook := &mock.BlockChainHookStub{GetUserAccountCalled: func(address []byte) (a vmcommon.UserAccountHandler, e error) {


### PR DESCRIPTION
## Reasoning behind the pull request
- propagate enableEpochsHandler to userAccount
  
## Proposed changes
- create a new flag for the activation of data tries auto-balancing
- add some parameters to the account factory instead of the Create() method
- propagate enableEpochsHandler to userAccount

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
