### PR TITLE
Unittests for topicRequestSender and requestersContainer

### DIFF
--- a/dataRetriever/factory/containers/export_test.go
+++ b/dataRetriever/factory/containers/export_test.go
@@ -2,18 +2,22 @@ package containers
 
 import "github.com/ElrondNetwork/elrond-go-core/core/container"
 
+// Insert -
 func (rc *resolversContainer) Insert(key string, value interface{}) bool {
 	return rc.objects.Insert(key, value)
 }
 
+// Objects -
 func (rc *resolversContainer) Objects() *container.MutexMap {
 	return rc.objects
 }
 
+// Insert -
 func (rc *requestersContainer) Insert(key string, value interface{}) bool {
 	return rc.objects.Insert(key, value)
 }
 
+// Objects -
 func (rc *requestersContainer) Objects() *container.MutexMap {
 	return rc.objects
 }

--- a/dataRetriever/factory/containers/export_test.go
+++ b/dataRetriever/factory/containers/export_test.go
@@ -9,3 +9,11 @@ func (rc *resolversContainer) Insert(key string, value interface{}) bool {
 func (rc *resolversContainer) Objects() *container.MutexMap {
 	return rc.objects
 }
+
+func (rc *requestersContainer) Insert(key string, value interface{}) bool {
+	return rc.objects.Insert(key, value)
+}
+
+func (rc *requestersContainer) Objects() *container.MutexMap {
+	return rc.objects
+}

--- a/dataRetriever/factory/containers/requestersContainer.go
+++ b/dataRetriever/factory/containers/requestersContainer.go
@@ -13,7 +13,6 @@ import (
 var _ dataRetriever.RequestersContainer = (*requestersContainer)(nil)
 
 // requestersContainer is a requesters holder organized by type
-// TODO[Sorin]: next PR, add unittests
 // TODO: extract resolversContainer + requestersContainer in a general container struct
 type requestersContainer struct {
 	objects *container.MutexMap

--- a/dataRetriever/factory/containers/requestersContainer_test.go
+++ b/dataRetriever/factory/containers/requestersContainer_test.go
@@ -266,28 +266,6 @@ func TestRequestersContainer_Iterate(t *testing.T) {
 
 		c.Iterate(nil)
 	})
-	t.Run("invalid key should work", func(t *testing.T) {
-		t.Parallel()
-
-		defer func() {
-			r := recover()
-			if r != nil {
-				assert.Fail(t, "should not have panicked")
-			}
-		}()
-
-		c := containers.NewRequestersContainer()
-
-		_ = c.Add("key1", &dataRetrieverTests.RequesterStub{})
-
-		runs := uint32(0)
-		c.Iterate(func(key string, requester dataRetriever.Requester) bool {
-			atomic.AddUint32(&runs, 1)
-			return true
-		})
-
-		assert.Equal(t, uint32(1), atomic.LoadUint32(&runs))
-	})
 	t.Run("early exist should work", func(t *testing.T) {
 		t.Parallel()
 

--- a/dataRetriever/factory/containers/requestersContainer_test.go
+++ b/dataRetriever/factory/containers/requestersContainer_test.go
@@ -1,0 +1,331 @@
+package containers_test
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever/factory/containers"
+	"github.com/ElrondNetwork/elrond-go/process"
+	dataRetrieverTests "github.com/ElrondNetwork/elrond-go/testscommon/dataRetriever"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRequestersContainer_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		r := recover()
+		if r != nil {
+			assert.Fail(t, "should have not panicked")
+		}
+	}()
+
+	c := containers.NewRequestersContainer()
+
+	assert.False(t, check.IfNil(c))
+	assert.Nil(t, c.Close())
+}
+
+func TestRequestersContainer_Add(t *testing.T) {
+	t.Parallel()
+
+	t.Run("already existing should error", func(t *testing.T) {
+		t.Parallel()
+
+		c := containers.NewRequestersContainer()
+
+		_ = c.Add("key", &dataRetrieverTests.RequesterStub{})
+		err := c.Add("key", &dataRetrieverTests.RequesterStub{})
+
+		assert.Equal(t, process.ErrContainerKeyAlreadyExists, err)
+	})
+	t.Run("nil requester should error", func(t *testing.T) {
+		t.Parallel()
+
+		c := containers.NewRequestersContainer()
+
+		err := c.Add("key", nil)
+
+		assert.Equal(t, process.ErrNilContainerElement, err)
+	})
+	t.Run("empty key should work", func(t *testing.T) {
+		t.Parallel()
+
+		c := containers.NewRequestersContainer()
+
+		err := c.Add("", &dataRetrieverTests.RequesterStub{})
+
+		assert.Nil(t, err)
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		c := containers.NewRequestersContainer()
+
+		err := c.Add("key", &dataRetrieverTests.RequesterStub{})
+
+		assert.Nil(t, err)
+	})
+}
+
+func TestRequestersContainer_AddMultiple(t *testing.T) {
+	t.Parallel()
+
+	t.Run("already existing should error", func(t *testing.T) {
+		t.Parallel()
+
+		c := containers.NewRequestersContainer()
+
+		keys := []string{"key", "key"}
+		requesters := []dataRetriever.Requester{&dataRetrieverTests.RequesterStub{}, &dataRetrieverTests.RequesterStub{}}
+
+		err := c.AddMultiple(keys, requesters)
+
+		assert.Equal(t, process.ErrContainerKeyAlreadyExists, err)
+	})
+	t.Run("len mismatch should error", func(t *testing.T) {
+		t.Parallel()
+
+		c := containers.NewRequestersContainer()
+
+		keys := []string{"key"}
+		requesters := []dataRetriever.Requester{&dataRetrieverTests.RequesterStub{}, &dataRetrieverTests.RequesterStub{}}
+
+		err := c.AddMultiple(keys, requesters)
+
+		assert.Equal(t, process.ErrLenMismatch, err)
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		c := containers.NewRequestersContainer()
+
+		keys := []string{"key1", "key2"}
+		requesters := []dataRetriever.Requester{&dataRetrieverTests.RequesterStub{}, &dataRetrieverTests.RequesterStub{}}
+
+		err := c.AddMultiple(keys, requesters)
+
+		assert.Nil(t, err)
+		assert.Equal(t, 2, c.Len())
+	})
+}
+
+func TestRequestersContainer_Get(t *testing.T) {
+	t.Parallel()
+
+	t.Run("key not found should error", func(t *testing.T) {
+		t.Parallel()
+
+		c := containers.NewRequestersContainer()
+
+		key := "key"
+		keyNotFound := "key not found"
+		val := &dataRetrieverTests.RequesterStub{}
+
+		_ = c.Add(key, val)
+		valRecovered, err := c.Get(keyNotFound)
+
+		assert.Nil(t, valRecovered)
+		assert.True(t, errors.Is(err, dataRetriever.ErrInvalidContainerKey))
+	})
+	t.Run("wrong type should error", func(t *testing.T) {
+		t.Parallel()
+
+		c := containers.NewRequestersContainer()
+
+		key := "key"
+
+		_ = c.Insert(key, "string value")
+		valRecovered, err := c.Get(key)
+
+		assert.Nil(t, valRecovered)
+		assert.Equal(t, process.ErrWrongTypeInContainer, err)
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		c := containers.NewRequestersContainer()
+
+		key := "key"
+		val := &dataRetrieverTests.RequesterStub{}
+
+		_ = c.Add(key, val)
+		valRecovered, err := c.Get(key)
+
+		assert.True(t, val == valRecovered)
+		assert.Nil(t, err)
+	})
+}
+
+func TestRequestersContainer_Replace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil value should error", func(t *testing.T) {
+		t.Parallel()
+
+		c := containers.NewRequestersContainer()
+
+		key := "key"
+		val := &dataRetrieverTests.RequesterStub{}
+
+		_ = c.Add(key, val)
+		err := c.Replace(key, nil)
+
+		valRecovered, _ := c.Get(key)
+
+		assert.Equal(t, process.ErrNilContainerElement, err)
+		assert.Equal(t, val, valRecovered)
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		c := containers.NewRequestersContainer()
+
+		key := "key"
+		val := &dataRetrieverTests.RequesterStub{}
+		val2 := &dataRetrieverTests.RequesterStub{}
+
+		_ = c.Add(key, val)
+		err := c.Replace(key, val2)
+
+		valRecovered, _ := c.Get(key)
+
+		assert.True(t, val2 == valRecovered)
+		assert.Nil(t, err)
+	})
+}
+
+func TestRequestersContainer_Remove(t *testing.T) {
+	t.Parallel()
+
+	c := containers.NewRequestersContainer()
+
+	key := "key"
+	val := &dataRetrieverTests.RequesterStub{}
+
+	_ = c.Add(key, val)
+	c.Remove(key)
+
+	valRecovered, err := c.Get(key)
+
+	assert.Nil(t, valRecovered)
+	assert.True(t, errors.Is(err, dataRetriever.ErrInvalidContainerKey))
+}
+
+func TestRequestersContainer_Len(t *testing.T) {
+	t.Parallel()
+
+	c := containers.NewRequestersContainer()
+
+	_ = c.Add("key1", &dataRetrieverTests.RequesterStub{})
+	assert.Equal(t, 1, c.Len())
+
+	_ = c.Add("key2", &dataRetrieverTests.RequesterStub{})
+	assert.Equal(t, 2, c.Len())
+
+	c.Remove("key1")
+	assert.Equal(t, 1, c.Len())
+}
+
+func TestRequestersContainer_RequesterKeys(t *testing.T) {
+	t.Parallel()
+
+	c := containers.NewRequestersContainer()
+
+	_ = c.Add("key1", &dataRetrieverTests.RequesterStub{})
+	_ = c.Add("key0", &dataRetrieverTests.RequesterStub{})
+	_ = c.Add("key2", &dataRetrieverTests.RequesterStub{})
+	_ = c.Add("a", &dataRetrieverTests.RequesterStub{})
+	c.Objects().Insert(1234, &dataRetrieverTests.RequesterStub{}) // key not string should be skipped
+
+	expectedString := "a, key0, key1, key2"
+
+	assert.Equal(t, expectedString, c.RequesterKeys())
+}
+
+func TestRequestersContainer_Iterate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil handler should not panic", func(t *testing.T) {
+		t.Parallel()
+
+		defer func() {
+			r := recover()
+			if r != nil {
+				assert.Fail(t, "should not have panicked")
+			}
+		}()
+
+		c := containers.NewRequestersContainer()
+
+		_ = c.Add("key1", &dataRetrieverTests.RequesterStub{})
+		_ = c.Add("key2", &dataRetrieverTests.RequesterStub{})
+
+		c.Iterate(nil)
+	})
+	t.Run("invalid key should work", func(t *testing.T) {
+		t.Parallel()
+
+		defer func() {
+			r := recover()
+			if r != nil {
+				assert.Fail(t, "should not have panicked")
+			}
+		}()
+
+		c := containers.NewRequestersContainer()
+
+		_ = c.Add("key1", &dataRetrieverTests.RequesterStub{})
+
+		runs := uint32(0)
+		c.Iterate(func(key string, requester dataRetriever.Requester) bool {
+			atomic.AddUint32(&runs, 1)
+			return true
+		})
+
+		assert.Equal(t, uint32(1), atomic.LoadUint32(&runs))
+	})
+	t.Run("early exist should work", func(t *testing.T) {
+		t.Parallel()
+
+		c := containers.NewRequestersContainer()
+
+		_ = c.Add("key1", &dataRetrieverTests.RequesterStub{})
+		_ = c.Add("key2", &dataRetrieverTests.RequesterStub{})
+
+		runs := uint32(0)
+		c.Iterate(func(key string, requester dataRetriever.Requester) bool {
+			atomic.AddUint32(&runs, 1)
+			return false
+		})
+
+		assert.Equal(t, uint32(1), atomic.LoadUint32(&runs))
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		defer func() {
+			r := recover()
+			if r != nil {
+				assert.Fail(t, "should not have panicked")
+			}
+		}()
+
+		c := containers.NewRequestersContainer()
+
+		_ = c.Add("key1", &dataRetrieverTests.RequesterStub{})
+		c.Objects().Insert(1234, &dataRetrieverTests.RequesterStub{}) // key not string should be skipped
+		c.Objects().Set("key 2", struct{}{})                          // value not requester should be skipped
+
+		runs := uint32(0)
+		c.Iterate(func(key string, requester dataRetriever.Requester) bool {
+			atomic.AddUint32(&runs, 1)
+			return true
+		})
+
+		assert.Equal(t, uint32(1), atomic.LoadUint32(&runs))
+	})
+}

