### PR TITLE
HardforkExclusionHandler into header interceptor

### DIFF
--- a/epochStart/bootstrap/common.go
+++ b/epochStart/bootstrap/common.go
@@ -109,6 +109,9 @@ func checkArguments(args ArgsEpochStartBootstrap) error {
 	if args.GeneralConfig.TrieSync.NumConcurrentTrieSyncers < 1 {
 		return fmt.Errorf("%s: %w", baseErrorMessage, epochStart.ErrInvalidNumConcurrentTrieSyncers)
 	}
+	if check.IfNil(args.HardforkExclusionHandler) {
+		return fmt.Errorf("%s: %w", baseErrorMessage, epochStart.ErrNilHardforkExclusionHandler)
+	}
 
 	return nil
 }

--- a/epochStart/bootstrap/factory/epochStartInterceptorsContainerFactory.go
+++ b/epochStart/bootstrap/factory/epochStartInterceptorsContainerFactory.go
@@ -25,21 +25,22 @@ const timeSpanForBadHeaders = time.Minute
 // ArgsEpochStartInterceptorContainer holds the arguments needed for creating a new epoch start interceptors
 // container factory
 type ArgsEpochStartInterceptorContainer struct {
-	CoreComponents          process.CoreComponentsHolder
-	CryptoComponents        process.CryptoComponentsHolder
-	Config                  config.Config
-	ShardCoordinator        sharding.Coordinator
-	Messenger               process.TopicHandler
-	DataPool                dataRetriever.PoolsHolder
-	WhiteListHandler        update.WhiteListHandler
-	WhiteListerVerifiedTxs  update.WhiteListHandler
-	AddressPubkeyConv       core.PubkeyConverter
-	NonceConverter          typeConverters.Uint64ByteSliceConverter
-	ChainID                 []byte
-	ArgumentsParser         process.ArgumentsParser
-	HeaderIntegrityVerifier process.HeaderIntegrityVerifier
-	RequestHandler          process.RequestHandler
-	SignaturesHandler       process.SignaturesHandler
+	CoreComponents           process.CoreComponentsHolder
+	CryptoComponents         process.CryptoComponentsHolder
+	Config                   config.Config
+	ShardCoordinator         sharding.Coordinator
+	Messenger                process.TopicHandler
+	DataPool                 dataRetriever.PoolsHolder
+	WhiteListHandler         update.WhiteListHandler
+	WhiteListerVerifiedTxs   update.WhiteListHandler
+	AddressPubkeyConv        core.PubkeyConverter
+	NonceConverter           typeConverters.Uint64ByteSliceConverter
+	ChainID                  []byte
+	ArgumentsParser          process.ArgumentsParser
+	HeaderIntegrityVerifier  process.HeaderIntegrityVerifier
+	RequestHandler           process.RequestHandler
+	SignaturesHandler        process.SignaturesHandler
+	HardforkExclusionHandler common.HardforkExclusionHandler
 }
 
 // NewEpochStartInterceptorsContainer will return a real interceptors container factory, but with many disabled components
@@ -53,6 +54,9 @@ func NewEpochStartInterceptorsContainer(args ArgsEpochStartInterceptorContainer)
 
 	if check.IfNil(args.CoreComponents.AddressPubKeyConverter()) {
 		return nil, epochStart.ErrNilPubkeyConverter
+	}
+	if check.IfNil(args.HardforkExclusionHandler) {
+		return nil, epochStart.ErrNilHardforkExclusionHandler
 	}
 
 	cryptoComponents := args.CryptoComponents.Clone().(process.CryptoComponentsHolder)
@@ -103,6 +107,7 @@ func NewEpochStartInterceptorsContainer(args ArgsEpochStartInterceptorContainer)
 		HeartbeatExpiryTimespanInSec: args.Config.HeartbeatV2.HeartbeatExpiryTimespanInSec,
 		PeerShardMapper:              peerShardMapper,
 		HardforkTrigger:              hardforkTrigger,
+		HardforkExclusionHandler:     args.HardforkExclusionHandler,
 	}
 
 	interceptorsContainerFactory, err := interceptorscontainer.NewMetaInterceptorsContainerFactory(containerFactoryArgs)

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -114,6 +114,7 @@ type epochStartBootstrap struct {
 	checkNodesOnDisk           bool
 	bootstrapHeartbeatSender   update.Closer
 	trieSyncStatisticsProvider common.SizeSyncStatisticsHandler
+	hardforkExclusionHandler   common.HardforkExclusionHandler
 
 	// created components
 	requestHandler            process.RequestHandler
@@ -177,6 +178,7 @@ type ArgsEpochStartBootstrap struct {
 	DataSyncerCreator          types.ScheduledDataSyncerCreator
 	ScheduledSCRsStorer        storage.Storer
 	TrieSyncStatisticsProvider common.SizeSyncStatisticsHandler
+	HardforkExclusionHandler   common.HardforkExclusionHandler
 }
 
 type dataToSync struct {
@@ -222,6 +224,7 @@ func NewEpochStartBootstrap(args ArgsEpochStartBootstrap) (*epochStartBootstrap,
 		storerScheduledSCRs:        args.ScheduledSCRsStorer,
 		shardCoordinator:           args.GenesisShardCoordinator,
 		trieSyncStatisticsProvider: args.TrieSyncStatisticsProvider,
+		hardforkExclusionHandler:   args.HardforkExclusionHandler,
 	}
 
 	whiteListCache, err := storageunit.NewCache(storageFactory.GetCacherFromConfig(epochStartProvider.generalConfig.WhiteListPool))
@@ -534,18 +537,19 @@ func (e *epochStartBootstrap) prepareComponentsToSyncFromNetwork() error {
 func (e *epochStartBootstrap) createSyncers() error {
 	var err error
 	args := factoryInterceptors.ArgsEpochStartInterceptorContainer{
-		CoreComponents:          e.coreComponentsHolder,
-		CryptoComponents:        e.cryptoComponentsHolder,
-		Config:                  e.generalConfig,
-		ShardCoordinator:        e.shardCoordinator,
-		Messenger:               e.messenger,
-		DataPool:                e.dataPool,
-		WhiteListHandler:        e.whiteListHandler,
-		WhiteListerVerifiedTxs:  e.whiteListerVerifiedTxs,
-		ArgumentsParser:         e.argumentsParser,
-		HeaderIntegrityVerifier: e.headerIntegrityVerifier,
-		RequestHandler:          e.requestHandler,
-		SignaturesHandler:       e.messenger,
+		CoreComponents:           e.coreComponentsHolder,
+		CryptoComponents:         e.cryptoComponentsHolder,
+		Config:                   e.generalConfig,
+		ShardCoordinator:         e.shardCoordinator,
+		Messenger:                e.messenger,
+		DataPool:                 e.dataPool,
+		WhiteListHandler:         e.whiteListHandler,
+		WhiteListerVerifiedTxs:   e.whiteListerVerifiedTxs,
+		ArgumentsParser:          e.argumentsParser,
+		HeaderIntegrityVerifier:  e.headerIntegrityVerifier,
+		RequestHandler:           e.requestHandler,
+		SignaturesHandler:        e.messenger,
+		HardforkExclusionHandler: e.hardforkExclusionHandler,
 	}
 
 	e.interceptorContainer, err = factoryInterceptors.NewEpochStartInterceptorsContainer(args)

--- a/epochStart/bootstrap/process_test.go
+++ b/epochStart/bootstrap/process_test.go
@@ -225,6 +225,7 @@ func createMockEpochStartBootstrapArgs(
 			ForceStartFromNetwork: false,
 		},
 		TrieSyncStatisticsProvider: &testscommon.SizeSyncStatisticsHandlerStub{},
+		HardforkExclusionHandler:   &testscommon.HardforkExclusionHandlerStub{},
 	}
 }
 
@@ -582,6 +583,16 @@ func TestNewEpochStartBootstrap_NilArgsChecks(t *testing.T) {
 
 		epochStartProvider, err := NewEpochStartBootstrap(args)
 		assert.Equal(t, storage.ErrNotSupportedCacheType, err)
+		assert.Nil(t, epochStartProvider)
+	})
+	t.Run("nil hardfork exclusion handler should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockEpochStartBootstrapArgs(createComponentsForEpochStart())
+		args.HardforkExclusionHandler = nil
+
+		epochStartProvider, err := NewEpochStartBootstrap(args)
+		require.True(t, errors.Is(err, epochStart.ErrNilHardforkExclusionHandler))
 		assert.Nil(t, epochStartProvider)
 	})
 }

