### PR TITLE
EN-13547: improve nft wipe sys account liquidity

### DIFF
--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -230,6 +230,9 @@
     # RefactorPeersMiniBlocksEnableEpoch represents the epoch when refactor of the peers mini blocks will be enabled
     RefactorPeersMiniBlocksEnableEpoch = 5
 
+    # WipeSingleNFTLiquidityDecreaseEnableEpoch represents the epoch when the system account liquidity is decreased for wipeSingleNFT as well
+    WipeSingleNFTLiquidityDecreaseEnableEpoch = 5
+
     # BLSMultiSignerEnableEpoch represents the activation epoch for different types of BLS multi-signers
     BLSMultiSignerEnableEpoch = [
         { EnableEpoch = 0, Type = "no-KOSK"},

--- a/common/enablers/enableEpochsHandler.go
+++ b/common/enablers/enableEpochsHandler.go
@@ -114,6 +114,7 @@ func (handler *enableEpochsHandler) EpochConfirmed(epoch uint32, _ uint64) {
 	handler.setFlagValue(epoch >= handler.enableEpochsConfig.FixAsyncCallBackArgsListEnableEpoch, handler.fixAsyncCallBackArgsList, "fixAsyncCallBackArgsList")
 	handler.setFlagValue(epoch >= handler.enableEpochsConfig.FixOldTokenLiquidityEnableEpoch, handler.fixOldTokenLiquidity, "fixOldTokenLiquidity")
 	handler.setFlagValue(epoch >= handler.enableEpochsConfig.RuntimeMemStoreLimitEnableEpoch, handler.runtimeMemStoreLimitFlag, "runtimeMemStoreLimitFlag")
+	handler.setFlagValue(epoch >= handler.enableEpochsConfig.WipeSingleNFTLiquidityDecreaseEnableEpoch, handler.wipeSingleNFTLiquidityDecreaseFlag, "wipeSingleNFTLiquidityDecreaseFlag")
 }
 
 func (handler *enableEpochsHandler) setFlagValue(value bool, flag *atomic.Flag, flagName string) {

--- a/common/enablers/enableEpochsHandler_test.go
+++ b/common/enablers/enableEpochsHandler_test.go
@@ -87,6 +87,7 @@ func createEnableEpochsConfig() config.EnableEpochs {
 		FixAsyncCallBackArgsListEnableEpoch:               71,
 		FixOldTokenLiquidityEnableEpoch:                   72,
 		RuntimeMemStoreLimitEnableEpoch:                   73,
+		WipeSingleNFTLiquidityDecreaseEnableEpoch:         74,
 	}
 }
 
@@ -302,6 +303,7 @@ func TestNewEnableEpochsHandler_EpochConfirmed(t *testing.T) {
 		assert.True(t, handler.IsFixAsyncCallBackArgsListFlagEnabled())
 		assert.True(t, handler.IsFixOldTokenLiquidityEnabled())
 		assert.True(t, handler.IsRuntimeMemStoreLimitEnabled())
+		assert.True(t, handler.IsWipeSingleNFTLiquidityDecreaseEnabled())
 	})
 	t.Run("flags with < should be set", func(t *testing.T) {
 		t.Parallel()
@@ -393,5 +395,6 @@ func TestNewEnableEpochsHandler_EpochConfirmed(t *testing.T) {
 		assert.False(t, handler.IsFixAsyncCallBackArgsListFlagEnabled())
 		assert.False(t, handler.IsFixOldTokenLiquidityEnabled())
 		assert.False(t, handler.IsRuntimeMemStoreLimitEnabled())
+		assert.False(t, handler.IsWipeSingleNFTLiquidityDecreaseEnabled())
 	})
 }

