### PR TITLE
Add missing call to DecreaseRating on peersRatingHandler

### DIFF
--- a/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
+++ b/dataRetriever/resolvers/topicResolverSender/topicResolverSender.go
@@ -227,6 +227,7 @@ func (trs *topicResolverSender) sendOnTopic(
 		if err != nil {
 			continue
 		}
+		trs.peersRatingHandler.DecreaseRating(peer)
 
 		logData = append(logData, peerType)
 		logData = append(logData, peer.Pretty())


### PR DESCRIPTION
## Reasoning behind the pull request
- peers rating should be decreased when a request is made to a peer
  
## Proposed changes
- added DecreaseRating call

## Testing procedure
- TBD

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