--- a/epochStart/errors.go
+++ b/epochStart/errors.go
@@ -325,3 +325,6 @@ var ErrNilValidatorInfoStorage = errors.New("nil validator info storage")
 
 // ErrNilTrieSyncStatistics signals that nil trie sync statistics has been provided
 var ErrNilTrieSyncStatistics = errors.New("nil trie sync statistics")
+
+// ErrNilHardforkExclusionHandler signals that a nil hardfork exclusion handler was provided
+var ErrNilHardforkExclusionHandler = errors.New("nil hardfork exclusion handler")

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -529,3 +529,6 @@ var ErrNilPersistentHandler = errors.New("nil persistent handler")
 
 // ErrNilGenesisNodesSetupHandler signals that a nil genesis nodes setup handler has been provided
 var ErrNilGenesisNodesSetupHandler = errors.New("nil genesis nodes setup handler")
+
+// ErrNilHardforkExclusionHandler signals that a nil hardfork exclusion handler was provided
+var ErrNilHardforkExclusionHandler = errors.New("nil hardfork exclusion handler")

--- a/factory/bootstrap/bootstrapComponents.go
+++ b/factory/bootstrap/bootstrapComponents.go
@@ -28,28 +28,30 @@ var log = logger.GetOrCreate("factory")
 
 // BootstrapComponentsFactoryArgs holds the arguments needed to create a botstrap components factory
 type BootstrapComponentsFactoryArgs struct {
-	Config               config.Config
-	RoundConfig          config.RoundConfig
-	PrefConfig           config.Preferences
-	ImportDbConfig       config.ImportDbConfig
-	FlagsConfig          config.ContextFlagsConfig
-	WorkingDir           string
-	CoreComponents       factory.CoreComponentsHolder
-	CryptoComponents     factory.CryptoComponentsHolder
-	NetworkComponents    factory.NetworkComponentsHolder
-	StatusCoreComponents factory.StatusCoreComponentsHolder
+	Config                   config.Config
+	RoundConfig              config.RoundConfig
+	PrefConfig               config.Preferences
+	ImportDbConfig           config.ImportDbConfig
+	FlagsConfig              config.ContextFlagsConfig
+	WorkingDir               string
+	CoreComponents           factory.CoreComponentsHolder
+	CryptoComponents         factory.CryptoComponentsHolder
+	NetworkComponents        factory.NetworkComponentsHolder
+	StatusCoreComponents     factory.StatusCoreComponentsHolder
+	HardforkExclusionHandler common.HardforkExclusionHandler
 }
 
 type bootstrapComponentsFactory struct {
-	config               config.Config
-	prefConfig           config.Preferences
-	importDbConfig       config.ImportDbConfig
-	flagsConfig          config.ContextFlagsConfig
-	workingDir           string
-	coreComponents       factory.CoreComponentsHolder
-	cryptoComponents     factory.CryptoComponentsHolder
-	networkComponents    factory.NetworkComponentsHolder
-	statusCoreComponents factory.StatusCoreComponentsHolder
+	config                   config.Config
+	prefConfig               config.Preferences
+	importDbConfig           config.ImportDbConfig
+	flagsConfig              config.ContextFlagsConfig
+	workingDir               string
+	coreComponents           factory.CoreComponentsHolder
+	cryptoComponents         factory.CryptoComponentsHolder
+	networkComponents        factory.NetworkComponentsHolder
+	statusCoreComponents     factory.StatusCoreComponentsHolder
+	hardforkExclusionHandler common.HardforkExclusionHandler
 }
 
 type bootstrapComponents struct {
@@ -88,17 +90,21 @@ func NewBootstrapComponentsFactory(args BootstrapComponentsFactoryArgs) (*bootst
 	if check.IfNil(args.StatusCoreComponents.AppStatusHandler()) {
 		return nil, errors.ErrNilAppStatusHandler
 	}
+	if check.IfNil(args.HardforkExclusionHandler) {
+		return nil, errors.ErrNilHardforkExclusionHandler
+	}
 
 	return &bootstrapComponentsFactory{
-		config:               args.Config,
-		prefConfig:           args.PrefConfig,
-		importDbConfig:       args.ImportDbConfig,
-		flagsConfig:          args.FlagsConfig,
-		workingDir:           args.WorkingDir,
-		coreComponents:       args.CoreComponents,
-		cryptoComponents:     args.CryptoComponents,
-		networkComponents:    args.NetworkComponents,
-		statusCoreComponents: args.StatusCoreComponents,
+		config:                   args.Config,
+		prefConfig:               args.PrefConfig,
+		importDbConfig:           args.ImportDbConfig,
+		flagsConfig:              args.FlagsConfig,
+		workingDir:               args.WorkingDir,
+		coreComponents:           args.CoreComponents,
+		cryptoComponents:         args.CryptoComponents,
+		networkComponents:        args.NetworkComponents,
+		statusCoreComponents:     args.StatusCoreComponents,
+		hardforkExclusionHandler: args.HardforkExclusionHandler,
 	}, nil
 }
 
@@ -201,6 +207,7 @@ func (bcf *bootstrapComponentsFactory) Create() (*bootstrapComponents, error) {
 		DataSyncerCreator:          dataSyncerFactory,
 		ScheduledSCRsStorer:        nil, // will be updated after sync from network
 		TrieSyncStatisticsProvider: tss,
+		HardforkExclusionHandler:   bcf.hardforkExclusionHandler,
 	}
 
 	var epochStartBootstrapper factory.EpochStartBootstrapper

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -141,14 +141,15 @@ type ProcessComponentsFactoryArgs struct {
 	WorkingDir             string
 	HistoryRepo            dblookupext.HistoryRepository
 
-	Data                 factory.DataComponentsHolder
-	CoreData             factory.CoreComponentsHolder
-	Crypto               factory.CryptoComponentsHolder
-	State                factory.StateComponentsHolder
-	Network              factory.NetworkComponentsHolder
-	BootstrapComponents  factory.BootstrapComponentsHolder
-	StatusComponents     factory.StatusComponentsHolder
-	StatusCoreComponents factory.StatusCoreComponentsHolder
+	Data                     factory.DataComponentsHolder
+	CoreData                 factory.CoreComponentsHolder
+	Crypto                   factory.CryptoComponentsHolder
+	State                    factory.StateComponentsHolder
+	Network                  factory.NetworkComponentsHolder
+	BootstrapComponents      factory.BootstrapComponentsHolder
+	StatusComponents         factory.StatusComponentsHolder
+	StatusCoreComponents     factory.StatusCoreComponentsHolder
+	HardforkExclusionHandler common.HardforkExclusionHandler
 }
 
 type processComponentsFactory struct {
@@ -174,14 +175,15 @@ type processComponentsFactory struct {
 	importHandler          update.ImportHandler
 	esdtNftStorage         vmcommon.ESDTNFTStorageHandler
 
-	data                 factory.DataComponentsHolder
-	coreData             factory.CoreComponentsHolder
-	crypto               factory.CryptoComponentsHolder
-	state                factory.StateComponentsHolder
-	network              factory.NetworkComponentsHolder
-	bootstrapComponents  factory.BootstrapComponentsHolder
-	statusComponents     factory.StatusComponentsHolder
-	statusCoreComponents factory.StatusCoreComponentsHolder
+	data                     factory.DataComponentsHolder
+	coreData                 factory.CoreComponentsHolder
+	crypto                   factory.CryptoComponentsHolder
+	state                    factory.StateComponentsHolder
+	network                  factory.NetworkComponentsHolder
+	bootstrapComponents      factory.BootstrapComponentsHolder
+	statusComponents         factory.StatusComponentsHolder
+	statusCoreComponents     factory.StatusCoreComponentsHolder
+	hardforkExclusionHandler common.HardforkExclusionHandler
 }
 
 // NewProcessComponentsFactory will return a new instance of processComponentsFactory
@@ -192,32 +194,33 @@ func NewProcessComponentsFactory(args ProcessComponentsFactoryArgs) (*processCom
 	}
 
 	return &processComponentsFactory{
-		config:                 args.Config,
-		epochConfig:            args.EpochConfig,
-		prefConfigs:            args.PrefConfigs,
-		importDBConfig:         args.ImportDBConfig,
-		accountsParser:         args.AccountsParser,
-		smartContractParser:    args.SmartContractParser,
-		gasSchedule:            args.GasSchedule,
-		nodesCoordinator:       args.NodesCoordinator,
-		data:                   args.Data,
-		coreData:               args.CoreData,
-		crypto:                 args.Crypto,
-		state:                  args.State,
-		network:                args.Network,
-		bootstrapComponents:    args.BootstrapComponents,
-		statusComponents:       args.StatusComponents,
-		requestedItemsHandler:  args.RequestedItemsHandler,
-		whiteListHandler:       args.WhiteListHandler,
-		whiteListerVerifiedTxs: args.WhiteListerVerifiedTxs,
-		maxRating:              args.MaxRating,
-		systemSCConfig:         args.SystemSCConfig,
-		version:                args.Version,
-		importStartHandler:     args.ImportStartHandler,
-		workingDir:             args.WorkingDir,
-		historyRepo:            args.HistoryRepo,
-		epochNotifier:          args.CoreData.EpochNotifier(),
-		statusCoreComponents:   args.StatusCoreComponents,
+		config:                   args.Config,
+		epochConfig:              args.EpochConfig,
+		prefConfigs:              args.PrefConfigs,
+		importDBConfig:           args.ImportDBConfig,
+		accountsParser:           args.AccountsParser,
+		smartContractParser:      args.SmartContractParser,
+		gasSchedule:              args.GasSchedule,
+		nodesCoordinator:         args.NodesCoordinator,
+		data:                     args.Data,
+		coreData:                 args.CoreData,
+		crypto:                   args.Crypto,
+		state:                    args.State,
+		network:                  args.Network,
+		bootstrapComponents:      args.BootstrapComponents,
+		statusComponents:         args.StatusComponents,
+		requestedItemsHandler:    args.RequestedItemsHandler,
+		whiteListHandler:         args.WhiteListHandler,
+		whiteListerVerifiedTxs:   args.WhiteListerVerifiedTxs,
+		maxRating:                args.MaxRating,
+		systemSCConfig:           args.SystemSCConfig,
+		version:                  args.Version,
+		importStartHandler:       args.ImportStartHandler,
+		workingDir:               args.WorkingDir,
+		historyRepo:              args.HistoryRepo,
+		epochNotifier:            args.CoreData.EpochNotifier(),
+		statusCoreComponents:     args.StatusCoreComponents,
+		hardforkExclusionHandler: args.HardforkExclusionHandler,
 	}, nil
 }
 
@@ -1585,6 +1588,7 @@ func (pcf *processComponentsFactory) newShardInterceptorContainerFactory(
 		HeartbeatExpiryTimespanInSec: pcf.config.HeartbeatV2.HeartbeatExpiryTimespanInSec,
 		PeerShardMapper:              peerShardMapper,
 		HardforkTrigger:              hardforkTrigger,
+		HardforkExclusionHandler:     pcf.hardforkExclusionHandler,
 	}
 
 	interceptorContainerFactory, err := interceptorscontainer.NewShardInterceptorsContainerFactory(shardInterceptorsContainerFactoryArgs)
@@ -1633,6 +1637,7 @@ func (pcf *processComponentsFactory) newMetaInterceptorContainerFactory(
 		HeartbeatExpiryTimespanInSec: pcf.config.HeartbeatV2.HeartbeatExpiryTimespanInSec,
 		PeerShardMapper:              peerShardMapper,
 		HardforkTrigger:              hardforkTrigger,
+		HardforkExclusionHandler:     pcf.hardforkExclusionHandler,
 	}
 
 	interceptorContainerFactory, err := interceptorscontainer.NewMetaInterceptorsContainerFactory(metaInterceptorsContainerFactoryArgs)
@@ -1730,6 +1735,7 @@ func (pcf *processComponentsFactory) createExportFactoryHandler(
 		NumConcurrentTrieSyncers:  pcf.config.TrieSync.NumConcurrentTrieSyncers,
 		TrieSyncerVersion:         pcf.config.TrieSync.TrieSyncerVersion,
 		PeersRatingHandler:        pcf.network.PeersRatingHandler(),
+		HardforkExclusionHandler:  pcf.hardforkExclusionHandler,
 	}
 	return updateFactory.NewExportHandlerFactory(argsExporter)
 }
