### PR TITLE
Bootstrap from storage or from epoch start for sovereign chain

### DIFF
--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -126,15 +126,16 @@ type epochStartBootstrap struct {
 	storageService            dataRetriever.StorageService
 
 	// gathered data
-	epochStartMeta     data.MetaHeaderHandler
-	prevEpochStartMeta data.MetaHeaderHandler
-	syncedHeaders      map[string]data.HeaderHandler
-	nodesConfig        *nodesCoordinator.NodesCoordinatorRegistry
-	baseData           baseDataInStorage
-	startRound         int64
-	nodeType           core.NodeType
-	startEpoch         uint32
-	shuffledOut        bool
+	epochStartMeta      data.MetaHeaderHandler
+	prevEpochStartMeta  data.MetaHeaderHandler
+	syncedHeaders       map[string]data.HeaderHandler
+	nodesConfig         *nodesCoordinator.NodesCoordinatorRegistry
+	baseData            baseDataInStorage
+	startRound          int64
+	nodeType            core.NodeType
+	startEpoch          uint32
+	shuffledOut         bool
+	getDataToSyncMethod func(epochStartData data.EpochStartShardDataHandler, shardNotarizedHeader data.ShardHeaderHandler) (*dataToSync, error)
 }
 
 type baseDataInStorage struct {
@@ -239,6 +240,8 @@ func NewEpochStartBootstrap(args ArgsEpochStartBootstrap) (*epochStartBootstrap,
 		epochStartProvider.baseData.lastRound = epochStartProvider.startRound
 		epochStartProvider.baseData.epochStartRound = uint64(epochStartProvider.startRound)
 	}
+
+	epochStartProvider.getDataToSyncMethod = epochStartProvider.getDataToSync
 
 	return epochStartProvider, nil
 }
@@ -883,7 +886,7 @@ func (e *epochStartBootstrap) requestAndProcessForShard(peerMiniBlocks []*block.
 		return epochStart.ErrWrongTypeAssertion
 	}
 
-	dts, err := e.getDataToSync(
+	dts, err := e.getDataToSyncMethod(
 		epochStartData,
 		shardNotarizedHeader,
 	)

--- a/epochStart/bootstrap/sovereignChainProcess.go
+++ b/epochStart/bootstrap/sovereignChainProcess.go
@@ -1,0 +1,37 @@
+package bootstrap
+
+import (
+	"github.com/ElrondNetwork/elrond-go-core/data"
+	"github.com/ElrondNetwork/elrond-go/errors"
+)
+
+type sovereignChainEpochStartBootstrap struct {
+	*epochStartBootstrap
+}
+
+// NewSovereignChainEpochStartBootstrap creates a new instance of sovereignChainEpochStartBootstrap
+func NewSovereignChainEpochStartBootstrap(epochStartBootstrap *epochStartBootstrap) (*sovereignChainEpochStartBootstrap, error) {
+	if epochStartBootstrap == nil {
+		return nil, errors.ErrNilEpochStartBootstrapper
+	}
+
+	scesb := &sovereignChainEpochStartBootstrap{
+		epochStartBootstrap,
+	}
+
+	scesb.getDataToSyncMethod = scesb.getDataToSync
+
+	return scesb, nil
+}
+
+func (scesb *sovereignChainEpochStartBootstrap) getDataToSync(
+	_ data.EpochStartShardDataHandler,
+	shardNotarizedHeader data.ShardHeaderHandler,
+) (*dataToSync, error) {
+	return &dataToSync{
+		ownShardHdr:       shardNotarizedHeader,
+		rootHashToSync:    shardNotarizedHeader.GetRootHash(),
+		withScheduled:     false,
+		additionalHeaders: nil,
+	}, nil
+}

--- a/epochStart/bootstrap/sovereignChainProcess_test.go
+++ b/epochStart/bootstrap/sovereignChainProcess_test.go
@@ -1,3 +1,58 @@
 package bootstrap
 
-//TODO: Add unit tests
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/data/block"
+	"github.com/ElrondNetwork/elrond-go/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSovereignChainEpochStartBootstrap(t *testing.T) {
+	t.Parallel()
+
+	coreComp, cryptoComp := createComponentsForEpochStart()
+
+	t.Run("should error when epoch start bootstrapper is nil", func(t *testing.T) {
+		t.Parallel()
+
+		scesb, err := NewSovereignChainEpochStartBootstrap(nil)
+
+		assert.Nil(t, scesb)
+		assert.Equal(t, errors.ErrNilEpochStartBootstrapper, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockEpochStartBootstrapArgs(coreComp, cryptoComp)
+		esb, _ := NewEpochStartBootstrap(args)
+		scesb, err := NewSovereignChainEpochStartBootstrap(esb)
+
+		assert.NotNil(t, scesb)
+		assert.Nil(t, err)
+	})
+}
+
+func TestGetDataToSync_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	coreComp, cryptoComp := createComponentsForEpochStart()
+	args := createMockEpochStartBootstrapArgs(coreComp, cryptoComp)
+	esb, _ := NewEpochStartBootstrap(args)
+	scesb, _ := NewSovereignChainEpochStartBootstrap(esb)
+
+	rootHash := []byte("rootHash")
+	hdr := &block.Header{
+		RootHash: rootHash,
+	}
+
+	dts, err := scesb.getDataToSync(nil, hdr)
+
+	require.Nil(t, err)
+	assert.Equal(t, hdr, dts.ownShardHdr)
+	assert.Equal(t, rootHash, dts.rootHashToSync)
+	assert.False(t, dts.withScheduled)
+	assert.Nil(t, dts.additionalHeaders)
+}

