### PR TITLE
Load private keys

### DIFF
--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -208,6 +208,13 @@ var (
 		Usage: "The `filepath` for the PEM file which contains the secret keys for the validator key.",
 		Value: "./config/validatorKey.pem",
 	}
+	// allValidatorKeysPemFile defines a flag for the path to the file that hold all validator keys used in block signing
+	// managed by the current node
+	allValidatorKeysPemFile = cli.StringFlag{
+		Name:  "all-validator-keys-pem-file",
+		Usage: "The `filepath` for the PEM file which contains all the secret keys managed by the current node.",
+		Value: "./config/allValidatorsKey.pem",
+	}
 
 	// logLevel defines the logger level
 	logLevel = cli.StringFlag{
@@ -379,6 +386,7 @@ func getFlags() []cli.Flag {
 		gasScheduleConfigurationDirectory,
 		validatorKeyIndex,
 		validatorKeyPemFile,
+		allValidatorKeysPemFile,
 		port,
 		profileMode,
 		useHealthService,
@@ -452,6 +460,7 @@ func applyFlags(ctx *cli.Context, cfgs *config.Configs, flagsConfig *config.Cont
 	cfgs.ConfigurationPathsHolder.GasScheduleDirectoryName = ctx.GlobalString(gasScheduleConfigurationDirectory.Name)
 	cfgs.ConfigurationPathsHolder.SmartContracts = ctx.GlobalString(smartContractsFile.Name)
 	cfgs.ConfigurationPathsHolder.ValidatorKey = ctx.GlobalString(validatorKeyPemFile.Name)
+	cfgs.ConfigurationPathsHolder.AllValidatorKeys = ctx.GlobalString(allValidatorKeysPemFile.Name)
 	cfgs.ConfigurationPathsHolder.P2pKey = ctx.GlobalString(p2pKeyPemFile.Name)
 
 	if ctx.IsSet(startInEpoch.Name) {

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -213,7 +213,7 @@ var (
 	allValidatorKeysPemFile = cli.StringFlag{
 		Name:  "all-validator-keys-pem-file",
 		Usage: "The `filepath` for the PEM file which contains all the secret keys managed by the current node.",
-		Value: "./config/allValidatorsKey.pem",
+		Value: "./config/allValidatorsKeys.pem",
 	}
 
 	// logLevel defines the logger level

--- a/common/constants.go
+++ b/common/constants.go
@@ -834,7 +834,3 @@ const MetricTrieSyncNumReceivedBytes = "erd_trie_sync_num_bytes_received"
 
 // MetricTrieSyncNumProcessedNodes is the metric that outputs the number of trie nodes processed for accounts during trie sync
 const MetricTrieSyncNumProcessedNodes = "erd_trie_sync_num_nodes_processed"
-
-// MaxMachineIDLen is the maximum machine ID length
-// TODO: move this to elrond-go-core
-const MaxMachineIDLen = 10

--- a/config/config.go
+++ b/config/config.go
@@ -588,6 +588,7 @@ type ConfigurationPathsHolder struct {
 	Genesis                  string
 	SmartContracts           string
 	ValidatorKey             string
+	AllValidatorKeys         string
 	Epoch                    string
 	RoundActivation          string
 	P2pKey                   string

--- a/factory/crypto/cryptoComponents.go
+++ b/factory/crypto/cryptoComponents.go
@@ -40,6 +40,7 @@ const (
 // CryptoComponentsFactoryArgs holds the arguments needed for creating crypto components
 type CryptoComponentsFactoryArgs struct {
 	ValidatorKeyPemFileName              string
+	AllValidatorKeysPemFileName          string
 	SkIndex                              int
 	Config                               config.Config
 	EnableEpochs                         config.EnableEpochs
@@ -56,6 +57,7 @@ type CryptoComponentsFactoryArgs struct {
 type cryptoComponentsFactory struct {
 	consensusType                        string
 	validatorKeyPemFileName              string
+	allValidatorKeysPemFileName          string
 	skIndex                              int
 	config                               config.Config
 	enableEpochs                         config.EnableEpochs

--- a/factory/crypto/cryptoComponents_test.go
+++ b/factory/crypto/cryptoComponents_test.go
@@ -11,12 +11,13 @@ import (
 	errErd "github.com/ElrondNetwork/elrond-go/errors"
 	cryptoComp "github.com/ElrondNetwork/elrond-go/factory/crypto"
 	"github.com/ElrondNetwork/elrond-go/factory/mock"
+	integrationTestsMock "github.com/ElrondNetwork/elrond-go/integrationTests/mock"
 	componentsMock "github.com/ElrondNetwork/elrond-go/testscommon/components"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewCryptoComponentsFactory_NiCoreComponentsHandlerShouldErr(t *testing.T) {
+func TestNewCryptoComponentsFactory_NilCoreComponentsHandlerShouldErr(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("this is not a short test")
@@ -26,6 +27,22 @@ func TestNewCryptoComponentsFactory_NiCoreComponentsHandlerShouldErr(t *testing.
 	ccf, err := cryptoComp.NewCryptoComponentsFactory(args)
 	require.Nil(t, ccf)
 	require.Equal(t, errErd.ErrNilCoreComponents, err)
+}
+
+func TestNewCryptoComponentsFactory_NilValidatorPublicKeyConverterShouldErr(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	args := componentsMock.GetCryptoArgs(nil)
+	args.CoreComponentsHolder = &integrationTestsMock.CoreComponentsStub{
+		ValidatorPubKeyConverterField: nil,
+	}
+
+	ccf, err := cryptoComp.NewCryptoComponentsFactory(args)
+	require.Nil(t, ccf)
+	require.Equal(t, errErd.ErrNilPubKeyConverter, err)
 }
 
 func TestNewCryptoComponentsFactory_NilPemFileShouldErr(t *testing.T) {

--- a/factory/crypto/cryptoComponents_test.go
+++ b/factory/crypto/cryptoComponents_test.go
@@ -12,6 +12,7 @@ import (
 	cryptoComp "github.com/ElrondNetwork/elrond-go/factory/crypto"
 	"github.com/ElrondNetwork/elrond-go/factory/mock"
 	componentsMock "github.com/ElrondNetwork/elrond-go/testscommon/components"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -166,6 +167,7 @@ func TestCryptoComponentsFactory_CreateOK(t *testing.T) {
 	cc, err := ccf.Create()
 	require.NoError(t, err)
 	require.NotNil(t, cc)
+	assert.Equal(t, 0, len(cc.GetManagedPeersHolder().GetManagedKeysByCurrentNode()))
 }
 
 func TestCryptoComponentsFactory_CreateWithDisabledSig(t *testing.T) {
@@ -182,6 +184,7 @@ func TestCryptoComponentsFactory_CreateWithDisabledSig(t *testing.T) {
 	cc, err := ccf.Create()
 	require.NoError(t, err)
 	require.NotNil(t, cc)
+	assert.Equal(t, 0, len(cc.GetManagedPeersHolder().GetManagedKeysByCurrentNode()))
 }
 
 func TestCryptoComponentsFactory_CreateWithAutoGenerateKey(t *testing.T) {
@@ -198,6 +201,7 @@ func TestCryptoComponentsFactory_CreateWithAutoGenerateKey(t *testing.T) {
 	cc, err := ccf.Create()
 	require.NoError(t, err)
 	require.NotNil(t, cc)
+	assert.Equal(t, 0, len(cc.GetManagedPeersHolder().GetManagedKeysByCurrentNode()))
 }
 
 func TestCryptoComponentsFactory_CreateSingleSignerInvalidConsensusTypeShouldErr(t *testing.T) {
@@ -424,4 +428,175 @@ func TestCryptoComponentsFactory_GetSkPkOK(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, expectedSk, sk)
 	require.Equal(t, expectedPk, pk)
+}
+
+func TestCryptoComponentsFactory_MultiKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("internal error, LoadAllKeys returns different lengths for private and public keys", func(t *testing.T) {
+		t.Parallel()
+
+		coreComponents := componentsMock.GetCoreComponents()
+		args := componentsMock.GetCryptoArgs(coreComponents)
+
+		privateKeys, publicKeys := createBLSPrivatePublicKeys()
+
+		args.KeyLoader = &mock.KeyLoaderStub{
+			LoadKeyCalled: func(relativePath string, skIndex int) ([]byte, string, error) {
+				return privateKeys[0], publicKeys[0], nil
+			},
+			LoadAllKeysCalled: func(path string) ([][]byte, []string, error) {
+				return privateKeys[2:], publicKeys[1:], nil
+			},
+		}
+
+		ccf, err := cryptoComp.NewCryptoComponentsFactory(args)
+		require.Nil(t, err)
+
+		cc, err := ccf.Create()
+		assert.Nil(t, cc)
+		assert.Contains(t, err.Error(), "key loading error for the allValidatorsKeys file: mismatch number of private and public keys")
+	})
+	t.Run("encoded private key can not be hex decoded", func(t *testing.T) {
+		t.Parallel()
+
+		coreComponents := componentsMock.GetCoreComponents()
+		args := componentsMock.GetCryptoArgs(coreComponents)
+		privateKeys, publicKeys := createBLSPrivatePublicKeys()
+
+		args.KeyLoader = &mock.KeyLoaderStub{
+			LoadKeyCalled: func(relativePath string, skIndex int) ([]byte, string, error) {
+				return privateKeys[0], publicKeys[0], nil
+			},
+			LoadAllKeysCalled: func(path string) ([][]byte, []string, error) {
+				return [][]byte{[]byte("not a hex")}, []string{"a"}, nil
+			},
+		}
+
+		ccf, err := cryptoComp.NewCryptoComponentsFactory(args)
+		require.Nil(t, err)
+
+		cc, err := ccf.Create()
+		assert.Nil(t, cc)
+		assert.Contains(t, err.Error(), "for encoded secret key, key index 0")
+	})
+	t.Run("encoded public key can not be hex decoded", func(t *testing.T) {
+		t.Parallel()
+
+		coreComponents := componentsMock.GetCoreComponents()
+		args := componentsMock.GetCryptoArgs(coreComponents)
+		privateKeys, publicKeys := createBLSPrivatePublicKeys()
+
+		args.KeyLoader = &mock.KeyLoaderStub{
+			LoadKeyCalled: func(relativePath string, skIndex int) ([]byte, string, error) {
+				return privateKeys[0], publicKeys[0], nil
+			},
+			LoadAllKeysCalled: func(path string) ([][]byte, []string, error) {
+				return [][]byte{[]byte("aa")}, []string{"not hex"}, nil
+			},
+		}
+
+		ccf, err := cryptoComp.NewCryptoComponentsFactory(args)
+		require.Nil(t, err)
+
+		cc, err := ccf.Create()
+		assert.Nil(t, cc)
+		assert.Contains(t, err.Error(), "for encoded public key not hex, key index 0")
+	})
+	t.Run("not a valid private key", func(t *testing.T) {
+		t.Parallel()
+
+		coreComponents := componentsMock.GetCoreComponents()
+		args := componentsMock.GetCryptoArgs(coreComponents)
+		privateKeys, publicKeys := createBLSPrivatePublicKeys()
+
+		args.KeyLoader = &mock.KeyLoaderStub{
+			LoadKeyCalled: func(relativePath string, skIndex int) ([]byte, string, error) {
+				return privateKeys[0], publicKeys[0], nil
+			},
+			LoadAllKeysCalled: func(path string) ([][]byte, []string, error) {
+				return [][]byte{[]byte("aa")}, []string{publicKeys[0]}, nil
+			},
+		}
+
+		ccf, err := cryptoComp.NewCryptoComponentsFactory(args)
+		require.Nil(t, err)
+
+		cc, err := ccf.Create()
+		assert.Nil(t, cc)
+		assert.Contains(t, err.Error(), "secret key, key index 0")
+	})
+	t.Run("wrong public string read from file", func(t *testing.T) {
+		t.Parallel()
+
+		coreComponents := componentsMock.GetCoreComponents()
+		args := componentsMock.GetCryptoArgs(coreComponents)
+		privateKeys, publicKeys := createBLSPrivatePublicKeys()
+
+		args.KeyLoader = &mock.KeyLoaderStub{
+			LoadKeyCalled: func(relativePath string, skIndex int) ([]byte, string, error) {
+				return privateKeys[0], publicKeys[0], nil
+			},
+			LoadAllKeysCalled: func(path string) ([][]byte, []string, error) {
+				return [][]byte{privateKeys[0]}, []string{publicKeys[1]}, nil
+			},
+		}
+
+		ccf, err := cryptoComp.NewCryptoComponentsFactory(args)
+		require.Nil(t, err)
+
+		cc, err := ccf.Create()
+		assert.Nil(t, cc)
+		assert.Contains(t, err.Error(), "public keys mismatch, read "+
+			"ae33fdd47ca6eed4b4e33a87beb580a20e908898a88c1d91a8b376cc35e8240e5083696ba6a1eeaa4cf50431980c38086dd7acc535c7571fb952d5c025d27c422fca999eaeaa13451946504d2b0a0c5b08958da236a4877b08abbd8059218f05"+
+			", generated ae33fdd47ca6eed4b4e33a87beb580a20e908898a88c1d91a8b376cc35e8240e5083696ba6a1eeaa4cf50431980c38086dd7acc535c7571fb952d5c025d27c422fca999eaeaa13451946504d2b0a0c5b08958da236a4877b08abbd8059218f05"+
+			", key index 0")
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		coreComponents := componentsMock.GetCoreComponents()
+		args := componentsMock.GetCryptoArgs(coreComponents)
+
+		privateKeys, publicKeys := createBLSPrivatePublicKeys()
+
+		args.KeyLoader = &mock.KeyLoaderStub{
+			LoadKeyCalled: func(relativePath string, skIndex int) ([]byte, string, error) {
+				return privateKeys[0], publicKeys[0], nil
+			},
+			LoadAllKeysCalled: func(path string) ([][]byte, []string, error) {
+				return privateKeys[1:], publicKeys[1:], nil
+			},
+		}
+
+		ccf, err := cryptoComp.NewCryptoComponentsFactory(args)
+		require.Nil(t, err)
+
+		cc, err := ccf.Create()
+		require.Nil(t, err)
+		// should hold num(publicKeys) - 1 as the first was used as the main key of the node
+		assert.Equal(t, len(publicKeys)-1, len(cc.GetManagedPeersHolder().GetManagedKeysByCurrentNode()))
+		skBytes, _, _ := ccf.GetSkPk()
+		assert.NotEqual(t, skBytes, privateKeys[0]) // should generate another private key and not use the one loaded with LoadKey call
+	})
+}
+
+func createBLSPrivatePublicKeys() ([][]byte, []string) {
+	privateKeys := [][]byte{
+		[]byte("13508f73f4bac43014ca5cdf16903bed4dcfd60f74123346f933e1cd0042ca52"),
+		[]byte("4195470da0224c832b8cb3227fdfa2431fac50efce332dadc2e970c0977f6d3b"),
+		[]byte("a65c1bbef47b833c2c2262cc341ad34745a10034b68e117e60c3391ed3503b49"),
+		[]byte("1bccb646905256d20da48c875ddfa7db92a182bd0b7738560d7df6ead909892e"),
+		[]byte("f9c165744018c13a098b7e4915d24d86379f8a06fab28bd7970092ab5a19fd41"),
+	}
+
+	publicKeys := []string{
+		"c1135f9b0fcae055218cc7916f626f3da33e2ccc0252fd8036be35d4e2d93b9b54a6c355b3e6520b49d32ca005a757156e2a8dc1b14e5c7773a294f6ea1faecae6739e5b3d832eab7f36ff9a6c200ca471a948dcf7671291347b79c3f1b63e93",
+		"ae33fdd47ca6eed4b4e33a87beb580a20e908898a88c1d91a8b376cc35e8240e5083696ba6a1eeaa4cf50431980c38086dd7acc535c7571fb952d5c025d27c422fca999eaeaa13451946504d2b0a0c5b08958da236a4877b08abbd8059218f05",
+		"85c447d1a50ac4dd6c8b38dd39ade1126caf16654d59ea8ef7dbec658b36ccd5cbcd946f9c4acccacdde564739f224002ea0a2ce083abd60cafbcae9d817f674966e49c3b3322a2028c64fa74b01610e25e3f9ceb7c2b2077eaed83ca6e08090",
+		"c550ac126ce520d7a6bbd7d5f375273df8f1a8c6d74f44d3e3b71872fc65e436ef52696674883ff27de8f674bc4c7713c4b7bdabe2292c069e81e5c8e131ea8a90215ee4038a882687e532a8c27dea94c5c2ca9f7f6072163bb0b6151c93b00a",
+		"1ecad7660e5a77a09661207c7a22f4a84f9be98ac520d4cc875d0caea2fc98f0ab67c2b4966a3ba1cefaa6013517b30f8c43327b46896111886fe2ba10e66d2589aea52e9bf3d72f630c051733fddba412e7c7768b80c8fb7b7e104156db0a0a",
+	}
+
+	return privateKeys, publicKeys
 }

--- a/factory/crypto/export_test.go
+++ b/factory/crypto/export_test.go
@@ -3,6 +3,7 @@ package crypto
 import (
 	crypto "github.com/ElrondNetwork/elrond-go-crypto"
 	cryptoCommon "github.com/ElrondNetwork/elrond-go/common/crypto"
+	"github.com/ElrondNetwork/elrond-go/heartbeat"
 )
 
 // GetSkPk -
@@ -36,4 +37,9 @@ func (ccf *cryptoComponentsFactory) CreateMultiSignerContainer(
 // GetSuite -
 func (ccf *cryptoComponentsFactory) GetSuite() (crypto.Suite, error) {
 	return ccf.getSuite()
+}
+
+// GetManagedPeersHolder -
+func (cc *cryptoComponents) GetManagedPeersHolder() heartbeat.ManagedPeersHolder {
+	return cc.managedPeersHolder
 }

--- a/factory/interface.go
+++ b/factory/interface.go
@@ -190,6 +190,8 @@ type CryptoComponentsHolder interface {
 // KeyLoaderHandler defines the loading of a key from a pem file and index
 type KeyLoaderHandler interface {
 	LoadKey(string, int) ([]byte, string, error)
+	LoadAllKeys(path string) ([][]byte, []string, error)
+	IsInterfaceNil() bool
 }
 
 // CryptoComponentsHandler defines the crypto components handler actions

--- a/factory/mock/keyLoaderStub.go
+++ b/factory/mock/keyLoaderStub.go
@@ -1,8 +1,11 @@
 package mock
 
+import "errors"
+
 // KeyLoaderStub -
 type KeyLoaderStub struct {
-	LoadKeyCalled func(relativePath string, skIndex int) ([]byte, string, error)
+	LoadKeyCalled     func(relativePath string, skIndex int) ([]byte, string, error)
+	LoadAllKeysCalled func(path string) ([][]byte, []string, error)
 }
 
 // LoadKey -
@@ -12,4 +15,18 @@ func (kl *KeyLoaderStub) LoadKey(relativePath string, skIndex int) ([]byte, stri
 	}
 
 	return nil, "", nil
+}
+
+// LoadAllKeys -
+func (kl *KeyLoaderStub) LoadAllKeys(path string) ([][]byte, []string, error) {
+	if kl.LoadAllKeysCalled != nil {
+		return kl.LoadAllKeysCalled(path)
+	}
+
+	return nil, nil, errors.New("not implemented")
+}
+
+// IsInterfaceNil -
+func (kl *KeyLoaderStub) IsInterfaceNil() bool {
+	return kl == nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/ElrondNetwork/elastic-indexer-go v1.3.3
-	github.com/ElrondNetwork/elrond-go-core v1.1.26
+	github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221201082151-bfd48dfa2e7c
 	github.com/ElrondNetwork/elrond-go-crypto v1.2.2
 	github.com/ElrondNetwork/elrond-go-logger v1.0.10
 	github.com/ElrondNetwork/elrond-go-p2p v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,9 @@ github.com/ElrondNetwork/concurrent-map v0.1.3 h1:j2LtPrNJuerannC1cQDE79STvi/P04
 github.com/ElrondNetwork/concurrent-map v0.1.3/go.mod h1:3XwSwn4JHI0lrKxWLZvtp53Emr8BXYTmNQGwcukHJEE=
 github.com/ElrondNetwork/elastic-indexer-go v1.3.3 h1:RgJ043yt92PUWMbSAQHRrC+GiyNnFdwdM/kseHlpLoo=
 github.com/ElrondNetwork/elastic-indexer-go v1.3.3/go.mod h1:E3VO5712GkGSGYnOTJ+0wxW74JXgjV6XCRPlcHiTTK0=
-github.com/ElrondNetwork/elrond-go-core v1.1.26 h1:5syiJMlkWlH7HHnuiOafJJzeI+oUfYqL8mXREqrFerY=
 github.com/ElrondNetwork/elrond-go-core v1.1.26/go.mod h1:N/RI++YU2M6OlnD1GSZepc1wPhI84ykRDQ1IyD3B0wk=
+github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221201082151-bfd48dfa2e7c h1:q+Nty5RTQa2d22AMOhz5FDj0QKeD9JTuSI7gBedcSwc=
+github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221201082151-bfd48dfa2e7c/go.mod h1:N/RI++YU2M6OlnD1GSZepc1wPhI84ykRDQ1IyD3B0wk=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.2 h1:Q59dZUeyibuskq5vjgk3ng/87ifOcd9YZMTnlYJAuIU=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.2/go.mod h1:MyQPKUKti7Axnx/eihhL0F2jLTalvSV/Ytv1mIxvYyM=
 github.com/ElrondNetwork/elrond-go-logger v1.0.10 h1:2xQOWZErcHW5sl9qSRO+7mGNw+QhFhqiUlLLtOgvuuk=

--- a/heartbeat/sender/multikeyHeartbeatSender.go
+++ b/heartbeat/sender/multikeyHeartbeatSender.go
@@ -200,7 +200,7 @@ func (sender *multikeyHeartbeatSender) processIfShouldSend(pk []byte) bool {
 	}
 
 	if shardID != sender.shardCoordinator.SelfId() {
-		log.Debug("processIfShouldSend: shard id does not match",
+		log.Trace("processIfShouldSend: shard id does not match",
 			"pk", pk,
 			"self shard", sender.shardCoordinator.SelfId(),
 			"pk shard", shardID)

--- a/keysManagement/managedPeersHolder.go
+++ b/keysManagement/managedPeersHolder.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	crypto "github.com/ElrondNetwork/elrond-go-crypto"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
-	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/config"
 )
 
@@ -164,7 +163,7 @@ func (holder *managedPeersHolder) getPeerInfo(pkBytes []byte) *peerInfo {
 }
 
 func generateRandomMachineID() string {
-	buff := make([]byte, common.MaxMachineIDLen/2)
+	buff := make([]byte, core.MaxMachineIDLen/2)
 	_, _ = rand.Read(buff)
 
 	return hex.EncodeToString(buff)

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -1477,8 +1477,10 @@ func (nr *nodeRunner) CreateManagedCryptoComponents(
 ) (mainFactory.CryptoComponentsHandler, error) {
 	configs := nr.configs
 	validatorKeyPemFileName := configs.ConfigurationPathsHolder.ValidatorKey
+	allValidatorKeysPemFileName := configs.ConfigurationPathsHolder.AllValidatorKeys
 	cryptoComponentsHandlerArgs := cryptoComp.CryptoComponentsFactoryArgs{
 		ValidatorKeyPemFileName:              validatorKeyPemFileName,
+		AllValidatorKeysPemFileName:          allValidatorKeysPemFileName,
 		SkIndex:                              configs.FlagsConfig.ValidatorKeyIndex,
 		Config:                               *configs.GeneralConfig,
 		CoreComponentsHolder:                 coreComponents,

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -1485,7 +1485,7 @@ func (nr *nodeRunner) CreateManagedCryptoComponents(
 		Config:                               *configs.GeneralConfig,
 		CoreComponentsHolder:                 coreComponents,
 		ActivateBLSPubKeyMessageVerification: configs.SystemSCConfig.StakingSystemSCConfig.ActivateBLSPubKeyMessageVerification,
-		KeyLoader:                            &core.KeyLoader{},
+		KeyLoader:                            core.NewKeyLoader(),
 		ImportModeNoSigCheck:                 configs.ImportDbConfig.ImportDbNoSigCheckFlag,
 		IsInImportMode:                       configs.ImportDbConfig.IsImportDBMode,
 		EnableEpochs:                         configs.EpochConfig.EnableEpochs,

--- a/scripts/testnet/include/build.sh
+++ b/scripts/testnet/include/build.sh
@@ -56,19 +56,6 @@ buildNode() {
   popd
 }
 
-buildArwen() {
-  echo "Building Arwen executable..."
-  pushd $ELRONDDIR
-  make arwen
-  echo "Arwen executable built."
-  popd
-
-  pushd $TESTNETDIR
-  cp $ARWEN_PATH ./node/arwen
-  echo "Arwen executable copied."
-  popd
-}
-
 buildSeednode() {
   echo "Building Seednode executable..."
   pushd $SEEDNODEDIR

--- a/scripts/testnet/start.sh
+++ b/scripts/testnet/start.sh
@@ -18,11 +18,6 @@ prepareFolders
 buildSeednode
 buildNode
 
-if [ $ALWAYS_BUILD_ARWEN -eq 1 ]; then
-  buildArwen
-fi
-
-
 # Phase 2: generate configuration
 if [ $ALWAYS_UPDATE_CONFIGS -eq 1 ]; then
   copyConfig

--- a/scripts/testnet/variables.sh
+++ b/scripts/testnet/variables.sh
@@ -62,6 +62,8 @@ export META_VALIDATORCOUNT=3
 export META_OBSERVERCOUNT=1
 export META_CONSENSUS_SIZE=$META_VALIDATORCOUNT
 
+export MULTI_KEY_NODES=0 #set this to 1 to make all generated keys be used only by (SHARDCOUNT + 1) nodes
+
 # ALWAYS_NEW_CHAINID will generate a fresh new chain ID each time start.sh/config.sh is called
 export ALWAYS_NEW_CHAINID=1
 
@@ -75,9 +77,6 @@ export ALWAYS_NEW_APP_VERSION=0
 # Set this variable to 0 when testing bootstrap from storage or other edge cases where you do not want a fresh new config
 # each time.
 export ALWAYS_UPDATE_CONFIGS=1
-
-# Always rebuild Arwen from its sources and copy the executable to the testnet folder.
-export ALWAYS_BUILD_ARWEN=1
 
 # IP of the seednode
 export SEEDNODE_IP="127.0.0.1"


### PR DESCRIPTION
## Reasoning behind the pull request
- added the possibility to load multiple private keys to be handled by the node
  
## Proposed changes
- added new .pem file flag
- modified the crypto factory to take into account this new flag and apply the newly handled keys. In this scenario, the node will autogenerate a public key for use in the normal operation (just as it does in the backup operation)

## Testing procedure
- standard system test
- system test with 4 observers, each on a different shard, allValidatorsKey.pem containing all private keys registered on the network, the chain should advance normally

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