@@ -1882,6 +1888,9 @@ func checkProcessComponentsArgs(args ProcessComponentsFactoryArgs) error {
 	}
 	if check.IfNil(args.StatusCoreComponents.AppStatusHandler()) {
 		return fmt.Errorf("%s: %w", baseErrMessage, errErd.ErrNilAppStatusHandler)
+	}
+	if check.IfNil(args.HardforkExclusionHandler) {
+		return fmt.Errorf("%s: %w", baseErrMessage, errErd.ErrNilHardforkExclusionHandler)
 	}
 
 	return nil

--- a/integrationTests/factory/bootstrapComponents/bootstrapComponents_test.go
+++ b/integrationTests/factory/bootstrapComponents/bootstrapComponents_test.go
@@ -38,7 +38,13 @@ func TestBootstrapComponents_Create_Close_ShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	managedNetworkComponents, err := nr.CreateManagedNetworkComponents(managedCoreComponents, managedStatusCoreComponents)
 	require.Nil(t, err)
-	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents, &testscommon.HardforkExclusionHandlerStub{})
+	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(
+		managedStatusCoreComponents,
+		managedCoreComponents,
+		managedCryptoComponents,
+		managedNetworkComponents,
+		&testscommon.HardforkExclusionHandlerStub{},
+	)
 	require.Nil(t, err)
 	require.NotNil(t, managedBootstrapComponents)
 