--- a/dataRetriever/resolvers/topicResolverSender/topicResolverSender_test.go
+++ b/dataRetriever/resolvers/topicResolverSender/topicResolverSender_test.go
@@ -215,6 +215,7 @@ func TestNewTopicResolverSender_OkValsWithNumZeroShouldWork(t *testing.T) {
 }
 
 //------- SendOnRequestTopic
+// TODO[Sorin]: remove these tests with cleanup as they were moved to topicSender/topicRequestSender_test.go
 
 func TestTopicResolverSender_SendOnRequestTopicMarshalizerFailsShouldErr(t *testing.T) {
 	t.Parallel()

--- a/dataRetriever/topicSender/topicRequestSender.go
+++ b/dataRetriever/topicSender/topicRequestSender.go
@@ -27,7 +27,6 @@ type ArgTopicRequestSender struct {
 	PeersRatingHandler          dataRetriever.PeersRatingHandler
 }
 
-// TODO[Sorin]: add more unittests
 type topicRequestSender struct {
 	*baseTopicSender
 	marshaller                         marshal.Marshalizer

--- a/dataRetriever/topicSender/topicRequestSender_test.go
+++ b/dataRetriever/topicSender/topicRequestSender_test.go
@@ -1,14 +1,20 @@
 package topicsender
 
 import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/mock"
+	"github.com/ElrondNetwork/elrond-go/p2p"
 	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createMockArgTopicRequestSender() ArgTopicRequestSender {
@@ -39,14 +45,645 @@ func createMockArgTopicRequestSender() ArgTopicRequestSender {
 func TestNewTopicRequestSender(t *testing.T) {
 	t.Parallel()
 
-	t.Run("", func(t *testing.T) {
+	t.Run("nil Messenger should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgTopicRequestSender()
+		arg.Messenger = nil
+		trs, err := NewTopicRequestSender(arg)
+		assert.True(t, check.IfNil(trs))
+		assert.Equal(t, dataRetriever.ErrNilMessenger, err)
+	})
+	t.Run("nil OutputAntiflooder should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgTopicRequestSender()
+		arg.OutputAntiflooder = nil
+		trs, err := NewTopicRequestSender(arg)
+		assert.True(t, check.IfNil(trs))
+		assert.Equal(t, dataRetriever.ErrNilAntifloodHandler, err)
+	})
+	t.Run("nil PreferredPeersHolder should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgTopicRequestSender()
+		arg.PreferredPeersHolder = nil
+		trs, err := NewTopicRequestSender(arg)
+		assert.True(t, check.IfNil(trs))
+		assert.Equal(t, dataRetriever.ErrNilPreferredPeersHolder, err)
+	})
+	t.Run("nil Marshaller should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgTopicRequestSender()
+		arg.Marshaller = nil
+		trs, err := NewTopicRequestSender(arg)
+		assert.True(t, check.IfNil(trs))
+		assert.Equal(t, dataRetriever.ErrNilMarshalizer, err)
+	})
+	t.Run("nil Randomizer should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgTopicRequestSender()
+		arg.Randomizer = nil
+		trs, err := NewTopicRequestSender(arg)
+		assert.True(t, check.IfNil(trs))
+		assert.Equal(t, dataRetriever.ErrNilRandomizer, err)
+	})
+	t.Run("nil PeerListCreator should error", func(t *testing.T) {
 		t.Parallel()
 
 		arg := createMockArgTopicRequestSender()
 		arg.PeerListCreator = nil
 		trs, err := NewTopicRequestSender(arg)
-
 		assert.True(t, check.IfNil(trs))
 		assert.Equal(t, dataRetriever.ErrNilPeerListCreator, err)
 	})
+	t.Run("nil CurrentNetworkEpochProvider should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgTopicRequestSender()
+		arg.CurrentNetworkEpochProvider = nil
+		trs, err := NewTopicRequestSender(arg)
+		assert.True(t, check.IfNil(trs))
+		assert.Equal(t, dataRetriever.ErrNilCurrentNetworkEpochProvider, err)
+	})
+	t.Run("nil PeersRatingHandler should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgTopicRequestSender()
+		arg.PeersRatingHandler = nil
+		trs, err := NewTopicRequestSender(arg)
+		assert.True(t, check.IfNil(trs))
+		assert.Equal(t, dataRetriever.ErrNilPeersRatingHandler, err)
+	})
+	t.Run("nil SelfShardIdProvider should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgTopicRequestSender()
+		arg.SelfShardIdProvider = nil
+		trs, err := NewTopicRequestSender(arg)
+		assert.True(t, check.IfNil(trs))
+		assert.Equal(t, dataRetriever.ErrNilSelfShardIDProvider, err)
+	})
+	t.Run("invalid NumIntraShardPeers should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgTopicRequestSender()
+		arg.NumIntraShardPeers = -1
+		trs, err := NewTopicRequestSender(arg)
+		assert.True(t, check.IfNil(trs))
+		assert.True(t, errors.Is(err, dataRetriever.ErrInvalidValue))
+		assert.True(t, strings.Contains(err.Error(), "NumIntraShardPeers"))
+	})
+	t.Run("invalid NumCrossShardPeers should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgTopicRequestSender()
+		arg.NumCrossShardPeers = -1
+		trs, err := NewTopicRequestSender(arg)
+		assert.True(t, check.IfNil(trs))
+		assert.True(t, errors.Is(err, dataRetriever.ErrInvalidValue))
+		assert.True(t, strings.Contains(err.Error(), "NumCrossShardPeers"))
+	})
+	t.Run("invalid NumFullHistoryPeers should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgTopicRequestSender()
+		arg.NumFullHistoryPeers = -1
+		trs, err := NewTopicRequestSender(arg)
+		assert.True(t, check.IfNil(trs))
+		assert.True(t, errors.Is(err, dataRetriever.ErrInvalidValue))
+		assert.True(t, strings.Contains(err.Error(), "NumFullHistoryPeers"))
+	})
+	t.Run("invalid total number of peers should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgTopicRequestSender()
+		arg.NumCrossShardPeers = 0
+		arg.NumIntraShardPeers = 0
+		trs, err := NewTopicRequestSender(arg)
+		assert.True(t, check.IfNil(trs))
+		assert.True(t, errors.Is(err, dataRetriever.ErrInvalidValue))
+		assert.True(t, strings.Contains(err.Error(), "NumIntraShardPeers"))
+		assert.True(t, strings.Contains(err.Error(), "NumCrossShardPeers"))
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		trs, err := NewTopicRequestSender(createMockArgTopicRequestSender())
+		assert.False(t, check.IfNil(trs))
+		assert.Nil(t, err)
+	})
+}
+
+func TestTopicResolverSender_SendOnRequestTopic(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("expected error")
+	var defaultHashes = [][]byte{[]byte("hash")}
+
+	t.Run("marshal fails", func(t *testing.T) {
+		arg := createMockArgTopicRequestSender()
+		arg.Marshaller = &mock.MarshalizerStub{
+			MarshalCalled: func(obj interface{}) (bytes []byte, e error) {
+				return nil, expectedErr
+			},
+		}
+		trs, _ := NewTopicRequestSender(arg)
+
+		err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)
+
+		assert.Equal(t, expectedErr, err)
+	})
+	t.Run("no peers should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgTopicRequestSender()
+		arg.PeerListCreator = &mock.PeerListCreatorStub{
+			CrossShardPeerListCalled: func() []core.PeerID {
+				return make([]core.PeerID, 0)
+			},
+			IntraShardPeerListCalled: func() []core.PeerID {
+				return make([]core.PeerID, 0)
+			},
+		}
+		trs, _ := NewTopicRequestSender(arg)
+
+		err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)
+
+		assert.True(t, errors.Is(err, dataRetriever.ErrSendRequest))
+	})
+	t.Run("should work and not send to full history", func(t *testing.T) {
+		t.Parallel()
+
+		pID1 := core.PeerID("peer1")
+		pID2 := core.PeerID("peer2")
+		sentToPid1 := false
+		sentToPid2 := false
+
+		arg := createMockArgTopicRequestSender()
+		arg.Messenger = &mock.MessageHandlerStub{
+			SendToConnectedPeerCalled: func(topic string, buff []byte, peerID core.PeerID) error {
+				if bytes.Equal(peerID.Bytes(), pID1.Bytes()) {
+					sentToPid1 = true
+				}
+				if bytes.Equal(peerID.Bytes(), pID2.Bytes()) {
+					sentToPid2 = true
+				}
+
+				return nil
+			},
+		}
+		arg.PeerListCreator = &mock.PeerListCreatorStub{
+			CrossShardPeerListCalled: func() []core.PeerID {
+				return []core.PeerID{pID1}
+			},
+			IntraShardPeerListCalled: func() []core.PeerID {
+				return []core.PeerID{pID2}
+			},
+		}
+		trs, _ := NewTopicRequestSender(arg)
+
+		err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)
+
+		assert.Nil(t, err)
+		assert.True(t, sentToPid1)
+		assert.True(t, sentToPid2)
+	})
+	t.Run("should work and send to full history", func(t *testing.T) {
+		t.Parallel()
+
+		pIDfullHistory := core.PeerID("full history peer")
+		sentToFullHistoryPeer := false
+
+		arg := createMockArgTopicRequestSender()
+		arg.Messenger = &mock.MessageHandlerStub{
+			SendToConnectedPeerCalled: func(topic string, buff []byte, peerID core.PeerID) error {
+				if bytes.Equal(peerID.Bytes(), pIDfullHistory.Bytes()) {
+					sentToFullHistoryPeer = true
+				}
+
+				return nil
+			},
+		}
+		arg.PeerListCreator = &mock.PeerListCreatorStub{
+			FullHistoryListCalled: func() []core.PeerID {
+				return []core.PeerID{pIDfullHistory}
+			},
+		}
+		arg.CurrentNetworkEpochProvider = &mock.CurrentNetworkEpochProviderStub{
+			EpochIsActiveInNetworkCalled: func(epoch uint32) bool {
+				return false
+			},
+		}
+		trs, _ := NewTopicRequestSender(arg)
+
+		err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)
+		assert.Nil(t, err)
+		assert.True(t, sentToFullHistoryPeer)
+	})
+	t.Run("should work and send to preferred peers", func(t *testing.T) {
+		t.Parallel()
+
+		selfShardID := uint32(0)
+		targetShardID := uint32(1)
+		countPrefPeersSh0 := 0
+		preferredPeersShard0 := make([]core.PeerID, 0)
+		for idx := 0; idx < 5; idx++ {
+			preferredPeersShard0 = append(preferredPeersShard0, core.PeerID(fmt.Sprintf("prefPIDsh0-%d", idx)))
+		}
+
+		countPrefPeersSh1 := 0
+		preferredPeersShard1 := make([]core.PeerID, 0)
+		for idx := 0; idx < 5; idx++ {
+			preferredPeersShard1 = append(preferredPeersShard1, core.PeerID(fmt.Sprintf("prefPIDsh1-%d", idx)))
+		}
+		regularPeer0, regularPeer1 := core.PeerID("peer0"), core.PeerID("peer1")
+
+		arg := createMockArgTopicRequestSender()
+		arg.TargetShardId = targetShardID
+
+		selfShardIDProvider := mock.NewMultipleShardsCoordinatorMock()
+		selfShardIDProvider.CurrentShard = selfShardID
+		arg.SelfShardIdProvider = selfShardIDProvider
+
+		arg.PeerListCreator = &mock.PeerListCreatorStub{
+			CrossShardPeerListCalled: func() []core.PeerID {
+				return []core.PeerID{regularPeer0}
+			},
+			IntraShardPeerListCalled: func() []core.PeerID {
+				return []core.PeerID{regularPeer1}
+			},
+		}
+		arg.PreferredPeersHolder = &p2pmocks.PeersHolderStub{
+			GetCalled: func() map[uint32][]core.PeerID {
+				return map[uint32][]core.PeerID{
+					selfShardID:   preferredPeersShard0,
+					targetShardID: preferredPeersShard1,
+				}
+			},
+		}
+		arg.NumCrossShardPeers = 5
+		arg.NumIntraShardPeers = 5
+		arg.Messenger = &mock.MessageHandlerStub{
+			SendToConnectedPeerCalled: func(topic string, buff []byte, peerID core.PeerID) error {
+				if strings.HasPrefix(string(peerID), "prefPIDsh0") {
+					countPrefPeersSh0++
+				}
+
+				if strings.HasPrefix(string(peerID), "prefPIDsh1") {
+					countPrefPeersSh1++
+				}
+
+				return nil
+			},
+		}
+		trs, _ := NewTopicRequestSender(arg)
+
+		err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)
+		assert.Nil(t, err)
+		assert.Equal(t, 1, countPrefPeersSh1)
+	})
+	t.Run("should work and send to preferred cross peer first", func(t *testing.T) {
+		t.Parallel()
+
+		targetShardID := uint32(37)
+		pidPreferred := core.PeerID("preferred peer")
+		numTimesSent := 0
+		regularPeer0, regularPeer1 := core.PeerID("peer0"), core.PeerID("peer1")
+		sentToPreferredPeer := false
+
+		arg := createMockArgTopicRequestSender()
+		arg.TargetShardId = targetShardID
+		arg.NumCrossShardPeers = 5
+		arg.PeerListCreator = &mock.PeerListCreatorStub{
+			CrossShardPeerListCalled: func() []core.PeerID {
+				return []core.PeerID{regularPeer0, regularPeer1, regularPeer0, regularPeer1}
+			},
+			IntraShardPeerListCalled: func() []core.PeerID {
+				return []core.PeerID{}
+			},
+		}
+		arg.PreferredPeersHolder = &p2pmocks.PeersHolderStub{
+			GetCalled: func() map[uint32][]core.PeerID {
+				return map[uint32][]core.PeerID{
+					targetShardID: {pidPreferred},
+				}
+			},
+		}
+
+		arg.Messenger = &mock.MessageHandlerStub{
+			SendToConnectedPeerCalled: func(topic string, buff []byte, peerID core.PeerID) error {
+				if bytes.Equal(peerID.Bytes(), pidPreferred.Bytes()) {
+					sentToPreferredPeer = true
+					require.Zero(t, numTimesSent)
+				}
+
+				numTimesSent++
+				return nil
+			},
+		}
+		trs, _ := NewTopicRequestSender(arg)
+
+		err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)
+		assert.Nil(t, err)
+		assert.True(t, sentToPreferredPeer)
+	})
+	t.Run("should work and send to preferred intra peer first", func(t *testing.T) {
+		t.Parallel()
+
+		selfShardID := uint32(37)
+		pidPreferred := core.PeerID("preferred peer")
+		numTimesSent := 0
+		regularPeer0, regularPeer1 := core.PeerID("peer0"), core.PeerID("peer1")
+		sentToPreferredPeer := false
+
+		arg := createMockArgTopicRequestSender()
+		arg.TargetShardId = 0
+		arg.NumCrossShardPeers = 5
+		arg.PeerListCreator = &mock.PeerListCreatorStub{
+			CrossShardPeerListCalled: func() []core.PeerID {
+				return []core.PeerID{}
+			},
+			IntraShardPeerListCalled: func() []core.PeerID {
+				return []core.PeerID{regularPeer0, regularPeer1, regularPeer0, regularPeer1}
+			},
+		}
+		arg.PreferredPeersHolder = &p2pmocks.PeersHolderStub{
+			GetCalled: func() map[uint32][]core.PeerID {
+				return map[uint32][]core.PeerID{
+					selfShardID: {pidPreferred},
+				}
+			},
+		}
+
+		arg.Messenger = &mock.MessageHandlerStub{
+			SendToConnectedPeerCalled: func(topic string, buff []byte, peerID core.PeerID) error {
+				if bytes.Equal(peerID.Bytes(), pidPreferred.Bytes()) {
+					sentToPreferredPeer = true
+					require.Zero(t, numTimesSent)
+				}
+
+				numTimesSent++
+				return nil
+			},
+		}
+
+		selfShardIDProvider := mock.NewMultipleShardsCoordinatorMock()
+		selfShardIDProvider.CurrentShard = selfShardID
+		arg.SelfShardIdProvider = selfShardIDProvider
+
+		trs, _ := NewTopicRequestSender(arg)
+
+		err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)
+		assert.Nil(t, err)
+		assert.True(t, sentToPreferredPeer)
+	})
+	t.Run("should work and skip antiflood checks for preferred peers", func(t *testing.T) {
+		t.Parallel()
+
+		selfShardID := uint32(37)
+		pidPreferred := core.PeerID("preferred peer")
+		regularPeer0, regularPeer1 := core.PeerID("peer0"), core.PeerID("peer1")
+		targetShardID := uint32(55)
+
+		sentToPreferredPeer := false
+
+		arg := createMockArgTopicRequestSender()
+		arg.TargetShardId = targetShardID
+		arg.NumCrossShardPeers = 5
+		arg.PeerListCreator = &mock.PeerListCreatorStub{
+			CrossShardPeerListCalled: func() []core.PeerID {
+				return []core.PeerID{regularPeer0, regularPeer1, regularPeer0, regularPeer1}
+			},
+			IntraShardPeerListCalled: func() []core.PeerID {
+				return []core.PeerID{}
+			},
+		}
+		arg.PreferredPeersHolder = &p2pmocks.PeersHolderStub{
+			GetCalled: func() map[uint32][]core.PeerID {
+				return map[uint32][]core.PeerID{
+					targetShardID: {pidPreferred},
+				}
+			},
+			ContainsCalled: func(peerID core.PeerID) bool {
+				return peerID == pidPreferred
+			},
+		}
+
+		arg.Messenger = &mock.MessageHandlerStub{
+			SendToConnectedPeerCalled: func(topic string, buff []byte, peerID core.PeerID) error {
+				if peerID == pidPreferred {
+					sentToPreferredPeer = true
+				}
+				return nil
+			},
+		}
+		arg.OutputAntiflooder = &mock.P2PAntifloodHandlerStub{
+			CanProcessMessageCalled: func(message p2p.MessageP2P, fromConnectedPeer core.PeerID) error {
+				if fromConnectedPeer == pidPreferred {
+					require.Fail(t, "CanProcessMessage should have not be called for preferred peer")
+				}
+
+				return nil
+			},
+		}
+
+		selfShardIDProvider := mock.NewMultipleShardsCoordinatorMock()
+		selfShardIDProvider.CurrentShard = selfShardID
+		arg.SelfShardIdProvider = selfShardIDProvider
+
+		trs, _ := NewTopicRequestSender(arg)
+
+		err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)
+		require.NoError(t, err)
+		require.True(t, sentToPreferredPeer)
+	})
+	t.Run("should not send to preferred peer if only one peer to request", func(t *testing.T) {
+		pidPreferred := core.PeerID("preferred peer")
+		numTimesSent := 0
+		regularPeer0, regularPeer1 := core.PeerID("peer0"), core.PeerID("peer1")
+		sentToPreferredPeer := false
+
+		arg := createMockArgTopicRequestSender()
+		arg.TargetShardId = 1
+		arg.NumCrossShardPeers = 1
+		arg.PeerListCreator = &mock.PeerListCreatorStub{
+			CrossShardPeerListCalled: func() []core.PeerID {
+				return []core.PeerID{regularPeer0, regularPeer1, regularPeer0, regularPeer1}
+			},
+			IntraShardPeerListCalled: func() []core.PeerID {
+				return []core.PeerID{}
+			},
+		}
+		arg.PreferredPeersHolder = &p2pmocks.PeersHolderStub{
+			GetCalled: func() map[uint32][]core.PeerID {
+				return map[uint32][]core.PeerID{
+					37: {pidPreferred},
+				}
+			},
+		}
+
+		arg.Messenger = &mock.MessageHandlerStub{
+			SendToConnectedPeerCalled: func(topic string, buff []byte, peerID core.PeerID) error {
+				if bytes.Equal(peerID.Bytes(), pidPreferred.Bytes()) {
+					sentToPreferredPeer = true
+					require.Zero(t, numTimesSent)
+				}
+
+				numTimesSent++
+				return nil
+			},
+		}
+		trs, _ := NewTopicRequestSender(arg)
+
+		err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)
+		assert.Nil(t, err)
+		assert.False(t, sentToPreferredPeer)
+	})
+	t.Run("should stop after sending to required num", func(t *testing.T) {
+		t.Parallel()
+
+		pIDs := []core.PeerID{"pid1", "pid2", "pid3", "pid4", "pid5"}
+
+		numSent := 0
+		arg := createMockArgTopicRequestSender()
+		arg.Messenger = &mock.MessageHandlerStub{
+			SendToConnectedPeerCalled: func(topic string, buff []byte, peerID core.PeerID) error {
+				numSent++
+
+				return nil
+			},
+		}
+		arg.PeerListCreator = &mock.PeerListCreatorStub{
+			CrossShardPeerListCalled: func() []core.PeerID {
+				return pIDs
+			},
+			IntraShardPeerListCalled: func() []core.PeerID {
+				return pIDs
+			},
+		}
+		trs, _ := NewTopicRequestSender(arg)
+
+		err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)
+
+		assert.Nil(t, err)
+		assert.Equal(t, arg.NumCrossShardPeers+arg.NumIntraShardPeers, numSent)
+	})
+	t.Run("should not call intra shard peers", func(t *testing.T) {
+		t.Parallel()
+
+		pIDs := []core.PeerID{"pid1", "pid2", "pid3", "pid4", "pid5"}
+		pidNotCalled := core.PeerID("pid not called")
+
+		numSent := 0
+		arg := createMockArgTopicRequestSender()
+		arg.Messenger = &mock.MessageHandlerStub{
+			SendToConnectedPeerCalled: func(topic string, buff []byte, peerID core.PeerID) error {
+				if peerID == pidNotCalled {
+					assert.Fail(t, fmt.Sprintf("should not have called pid %s", peerID))
+				}
+				numSent++
+
+				return nil
+			},
+		}
+		arg.NumIntraShardPeers = 0
+		arg.PeerListCreator = &mock.PeerListCreatorStub{
+			CrossShardPeerListCalled: func() []core.PeerID {
+				return pIDs
+			},
+			IntraShardPeerListCalled: func() []core.PeerID {
+				return []core.PeerID{pidNotCalled}
+			},
+		}
+		trs, _ := NewTopicRequestSender(arg)
+
+		err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)
+
+		assert.Nil(t, err)
+		assert.Equal(t, arg.NumCrossShardPeers, numSent)
+	})
+	t.Run("should not call cross shard", func(t *testing.T) {
+		t.Parallel()
+
+		pIDs := []core.PeerID{"pid1", "pid2", "pid3", "pid4", "pid5"}
+		pidNotCalled := core.PeerID("pid not called")
+
+		numSent := 0
+		arg := createMockArgTopicRequestSender()
+		arg.Messenger = &mock.MessageHandlerStub{
+			SendToConnectedPeerCalled: func(topic string, buff []byte, peerID core.PeerID) error {
+				if peerID == pidNotCalled {
+					assert.Fail(t, fmt.Sprintf("should not have called pid %s", peerID))
+				}
+				numSent++
+
+				return nil
+			},
+		}
+		arg.NumCrossShardPeers = 0
+		arg.PeerListCreator = &mock.PeerListCreatorStub{
+			CrossShardPeerListCalled: func() []core.PeerID {
+				return []core.PeerID{pidNotCalled}
+			},
+			IntraShardPeerListCalled: func() []core.PeerID {
+				return pIDs
+			},
+		}
+		trs, _ := NewTopicRequestSender(arg)
+
+		err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)
+
+		assert.Nil(t, err)
+		assert.Equal(t, arg.NumIntraShardPeers, numSent)
+	})
+	t.Run("SendToConnectedPeerCalled returns error", func(t *testing.T) {
+		t.Parallel()
+
+		pID1 := core.PeerID("peer1")
+		sentToPid1 := false
+
+		arg := createMockArgTopicRequestSender()
+		arg.Messenger = &mock.MessageHandlerStub{
+			SendToConnectedPeerCalled: func(topic string, buff []byte, peerID core.PeerID) error {
+				if bytes.Equal(peerID.Bytes(), pID1.Bytes()) {
+					sentToPid1 = true
+				}
+
+				return expectedErr
+			},
+		}
+		arg.PeerListCreator = &mock.PeerListCreatorStub{
+			CrossShardPeerListCalled: func() []core.PeerID {
+				return []core.PeerID{pID1}
+			},
+			IntraShardPeerListCalled: func() []core.PeerID {
+				return make([]core.PeerID, 0)
+			},
+		}
+		trs, _ := NewTopicRequestSender(arg)
+
+		err := trs.SendOnRequestTopic(&dataRetriever.RequestData{}, defaultHashes)
+
+		assert.True(t, errors.Is(err, dataRetriever.ErrSendRequest))
+		assert.True(t, sentToPid1)
+	})
+}
+
+func TestTopicRequestSender_NumPeersToQuery(t *testing.T) {
+	t.Parallel()
+
+	arg := createMockArgTopicRequestSender()
+	trs, _ := NewTopicRequestSender(arg)
+
+	intra := 1123
+	cross := 2143
+
+	trs.SetNumPeersToQuery(intra, cross)
+	recoveredIntra, recoveredCross := trs.NumPeersToQuery()
+
+	assert.Equal(t, intra, recoveredIntra)
+	assert.Equal(t, cross, recoveredCross)
 }

