### PR TITLE
HardforkExclusionHandler into shouldAllowRollback

### DIFF
--- a/common/hardfork/hardforkExclusionHandler.go
+++ b/common/hardfork/hardforkExclusionHandler.go
@@ -26,6 +26,11 @@ func (handler *hardforkExclusionHandler) IsRoundExcluded(round uint64) bool {
 	return handler.tree.Contains(round)
 }
 
+// IsRollbackForbidden returns true if the provided round is left margin of any interval
+func (handler *hardforkExclusionHandler) IsRollbackForbidden(round uint64) bool {
+	return handler.tree.IsLeftMargin(round)
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (handler *hardforkExclusionHandler) IsInterfaceNil() bool {
 	return handler == nil

--- a/common/interface.go
+++ b/common/interface.go
@@ -339,5 +339,6 @@ type EnableEpochsHandler interface {
 // HardforkExclusionHandler defines what a hardfork exclusion handler can do
 type HardforkExclusionHandler interface {
 	IsRoundExcluded(round uint64) bool
+	IsRollbackForbidden(round uint64) bool
 	IsInterfaceNil() bool
 }

--- a/factory/consensus/consensusComponents.go
+++ b/factory/consensus/consensusComponents.go
@@ -34,35 +34,37 @@ var log = logger.GetOrCreate("factory")
 
 // ConsensusComponentsFactoryArgs holds the arguments needed to create a consensus components factory
 type ConsensusComponentsFactoryArgs struct {
-	Config                config.Config
-	BootstrapRoundIndex   uint64
-	CoreComponents        factory.CoreComponentsHolder
-	NetworkComponents     factory.NetworkComponentsHolder
-	CryptoComponents      factory.CryptoComponentsHolder
-	DataComponents        factory.DataComponentsHolder
-	ProcessComponents     factory.ProcessComponentsHolder
-	StateComponents       factory.StateComponentsHolder
-	StatusComponents      factory.StatusComponentsHolder
-	StatusCoreComponents  factory.StatusCoreComponentsHolder
-	ScheduledProcessor    consensus.ScheduledProcessor
-	IsInImportMode        bool
-	ShouldDisableWatchdog bool
+	Config                   config.Config
+	BootstrapRoundIndex      uint64
+	CoreComponents           factory.CoreComponentsHolder
+	NetworkComponents        factory.NetworkComponentsHolder
+	CryptoComponents         factory.CryptoComponentsHolder
+	DataComponents           factory.DataComponentsHolder
+	ProcessComponents        factory.ProcessComponentsHolder
+	StateComponents          factory.StateComponentsHolder
+	StatusComponents         factory.StatusComponentsHolder
+	StatusCoreComponents     factory.StatusCoreComponentsHolder
+	ScheduledProcessor       consensus.ScheduledProcessor
+	IsInImportMode           bool
+	ShouldDisableWatchdog    bool
+	HardforkExclusionHandler common.HardforkExclusionHandler
 }
 
 type consensusComponentsFactory struct {
-	config                config.Config
-	bootstrapRoundIndex   uint64
-	coreComponents        factory.CoreComponentsHolder
-	networkComponents     factory.NetworkComponentsHolder
-	cryptoComponents      factory.CryptoComponentsHolder
-	dataComponents        factory.DataComponentsHolder
-	processComponents     factory.ProcessComponentsHolder
-	stateComponents       factory.StateComponentsHolder
-	statusComponents      factory.StatusComponentsHolder
-	statusCoreComponents  factory.StatusCoreComponentsHolder
-	scheduledProcessor    consensus.ScheduledProcessor
-	isInImportMode        bool
-	shouldDisableWatchdog bool
+	config                   config.Config
+	bootstrapRoundIndex      uint64
+	coreComponents           factory.CoreComponentsHolder
+	networkComponents        factory.NetworkComponentsHolder
+	cryptoComponents         factory.CryptoComponentsHolder
+	dataComponents           factory.DataComponentsHolder
+	processComponents        factory.ProcessComponentsHolder
+	stateComponents          factory.StateComponentsHolder
+	statusComponents         factory.StatusComponentsHolder
+	statusCoreComponents     factory.StatusCoreComponentsHolder
+	scheduledProcessor       consensus.ScheduledProcessor
+	isInImportMode           bool
+	shouldDisableWatchdog    bool
+	hardforkExclusionHandler common.HardforkExclusionHandler
 }
 
 type consensusComponents struct {
@@ -103,21 +105,25 @@ func NewConsensusComponentsFactory(args ConsensusComponentsFactoryArgs) (*consen
 	if check.IfNil(args.StatusCoreComponents) {
 		return nil, errors.ErrNilStatusCoreComponents
 	}
+	if check.IfNil(args.HardforkExclusionHandler) {
+		return nil, errors.ErrNilHardforkExclusionHandler
+	}
 
 	return &consensusComponentsFactory{
-		config:                args.Config,
-		bootstrapRoundIndex:   args.BootstrapRoundIndex,
-		coreComponents:        args.CoreComponents,
-		networkComponents:     args.NetworkComponents,
-		cryptoComponents:      args.CryptoComponents,
-		dataComponents:        args.DataComponents,
-		processComponents:     args.ProcessComponents,
-		stateComponents:       args.StateComponents,
-		statusComponents:      args.StatusComponents,
-		statusCoreComponents:  args.StatusCoreComponents,
-		scheduledProcessor:    args.ScheduledProcessor,
-		isInImportMode:        args.IsInImportMode,
-		shouldDisableWatchdog: args.ShouldDisableWatchdog,
+		config:                   args.Config,
+		bootstrapRoundIndex:      args.BootstrapRoundIndex,
+		coreComponents:           args.CoreComponents,
+		networkComponents:        args.NetworkComponents,
+		cryptoComponents:         args.CryptoComponents,
+		dataComponents:           args.DataComponents,
+		processComponents:        args.ProcessComponents,
+		stateComponents:          args.StateComponents,
+		statusComponents:         args.StatusComponents,
+		statusCoreComponents:     args.StatusCoreComponents,
+		scheduledProcessor:       args.ScheduledProcessor,
+		isInImportMode:           args.IsInImportMode,
+		shouldDisableWatchdog:    args.ShouldDisableWatchdog,
+		hardforkExclusionHandler: args.HardforkExclusionHandler,
 	}, nil
 }
 
@@ -483,6 +489,7 @@ func (ccf *consensusComponentsFactory) createShardBootstrapper() (process.Bootst
 		HistoryRepo:                  ccf.processComponents.HistoryRepository(),
 		ScheduledTxsExecutionHandler: ccf.processComponents.ScheduledTxsExecutionHandler(),
 		ProcessWaitTime:              time.Duration(ccf.config.GeneralSettings.SyncProcessTimeInMillis) * time.Millisecond,
+		HardforkExclusionHandler:     ccf.hardforkExclusionHandler,
 	}
 
 	argsShardBootstrapper := sync.ArgShardBootstrapper{
@@ -617,6 +624,7 @@ func (ccf *consensusComponentsFactory) createMetaChainBootstrapper() (process.Bo
 		HistoryRepo:                  ccf.processComponents.HistoryRepository(),
 		ScheduledTxsExecutionHandler: ccf.processComponents.ScheduledTxsExecutionHandler(),
 		ProcessWaitTime:              time.Duration(ccf.config.GeneralSettings.SyncProcessTimeInMillis) * time.Millisecond,
+		HardforkExclusionHandler:     ccf.hardforkExclusionHandler,
 	}
 
 	argsMetaBootstrapper := sync.ArgMetaBootstrapper{

--- a/factory/consensus/consensusComponents_test.go
+++ b/factory/consensus/consensusComponents_test.go
@@ -133,6 +133,22 @@ func TestNewConsensusComponentsFactory_NilStateComponents(t *testing.T) {
 	require.Equal(t, errorsErd.ErrNilStateComponentsHolder, err)
 }
 
+func TestNewConsensusComponentsFactory_NilHardforkExclusionHandler(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
+	args := componentsMock.GetConsensusArgs(shardCoordinator)
+	args.HardforkExclusionHandler = nil
+
+	bcf, err := consensusComp.NewConsensusComponentsFactory(args)
+
+	require.Nil(t, bcf)
+	require.Equal(t, errorsErd.ErrNilHardforkExclusionHandler, err)
+}
+
 // ------------ Test Old Use Cases --------------------
 func TestConsensusComponentsFactory_CreateGenesisBlockNotInitializedShouldErr(t *testing.T) {
 	t.Parallel()

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/ElrondNetwork/elastic-indexer-go v1.3.1
-	github.com/ElrondNetwork/elrond-go-core v1.1.26-0.20221125145412-1f2ee91eaa65
+	github.com/ElrondNetwork/elrond-go-core v1.1.26-0.20221128105654-1ca3a323245b
 	github.com/ElrondNetwork/elrond-go-crypto v1.2.1
 	github.com/ElrondNetwork/elrond-go-logger v1.0.9
 	github.com/ElrondNetwork/elrond-go-p2p v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/ElrondNetwork/elrond-go-core v1.1.19/go.mod h1:Yz8JK5sGBctw7+gU8j2mZH
 github.com/ElrondNetwork/elrond-go-core v1.1.24/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
 github.com/ElrondNetwork/elrond-go-core v1.1.26-0.20221125145412-1f2ee91eaa65 h1:iQIIlkWhNV10rqB9HbZrh07iskiS0xetgOq542XZ8ao=
 github.com/ElrondNetwork/elrond-go-core v1.1.26-0.20221125145412-1f2ee91eaa65/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
+github.com/ElrondNetwork/elrond-go-core v1.1.26-0.20221128105654-1ca3a323245b h1:MK0XQvJdiQFVU3OMQxmOEHim8XIpZy5SJjIuvfBfwlc=
+github.com/ElrondNetwork/elrond-go-core v1.1.26-0.20221128105654-1ca3a323245b/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
 github.com/ElrondNetwork/elrond-go-crypto v1.0.0/go.mod h1:DGiR7/j1xv729Xg8SsjYaUzWXL5svMd44REXjWS/gAc=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.1 h1:5wWCBEZp5SMFO2+Nal8UaJNJcG9G9J4PHNNZvQpEeUE=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.1/go.mod h1:UNmpDaJjLTKxfzUcwua2R7Mh9bicw/L3ICJt5V7zqMo=

--- a/integrationTests/consensus/consensus_test.go
+++ b/integrationTests/consensus/consensus_test.go
@@ -14,6 +14,7 @@ import (
 	consensusComp "github.com/ElrondNetwork/elrond-go/factory/consensus"
 	"github.com/ElrondNetwork/elrond-go/integrationTests"
 	"github.com/ElrondNetwork/elrond-go/process"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	consensusMocks "github.com/ElrondNetwork/elrond-go/testscommon/consensus"
 	"github.com/stretchr/testify/assert"
 )
@@ -130,17 +131,18 @@ func startNodesWithCommitBlock(nodes []*integrationTests.TestConsensusNode, mute
 					SyncProcessTimeInMillis: 6000,
 				},
 			},
-			BootstrapRoundIndex:  0,
-			CoreComponents:       n.Node.GetCoreComponents(),
-			NetworkComponents:    n.Node.GetNetworkComponents(),
-			CryptoComponents:     n.Node.GetCryptoComponents(),
-			DataComponents:       n.Node.GetDataComponents(),
-			ProcessComponents:    n.Node.GetProcessComponents(),
-			StateComponents:      n.Node.GetStateComponents(),
-			StatusComponents:     statusComponents,
-			StatusCoreComponents: n.Node.GetStatusCoreComponents(),
-			ScheduledProcessor:   &consensusMocks.ScheduledProcessorStub{},
-			IsInImportMode:       n.Node.IsInImportMode(),
+			BootstrapRoundIndex:      0,
+			CoreComponents:           n.Node.GetCoreComponents(),
+			NetworkComponents:        n.Node.GetNetworkComponents(),
+			CryptoComponents:         n.Node.GetCryptoComponents(),
+			DataComponents:           n.Node.GetDataComponents(),
+			ProcessComponents:        n.Node.GetProcessComponents(),
+			StateComponents:          n.Node.GetStateComponents(),
+			StatusComponents:         statusComponents,
+			StatusCoreComponents:     n.Node.GetStatusCoreComponents(),
+			ScheduledProcessor:       &consensusMocks.ScheduledProcessorStub{},
+			IsInImportMode:           n.Node.IsInImportMode(),
+			HardforkExclusionHandler: &testscommon.HardforkExclusionHandlerStub{},
 		}
 
 		consensusFactory, err := consensusComp.NewConsensusComponentsFactory(consensusArgs)

--- a/integrationTests/factory/consensusComponents/consensusComponents_test.go
+++ b/integrationTests/factory/consensusComponents/consensusComponents_test.go
@@ -121,6 +121,7 @@ func TestConsensusComponents_Close_ShouldWork(t *testing.T) {
 		managedStatusComponents,
 		managedProcessComponents,
 		managedStatusCoreComponents,
+		&testscommon.HardforkExclusionHandlerStub{},
 	)
 	require.Nil(t, err)
 	require.NotNil(t, managedConsensusComponents)

--- a/integrationTests/testSyncNode.go
+++ b/integrationTests/testSyncNode.go
@@ -166,6 +166,7 @@ func (tpn *TestProcessorNode) createShardBootstrapper() (TestBootstrapper, error
 		HistoryRepo:                  &dblookupext.HistoryRepositoryStub{},
 		ScheduledTxsExecutionHandler: &testscommon.ScheduledTxsExecutionStub{},
 		ProcessWaitTime:              tpn.RoundHandler.TimeDuration(),
+		HardforkExclusionHandler:     &testscommon.HardforkExclusionHandlerStub{},
 	}
 
 	argsShardBootstrapper := sync.ArgShardBootstrapper{
@@ -211,6 +212,7 @@ func (tpn *TestProcessorNode) createMetaChainBootstrapper() (TestBootstrapper, e
 		HistoryRepo:                  &dblookupext.HistoryRepositoryStub{},
 		ScheduledTxsExecutionHandler: &testscommon.ScheduledTxsExecutionStub{},
 		ProcessWaitTime:              tpn.RoundHandler.TimeDuration(),
+		HardforkExclusionHandler:     &testscommon.HardforkExclusionHandlerStub{},
 	}
 
 	argsMetaBootstrapper := sync.ArgMetaBootstrapper{

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -462,6 +462,7 @@ func (nr *nodeRunner) executeOneComponentCreationCycle(
 		managedStatusComponents,
 		managedProcessComponents,
 		managedStatusCoreComponents,
+		hardforkExclusionHandler,
 	)
 	if err != nil {
 		return true, err
@@ -840,6 +841,7 @@ func (nr *nodeRunner) CreateManagedConsensusComponents(
 	statusComponents mainFactory.StatusComponentsHolder,
 	processComponents mainFactory.ProcessComponentsHolder,
 	statusCoreComponents mainFactory.StatusCoreComponentsHolder,
+	hardforkExclusionHandler common.HardforkExclusionHandler,
 ) (mainFactory.ConsensusComponentsHandler, error) {
 	scheduledProcessorArgs := spos.ScheduledProcessorWrapperArgs{
 		SyncTimer:                coreComponents.SyncTimer(),
@@ -853,19 +855,20 @@ func (nr *nodeRunner) CreateManagedConsensusComponents(
 	}
 
 	consensusArgs := consensusComp.ConsensusComponentsFactoryArgs{
-		Config:                *nr.configs.GeneralConfig,
-		BootstrapRoundIndex:   nr.configs.FlagsConfig.BootstrapRoundIndex,
-		CoreComponents:        coreComponents,
-		NetworkComponents:     networkComponents,
-		CryptoComponents:      cryptoComponents,
-		DataComponents:        dataComponents,
-		ProcessComponents:     processComponents,
-		StateComponents:       stateComponents,
-		StatusComponents:      statusComponents,
-		StatusCoreComponents:  statusCoreComponents,
-		ScheduledProcessor:    scheduledProcessor,
-		IsInImportMode:        nr.configs.ImportDbConfig.IsImportDBMode,
-		ShouldDisableWatchdog: nr.configs.FlagsConfig.DisableConsensusWatchdog,
+		Config:                   *nr.configs.GeneralConfig,
+		BootstrapRoundIndex:      nr.configs.FlagsConfig.BootstrapRoundIndex,
+		CoreComponents:           coreComponents,
+		NetworkComponents:        networkComponents,
+		CryptoComponents:         cryptoComponents,
+		DataComponents:           dataComponents,
+		ProcessComponents:        processComponents,
+		StateComponents:          stateComponents,
+		StatusComponents:         statusComponents,
+		StatusCoreComponents:     statusCoreComponents,
+		ScheduledProcessor:       scheduledProcessor,
+		IsInImportMode:           nr.configs.ImportDbConfig.IsImportDBMode,
+		ShouldDisableWatchdog:    nr.configs.FlagsConfig.DisableConsensusWatchdog,
+		HardforkExclusionHandler: hardforkExclusionHandler,
 	}
 
 	consensusFactory, err := consensusComp.NewConsensusComponentsFactory(consensusArgs)

--- a/process/sync/argBootstrapper.go
+++ b/process/sync/argBootstrapper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/typeConverters"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
+	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/consensus"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/dblookupext"
@@ -47,6 +48,7 @@ type ArgBaseBootstrapper struct {
 	IsInImportMode               bool
 	ScheduledTxsExecutionHandler process.ScheduledTxsExecutionHandler
 	ProcessWaitTime              time.Duration
+	HardforkExclusionHandler     common.HardforkExclusionHandler
 }
 
 // ArgShardBootstrapper holds all dependencies required by the bootstrap data factory in order to create

--- a/process/sync/baseSync_test.go
+++ b/process/sync/baseSync_test.go
@@ -251,6 +251,11 @@ func TestBaseSync_shouldAllowRollback(t *testing.T) {
 				return *firstBlockNonce
 			},
 		},
+		hardforkExclusionHandler: &testscommon.HardforkExclusionHandlerStub{
+			IsRollbackForbiddenCalled: func(round uint64) bool {
+				return round == 15
+			},
+		},
 	}
 
 	t.Run("should allow rollback nonces above final", func(t *testing.T) {
@@ -353,5 +358,17 @@ func TestBaseSync_shouldAllowRollback(t *testing.T) {
 		}
 		require.False(t, boot.shouldAllowRollback(header, finalBlockHash))
 		require.False(t, boot.shouldAllowRollback(header, notFinalBlockHash))
+	})
+
+	t.Run("should not allow rollback of a final header if its round is excluded for hardfork", func(t *testing.T) {
+		firstBlockNonce.HasValue = false
+		header := &testscommon.HeaderHandlerStub{
+			RoundField: 15,
+			HasScheduledMiniBlocksCalled: func() bool {
+				return true
+			},
+		}
+		require.False(t, boot.shouldAllowRollback(header, finalBlockHash))
+		firstBlockNonce.HasValue = true
 	})
 }

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -76,6 +76,7 @@ func NewMetaBootstrap(arguments ArgMetaBootstrapper) (*MetaBootstrap, error) {
 		historyRepo:                  arguments.HistoryRepo,
 		scheduledTxsExecutionHandler: arguments.ScheduledTxsExecutionHandler,
 		processWaitTime:              arguments.ProcessWaitTime,
+		hardforkExclusionHandler:     arguments.HardforkExclusionHandler,
 	}
 
 	if base.isInImportMode {

--- a/process/sync/metablock_test.go
+++ b/process/sync/metablock_test.go
@@ -89,6 +89,7 @@ func CreateMetaBootstrapMockArguments() sync.ArgMetaBootstrapper {
 		HistoryRepo:                  &dblookupext.HistoryRepositoryStub{},
 		ScheduledTxsExecutionHandler: &testscommon.ScheduledTxsExecutionStub{},
 		ProcessWaitTime:              testProcessWaitTime,
+		HardforkExclusionHandler:     &testscommon.HardforkExclusionHandlerStub{},
 	}
 
 	argsMetaBootstrapper := sync.ArgMetaBootstrapper{
@@ -409,6 +410,18 @@ func testMetaWithMissingStorer(missingUnit dataRetriever.UnitType) func(t *testi
 		require.NotNil(t, err)
 		require.True(t, strings.Contains(err.Error(), storage.ErrKeyNotFound.Error()))
 	}
+}
+
+func TestNewMetaBootstrap_NilHardforkExclusionHandlerShouldErr(t *testing.T) {
+	t.Parallel()
+
+	args := CreateMetaBootstrapMockArguments()
+	args.HardforkExclusionHandler = nil
+
+	bs, err := sync.NewMetaBootstrap(args)
+
+	assert.True(t, check.IfNil(bs))
+	assert.Equal(t, process.ErrNilHardforkExclusionHandler, err)
 }
 
 func TestNewMetaBootstrap_OkValsShouldWork(t *testing.T) {

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -67,6 +67,7 @@ func NewShardBootstrap(arguments ArgShardBootstrapper) (*ShardBootstrap, error) 
 		historyRepo:                  arguments.HistoryRepo,
 		scheduledTxsExecutionHandler: arguments.ScheduledTxsExecutionHandler,
 		processWaitTime:              arguments.ProcessWaitTime,
+		hardforkExclusionHandler:     arguments.HardforkExclusionHandler,
 	}
 
 	if base.isInImportMode {

--- a/process/sync/shardblock_test.go
+++ b/process/sync/shardblock_test.go
@@ -215,6 +215,7 @@ func CreateShardBootstrapMockArguments() sync.ArgShardBootstrapper {
 		HistoryRepo:                  &dblookupext.HistoryRepositoryStub{},
 		ScheduledTxsExecutionHandler: &testscommon.ScheduledTxsExecutionStub{},
 		ProcessWaitTime:              testProcessWaitTime,
+		HardforkExclusionHandler:     &testscommon.HardforkExclusionHandlerStub{},
 	}
 
 	argsShardBootstrapper := sync.ArgShardBootstrapper{
@@ -465,6 +466,18 @@ func testShardWithMissingStorer(missingUnit dataRetriever.UnitType) func(t *test
 		require.NotNil(t, err)
 		require.True(t, strings.Contains(err.Error(), storage.ErrKeyNotFound.Error()))
 	}
+}
+
+func TestNewShardBootstrap_NilHardforkExclusionHandlerShouldErr(t *testing.T) {
+	t.Parallel()
+
+	args := CreateShardBootstrapMockArguments()
+	args.HardforkExclusionHandler = nil
+
+	bs, err := sync.NewShardBootstrap(args)
+
+	assert.True(t, check.IfNil(bs))
+	assert.Equal(t, process.ErrNilHardforkExclusionHandler, err)
 }
 
 func TestNewShardBootstrap_OkValsShouldWork(t *testing.T) {

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -161,17 +161,18 @@ func GetConsensusArgs(shardCoordinator sharding.Coordinator) consensusComp.Conse
 	scheduledProcessor, _ := spos.NewScheduledProcessorWrapper(args)
 
 	return consensusComp.ConsensusComponentsFactoryArgs{
-		Config:               testscommon.GetGeneralConfig(),
-		BootstrapRoundIndex:  0,
-		CoreComponents:       coreComponents,
-		NetworkComponents:    networkComponents,
-		CryptoComponents:     cryptoComponents,
-		DataComponents:       dataComponents,
-		ProcessComponents:    processComponents,
-		StateComponents:      stateComponents,
-		StatusComponents:     statusComponents,
-		StatusCoreComponents: GetStatusCoreComponents(),
-		ScheduledProcessor:   scheduledProcessor,
+		Config:                   testscommon.GetGeneralConfig(),
+		BootstrapRoundIndex:      0,
+		CoreComponents:           coreComponents,
+		NetworkComponents:        networkComponents,
+		CryptoComponents:         cryptoComponents,
+		DataComponents:           dataComponents,
+		ProcessComponents:        processComponents,
+		StateComponents:          stateComponents,
+		StatusComponents:         statusComponents,
+		StatusCoreComponents:     GetStatusCoreComponents(),
+		ScheduledProcessor:       scheduledProcessor,
+		HardforkExclusionHandler: &testscommon.HardforkExclusionHandlerStub{},
 	}
 }
 

--- a/testscommon/hardforkExclusionHandlerStub.go
+++ b/testscommon/hardforkExclusionHandlerStub.go
@@ -2,7 +2,8 @@ package testscommon
 
 // HardforkExclusionHandlerStub -
 type HardforkExclusionHandlerStub struct {
-	IsRoundExcludedCalled func(round uint64) bool
+	IsRoundExcludedCalled     func(round uint64) bool
+	IsRollbackForbiddenCalled func(round uint64) bool
 }
 
 // IsRoundExcluded -
@@ -11,6 +12,14 @@ func (stub *HardforkExclusionHandlerStub) IsRoundExcluded(round uint64) bool {
 		return stub.IsRoundExcludedCalled(round)
 	}
 	return false
+}
+
+// IsRollbackForbidden -
+func (stub *HardforkExclusionHandlerStub) IsRollbackForbidden(round uint64) bool {
+	if stub.IsRollbackForbiddenCalled != nil {
+		return stub.IsRollbackForbiddenCalled(round)
+	}
+	return true
 }
 
 // IsInterfaceNil -


### PR DESCRIPTION
## Reasoning behind the pull request
- integrate HardforkExclusionHandler into sync block in order to not allow rollback for rounds that are start of interval
  
## Proposed changes
- integrated HardforkExclusionHandler

## Testing procedure
- will be tested on feat branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