--- a/integrationTests/factory/bootstrapComponents/bootstrapComponents_test.go
+++ b/integrationTests/factory/bootstrapComponents/bootstrapComponents_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/endProcess"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/factory"
 	"github.com/ElrondNetwork/elrond-go/node"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/goroutines"
 	"github.com/stretchr/testify/require"
 )
@@ -37,7 +38,7 @@ func TestBootstrapComponents_Create_Close_ShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	managedNetworkComponents, err := nr.CreateManagedNetworkComponents(managedCoreComponents, managedStatusCoreComponents)
 	require.Nil(t, err)
-	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents)
+	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents, &testscommon.HardforkExclusionHandlerStub{})
 	require.Nil(t, err)
 	require.NotNil(t, managedBootstrapComponents)
 

--- a/integrationTests/factory/consensusComponents/consensusComponents_test.go
+++ b/integrationTests/factory/consensusComponents/consensusComponents_test.go
@@ -11,6 +11,7 @@ import (
 	bootstrapComp "github.com/ElrondNetwork/elrond-go/factory/bootstrap"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/factory"
 	"github.com/ElrondNetwork/elrond-go/node"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/goroutines"
 	"github.com/stretchr/testify/require"
 )
@@ -40,7 +41,7 @@ func TestConsensusComponents_Close_ShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	managedNetworkComponents, err := nr.CreateManagedNetworkComponents(managedCoreComponents, managedStatusCoreComponents)
 	require.Nil(t, err)
-	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents)
+	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents, &testscommon.HardforkExclusionHandlerStub{})
 	require.Nil(t, err)
 	managedDataComponents, err := nr.CreateManagedDataComponents(managedStatusCoreComponents, managedCoreComponents, managedBootstrapComponents)
 	require.Nil(t, err)
@@ -102,6 +103,7 @@ func TestConsensusComponents_Close_ShouldWork(t *testing.T) {
 		managedStatusCoreComponents,
 		gasScheduleNotifier,
 		nodesCoordinator,
+		&testscommon.HardforkExclusionHandlerStub{},
 	)
 	require.Nil(t, err)
 	time.Sleep(2 * time.Second)

--- a/integrationTests/factory/consensusComponents/consensusComponents_test.go
+++ b/integrationTests/factory/consensusComponents/consensusComponents_test.go
@@ -41,7 +41,13 @@ func TestConsensusComponents_Close_ShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	managedNetworkComponents, err := nr.CreateManagedNetworkComponents(managedCoreComponents, managedStatusCoreComponents)
 	require.Nil(t, err)
-	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents, &testscommon.HardforkExclusionHandlerStub{})
+	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(
+		managedStatusCoreComponents,
+		managedCoreComponents,
+		managedCryptoComponents,
+		managedNetworkComponents,
+		&testscommon.HardforkExclusionHandlerStub{},
+	)
 	require.Nil(t, err)
 	managedDataComponents, err := nr.CreateManagedDataComponents(managedStatusCoreComponents, managedCoreComponents, managedBootstrapComponents)
 	require.Nil(t, err)

--- a/integrationTests/factory/dataComponents/dataComponents_test.go
+++ b/integrationTests/factory/dataComponents/dataComponents_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/endProcess"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/factory"
 	"github.com/ElrondNetwork/elrond-go/node"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/goroutines"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +34,7 @@ func TestDataComponents_Create_Close_ShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	managedNetworkComponents, err := nr.CreateManagedNetworkComponents(managedCoreComponents, managedStatusCoreComponents)
 	require.Nil(t, err)
-	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents)
+	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents, &testscommon.HardforkExclusionHandlerStub{})
 	require.Nil(t, err)
 	managedDataComponents, err := nr.CreateManagedDataComponents(managedStatusCoreComponents, managedCoreComponents, managedBootstrapComponents)
 	require.Nil(t, err)

