### PR TITLE
Remove withMetaData query param

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -82,9 +82,6 @@ var ErrGetBlock = errors.New("getting block failed")
 // ErrGetAlteredAccountsForBlock signals an error happening when trying to fetch the altered accounts for a block
 var ErrGetAlteredAccountsForBlock = errors.New("getting altered accounts for block failed")
 
-// ErrIncompatibleWithMetadataParam signals a request error, because withMetadata should only be used with the tokens param
-var ErrIncompatibleWithMetadataParam = errors.New("withMetadata param should only be used with the tokens param")
-
 // ErrQueryError signals a general query error
 var ErrQueryError = errors.New("query error")
 

--- a/api/groups/blockGroup.go
+++ b/api/groups/blockGroup.go
@@ -237,7 +237,6 @@ func parseAlteredAccountsForBlockQueryOptionsWithoutRequestType(c *gin.Context) 
 
 	return api.GetAlteredAccountsForBlockOptions{
 		TokensFilter: tokensFilter,
-		WithMetadata: false,
 	}, nil
 }
 

--- a/api/groups/blockGroup.go
+++ b/api/groups/blockGroup.go
@@ -26,7 +26,6 @@ const (
 	urlParamTokensFilter      = "tokens"
 	urlParamWithTxs           = "withTxs"
 	urlParamWithLogs          = "withLogs"
-	urlParamWithMetadata      = "withMetadata"
 )
 
 // blockFacadeHandler defines the methods to be implemented by a facade for handling block requests