--- a/common/enablers/epochFlags.go
+++ b/common/enablers/epochFlags.go
@@ -86,6 +86,7 @@ type epochFlagsHolder struct {
 	fixAsyncCallBackArgsList                    *atomic.Flag
 	fixOldTokenLiquidity                        *atomic.Flag
 	runtimeMemStoreLimitFlag                    *atomic.Flag
+	wipeSingleNFTLiquidityDecreaseFlag          *atomic.Flag
 }
 
 func newEpochFlagsHolder() *epochFlagsHolder {
@@ -171,6 +172,7 @@ func newEpochFlagsHolder() *epochFlagsHolder {
 		fixAsyncCallBackArgsList:                    &atomic.Flag{},
 		fixOldTokenLiquidity:                        &atomic.Flag{},
 		runtimeMemStoreLimitFlag:                    &atomic.Flag{},
+		wipeSingleNFTLiquidityDecreaseFlag:          &atomic.Flag{},
 	}
 }
 
@@ -630,4 +632,9 @@ func (holder *epochFlagsHolder) IsFixOldTokenLiquidityEnabled() bool {
 // IsRuntimeMemStoreLimitEnabled returns true if runtimeMemStoreLimitFlag is enabled
 func (holder *epochFlagsHolder) IsRuntimeMemStoreLimitEnabled() bool {
 	return holder.runtimeMemStoreLimitFlag.IsSet()
+}
+
+// IsWipeSingleNFTLiquidityDecreaseEnabled returns true if runtimeMemStoreLimitFlag is enabled
+func (holder *epochFlagsHolder) IsWipeSingleNFTLiquidityDecreaseEnabled() bool {
+	return holder.wipeSingleNFTLiquidityDecreaseFlag.IsSet()
 }

--- a/common/interface.go
+++ b/common/interface.go
@@ -333,6 +333,7 @@ type EnableEpochsHandler interface {
 	IsFixAsyncCallBackArgsListFlagEnabled() bool
 	IsFixOldTokenLiquidityEnabled() bool
 	IsRuntimeMemStoreLimitEnabled() bool
+	IsWipeSingleNFTLiquidityDecreaseEnabled() bool
 
 	IsInterfaceNil() bool
 }

--- a/config/epochConfig.go
+++ b/config/epochConfig.go
@@ -89,6 +89,7 @@ type EnableEpochs struct {
 	RuntimeMemStoreLimitEnableEpoch                   uint32
 	SetSenderInEeiOutputTransferEnableEpoch           uint32
 	RefactorPeersMiniBlocksEnableEpoch                uint32
+	WipeSingleNFTLiquidityDecreaseEnableEpoch         uint32
 	BLSMultiSignerEnableEpoch                         []MultiSignerConfig
 }
 

--- a/config/tomlConfig_test.go
+++ b/config/tomlConfig_test.go
@@ -669,6 +669,9 @@ func TestEnableEpochConfig(t *testing.T) {
 	# SetSenderInEeiOutputTransferEnableEpoch represents the epoch when setting the sender in eei output transfers will be enabled
     SetSenderInEeiOutputTransferEnableEpoch = 58
 
+    # WipeSingleNFTLiquidityDecreaseEnableEpoch represents the epoch when the system account liquidity is decreased for wipeSingleNFT as well
+    WipeSingleNFTLiquidityDecreaseEnableEpoch = 59
+
     # MaxNodesChangeEnableEpoch holds configuration for changing the maximum number of nodes and the enabling epoch
     MaxNodesChangeEnableEpoch = [
         { EpochEnable = 44, MaxNumNodes = 2169, NodesToShufflePerShard = 80 },
@@ -759,6 +762,7 @@ func TestEnableEpochConfig(t *testing.T) {
 			FixAsyncCallBackArgsListEnableEpoch:         56,
 			FixOldTokenLiquidityEnableEpoch:             57,
 			SetSenderInEeiOutputTransferEnableEpoch:     58,
+			WipeSingleNFTLiquidityDecreaseEnableEpoch:   59,
 			BLSMultiSignerEnableEpoch: []MultiSignerConfig{
 				{
 					EnableEpoch: 0,

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ElrondNetwork/elrond-go-logger v1.0.10
 	github.com/ElrondNetwork/elrond-go-p2p v1.0.5
 	github.com/ElrondNetwork/elrond-go-storage v1.0.4
-	github.com/ElrondNetwork/elrond-vm-common v1.3.30
+	github.com/ElrondNetwork/elrond-vm-common v1.3.31-0.20221209141645-09c6be340647
 	github.com/ElrondNetwork/wasm-vm-v1_2 v1.2.48
 	github.com/ElrondNetwork/wasm-vm-v1_3 v1.3.48
 	github.com/ElrondNetwork/wasm-vm-v1_4 v1.4.68

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/ElrondNetwork/elrond-go-storage v1.0.4 h1:esyXbHQvlR6m4HGeC86Nq0xAJ74
 github.com/ElrondNetwork/elrond-go-storage v1.0.4/go.mod h1:SRsv4hUtL1BCiQe0eADth3C0EZH9baijzIJDCUitR34=
 github.com/ElrondNetwork/elrond-vm-common v1.3.27/go.mod h1:3GKLv9hUFYEVxoBgtaCmaZo9HMNfKN9mM/O/xX83Rbw=
 github.com/ElrondNetwork/elrond-vm-common v1.3.28/go.mod h1:3GKLv9hUFYEVxoBgtaCmaZo9HMNfKN9mM/O/xX83Rbw=
-github.com/ElrondNetwork/elrond-vm-common v1.3.30 h1:nLMORp46GcvK9qwx/Iiz+8h/MB5qlPppaX+VJikOz8I=
-github.com/ElrondNetwork/elrond-vm-common v1.3.30/go.mod h1:3GKLv9hUFYEVxoBgtaCmaZo9HMNfKN9mM/O/xX83Rbw=
+github.com/ElrondNetwork/elrond-vm-common v1.3.31-0.20221209141645-09c6be340647 h1:WQz6bD0CUiz2LOpo62HXosDYtPbUXcf9fGvzmmq+KBc=
+github.com/ElrondNetwork/elrond-vm-common v1.3.31-0.20221209141645-09c6be340647/go.mod h1:3GKLv9hUFYEVxoBgtaCmaZo9HMNfKN9mM/O/xX83Rbw=
 github.com/ElrondNetwork/protobuf v1.3.2 h1:qoCSYiO+8GtXBEZWEjw0WPcZfM3g7QuuJrwpN+y6Mvg=
 github.com/ElrondNetwork/protobuf v1.3.2/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/ElrondNetwork/wasm-vm-v1_2 v1.2.48 h1:il52OCaEpYDQFRkUtlsBwBqnbpkoN9S2FAnjF4z3VHk=

--- a/integrationTests/vm/txsFee/multiShard/esdtLiquidity_test.go
+++ b/integrationTests/vm/txsFee/multiShard/esdtLiquidity_test.go
@@ -1,0 +1,197 @@
+package multiShard
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/data/esdt"
+	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/integrationTests/vm"
+	"github.com/ElrondNetwork/elrond-go/integrationTests/vm/txsFee/utils"
+	"github.com/ElrondNetwork/elrond-go/state"
+	"github.com/ElrondNetwork/elrond-go/testscommon/integrationtests"
+	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemAccountLiquidityAfterCrossShardTransferAndBurn(t *testing.T) {
+	tokenID := []byte("MYNFT")
+	sh0Addr := []byte("12345678901234567890123456789010")
+	sh1Addr := []byte("12345678901234567890123456789011")
+	sh0Context, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(0, config.EnableEpochs{})
+	require.Nil(t, err)
+	defer sh0Context.Close()
+
+	sh1Context, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(1, config.EnableEpochs{})
+	require.Nil(t, err)
+	defer sh1Context.Close()
+	_, _ = vm.CreateAccount(sh1Context.Accounts, sh1Addr, 0, big.NewInt(1000000000))
+
+	// create the nft and ensure that it exists on the account's trie and the liquidity is set on the system account
+	utils.CreateAccountWithESDTBalance(t, sh0Context.Accounts, sh0Addr, big.NewInt(100000000), tokenID, 1, big.NewInt(1))
+	utils.CheckESDTNFTBalance(t, sh0Context, sh0Addr, tokenID, 1, big.NewInt(1))
+	utils.CheckESDTNFTBalance(t, sh0Context, core.SystemAccountAddress, tokenID, 1, big.NewInt(1))
+
+	sh0Accnt, _ := sh0Context.Accounts.LoadAccount(sh0Addr)
+	crossShardTransferTx := utils.CreateESDTNFTTransferTx(sh0Accnt.GetNonce(), sh0Addr, sh1Addr, tokenID, 1, big.NewInt(1), 10, 1000000, "")
+	retCode, err := sh0Context.TxProcessor.ProcessTransaction(crossShardTransferTx)
+	require.Equal(t, vmcommon.Ok, retCode)
+	require.NoError(t, err)
+
+	scrs := sh0Context.GetIntermediateTransactions(t)
+
+	// check the balances after the transfer, as well as the liquidity
+	utils.ProcessSCRResult(t, sh1Context, scrs[0], vmcommon.Ok, nil)
+	utils.CheckESDTNFTBalance(t, sh0Context, sh0Addr, tokenID, 1, big.NewInt(0))
+	utils.CheckESDTNFTBalance(t, sh0Context, core.SystemAccountAddress, tokenID, 1, big.NewInt(0))
+	utils.CheckESDTNFTBalance(t, sh1Context, sh1Addr, tokenID, 1, big.NewInt(1))
+	utils.CheckESDTNFTBalance(t, sh1Context, core.SystemAccountAddress, tokenID, 1, big.NewInt(1))
+
+	// set roles and burn the NFT on shard 1
+	utils.SetESDTRoles(t, sh1Context.Accounts, sh1Addr, tokenID, [][]byte{[]byte(core.ESDTRoleNFTBurn)})
+
+	tx := utils.CreateESDTNFTBurnTx(0, sh1Addr, sh1Addr, tokenID, 1, big.NewInt(1), 10, 100000)
+	retCode, err = sh1Context.TxProcessor.ProcessTransaction(tx)
+	require.Equal(t, vmcommon.Ok, retCode)
+	require.Nil(t, err)
+
+	// ensure that the token is burnt from all addresses and system account liquidity
+	utils.CheckESDTNFTBalance(t, sh0Context, sh0Addr, tokenID, 1, big.NewInt(0))
+	utils.CheckESDTNFTBalance(t, sh0Context, core.SystemAccountAddress, tokenID, 1, big.NewInt(0))
+	utils.CheckESDTNFTBalance(t, sh1Context, sh1Addr, tokenID, 1, big.NewInt(0))
+	utils.CheckESDTNFTBalance(t, sh1Context, core.SystemAccountAddress, tokenID, 1, big.NewInt(0))
+}
+
+func TestSystemAccountLiquidityAfterNFTWipe(t *testing.T) {
+	tokenID := []byte("MYNFT-0a0a0a")
+	sh0Addr := bytes.Repeat([]byte{1}, 31)
+	sh0Addr = append(sh0Addr, 0)
+	sh0Context, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(0, config.EnableEpochs{})
+	require.Nil(t, err)
+	defer sh0Context.Close()
+
+	metaContext, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(core.MetachainShardId, config.EnableEpochs{})
+	require.Nil(t, err)
+	defer metaContext.Close()
+
+	// create the nft and ensure that it exists on the account's trie and the liquidity is set on the system account
+	utils.CreateAccountWithESDTBalance(t, sh0Context.Accounts, sh0Addr, big.NewInt(10000000000000), tokenID, 1, big.NewInt(1))
+	utils.CheckESDTNFTBalance(t, sh0Context, sh0Addr, tokenID, 1, big.NewInt(1))
+	utils.CheckESDTNFTBalance(t, sh0Context, core.SystemAccountAddress, tokenID, 1, big.NewInt(1))
+
+	addTokenInMeta(t, metaContext, tokenID, &systemSmartContracts.ESDTDataV2{
+		OwnerAddress: sh0Addr,
+		CanFreeze:    true,
+		CanWipe:      true,
+	})
+	sh0Accnt, _ := sh0Context.Accounts.LoadAccount(sh0Addr)
+	freezeTx, wipeTx := utils.CreateESDTFreezeAndWipeTxs(sh0Accnt.GetNonce(), sh0Addr, sh0Addr, tokenID, 1, 10, 1000000000)
+	retCode, err := metaContext.TxProcessor.ProcessTransaction(freezeTx)
+	require.NoError(t, err)
+	require.Equal(t, vmcommon.Ok, retCode)
+
+	scrs := metaContext.GetIntermediateTransactions(t)
+	utils.ProcessSCRResult(t, sh0Context, scrs[0], vmcommon.Ok, nil)
+
+	retCode, err = metaContext.TxProcessor.ProcessTransaction(wipeTx)
+	require.Equal(t, vmcommon.Ok, retCode)
+	require.NoError(t, err)
+
+	scrs = metaContext.GetIntermediateTransactions(t)
+	utils.ProcessSCRResult(t, sh0Context, scrs[1], vmcommon.Ok, nil)
+
+	_, _ = sh0Context.Accounts.Commit()
+
+	// check the balances after the transfer, as well as the liquidity
+
+	checkEsdtBalanceInAccountStorage(t, sh0Context, sh0Addr, tokenID, 1, big.NewInt(0))
+	utils.CheckESDTNFTBalance(t, sh0Context, core.SystemAccountAddress, tokenID, 1, big.NewInt(0))
+}
+
+func TestSystemAccountLiquidityAfterSFTWipe(t *testing.T) {
+	tokenID := []byte("MYSFT-0a0a0a")
+	sh0Addr := bytes.Repeat([]byte{1}, 31)
+	sh0Addr = append(sh0Addr, 0)
+	sh0Context, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(0, config.EnableEpochs{})
+	require.Nil(t, err)
+	defer sh0Context.Close()
+
+	metaContext, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(core.MetachainShardId, config.EnableEpochs{})
+	require.Nil(t, err)
+	defer metaContext.Close()
+
+	// create the nft and ensure that it exists on the account's trie and the liquidity is set on the system account
+	utils.CreateAccountWithESDTBalance(t, sh0Context.Accounts, sh0Addr, big.NewInt(10000000000000), tokenID, 1, big.NewInt(10))
+	utils.CheckESDTNFTBalance(t, sh0Context, sh0Addr, tokenID, 1, big.NewInt(10))
+	utils.CheckESDTNFTBalance(t, sh0Context, core.SystemAccountAddress, tokenID, 1, big.NewInt(10))
+
+	addTokenInMeta(t, metaContext, tokenID, &systemSmartContracts.ESDTDataV2{
+		OwnerAddress: sh0Addr,
+		CanFreeze:    true,
+		CanWipe:      true,
+	})
+	sh0Accnt, _ := sh0Context.Accounts.LoadAccount(sh0Addr)
+	freezeTx, wipeTx := utils.CreateESDTFreezeAndWipeTxs(sh0Accnt.GetNonce(), sh0Addr, sh0Addr, tokenID, 1, 10, 1000000000)
+	retCode, err := metaContext.TxProcessor.ProcessTransaction(freezeTx)
+	require.NoError(t, err)
+	require.Equal(t, vmcommon.Ok, retCode)
+
+	scrs := metaContext.GetIntermediateTransactions(t)
+	utils.ProcessSCRResult(t, sh0Context, scrs[0], vmcommon.Ok, nil)
+
+	retCode, err = metaContext.TxProcessor.ProcessTransaction(wipeTx)
+	require.Equal(t, vmcommon.Ok, retCode)
+	require.NoError(t, err)
+
+	scrs = metaContext.GetIntermediateTransactions(t)
+	utils.ProcessSCRResult(t, sh0Context, scrs[1], vmcommon.Ok, nil)
+
+	// ensure that there is no liquidity left in the account or the system account
+	checkEsdtBalanceInAccountStorage(t, sh0Context, sh0Addr, tokenID, 1, big.NewInt(0))
+	utils.CheckESDTNFTBalance(t, sh0Context, core.SystemAccountAddress, tokenID, 1, big.NewInt(0))
+}
+
+func addTokenInMeta(t *testing.T, metaContext *vm.VMTestContext, tokenID []byte, token *systemSmartContracts.ESDTDataV2) {
+	marshaledData, err := integrationtests.TestMarshalizer.Marshal(token)
+	require.NoError(t, err)
+
+	esdtAccnt, err := metaContext.Accounts.LoadAccount(core.ESDTSCAddress)
+	require.NoError(t, err)
+
+	esdtAccntUser, ok := esdtAccnt.(state.UserAccountHandler)
+	require.True(t, ok)
+
+	err = esdtAccntUser.SaveKeyValue(tokenID, marshaledData)
+	require.NoError(t, err)
+
+	err = metaContext.Accounts.SaveAccount(esdtAccntUser)
+	require.NoError(t, err)
+	_, err = metaContext.Accounts.Commit()
+	require.NoError(t, err)
+}
+
+func checkEsdtBalanceInAccountStorage(t *testing.T, context *vm.VMTestContext, address []byte, tokenID []byte, nonce uint64, expectedValue *big.Int) {
+	res, err := context.Accounts.LoadAccount(address)
+	require.NoError(t, err)
+
+	userAcc, ok := res.(state.UserAccountHandler)
+	require.True(t, ok)
+
+	esdtTokenKey := []byte(core.ElrondProtectedKeyPrefix + core.ESDTKeyIdentifier + string(tokenID))
+	esdtTokenKey = append(esdtTokenKey, big.NewInt(int64(nonce)).Bytes()...)
+	tokenBytes, _, err := userAcc.RetrieveValue(esdtTokenKey)
+	require.NoError(t, err)
+
+	esToken := esdt.ESDigitalToken{}
+	err = integrationtests.TestMarshalizer.Unmarshal(&esToken, tokenBytes)
+	require.NoError(t, err)
+
+	if expectedValue.Uint64() == 0 {
+		require.Nil(t, esToken.Value)
+	} else {
+		require.Equal(t, expectedValue, esToken.Value)
+	}
+}

--- a/sharding/mock/enableEpochsHandlerMock.go
+++ b/sharding/mock/enableEpochsHandlerMock.go
@@ -546,6 +546,11 @@ func (mock *EnableEpochsHandlerMock) IsRuntimeMemStoreLimitEnabled() bool {
 	return false
 }
 
+// IsWipeSingleNFTLiquidityDecreaseEnabled -
+func (mock *EnableEpochsHandlerMock) IsWipeSingleNFTLiquidityDecreaseEnabled() bool {
+	return false
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (mock *EnableEpochsHandlerMock) IsInterfaceNil() bool {
 	return mock == nil

--- a/testscommon/enableEpochsHandlerStub.go
+++ b/testscommon/enableEpochsHandlerStub.go
@@ -113,6 +113,7 @@ type EnableEpochsHandlerStub struct {
 	IsFixAsyncCallBackArgsListFlagEnabledField                   bool
 	IsFixOldTokenLiquidityEnabledField                           bool
 	IsRuntimeMemStoreLimitEnabledField                           bool
+	IsWipeSingleNFTLiquidityDecreaseEnabledField                 bool
 }
 
 // ResetPenalizedTooMuchGasFlag -
@@ -976,6 +977,14 @@ func (stub *EnableEpochsHandlerStub) IsRuntimeMemStoreLimitEnabled() bool {
 	defer stub.RUnlock()
 
 	return stub.IsRuntimeMemStoreLimitEnabledField
+}
+
+// IsWipeSingleNFTLiquidityDecreaseEnabled -
+func (stub *EnableEpochsHandlerStub) IsWipeSingleNFTLiquidityDecreaseEnabled() bool {
+	stub.RLock()
+	defer stub.RUnlock()
+
+	return stub.IsWipeSingleNFTLiquidityDecreaseEnabledField
 }
 
 // IsInterfaceNil -


### PR DESCRIPTION
## Reasoning behind the pull request
- there were small inconsistencies on the system account liquidity level when performing nft wipe operations
  
## Proposed changes
- referenced  new vm-common with fixes
- add enable epoch flag

## Testing procedure
- [tbd]

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