--- a/integrationTests/factory/dataComponents/dataComponents_test.go
+++ b/integrationTests/factory/dataComponents/dataComponents_test.go
@@ -34,7 +34,13 @@ func TestDataComponents_Create_Close_ShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	managedNetworkComponents, err := nr.CreateManagedNetworkComponents(managedCoreComponents, managedStatusCoreComponents)
 	require.Nil(t, err)
-	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents, &testscommon.HardforkExclusionHandlerStub{})
+	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(
+		managedStatusCoreComponents,
+		managedCoreComponents,
+		managedCryptoComponents,
+		managedNetworkComponents,
+		&testscommon.HardforkExclusionHandlerStub{},
+	)
 	require.Nil(t, err)
 	managedDataComponents, err := nr.CreateManagedDataComponents(managedStatusCoreComponents, managedCoreComponents, managedBootstrapComponents)
 	require.Nil(t, err)

--- a/integrationTests/factory/heartbeatComponents/heartbeatComponents_test.go
+++ b/integrationTests/factory/heartbeatComponents/heartbeatComponents_test.go
@@ -41,7 +41,13 @@ func TestHeartbeatComponents_Close_ShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	managedNetworkComponents, err := nr.CreateManagedNetworkComponents(managedCoreComponents, managedStatusCoreComponents)
 	require.Nil(t, err)
-	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents, &testscommon.HardforkExclusionHandlerStub{})
+	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(
+		managedStatusCoreComponents,
+		managedCoreComponents,
+		managedCryptoComponents,
+		managedNetworkComponents,
+		&testscommon.HardforkExclusionHandlerStub{},
+	)
 	require.Nil(t, err)
 	managedDataComponents, err := nr.CreateManagedDataComponents(managedStatusCoreComponents, managedCoreComponents, managedBootstrapComponents)
 	require.Nil(t, err)

--- a/integrationTests/factory/heartbeatComponents/heartbeatComponents_test.go
+++ b/integrationTests/factory/heartbeatComponents/heartbeatComponents_test.go
@@ -11,6 +11,7 @@ import (
 	bootstrapComp "github.com/ElrondNetwork/elrond-go/factory/bootstrap"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/factory"
 	"github.com/ElrondNetwork/elrond-go/node"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/goroutines"
 	"github.com/stretchr/testify/require"
 )
@@ -40,7 +41,7 @@ func TestHeartbeatComponents_Close_ShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	managedNetworkComponents, err := nr.CreateManagedNetworkComponents(managedCoreComponents, managedStatusCoreComponents)
 	require.Nil(t, err)
-	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents)
+	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents, &testscommon.HardforkExclusionHandlerStub{})
 	require.Nil(t, err)
 	managedDataComponents, err := nr.CreateManagedDataComponents(managedStatusCoreComponents, managedCoreComponents, managedBootstrapComponents)
 	require.Nil(t, err)
@@ -102,6 +103,7 @@ func TestHeartbeatComponents_Close_ShouldWork(t *testing.T) {
 		managedStatusCoreComponents,
 		gasScheduleNotifier,
 		nodesCoordinator,
+		&testscommon.HardforkExclusionHandlerStub{},
 	)
 	require.Nil(t, err)
 	time.Sleep(2 * time.Second)

--- a/integrationTests/factory/processComponents/processComponents_test.go
+++ b/integrationTests/factory/processComponents/processComponents_test.go
@@ -11,6 +11,7 @@ import (
 	bootstrapComp "github.com/ElrondNetwork/elrond-go/factory/bootstrap"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/factory"
 	"github.com/ElrondNetwork/elrond-go/node"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/goroutines"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +42,7 @@ func TestProcessComponents_Close_ShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	managedNetworkComponents, err := nr.CreateManagedNetworkComponents(managedCoreComponents, managedStatusCoreComponents)
 	require.Nil(t, err)
-	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents)
+	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents, &testscommon.HardforkExclusionHandlerStub{})
 	require.Nil(t, err)
 	managedDataComponents, err := nr.CreateManagedDataComponents(managedStatusCoreComponents, managedCoreComponents, managedBootstrapComponents)
 	require.Nil(t, err)
@@ -101,6 +102,7 @@ func TestProcessComponents_Close_ShouldWork(t *testing.T) {
 		managedStatusCoreComponents,
 		gasScheduleNotifier,
 		nodesCoordinator,
+		&testscommon.HardforkExclusionHandlerStub{},
 	)
 	require.Nil(t, err)
 	require.NotNil(t, managedProcessComponents)

--- a/integrationTests/factory/processComponents/processComponents_test.go
+++ b/integrationTests/factory/processComponents/processComponents_test.go
@@ -42,7 +42,13 @@ func TestProcessComponents_Close_ShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	managedNetworkComponents, err := nr.CreateManagedNetworkComponents(managedCoreComponents, managedStatusCoreComponents)
 	require.Nil(t, err)
-	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents, &testscommon.HardforkExclusionHandlerStub{})
+	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(
+		managedStatusCoreComponents,
+		managedCoreComponents,
+		managedCryptoComponents,
+		managedNetworkComponents,
+		&testscommon.HardforkExclusionHandlerStub{},
+	)
 	require.Nil(t, err)
 	managedDataComponents, err := nr.CreateManagedDataComponents(managedStatusCoreComponents, managedCoreComponents, managedBootstrapComponents)
 	require.Nil(t, err)

--- a/integrationTests/factory/stateComponents/stateComponents_test.go
+++ b/integrationTests/factory/stateComponents/stateComponents_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/endProcess"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/factory"
 	"github.com/ElrondNetwork/elrond-go/node"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/goroutines"
 	"github.com/stretchr/testify/require"
 )
@@ -37,7 +38,7 @@ func TestStateComponents_Create_Close_ShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	managedNetworkComponents, err := nr.CreateManagedNetworkComponents(managedCoreComponents, managedStatusCoreComponents)
 	require.Nil(t, err)
-	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents)
+	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents, &testscommon.HardforkExclusionHandlerStub{})
 	require.Nil(t, err)
 	managedDataComponents, err := nr.CreateManagedDataComponents(managedStatusCoreComponents, managedCoreComponents, managedBootstrapComponents)
 	require.Nil(t, err)

--- a/integrationTests/factory/stateComponents/stateComponents_test.go
+++ b/integrationTests/factory/stateComponents/stateComponents_test.go
@@ -38,7 +38,13 @@ func TestStateComponents_Create_Close_ShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	managedNetworkComponents, err := nr.CreateManagedNetworkComponents(managedCoreComponents, managedStatusCoreComponents)
 	require.Nil(t, err)
