### PR TITLE
Disable in-epoch trie pruning 

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -668,7 +668,7 @@
     CheckpointRoundsModulus = 100
     CheckpointsEnabled = false
     SnapshotsEnabled = true
-    AccountsStatePruningEnabled = true
+    AccountsStatePruningEnabled = false
     PeerStatePruningEnabled = true
     MaxStateTrieLevelInMemory = 5
     MaxPeerTrieLevelInMemory = 5


### PR DESCRIPTION
## Reasoning behind the pull request
- Now, the node does a trie pruning operation on each new committed block. This makes the trie history unavailable after ~10 consecutive final blocks are committed
   
## Proposed changes
- disable in-epoch trie pruning

## Testing procedure
- standard system test in which, after the upgrade, you pick an old block (>50 rounds old block) and query a get operation as follows:
```
http://<proxy>/address/<address>?blockNonce=<block_nonce>
```

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