--- a/epochStart/bootstrap/sovereignChainProcess_test.go
+++ b/epochStart/bootstrap/sovereignChainProcess_test.go
@@ -1,0 +1,3 @@
+package bootstrap
+
+//TODO: Add unit tests

--- a/epochStart/bootstrap/sovereignChainProcess_test.go
+++ b/epochStart/bootstrap/sovereignChainProcess_test.go
@@ -27,6 +27,7 @@ func TestNewSovereignChainEpochStartBootstrap(t *testing.T) {
 		t.Parallel()
 
 		args := createMockEpochStartBootstrapArgs(coreComp, cryptoComp)
+
 		esb, _ := NewEpochStartBootstrap(args)
 		scesb, err := NewSovereignChainEpochStartBootstrap(esb)
 
@@ -40,6 +41,7 @@ func TestGetDataToSync_ShouldWork(t *testing.T) {
 
 	coreComp, cryptoComp := createComponentsForEpochStart()
 	args := createMockEpochStartBootstrapArgs(coreComp, cryptoComp)
+
 	esb, _ := NewEpochStartBootstrap(args)
 	scesb, _ := NewSovereignChainEpochStartBootstrap(esb)
 
@@ -47,7 +49,6 @@ func TestGetDataToSync_ShouldWork(t *testing.T) {
 	hdr := &block.Header{
 		RootHash: rootHash,
 	}
-
 	dts, err := scesb.getDataToSync(nil, hdr)
 
 	require.Nil(t, err)

--- a/epochStart/bootstrap/storageProcess_test.go
+++ b/epochStart/bootstrap/storageProcess_test.go
@@ -81,6 +81,7 @@ func TestCreateEpochStartBootstrapper_ShouldWork(t *testing.T) {
 		args.ChainRunType = common.ChainRunTypeRegular
 
 		esb, err := createEpochStartBootstrapper(args)
+
 		require.NotNil(t, esb)
 		assert.Nil(t, err)
 		assert.Equal(t, esb.getDataToSync, esb.getDataToSyncMethod)
@@ -92,6 +93,7 @@ func TestCreateEpochStartBootstrapper_ShouldWork(t *testing.T) {
 		args.ChainRunType = common.ChainRunTypeSovereign
 
 		esb, err := createEpochStartBootstrapper(args)
+
 		require.NotNil(t, esb)
 		assert.Nil(t, err)
 		assert.NotEqual(t, esb.getDataToSync, esb.getDataToSyncMethod)
@@ -103,6 +105,7 @@ func TestCreateEpochStartBootstrapper_ShouldWork(t *testing.T) {
 		args.ChainRunType = "X"
 
 		esb, err := createEpochStartBootstrapper(args)
+
 		assert.Nil(t, esb)
 		require.True(t, errors.Is(err, errorsErd.ErrUnimplementedChainRunType))
 	})

--- a/epochStart/bootstrap/storageProcess_test.go
+++ b/epochStart/bootstrap/storageProcess_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/epochStart"
 	"github.com/ElrondNetwork/elrond-go/epochStart/mock"
+	errorsErd "github.com/ElrondNetwork/elrond-go/errors"
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/sharding/nodesCoordinator"
 	"github.com/ElrondNetwork/elrond-go/storage"
@@ -24,6 +25,7 @@ import (
 	dataRetrieverMock "github.com/ElrondNetwork/elrond-go/testscommon/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/testscommon/economicsmocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createMockStorageEpochStartBootstrapArgs(
@@ -65,6 +67,45 @@ func TestNewStorageEpochStartBootstrap_ShouldWork(t *testing.T) {
 	sesb, err := NewStorageEpochStartBootstrap(args)
 	assert.False(t, check.IfNil(sesb))
 	assert.Nil(t, err)
+}
+
+func TestCreateEpochStartBootstrapper_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	coreComp, cryptoComp := createComponentsForEpochStart()
+	args := createMockStorageEpochStartBootstrapArgs(coreComp, cryptoComp)
+
+	t.Run("should create a main chain instance", func(t *testing.T) {
+		t.Parallel()
+
+		args.ChainRunType = common.ChainRunTypeRegular
+
+		esb, err := createEpochStartBootstrapper(args)
+		require.NotNil(t, esb)
+		assert.Nil(t, err)
+		assert.Equal(t, esb.getDataToSync, esb.getDataToSyncMethod)
+	})
+
+	t.Run("should create a sovereign chain instance", func(t *testing.T) {
+		t.Parallel()
+
+		args.ChainRunType = common.ChainRunTypeSovereign
+
+		esb, err := createEpochStartBootstrapper(args)
+		require.NotNil(t, esb)
+		assert.Nil(t, err)
+		assert.NotEqual(t, esb.getDataToSync, esb.getDataToSyncMethod)
+	})
+
+	t.Run("should error when chain run type is not implemented", func(t *testing.T) {
+		t.Parallel()
+
+		args.ChainRunType = "X"
+
+		esb, err := createEpochStartBootstrapper(args)
+		assert.Nil(t, esb)
+		require.True(t, errors.Is(err, errorsErd.ErrUnimplementedChainRunType))
+	})
 }
 
 func TestStorageEpochStartBootstrap_BootstrapStartInEpochNotEnabled(t *testing.T) {

--- a/epochStart/bootstrap/storageProcess_test.go
+++ b/epochStart/bootstrap/storageProcess_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"errors"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"testing"
 	"time"
 
@@ -34,6 +35,7 @@ func createMockStorageEpochStartBootstrapArgs(
 		ImportDbConfig:             config.ImportDbConfig{},
 		ChanGracefullyClose:        make(chan endProcess.ArgEndProcess, 1),
 		TimeToWaitForRequestedData: time.Second,
+		ChainRunType:               common.ChainRunTypeRegular,
 	}
 }
 

--- a/epochStart/bootstrap/storageProcess_test.go
+++ b/epochStart/bootstrap/storageProcess_test.go
@@ -3,7 +3,6 @@ package bootstrap
 import (
 	"context"
 	"errors"
-	"github.com/ElrondNetwork/elrond-go/common"
 	"testing"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/endProcess"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/epochStart"

--- a/epochStart/bootstrap/storageProcess_test.go
+++ b/epochStart/bootstrap/storageProcess_test.go
@@ -84,7 +84,6 @@ func TestCreateEpochStartBootstrapper_ShouldWork(t *testing.T) {
 
 		require.NotNil(t, esb)
 		assert.Nil(t, err)
-		assert.Equal(t, esb.getDataToSync, esb.getDataToSyncMethod)
 	})
 
 	t.Run("should create a sovereign chain instance", func(t *testing.T) {
@@ -96,7 +95,6 @@ func TestCreateEpochStartBootstrapper_ShouldWork(t *testing.T) {
 
 		require.NotNil(t, esb)
 		assert.Nil(t, err)
-		assert.NotEqual(t, esb.getDataToSync, esb.getDataToSyncMethod)
 	})
 
 	t.Run("should error when chain run type is not implemented", func(t *testing.T) {

--- a/factory/bootstrap/bootstrapComponents.go
+++ b/factory/bootstrap/bootstrapComponents.go
@@ -202,7 +202,7 @@ func (bcf *bootstrapComponentsFactory) Create() (*bootstrapComponents, error) {
 	} else {
 		epochStartBootstrapper, err = bcf.createEpochStartBootstrapper(epochStartBootstrapArgs)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %v", errors.ErrNewEpochStartBootstrap, err)
+			return nil, err
 		}
 	}
 
@@ -245,7 +245,7 @@ func (bcf *bootstrapComponentsFactory) Create() (*bootstrapComponents, error) {
 func (bcf *bootstrapComponentsFactory) createEpochStartBootstrapper(epochStartBootstrapArgs bootstrap.ArgsEpochStartBootstrap) (factory.EpochStartBootstrapper, error) {
 	epochStartBootstrapper, err := bootstrap.NewEpochStartBootstrap(epochStartBootstrapArgs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", errors.ErrNewEpochStartBootstrap, err)
 	}
 
 	switch bcf.chainRunType {

--- a/factory/bootstrap/bootstrapComponents_test.go
+++ b/factory/bootstrap/bootstrapComponents_test.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ElrondNetwork/elrond-go/common"
 	errorsErd "github.com/ElrondNetwork/elrond-go/errors"
 	"github.com/ElrondNetwork/elrond-go/factory/bootstrap"
 	componentsMock "github.com/ElrondNetwork/elrond-go/testscommon/components"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -137,4 +139,47 @@ func TestBootstrapComponentsFactory_CreateEpochStartBootstrapCreationFail(t *tes
 
 	require.Nil(t, bc)
 	require.True(t, errors.Is(err, errorsErd.ErrNewEpochStartBootstrap))
+}
+
+func TestBootstrapComponentsFactory_CreateEpochStartBootstrapperShouldWork(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should create a epoch start bootstrapper main chain instance", func(t *testing.T) {
+		t.Parallel()
+
+		args := componentsMock.GetBootStrapFactoryArgs()
+		args.ChainRunType = common.ChainRunTypeRegular
+		bcf, _ := bootstrap.NewBootstrapComponentsFactory(args)
+
+		bc, err := bcf.Create()
+
+		require.NotNil(t, bc)
+		assert.Nil(t, err)
+	})
+
+	t.Run("should create a epoch start bootstrapper sovereign chain instance", func(t *testing.T) {
+		t.Parallel()
+
+		args := componentsMock.GetBootStrapFactoryArgs()
+		args.ChainRunType = common.ChainRunTypeSovereign
+		bcf, _ := bootstrap.NewBootstrapComponentsFactory(args)
+
+		bc, err := bcf.Create()
+
+		require.NotNil(t, bc)
+		assert.Nil(t, err)
+	})
+
+	t.Run("should error when chain run type is not implemented", func(t *testing.T) {
+		t.Parallel()
+
+		args := componentsMock.GetBootStrapFactoryArgs()
+		args.ChainRunType = "X"
+		bcf, _ := bootstrap.NewBootstrapComponentsFactory(args)
+
+		bc, err := bcf.Create()
+
+		assert.Nil(t, bc)
+		require.True(t, errors.Is(err, errorsErd.ErrUnimplementedChainRunType))
+	})
 }

--- a/factory/bootstrap/bootstrapComponents_test.go
+++ b/factory/bootstrap/bootstrapComponents_test.go
@@ -149,8 +149,8 @@ func TestBootstrapComponentsFactory_CreateEpochStartBootstrapperShouldWork(t *te
 
 		args := componentsMock.GetBootStrapFactoryArgs()
 		args.ChainRunType = common.ChainRunTypeRegular
-		bcf, _ := bootstrap.NewBootstrapComponentsFactory(args)
 
+		bcf, _ := bootstrap.NewBootstrapComponentsFactory(args)
 		bc, err := bcf.Create()
 
 		require.NotNil(t, bc)
@@ -162,8 +162,8 @@ func TestBootstrapComponentsFactory_CreateEpochStartBootstrapperShouldWork(t *te
 
 		args := componentsMock.GetBootStrapFactoryArgs()
 		args.ChainRunType = common.ChainRunTypeSovereign
-		bcf, _ := bootstrap.NewBootstrapComponentsFactory(args)
 
+		bcf, _ := bootstrap.NewBootstrapComponentsFactory(args)
 		bc, err := bcf.Create()
 
 		require.NotNil(t, bc)
@@ -175,8 +175,8 @@ func TestBootstrapComponentsFactory_CreateEpochStartBootstrapperShouldWork(t *te
 
 		args := componentsMock.GetBootStrapFactoryArgs()
 		args.ChainRunType = "X"
-		bcf, _ := bootstrap.NewBootstrapComponentsFactory(args)
 
+		bcf, _ := bootstrap.NewBootstrapComponentsFactory(args)
 		bc, err := bcf.Create()
 
 		assert.Nil(t, bc)

--- a/factory/consensus/consensusComponents_test.go
+++ b/factory/consensus/consensusComponents_test.go
@@ -315,6 +315,50 @@ func TestConsensusComponentsFactory_CreateNilSyncTimer(t *testing.T) {
 	require.Equal(t, chronology.ErrNilSyncTimer, err)
 }
 
+func TestConsensusComponentsFactory_CreateShardStorageAndSyncBootstrapperShouldWork(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should create a shard storage and sync bootstrapper main chain instance", func(t *testing.T) {
+		t.Parallel()
+
+		shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
+		args := componentsMock.GetConsensusArgs(shardCoordinator)
+		args.ChainRunType = common.ChainRunTypeRegular
+		ccf, _ := consensusComp.NewConsensusComponentsFactory(args)
+
+		cc, err := ccf.Create()
+		require.NotNil(t, cc)
+		assert.Nil(t, err)
+	})
+
+	t.Run("should create a shard storage and sync bootstrapper sovereign chain instance", func(t *testing.T) {
+		t.Parallel()
+
+		shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
+		args := componentsMock.GetConsensusArgs(shardCoordinator)
+		args.ChainRunType = common.ChainRunTypeSovereign
+		ccf, _ := consensusComp.NewConsensusComponentsFactory(args)
+
+		cc, err := ccf.Create()
+		require.NotNil(t, cc)
+		assert.Nil(t, err)
+	})
+
+	t.Run("should error when chain run type is not implemented", func(t *testing.T) {
+		t.Parallel()
+
+		shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
+		args := componentsMock.GetConsensusArgs(shardCoordinator)
+		args.ChainRunType = "X"
+		ccf, _ := consensusComp.NewConsensusComponentsFactory(args)
+
+		cc, err := ccf.Create()
+
+		assert.Nil(t, cc)
+		require.True(t, errors.Is(err, errorsErd.ErrUnimplementedChainRunType))
+	})
+}
+
 func TestStartConsensus_ShardBootstrapperNilAccounts(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {

--- a/factory/consensus/consensusComponents_test.go
+++ b/factory/consensus/consensusComponents_test.go
@@ -324,9 +324,10 @@ func TestConsensusComponentsFactory_CreateShardStorageAndSyncBootstrapperShouldW
 		shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 		args := componentsMock.GetConsensusArgs(shardCoordinator)
 		args.ChainRunType = common.ChainRunTypeRegular
-		ccf, _ := consensusComp.NewConsensusComponentsFactory(args)
 
+		ccf, _ := consensusComp.NewConsensusComponentsFactory(args)
 		cc, err := ccf.Create()
+
 		require.NotNil(t, cc)
 		assert.Nil(t, err)
 	})
@@ -337,9 +338,10 @@ func TestConsensusComponentsFactory_CreateShardStorageAndSyncBootstrapperShouldW
 		shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 		args := componentsMock.GetConsensusArgs(shardCoordinator)
 		args.ChainRunType = common.ChainRunTypeSovereign
-		ccf, _ := consensusComp.NewConsensusComponentsFactory(args)
 
+		ccf, _ := consensusComp.NewConsensusComponentsFactory(args)
 		cc, err := ccf.Create()
+
 		require.NotNil(t, cc)
 		assert.Nil(t, err)
 	})
@@ -350,8 +352,8 @@ func TestConsensusComponentsFactory_CreateShardStorageAndSyncBootstrapperShouldW
 		shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 		args := componentsMock.GetConsensusArgs(shardCoordinator)
 		args.ChainRunType = "X"
-		ccf, _ := consensusComp.NewConsensusComponentsFactory(args)
 
+		ccf, _ := consensusComp.NewConsensusComponentsFactory(args)
 		cc, err := ccf.Create()
 
 		assert.Nil(t, cc)

--- a/factory/consensus/consensusComponents_test.go
+++ b/factory/consensus/consensusComponents_test.go
@@ -338,6 +338,7 @@ func TestConsensusComponentsFactory_CreateShardStorageAndSyncBootstrapperShouldW
 		shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 		args := componentsMock.GetConsensusArgs(shardCoordinator)
 		args.ChainRunType = common.ChainRunTypeSovereign
+		args.SubroundBlockType = consensus.SubroundBlockTypeV2
 
 		ccf, _ := consensusComp.NewConsensusComponentsFactory(args)
 		cc, err := ccf.Create()

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -1356,6 +1356,7 @@ func (nr *nodeRunner) CreateManagedBootstrapComponents(
 		CoreComponents:    coreComponents,
 		CryptoComponents:  cryptoComponents,
 		NetworkComponents: networkComponents,
+		ChainRunType:      common.ChainRunTypeRegular,
 	}
 
 	bootstrapComponentsFactory, err := bootstrapComp.NewBootstrapComponentsFactory(bootstrapComponentsFactoryArgs)

--- a/process/errors.go
+++ b/process/errors.go
@@ -1154,3 +1154,6 @@ var ErrNilProcessDebugger = errors.New("nil process debugger")
 
 // ErrNilShardBootstrap signals that a nil shard bootstrap was provided
 var ErrNilShardBootstrap = errors.New("nil shard bootstrap")
+
+// ErrNilShardStorageBootstrapper signals that a nil shard storage bootstrapper was provided
+var ErrNilShardStorageBootstrapper = errors.New("nil shard storage bootstrapper")

--- a/process/interface.go
+++ b/process/interface.go
@@ -1187,12 +1187,12 @@ type ScheduledTxsExecutionHandler interface {
 	GetScheduledIntermediateTxs() map[block.Type][]data.TransactionHandler
 	GetScheduledMiniBlocks() block.MiniBlockSlice
 	GetScheduledGasAndFees() scheduled.GasAndFees
-	SetScheduledInfo(scheduledInfo *ScheduledInfo)
-	GetScheduledRootHashForHeader(headerHash []byte) ([]byte, error)
+	SetScheduledInfo(scheduledInfo *ScheduledInfo)                   // Here process/sync/storageBootstrap/baseStorageBootstrapper.go
+	GetScheduledRootHashForHeader(headerHash []byte) ([]byte, error) // Here process/sync/storageBootstrap/baseStorageBootstrapper.go
 	GetScheduledRootHashForHeaderWithEpoch(headerHash []byte, epoch uint32) ([]byte, error)
-	RollBackToBlock(headerHash []byte) error
+	RollBackToBlock(headerHash []byte) error // Here process/sync/storageBootstrap/baseStorageBootstrapper.go
 	SaveStateIfNeeded(headerHash []byte)
-	SaveState(headerHash []byte, scheduledInfo *ScheduledInfo)
+	SaveState(headerHash []byte, scheduledInfo *ScheduledInfo) // Here epochStart/bootstrap/startInEpochScheduled.go
 	GetScheduledRootHash() []byte
 	SetScheduledRootHash(rootHash []byte)
 	SetScheduledGasAndFees(gasAndFees scheduled.GasAndFees)

--- a/process/interface.go
+++ b/process/interface.go
@@ -1187,12 +1187,12 @@ type ScheduledTxsExecutionHandler interface {
 	GetScheduledIntermediateTxs() map[block.Type][]data.TransactionHandler
 	GetScheduledMiniBlocks() block.MiniBlockSlice
 	GetScheduledGasAndFees() scheduled.GasAndFees
-	SetScheduledInfo(scheduledInfo *ScheduledInfo)                   // Here process/sync/storageBootstrap/baseStorageBootstrapper.go
-	GetScheduledRootHashForHeader(headerHash []byte) ([]byte, error) // Here process/sync/storageBootstrap/baseStorageBootstrapper.go
+	SetScheduledInfo(scheduledInfo *ScheduledInfo)
+	GetScheduledRootHashForHeader(headerHash []byte) ([]byte, error)
 	GetScheduledRootHashForHeaderWithEpoch(headerHash []byte, epoch uint32) ([]byte, error)
-	RollBackToBlock(headerHash []byte) error // Here process/sync/storageBootstrap/baseStorageBootstrapper.go
+	RollBackToBlock(headerHash []byte) error
 	SaveStateIfNeeded(headerHash []byte)
-	SaveState(headerHash []byte, scheduledInfo *ScheduledInfo) // Here epochStart/bootstrap/startInEpochScheduled.go
+	SaveState(headerHash []byte, scheduledInfo *ScheduledInfo)
 	GetScheduledRootHash() []byte
 	SetScheduledRootHash(rootHash []byte)
 	SetScheduledGasAndFees(gasAndFees scheduled.GasAndFees)

--- a/process/sync/storageBootstrap/metaStorageBootstrapper.go
+++ b/process/sync/storageBootstrap/metaStorageBootstrapper.go
@@ -54,6 +54,9 @@ func NewMetaStorageBootstrapper(arguments ArgsMetaStorageBootstrapper) (*metaSto
 		return nil, err
 	}
 
+	base.getScheduledRootHashMethod = base.getScheduledRootHash
+	base.setScheduledInfoMethod = base.setScheduledInfo
+
 	return &boot, nil
 }
 

--- a/process/sync/storageBootstrap/shardStorageBootstrapper.go
+++ b/process/sync/storageBootstrap/shardStorageBootstrapper.go
@@ -55,6 +55,9 @@ func NewShardStorageBootstrapper(arguments ArgsShardStorageBootstrapper) (*shard
 		return nil, err
 	}
 
+	base.getScheduledRootHashMethod = base.getScheduledRootHash
+	base.setScheduledInfoMethod = base.setScheduledInfo
+
 	return &boot, nil
 }
 

--- a/process/sync/storageBootstrap/sovereignChainBaseStorageBootstrapper.go
+++ b/process/sync/storageBootstrap/sovereignChainBaseStorageBootstrapper.go
@@ -9,5 +9,5 @@ func (st *storageBootstrapper) sovereignChainGetScheduledRootHash(headerFromStor
 	return headerFromStorage.GetRootHash()
 }
 
-func (st *storageBootstrapper) sovereignChainSetScheduledInfo(headerInfo bootstrapStorage.BootstrapData) {
+func (st *storageBootstrapper) sovereignChainSetScheduledInfo(_ bootstrapStorage.BootstrapData) {
 }

--- a/process/sync/storageBootstrap/sovereignChainBaseStorageBootstrapper.go
+++ b/process/sync/storageBootstrap/sovereignChainBaseStorageBootstrapper.go
@@ -1,0 +1,13 @@
+package storageBootstrap
+
+import (
+	"github.com/ElrondNetwork/elrond-go-core/data"
+	"github.com/ElrondNetwork/elrond-go/process/block/bootstrapStorage"
+)
+
+func (st *storageBootstrapper) sovereignChainGetScheduledRootHash(headerFromStorage data.HeaderHandler, _ []byte) []byte {
+	return headerFromStorage.GetRootHash()
+}
+
+func (st *storageBootstrapper) sovereignChainSetScheduledInfo(headerInfo bootstrapStorage.BootstrapData) {
+}

--- a/process/sync/storageBootstrap/sovereignChainBaseStorageBootstrapper_test.go
+++ b/process/sync/storageBootstrap/sovereignChainBaseStorageBootstrapper_test.go
@@ -14,6 +14,7 @@ func TestBaseStorageBootstrapper_SovereignChainGetScheduledRootHash(t *testing.T
 	args := ArgsShardStorageBootstrapper{
 		ArgsBaseStorageBootstrapper: baseArgs,
 	}
+
 	ssb, _ := NewShardStorageBootstrapper(args)
 	scssb, _ := NewSovereignChainShardStorageBootstrapper(ssb)
 
@@ -21,7 +22,7 @@ func TestBaseStorageBootstrapper_SovereignChainGetScheduledRootHash(t *testing.T
 	hdr := &block.Header{
 		RootHash: expectedRootHash,
 	}
-
 	rootHash := scssb.sovereignChainGetScheduledRootHash(hdr, nil)
+
 	assert.Equal(t, expectedRootHash, rootHash)
 }

--- a/process/sync/storageBootstrap/sovereignChainBaseStorageBootstrapper_test.go
+++ b/process/sync/storageBootstrap/sovereignChainBaseStorageBootstrapper_test.go
@@ -1,0 +1,3 @@
+package storageBootstrap
+
+//TODO: Add unit tests

--- a/process/sync/storageBootstrap/sovereignChainBaseStorageBootstrapper_test.go
+++ b/process/sync/storageBootstrap/sovereignChainBaseStorageBootstrapper_test.go
@@ -1,3 +1,27 @@
 package storageBootstrap
 
-//TODO: Add unit tests
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/data/block"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBaseStorageBootstrapper_SovereignChainGetScheduledRootHash(t *testing.T) {
+	t.Parallel()
+
+	baseArgs := createMockShardStorageBoostrapperArgs()
+	args := ArgsShardStorageBootstrapper{
+		ArgsBaseStorageBootstrapper: baseArgs,
+	}
+	ssb, _ := NewShardStorageBootstrapper(args)
+	scssb, _ := NewSovereignChainShardStorageBootstrapper(ssb)
+
+	expectedRootHash := []byte("rootHash")
+	hdr := &block.Header{
+		RootHash: expectedRootHash,
+	}
+
+	rootHash := scssb.sovereignChainGetScheduledRootHash(hdr, nil)
+	assert.Equal(t, expectedRootHash, rootHash)
+}

--- a/process/sync/storageBootstrap/sovereignChainShardStorageBootstrapper.go
+++ b/process/sync/storageBootstrap/sovereignChainShardStorageBootstrapper.go
@@ -1,0 +1,23 @@
+package storageBootstrap
+
+import "github.com/ElrondNetwork/elrond-go/process"
+
+type sovereignChainShardStorageBootstrapper struct {
+	*shardStorageBootstrapper
+}
+
+// NewSovereignChainShardStorageBootstrapper creates a new instance of sovereignChainShardStorageBootstrapper
+func NewSovereignChainShardStorageBootstrapper(shardStorageBootstrapper *shardStorageBootstrapper) (*sovereignChainShardStorageBootstrapper, error) {
+	if shardStorageBootstrapper == nil {
+		return nil, process.ErrNilShardStorageBootstrapper
+	}
+
+	scssb := &sovereignChainShardStorageBootstrapper{
+		shardStorageBootstrapper,
+	}
+
+	scssb.getScheduledRootHashMethod = scssb.sovereignChainGetScheduledRootHash
+	scssb.setScheduledInfoMethod = scssb.sovereignChainSetScheduledInfo
+
+	return scssb, nil
+}

--- a/process/sync/storageBootstrap/sovereignChainShardStorageBootstrapper_test.go
+++ b/process/sync/storageBootstrap/sovereignChainShardStorageBootstrapper_test.go
@@ -27,7 +27,7 @@ func TestNewSovereignChainShardStorageBootstrapper(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		ssb, err := NewShardStorageBootstrapper(args)
+		ssb, _ := NewShardStorageBootstrapper(args)
 		scssb, err := NewSovereignChainShardStorageBootstrapper(ssb)
 
 		assert.NotNil(t, scssb)

--- a/process/sync/storageBootstrap/sovereignChainShardStorageBootstrapper_test.go
+++ b/process/sync/storageBootstrap/sovereignChainShardStorageBootstrapper_test.go
@@ -1,0 +1,3 @@
+package storageBootstrap
+
+//TODO: Add unit tests

--- a/process/sync/storageBootstrap/sovereignChainShardStorageBootstrapper_test.go
+++ b/process/sync/storageBootstrap/sovereignChainShardStorageBootstrapper_test.go
@@ -1,3 +1,36 @@
 package storageBootstrap
 
-//TODO: Add unit tests
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSovereignChainShardStorageBootstrapper(t *testing.T) {
+	t.Parallel()
+
+	baseArgs := createMockShardStorageBoostrapperArgs()
+	args := ArgsShardStorageBootstrapper{
+		ArgsBaseStorageBootstrapper: baseArgs,
+	}
+
+	t.Run("should error when shard storage bootstrapper is nil", func(t *testing.T) {
+		t.Parallel()
+
+		scesb, err := NewSovereignChainShardStorageBootstrapper(nil)
+
+		assert.Nil(t, scesb)
+		assert.Equal(t, process.ErrNilShardStorageBootstrapper, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		ssb, err := NewShardStorageBootstrapper(args)
+		scssb, err := NewSovereignChainShardStorageBootstrapper(ssb)
+
+		assert.NotNil(t, scssb)
+		assert.Nil(t, err)
+	})
+}

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -522,6 +522,7 @@ func GetBootStrapFactoryArgs() bootstrapComp.BootstrapComponentsFactoryArgs {
 		FlagsConfig: config.ContextFlagsConfig{
 			ForceStartFromNetwork: false,
 		},
+		ChainRunType: common.ChainRunTypeRegular,
 	}
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request

- To be able to support the sovereign chain implementation the EpochStartBootstrap, StorageEpochStartBootstrap and StorageBootstrap components should be adapted to the new approach by making a new version and use as much as we can the common code used also in the regular chain (main chain)
  
## Proposed changes

- Added support for sovereign chain bootstrapper from storage and from epoch start
- Added support for all the factories needed for sovereign chain components (EpochStartBootstrap, StorageEpochStartBootstrap, StorageBootstrap, etc.)

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