-	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents, &testscommon.HardforkExclusionHandlerStub{})
+	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(
+		managedStatusCoreComponents,
+		managedCoreComponents,
+		managedCryptoComponents,
+		managedNetworkComponents,
+		&testscommon.HardforkExclusionHandlerStub{},
+	)
 	require.Nil(t, err)
 	managedDataComponents, err := nr.CreateManagedDataComponents(managedStatusCoreComponents, managedCoreComponents, managedBootstrapComponents)
 	require.Nil(t, err)

--- a/integrationTests/factory/statusComponents/statusComponents_test.go
+++ b/integrationTests/factory/statusComponents/statusComponents_test.go
@@ -42,7 +42,13 @@ func TestStatusComponents_Create_Close_ShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	managedNetworkComponents, err := nr.CreateManagedNetworkComponents(managedCoreComponents, managedStatusCoreComponents)
 	require.Nil(t, err)
-	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents, &testscommon.HardforkExclusionHandlerStub{})
+	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(
+		managedStatusCoreComponents,
+		managedCoreComponents,
+		managedCryptoComponents,
+		managedNetworkComponents,
+		&testscommon.HardforkExclusionHandlerStub{},
+	)
 	require.Nil(t, err)
 	managedDataComponents, err := nr.CreateManagedDataComponents(managedStatusCoreComponents, managedCoreComponents, managedBootstrapComponents)
 	require.Nil(t, err)

--- a/integrationTests/factory/statusComponents/statusComponents_test.go
+++ b/integrationTests/factory/statusComponents/statusComponents_test.go
@@ -11,6 +11,7 @@ import (
 	bootstrapComp "github.com/ElrondNetwork/elrond-go/factory/bootstrap"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/factory"
 	"github.com/ElrondNetwork/elrond-go/node"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/goroutines"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +42,7 @@ func TestStatusComponents_Create_Close_ShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	managedNetworkComponents, err := nr.CreateManagedNetworkComponents(managedCoreComponents, managedStatusCoreComponents)
 	require.Nil(t, err)
-	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents)
+	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents, &testscommon.HardforkExclusionHandlerStub{})
 	require.Nil(t, err)
 	managedDataComponents, err := nr.CreateManagedDataComponents(managedStatusCoreComponents, managedCoreComponents, managedBootstrapComponents)
 	require.Nil(t, err)
@@ -103,6 +104,7 @@ func TestStatusComponents_Create_Close_ShouldWork(t *testing.T) {
 		managedStatusCoreComponents,
 		gasScheduleNotifier,
 		nodesCoordinator,
+		&testscommon.HardforkExclusionHandlerStub{},
 	)
 	require.Nil(t, err)
 	time.Sleep(2 * time.Second)

--- a/integrationTests/multiShard/endOfEpoch/startInEpoch/startInEpoch_test.go
+++ b/integrationTests/multiShard/endOfEpoch/startInEpoch/startInEpoch_test.go
@@ -259,6 +259,7 @@ func testNodeStartsInEpoch(t *testing.T, shardID uint32, expectedHighestRound ui
 			ForceStartFromNetwork: false,
 		},
 		TrieSyncStatisticsProvider: &testscommon.SizeSyncStatisticsHandlerStub{},
+		HardforkExclusionHandler:   &testscommon.HardforkExclusionHandlerStub{},
 	}
 
 	epochStartBootstrap, err := bootstrap.NewEpochStartBootstrap(argsBootstrapHandler)

--- a/integrationTests/multiShard/hardFork/hardFork_test.go
+++ b/integrationTests/multiShard/hardFork/hardFork_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/integrationTests/vm/arwen"
 	vmFactory "github.com/ElrondNetwork/elrond-go/process/factory"
 	"github.com/ElrondNetwork/elrond-go/state"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/cryptoMocks"
 	factoryTests "github.com/ElrondNetwork/elrond-go/testscommon/factory"
 	"github.com/ElrondNetwork/elrond-go/testscommon/genesisMocks"
@@ -629,6 +630,7 @@ func createHardForkExporter(
 			TrieSyncerVersion:         2,
 			PeersRatingHandler:        node.PeersRatingHandler,
 			CheckNodesOnDisk:          false,
+			HardforkExclusionHandler:  &testscommon.HardforkExclusionHandlerStub{},
 		}
 
 		exportHandler, err := factory.NewExportHandlerFactory(argsExportHandler)

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -1153,6 +1153,7 @@ func (tpn *TestProcessorNode) initInterceptors(heartbeatPk string) {
 			HeartbeatExpiryTimespanInSec: 30,
 			PeerShardMapper:              tpn.PeerShardMapper,
 			HardforkTrigger:              tpn.HardforkTrigger,
+			HardforkExclusionHandler:     &testscommon.HardforkExclusionHandlerStub{},
 		}
 		interceptorContainerFactory, _ := interceptorscontainer.NewMetaInterceptorsContainerFactory(metaInterceptorContainerFactoryArgs)
 
@@ -1218,6 +1219,7 @@ func (tpn *TestProcessorNode) initInterceptors(heartbeatPk string) {
 			HeartbeatExpiryTimespanInSec: 30,
 			PeerShardMapper:              tpn.PeerShardMapper,
 			HardforkTrigger:              tpn.HardforkTrigger,
+			HardforkExclusionHandler:     &testscommon.HardforkExclusionHandlerStub{},
 		}
 		interceptorContainerFactory, _ := interceptorscontainer.NewShardInterceptorsContainerFactory(shardIntereptorContainerFactoryArgs)
 

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -311,7 +311,13 @@ func (nr *nodeRunner) executeOneComponentCreationCycle(
 	}
 
 	log.Debug("creating bootstrap components")
-	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(managedStatusCoreComponents, managedCoreComponents, managedCryptoComponents, managedNetworkComponents, hardforkExclusionHandler)
+	managedBootstrapComponents, err := nr.CreateManagedBootstrapComponents(
+		managedStatusCoreComponents,
+		managedCoreComponents,
+		managedCryptoComponents,
+		managedNetworkComponents,
+		hardforkExclusionHandler,
+	)
 	if err != nil {
 		return true, err
 	}

--- a/process/errors.go
+++ b/process/errors.go
@@ -1145,3 +1145,9 @@ var ErrPropertyTooShort = errors.New("property too short")
 
 // ErrNilProcessDebugger signals that a nil process debugger was provided
 var ErrNilProcessDebugger = errors.New("nil process debugger")