--- a/testscommon/dataRetriever/requesterStub.go
+++ b/testscommon/dataRetriever/requesterStub.go
@@ -1,0 +1,47 @@
+package dataRetriever
+
+import "github.com/ElrondNetwork/elrond-go/dataRetriever"
+
+// RequesterStub -
+type RequesterStub struct {
+	RequestDataFromHashCalled     func(hash []byte, epoch uint32) error
+	SetNumPeersToQueryCalled      func(intra int, cross int)
+	NumPeersToQueryCalled         func() (int, int)
+	SetResolverDebugHandlerCalled func(handler dataRetriever.ResolverDebugHandler) error
+}
+
+// RequestDataFromHash -
+func (stub *RequesterStub) RequestDataFromHash(hash []byte, epoch uint32) error {
+	if stub.RequestDataFromHashCalled != nil {
+		return stub.RequestDataFromHashCalled(hash, epoch)
+	}
+	return nil
+}
+
+// SetNumPeersToQuery -
+func (stub *RequesterStub) SetNumPeersToQuery(intra int, cross int) {
+	if stub.SetNumPeersToQueryCalled != nil {
+		stub.SetNumPeersToQueryCalled(intra, cross)
+	}
+}
+
+// NumPeersToQuery -
+func (stub *RequesterStub) NumPeersToQuery() (int, int) {
+	if stub.NumPeersToQueryCalled != nil {
+		return stub.NumPeersToQueryCalled()
+	}
+	return 0, 0
+}
+
+// SetResolverDebugHandler -
+func (stub *RequesterStub) SetResolverDebugHandler(handler dataRetriever.ResolverDebugHandler) error {
+	if stub.SetResolverDebugHandlerCalled != nil {
+		return stub.SetResolverDebugHandlerCalled(handler)
+	}
+	return nil
+}
+
+// IsInterfaceNil -
+func (stub *RequesterStub) IsInterfaceNil() bool {
+	return stub == nil
+}


### PR DESCRIPTION
## Reasoning behind the pull request
- unittests only
  
## Proposed changes
- unittests only

## Testing procedure
- unittests only

**Notes for review** 
- tests from `topicRequestSender_test.go` are the same old tests from `topicResolverSender/topicResolverSender_test.go`, only changed the structure to use `t.Run`s
- tests from `requestersContainer_test.go` are more ore less same tests as in `resolversContainer_test.go`, but using `t.Run`s
## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
