### PR TITLE
use numeric instead of bool for snapshots in progress

### DIFF
--- a/node/metrics/metrics.go
+++ b/node/metrics/metrics.go
@@ -48,6 +48,7 @@ func InitBaseMetrics(appStatusHandler core.AppStatusHandler) error {
 	appStatusHandler.SetUInt64Value(common.MetricTrieSyncNumProcessedNodes, initUint)
 	appStatusHandler.SetUInt64Value(common.MetricTrieSyncNumReceivedBytes, initUint)
 	appStatusHandler.SetUInt64Value(common.MetricAccountsSnapshotInProgress, initUint)
+	appStatusHandler.SetUInt64Value(common.MetricPeersSnapshotInProgress, initUint)
 
 	appStatusHandler.SetInt64Value(common.MetricLastAccountsSnapshotDurationSec, initInt)
 	appStatusHandler.SetInt64Value(common.MetricLastPeersSnapshotDurationSec, initInt)
@@ -66,7 +67,6 @@ func InitBaseMetrics(appStatusHandler core.AppStatusHandler) error {
 	appStatusHandler.SetStringValue(common.MetricP2PCrossShardObservers, initString)
 	appStatusHandler.SetStringValue(common.MetricP2PFullHistoryObservers, initString)
 	appStatusHandler.SetStringValue(common.MetricP2PUnknownPeers, initString)
-	appStatusHandler.SetStringValue(common.MetricPeersSnapshotInProgress, initString)
 
 	appStatusHandler.SetStringValue(common.MetricInflation, initZeroString)
 	appStatusHandler.SetStringValue(common.MetricDevRewardsInEpoch, initZeroString)

--- a/node/metrics/metrics.go
+++ b/node/metrics/metrics.go
@@ -47,6 +47,7 @@ func InitBaseMetrics(appStatusHandler core.AppStatusHandler) error {
 	appStatusHandler.SetUInt64Value(common.MetricAccountsSnapshotNumNodes, initUint)
 	appStatusHandler.SetUInt64Value(common.MetricTrieSyncNumProcessedNodes, initUint)
 	appStatusHandler.SetUInt64Value(common.MetricTrieSyncNumReceivedBytes, initUint)
+	appStatusHandler.SetUInt64Value(common.MetricAccountsSnapshotInProgress, initUint)
 
 	appStatusHandler.SetInt64Value(common.MetricLastAccountsSnapshotDurationSec, initInt)
 	appStatusHandler.SetInt64Value(common.MetricLastPeersSnapshotDurationSec, initInt)
@@ -65,7 +66,6 @@ func InitBaseMetrics(appStatusHandler core.AppStatusHandler) error {
 	appStatusHandler.SetStringValue(common.MetricP2PCrossShardObservers, initString)
 	appStatusHandler.SetStringValue(common.MetricP2PFullHistoryObservers, initString)
 	appStatusHandler.SetStringValue(common.MetricP2PUnknownPeers, initString)
-	appStatusHandler.SetStringValue(common.MetricAccountsSnapshotInProgress, initString)
 	appStatusHandler.SetStringValue(common.MetricPeersSnapshotInProgress, initString)
 
 	appStatusHandler.SetStringValue(common.MetricInflation, initZeroString)

--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"runtime/debug"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -129,7 +128,7 @@ func NewAccountsDB(args ArgsAccountsDB) (*AccountsDB, error) {
 		return nil, err
 	}
 
-	args.AppStatusHandler.SetStringValue(common.MetricAccountsSnapshotInProgress, strconv.FormatBool(false))
+	args.AppStatusHandler.SetUInt64Value(common.MetricAccountsSnapshotInProgress, 0)
 
 	return createAccountsDb(args), nil
 }
@@ -1238,12 +1237,12 @@ func (adb *AccountsDB) finishSnapshotOperation(
 }
 
 func (adb *AccountsDB) updateMetricsOnSnapshotStart(metrics *accountMetrics) {
-	adb.appStatusHandler.SetStringValue(metrics.snapshotInProgressKey, "true")
+	adb.appStatusHandler.SetUInt64Value(metrics.snapshotInProgressKey, 1)
 	adb.appStatusHandler.SetInt64Value(metrics.lastSnapshotDurationKey, 0)
 }
 
 func (adb *AccountsDB) updateMetricsOnSnapshotCompletion(metrics *accountMetrics, stats *snapshotStatistics) {
-	adb.appStatusHandler.SetStringValue(metrics.snapshotInProgressKey, "false")
+	adb.appStatusHandler.SetUInt64Value(metrics.snapshotInProgressKey, 0)
 	adb.appStatusHandler.SetInt64Value(metrics.lastSnapshotDurationKey, stats.GetSnapshotDuration())
 	if metrics.snapshotMessage == userTrieSnapshotMsg {
 		adb.appStatusHandler.SetUInt64Value(common.MetricAccountsSnapshotNumNodes, stats.GetSnapshotNumNodes())

--- a/state/accountsDB_test.go
+++ b/state/accountsDB_test.go
@@ -1107,13 +1107,6 @@ func TestAccountsDB_SnapshotStateSnapshotSameRootHash(t *testing.T) {
 	args := createMockAccountsDBArgs()
 	args.Trie = trieStub
 
-	wasCalled := false
-	args.AppStatusHandler = &statusHandler.AppStatusHandlerStub{
-		SetUInt64ValueHandler: func(key string, value uint64) {
-			wasCalled = true
-		},
-	}
-
 	adb, _ := state.NewAccountsDB(args)
 	waitForOpToFinish := time.Millisecond * 100
 
@@ -1169,8 +1162,6 @@ func TestAccountsDB_SnapshotStateSnapshotSameRootHash(t *testing.T) {
 	snapshotMutex.Lock()
 	assert.Equal(t, 5, takeSnapshotCalled)
 	snapshotMutex.Unlock()
-
-	assert.True(t, wasCalled)
 }
 
 func TestAccountsDB_SnapshotStateSkipSnapshotIfSnapshotInProgress(t *testing.T) {

--- a/state/accountsDB_test.go
+++ b/state/accountsDB_test.go
@@ -1106,9 +1106,11 @@ func TestAccountsDB_SnapshotStateSnapshotSameRootHash(t *testing.T) {
 	}
 	args := createMockAccountsDBArgs()
 	args.Trie = trieStub
+
+	wasCalled := false
 	args.AppStatusHandler = &statusHandler.AppStatusHandlerStub{
 		SetUInt64ValueHandler: func(key string, value uint64) {
-			assert.Equal(t, common.MetricAccountsSnapshotNumNodes, key)
+			wasCalled = true
 		},
 	}
 
@@ -1167,6 +1169,8 @@ func TestAccountsDB_SnapshotStateSnapshotSameRootHash(t *testing.T) {
 	snapshotMutex.Lock()
 	assert.Equal(t, 5, takeSnapshotCalled)
 	snapshotMutex.Unlock()
+
+	assert.True(t, wasCalled)
 }
 
 func TestAccountsDB_SnapshotStateSkipSnapshotIfSnapshotInProgress(t *testing.T) {

--- a/state/peerAccountsDB.go
+++ b/state/peerAccountsDB.go
@@ -20,7 +20,7 @@ func NewPeerAccountsDB(args ArgsAccountsDB) (*PeerAccountsDB, error) {
 		AccountsDB: createAccountsDb(args),
 	}
 
-	args.AppStatusHandler.SetStringValue(common.MetricPeersSnapshotInProgress, "false")
+	args.AppStatusHandler.SetUInt64Value(common.MetricPeersSnapshotInProgress, 0)
 
 	return adb, nil
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- Set snapshot status metrics as integers instead of bool strings
  
## Proposed changes
- Update the metric for snaphost status in progress, from `false/true` to `0/1`

## Testing procedure
- check the updated metrics in node/status route when snapshot is in progress:
     - erd_accounts_snapshot_in_progress: 1 if the snapshot is in progress, 0 if it's not
     - erd_peers_snapshot_in_progress: 1 if the snapshot is in progress, 0 if it's not


## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