+
+// ErrNilHardforkExclusionHandler signals that a nil hardfork exclusion handler was provided
+var ErrNilHardforkExclusionHandler = errors.New("nil hardfork exclusion handler")
+
+// ErrExcludedHeader signals that the received header is excluded
+var ErrExcludedHeader = errors.New("excluded header")

--- a/process/factory/interceptorscontainer/args.go
+++ b/process/factory/interceptorscontainer/args.go
@@ -2,6 +2,7 @@ package interceptorscontainer
 
 import (
 	crypto "github.com/ElrondNetwork/elrond-go-crypto"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/heartbeat"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -39,4 +40,5 @@ type CommonInterceptorsContainerFactoryArgs struct {
 	HeartbeatExpiryTimespanInSec int64
 	PeerShardMapper              process.PeerShardMapper
 	HardforkTrigger              heartbeat.HardforkTrigger
+	HardforkExclusionHandler     common.HardforkExclusionHandler
 }

--- a/process/factory/interceptorscontainer/metaInterceptorsContainerFactory.go
+++ b/process/factory/interceptorscontainer/metaInterceptorsContainerFactory.go
@@ -41,6 +41,7 @@ func NewMetaInterceptorsContainerFactory(
 		args.RequestHandler,
 		args.PeerShardMapper,
 		args.HardforkTrigger,
+		args.HardforkExclusionHandler,
 	)
 	if err != nil {
 		return nil, err
@@ -101,24 +102,25 @@ func NewMetaInterceptorsContainerFactory(
 
 	container := containers.NewInterceptorsContainer()
 	base := &baseInterceptorsContainerFactory{
-		container:              container,
-		shardCoordinator:       args.ShardCoordinator,
-		messenger:              args.Messenger,
-		store:                  args.Store,
-		dataPool:               args.DataPool,
-		nodesCoordinator:       args.NodesCoordinator,
-		blockBlackList:         args.BlockBlackList,
-		argInterceptorFactory:  argInterceptorFactory,
-		maxTxNonceDeltaAllowed: args.MaxTxNonceDeltaAllowed,
-		accounts:               args.Accounts,
-		antifloodHandler:       args.AntifloodHandler,
-		whiteListHandler:       args.WhiteListHandler,
-		whiteListerVerifiedTxs: args.WhiteListerVerifiedTxs,
-		preferredPeersHolder:   args.PreferredPeersHolder,
-		hasher:                 args.CoreComponents.Hasher(),
-		requestHandler:         args.RequestHandler,
-		peerShardMapper:        args.PeerShardMapper,
-		hardforkTrigger:        args.HardforkTrigger,
+		container:                container,
+		shardCoordinator:         args.ShardCoordinator,
+		messenger:                args.Messenger,
+		store:                    args.Store,
+		dataPool:                 args.DataPool,
+		nodesCoordinator:         args.NodesCoordinator,
+		blockBlackList:           args.BlockBlackList,
+		argInterceptorFactory:    argInterceptorFactory,
+		maxTxNonceDeltaAllowed:   args.MaxTxNonceDeltaAllowed,
+		accounts:                 args.Accounts,
+		antifloodHandler:         args.AntifloodHandler,
+		whiteListHandler:         args.WhiteListHandler,
+		whiteListerVerifiedTxs:   args.WhiteListerVerifiedTxs,
+		preferredPeersHolder:     args.PreferredPeersHolder,
+		hasher:                   args.CoreComponents.Hasher(),
+		requestHandler:           args.RequestHandler,
+		peerShardMapper:          args.PeerShardMapper,
+		hardforkTrigger:          args.HardforkTrigger,
+		hardforkExclusionHandler: args.HardforkExclusionHandler,
 	}
 
 	icf := &metaInterceptorsContainerFactory{
@@ -248,8 +250,9 @@ func (micf *metaInterceptorsContainerFactory) createOneShardHeaderInterceptor(to
 	}
 
 	argProcessor := &processor.ArgHdrInterceptorProcessor{
-		Headers:        micf.dataPool.Headers(),
-		BlockBlackList: micf.blockBlackList,
+		Headers:                  micf.dataPool.Headers(),
+		BlockBlackList:           micf.blockBlackList,
+		HardforkExclusionHandler: micf.hardforkExclusionHandler,
 	}
 	hdrProcessor, err := processor.NewHdrInterceptorProcessor(argProcessor)
 	if err != nil {

--- a/process/factory/interceptorscontainer/metaInterceptorsContainerFactory_test.go
+++ b/process/factory/interceptorscontainer/metaInterceptorsContainerFactory_test.go
@@ -443,6 +443,18 @@ func TestNewMetaInterceptorsContainerFactory_NilHardforkTriggerShouldErr(t *test
 	assert.Equal(t, process.ErrNilHardforkTrigger, err)
 }
 
+func TestNewMetaInterceptorsContainerFactory_NilHardforkExclusionHandlerShouldErr(t *testing.T) {
+	t.Parallel()
+
+	coreComp, cryptoComp := createMockComponentHolders()
+	args := getArgumentsMeta(coreComp, cryptoComp)
+	args.HardforkExclusionHandler = nil
+	icf, err := interceptorscontainer.NewMetaInterceptorsContainerFactory(args)
+
+	assert.Nil(t, icf)
+	assert.Equal(t, process.ErrNilHardforkExclusionHandler, err)
+}
+
 func TestNewMetaInterceptorsContainerFactory_ShouldWork(t *testing.T) {
 	t.Parallel()
 
@@ -648,5 +660,6 @@ func getArgumentsMeta(
 		HeartbeatExpiryTimespanInSec: 30,
 		PeerShardMapper:              &p2pmocks.NetworkShardingCollectorStub{},
 		HardforkTrigger:              &testscommon.HardforkTriggerStub{},
+		HardforkExclusionHandler:     &testscommon.HardforkExclusionHandlerStub{},
 	}
 }

--- a/process/factory/interceptorscontainer/shardInterceptorsContainerFactory.go
+++ b/process/factory/interceptorscontainer/shardInterceptorsContainerFactory.go
@@ -39,6 +39,7 @@ func NewShardInterceptorsContainerFactory(
 		args.RequestHandler,
 		args.PeerShardMapper,
 		args.HardforkTrigger,
+		args.HardforkExclusionHandler,
 	)
 	if err != nil {
 		return nil, err
@@ -100,24 +101,25 @@ func NewShardInterceptorsContainerFactory(
 
 	container := containers.NewInterceptorsContainer()
 	base := &baseInterceptorsContainerFactory{
-		container:              container,
-		accounts:               args.Accounts,
-		shardCoordinator:       args.ShardCoordinator,
-		messenger:              args.Messenger,
-		store:                  args.Store,
-		dataPool:               args.DataPool,
-		nodesCoordinator:       args.NodesCoordinator,
-		argInterceptorFactory:  argInterceptorFactory,
-		blockBlackList:         args.BlockBlackList,
-		maxTxNonceDeltaAllowed: args.MaxTxNonceDeltaAllowed,
-		antifloodHandler:       args.AntifloodHandler,
-		whiteListHandler:       args.WhiteListHandler,
-		whiteListerVerifiedTxs: args.WhiteListerVerifiedTxs,
-		preferredPeersHolder:   args.PreferredPeersHolder,
-		hasher:                 args.CoreComponents.Hasher(),
-		requestHandler:         args.RequestHandler,
-		peerShardMapper:        args.PeerShardMapper,
-		hardforkTrigger:        args.HardforkTrigger,
+		container:                container,
+		accounts:                 args.Accounts,
+		shardCoordinator:         args.ShardCoordinator,
+		messenger:                args.Messenger,
+		store:                    args.Store,
+		dataPool:                 args.DataPool,
+		nodesCoordinator:         args.NodesCoordinator,
+		argInterceptorFactory:    argInterceptorFactory,
+		blockBlackList:           args.BlockBlackList,
+		maxTxNonceDeltaAllowed:   args.MaxTxNonceDeltaAllowed,
+		antifloodHandler:         args.AntifloodHandler,
+		whiteListHandler:         args.WhiteListHandler,
+		whiteListerVerifiedTxs:   args.WhiteListerVerifiedTxs,
+		preferredPeersHolder:     args.PreferredPeersHolder,
+		hasher:                   args.CoreComponents.Hasher(),
+		requestHandler:           args.RequestHandler,
+		peerShardMapper:          args.PeerShardMapper,
+		hardforkTrigger:          args.HardforkTrigger,
+		hardforkExclusionHandler: args.HardforkExclusionHandler,
 	}
 
 	icf := &shardInterceptorsContainerFactory{

--- a/process/factory/interceptorscontainer/shardInterceptorsContainerFactory_test.go
+++ b/process/factory/interceptorscontainer/shardInterceptorsContainerFactory_test.go
@@ -401,6 +401,18 @@ func TestNewShardInterceptorsContainerFactory_NilHardforkTriggerShouldErr(t *tes
 	assert.Equal(t, process.ErrNilHardforkTrigger, err)
 }
 
+func TestNewShardInterceptorsContainerFactory_NilHardforkExclusionHandlerShouldErr(t *testing.T) {
+	t.Parallel()
+
+	coreComp, cryptoComp := createMockComponentHolders()
+	args := getArgumentsShard(coreComp, cryptoComp)
+	args.HardforkExclusionHandler = nil
+	icf, err := interceptorscontainer.NewShardInterceptorsContainerFactory(args)
+
+	assert.Nil(t, icf)
+	assert.Equal(t, process.ErrNilHardforkExclusionHandler, err)
+}
+
 func TestNewShardInterceptorsContainerFactory_ShouldWork(t *testing.T) {
 	t.Parallel()
 
@@ -731,5 +743,6 @@ func getArgumentsShard(
 		HeartbeatExpiryTimespanInSec: 30,
 		PeerShardMapper:              &p2pmocks.NetworkShardingCollectorStub{},
 		HardforkTrigger:              &testscommon.HardforkTriggerStub{},
+		HardforkExclusionHandler:     &testscommon.HardforkExclusionHandlerStub{},
 	}
 }

--- a/process/interceptors/processor/argHdrInterceptorProcessor.go
+++ b/process/interceptors/processor/argHdrInterceptorProcessor.go
@@ -1,12 +1,14 @@
 package processor
 
 import (
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/process"
 )
 
 // ArgHdrInterceptorProcessor is the argument for the interceptor processor used for headers (shard, meta and so on)
 type ArgHdrInterceptorProcessor struct {
-	Headers        dataRetriever.HeadersPool
-	BlockBlackList process.TimeCacher
+	Headers                  dataRetriever.HeadersPool
+	BlockBlackList           process.TimeCacher
+	HardforkExclusionHandler common.HardforkExclusionHandler
 }

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -400,6 +400,7 @@ func GetBootStrapFactoryArgs() bootstrapComp.BootstrapComponentsFactoryArgs {
 		FlagsConfig: config.ContextFlagsConfig{
 			ForceStartFromNetwork: false,
 		},
+		HardforkExclusionHandler: &testscommon.HardforkExclusionHandlerStub{},
 	}
 }
 
@@ -561,8 +562,9 @@ func GetProcessArgs(
 				MaxServiceFee: 100,
 			},
 		},
-		Version:     "v1.0.0",
-		HistoryRepo: &dblookupext.HistoryRepositoryStub{},
+		Version:                  "v1.0.0",
+		HistoryRepo:              &dblookupext.HistoryRepositoryStub{},
+		HardforkExclusionHandler: &testscommon.HardforkExclusionHandlerStub{},
 	}
 }
 

--- a/testscommon/headerHandlerStub.go
+++ b/testscommon/headerHandlerStub.go
@@ -11,6 +11,7 @@ import (
 type HeaderHandlerStub struct {
 	EpochField                             uint32
 	TimestampField                         uint64
+	RoundField                             uint64
 	GetMiniBlockHeadersWithDstCalled       func(destId uint32) map[string]uint32
 	GetOrderedCrossMiniblocksWithDstCalled func(destId uint32) []*data.MiniBlockInfo
 	GetPubKeysBitmapCalled                 func() []byte
@@ -92,7 +93,7 @@ func (hhs *HeaderHandlerStub) GetEpoch() uint32 {
 
 // GetRound -
 func (hhs *HeaderHandlerStub) GetRound() uint64 {
-	return 1
+	return hhs.RoundField
 }
 
 // GetTimeStamp -

--- a/update/errors.go
+++ b/update/errors.go
@@ -286,3 +286,6 @@ var ErrNilStatusCoreComponentsHolder = errors.New("nil status core components ho
 
 // ErrNilAppStatusHandler signals that a nil app status handler was provided
 var ErrNilAppStatusHandler = errors.New("nil app status handler")
+
+// ErrNilHardforkExclusionHandler signals that a nil hardfork exclusion handler was provided
+var ErrNilHardforkExclusionHandler = errors.New("nil hardfork exclusion handler")


### PR DESCRIPTION
## Reasoning behind the pull request
- integrate HardforkExclusionHandler into interceptor in order to not validate headers from excluded intervals
  
## Proposed changes
- integrated HardforkExclusionHandler

## Testing procedure
- will be tested on feat branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