@@ -236,18 +235,9 @@ func parseBlockQueryOptions(c *gin.Context) (api.BlockQueryOptions, error) {
 func parseAlteredAccountsForBlockQueryOptionsWithoutRequestType(c *gin.Context) (api.GetAlteredAccountsForBlockOptions, error) {
 	tokensFilter := c.Request.URL.Query().Get(urlParamTokensFilter)
 
-	withMetadata, err := parseBoolUrlParam(c, urlParamWithMetadata)
-	if err != nil {
-		return api.GetAlteredAccountsForBlockOptions{}, err
-	}
-
-	if withMetadata && len(tokensFilter) == 0 {
-		return api.GetAlteredAccountsForBlockOptions{}, errors.ErrIncompatibleWithMetadataParam
-	}
-
 	return api.GetAlteredAccountsForBlockOptions{
 		TokensFilter: tokensFilter,
-		WithMetadata: withMetadata,
+		WithMetadata: false,
 	}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/ElrondNetwork/elastic-indexer-go v1.3.0
-	github.com/ElrondNetwork/elrond-go-core v1.1.24
+	github.com/ElrondNetwork/elrond-go-core v1.1.25-0.20221116135507-b8b878809ae7
 	github.com/ElrondNetwork/elrond-go-crypto v1.2.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.9
 	github.com/ElrondNetwork/elrond-go-p2p v1.0.3

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/ElrondNetwork/elastic-indexer-go v1.3.0
-	github.com/ElrondNetwork/elrond-go-core v1.1.25-0.20221116135507-b8b878809ae7
+	github.com/ElrondNetwork/elrond-go-core v1.1.25
 	github.com/ElrondNetwork/elrond-go-crypto v1.2.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.9
 	github.com/ElrondNetwork/elrond-go-p2p v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,9 @@ github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoC
 github.com/ElrondNetwork/elrond-go-core v1.1.13/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-core v1.1.18/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-core v1.1.19/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
-github.com/ElrondNetwork/elrond-go-core v1.1.24 h1:jamx50C1dP50uwh11EXT0+4pq0E0G3YYTK2xKEewDEk=
 github.com/ElrondNetwork/elrond-go-core v1.1.24/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
+github.com/ElrondNetwork/elrond-go-core v1.1.25-0.20221116135507-b8b878809ae7 h1:6ZV/4RzavGkIliQURvkdyLx0kKeCf6lJY9IfCdYsJMA=
+github.com/ElrondNetwork/elrond-go-core v1.1.25-0.20221116135507-b8b878809ae7/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.0/go.mod h1:DGiR7/j1xv729Xg8SsjYaUzWXL5svMd44REXjWS/gAc=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.1 h1:5wWCBEZp5SMFO2+Nal8UaJNJcG9G9J4PHNNZvQpEeUE=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.1/go.mod h1:UNmpDaJjLTKxfzUcwua2R7Mh9bicw/L3ICJt5V7zqMo=

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/ElrondNetwork/elrond-go-core v1.1.13/go.mod h1:Yz8JK5sGBctw7+gU8j2mZH
 github.com/ElrondNetwork/elrond-go-core v1.1.18/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-core v1.1.19/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-core v1.1.24/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
-github.com/ElrondNetwork/elrond-go-core v1.1.25-0.20221116135507-b8b878809ae7 h1:6ZV/4RzavGkIliQURvkdyLx0kKeCf6lJY9IfCdYsJMA=
-github.com/ElrondNetwork/elrond-go-core v1.1.25-0.20221116135507-b8b878809ae7/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
+github.com/ElrondNetwork/elrond-go-core v1.1.25 h1:jfO2TsV161bPMLbocjdNR+iy0lNKpfYwA4t5lNAFoK8=
+github.com/ElrondNetwork/elrond-go-core v1.1.25/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.0/go.mod h1:DGiR7/j1xv729Xg8SsjYaUzWXL5svMd44REXjWS/gAc=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.1 h1:5wWCBEZp5SMFO2+Nal8UaJNJcG9G9J4PHNNZvQpEeUE=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.1/go.mod h1:UNmpDaJjLTKxfzUcwua2R7Mh9bicw/L3ICJt5V7zqMo=

--- a/node/external/blockAPI/baseBlock.go
+++ b/node/external/blockAPI/baseBlock.go
@@ -358,7 +358,7 @@ func bigIntToStr(value *big.Int) string {
 	return value.String()
 }
 
-func alteredAccountsMapToAPIResponse(alteredAccounts map[string]*outport.AlteredAccount, tokensFilter string, withMetadata bool) []*outport.AlteredAccount {
+func alteredAccountsMapToAPIResponse(alteredAccounts map[string]*outport.AlteredAccount, tokensFilter string) []*outport.AlteredAccount {
 	response := make([]*outport.AlteredAccount, 0, len(alteredAccounts))
 
 	for address, altAccount := range alteredAccounts {
@@ -369,7 +369,7 @@ func alteredAccountsMapToAPIResponse(alteredAccounts map[string]*outport.Altered
 		}
 
 		if len(tokensFilter) > 0 {
-			attachTokensToAlteredAccount(apiAlteredAccount, altAccount, tokensFilter, withMetadata)
+			attachTokensToAlteredAccount(apiAlteredAccount, altAccount, tokensFilter)
 		}
 
 		response = append(response, apiAlteredAccount)
@@ -378,22 +378,19 @@ func alteredAccountsMapToAPIResponse(alteredAccounts map[string]*outport.Altered
 	return response
 }
 
-func attachTokensToAlteredAccount(apiAlteredAccount *outport.AlteredAccount, altAccount *outport.AlteredAccount, tokensFilter string, withMetadata bool) {
+func attachTokensToAlteredAccount(apiAlteredAccount *outport.AlteredAccount, altAccount *outport.AlteredAccount, tokensFilter string) {
 	for _, token := range altAccount.Tokens {
 		if !shouldAddTokenToResult(token.Identifier, tokensFilter) {
 			continue
 		}
-		if withMetadata {
-			apiAlteredAccount.Tokens = append(apiAlteredAccount.Tokens, token)
-			continue
-		}
 
 		apiAlteredAccount.Tokens = append(apiAlteredAccount.Tokens, &outport.AccountTokenData{
-			Identifier: token.Identifier,
-			Balance:    token.Balance,
-			Nonce:      token.Nonce,
-			Properties: token.Properties,
-			MetaData:   nil,
+			Identifier:     token.Identifier,
+			Balance:        token.Balance,
+			Nonce:          token.Nonce,
+			Properties:     token.Properties,
+			MetaData:       nil,
+			AdditionalData: nil,
 		})
 	}
 }
@@ -446,7 +443,7 @@ func (bap *baseAPIBlockProcessor) apiBlockToAlteredAccounts(apiBlock *api.Block,
 		return nil, err
 	}
 
-	alteredAccountsAPI := alteredAccountsMapToAPIResponse(alteredAccounts, options.TokensFilter, options.WithMetadata)
+	alteredAccountsAPI := alteredAccountsMapToAPIResponse(alteredAccounts, options.TokensFilter)
 	return alteredAccountsAPI, nil
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request
- Removed `MetaData` from api responses, since it could not be consistently provided.
- This information is also available from logs, at each `NFTCreate` builtin function call.
  
## Proposed changes
- Removed `withMetaData` flag from `alteredAccounts`

## Testing procedure
- Check that for each altered accounts endpoint, `MetaData` information is no longer available

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
