### PR TITLE
Blockchainhook counters refactor

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -51,14 +51,10 @@ github.com/ElrondNetwork/elastic-indexer-go v1.3.3/go.mod h1:E3VO5712GkGSGYnOTJ+
 github.com/ElrondNetwork/elrond-go-core v1.1.26 h1:5syiJMlkWlH7HHnuiOafJJzeI+oUfYqL8mXREqrFerY=
 github.com/ElrondNetwork/elrond-go-core v1.1.26/go.mod h1:N/RI++YU2M6OlnD1GSZepc1wPhI84ykRDQ1IyD3B0wk=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.2/go.mod h1:MyQPKUKti7Axnx/eihhL0F2jLTalvSV/Ytv1mIxvYyM=
-github.com/ElrondNetwork/elrond-go-crypto v1.2.3-0.20221207130836-796c2dff9ad7 h1:WSrV/gZ+YJQKU46udfni6b56YnMFVJ0GpGEjO1wFbn0=
-github.com/ElrondNetwork/elrond-go-crypto v1.2.3-0.20221207130836-796c2dff9ad7/go.mod h1:04TNYc9JT+bXGFjaWf1oP7iFudRprHp5iULyQaVYMao=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.3 h1:kX/xIWuQLKDvfPNSsCrFWcmNABa1h+DpbZ99RDwzCas=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.3/go.mod h1:04TNYc9JT+bXGFjaWf1oP7iFudRprHp5iULyQaVYMao=
 github.com/ElrondNetwork/elrond-go-logger v1.0.10 h1:2xQOWZErcHW5sl9qSRO+7mGNw+QhFhqiUlLLtOgvuuk=
 github.com/ElrondNetwork/elrond-go-logger v1.0.10/go.mod h1:+rMODFw4yQptTi5WuLUBzvl/AE26V+2YJtc52wX30Eg=
-github.com/ElrondNetwork/elrond-go-p2p v1.0.6-0.20221207134639-9d392e20bd13 h1:rPsjMIOYk7HFjR9RxQ3BetGBYUs3mIdir/fDeZtTb90=
-github.com/ElrondNetwork/elrond-go-p2p v1.0.6-0.20221207134639-9d392e20bd13/go.mod h1:u/tP7HotjCwksDyK9FpVKbUgSKcwlH2+v7/Fcw9HAmk=
 github.com/ElrondNetwork/elrond-go-p2p v1.0.6 h1:PMUMCoox64+d29iR+EYKMYSoAwyp69kHqtECDltqZKs=
 github.com/ElrondNetwork/elrond-go-p2p v1.0.6/go.mod h1:7Z4aiKnqGk2bX181Mo9cCuC1yJJ1VDENkk8GdjOGtRc=
 github.com/ElrondNetwork/elrond-go-storage v1.0.2/go.mod h1:SRsv4hUtL1BCiQe0eADth3C0EZH9baijzIJDCUitR34=

--- a/process/interface.go
+++ b/process/interface.go
@@ -506,6 +506,7 @@ type BlockChainHookHandler interface {
 	FilterCodeMetadataForUpgrade(input []byte) ([]byte, error)
 	ApplyFiltersOnCodeMetadata(codeMetadata vmcommon.CodeMetadata) vmcommon.CodeMetadata
 	ResetCounters()
+	GetCounterValues() map[string]uint64
 	IsInterfaceNil() bool
 }
 

--- a/process/smartContract/hooks/blockChainHook.go
+++ b/process/smartContract/hooks/blockChainHook.go
@@ -842,6 +842,11 @@ func (bh *BlockChainHookImpl) ResetCounters() {
 	bh.counter.ResetCounters()
 }
 
+// GetCounterValues returns the current counter values
+func (bh *BlockChainHookImpl) GetCounterValues() map[string]uint64 {
+	return bh.counter.GetCounterValues()
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (bh *BlockChainHookImpl) IsInterfaceNil() bool {
 	return bh == nil

--- a/process/smartContract/hooks/blockChainHook_test.go
+++ b/process/smartContract/hooks/blockChainHook_test.go
@@ -2180,6 +2180,25 @@ func TestBlockChainHookImpl_ResetCounters(t *testing.T) {
 	assert.True(t, resetCalled)
 }
 
+func TestBlockChainHookImpl_GetCounterValues(t *testing.T) {
+	t.Parallel()
+
+	countersMap := map[string]uint64{
+		"value": 37,
+	}
+	args := createMockBlockChainHookArgs()
+	args.Counter = &testscommon.BlockChainHookCounterStub{
+		GetCounterValuesCalled: func() map[string]uint64 {
+			return countersMap
+		},
+	}
+
+	bh, _ := hooks.NewBlockChainHookImpl(args)
+	m := bh.GetCounterValues()
+
+	assert.Equal(t, fmt.Sprintf("%p", m), fmt.Sprintf("%p", countersMap)) // pointer testing
+}
+
 func TestBlockChainHookImpl_GasScheduleChange(t *testing.T) {
 	t.Parallel()
 

--- a/process/smartContract/hooks/counters/disabledCounter.go
+++ b/process/smartContract/hooks/counters/disabledCounter.go
@@ -26,6 +26,11 @@ func (counter *disabledCounter) ResetCounters() {}
 // SetMaximumValues does nothing
 func (counter *disabledCounter) SetMaximumValues(_ map[string]uint64) {}
 
+// GetCounterValues returns an empty map
+func (counter *disabledCounter) GetCounterValues() map[string]uint64 {
+	return make(map[string]uint64)
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (counter *disabledCounter) IsInterfaceNil() bool {
 	return counter == nil

--- a/process/smartContract/hooks/counters/usageCounter.go
+++ b/process/smartContract/hooks/counters/usageCounter.go
@@ -16,6 +16,9 @@ const (
 	maxBuiltinCalls = "MaxBuiltInCallsPerTx"
 	maxTransfers    = "MaxNumberOfTransfersPerTx"
 	maxTrieReads    = "MaxNumberOfTrieReadsPerTx"
+	crtBuiltinCalls = "CrtBuiltInCallsPerTx"
+	crtTransfers    = "CrtNumberOfTransfersPerTx"
+	crtTrieReads    = "CrtNumberOfTrieReadsPerTx"
 )
 
 type usageCounter struct {
@@ -85,12 +88,6 @@ func (counter *usageCounter) ResetCounters() {
 	counter.mutCounters.Lock()
 	defer counter.mutCounters.Unlock()
 
-	log.Trace("BlockChainHookImpl.ResetCounters",
-		"crtNumberOfBuiltInFunctionCalls", counter.crtNumberOfBuiltInFunctionCalls,
-		"crtNumberOfTransfers", counter.crtNumberOfTransfers,
-		"crtNumberOfTrieReads", counter.crtNumberOfTrieReads,
-	)
-
 	counter.crtNumberOfBuiltInFunctionCalls = 0
 	counter.crtNumberOfTransfers = 0
 	counter.crtNumberOfTrieReads = 0
@@ -113,6 +110,20 @@ func readValue(mapsOfValues map[string]uint64, identifier string) uint64 {
 	}
 
 	return value
+}
+
+// GetCounterValues returns the current counter values
+func (counter *usageCounter) GetCounterValues() map[string]uint64 {
+	counter.mutCounters.RLock()
+	defer counter.mutCounters.RUnlock()
+
+	values := map[string]uint64{
+		crtBuiltinCalls: counter.crtNumberOfBuiltInFunctionCalls,
+		crtTransfers:    counter.crtNumberOfTransfers,
+		crtTrieReads:    counter.crtNumberOfTrieReads,
+	}
+
+	return values
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/process/smartContract/hooks/counters/usageCounter_test.go
+++ b/process/smartContract/hooks/counters/usageCounter_test.go
@@ -49,9 +49,24 @@ func TestUsageCounter_ProcessCrtNumberOfTrieReadsCounter(t *testing.T) {
 	assert.ErrorIs(t, counter.ProcessCrtNumberOfTrieReadsCounter(), process.ErrMaxBuiltInCallsReached) // counter is now 4, error signalled
 	assert.ErrorIs(t, counter.ProcessCrtNumberOfTrieReadsCounter(), process.ErrMaxBuiltInCallsReached) // counter is now 5, error signalled
 
+	countersMap := counter.GetCounterValues()
+	expectedMap := map[string]uint64{
+		crtBuiltinCalls: 0,
+		crtTransfers:    0,
+		crtTrieReads:    5,
+	}
+	assert.Equal(t, expectedMap, countersMap)
+
 	counter.ResetCounters()
 
 	assert.Nil(t, counter.ProcessCrtNumberOfTrieReadsCounter()) // counter is now 1
+	countersMap = counter.GetCounterValues()
+	expectedMap = map[string]uint64{
+		crtBuiltinCalls: 0,
+		crtTransfers:    0,
+		crtTrieReads:    1,
+	}
+	assert.Equal(t, expectedMap, countersMap)
 }
 
 func TestUsageCounter_ProcessMaxBuiltInCounters(t *testing.T) {
@@ -71,9 +86,24 @@ func TestUsageCounter_ProcessMaxBuiltInCounters(t *testing.T) {
 		assert.ErrorIs(t, counter.ProcessMaxBuiltInCounters(vmInput), process.ErrMaxBuiltInCallsReached) // counter is now 4, error signalled
 		assert.ErrorIs(t, counter.ProcessMaxBuiltInCounters(vmInput), process.ErrMaxBuiltInCallsReached) // counter is now 5, error signalled
 
+		countersMap := counter.GetCounterValues()
+		expectedMap := map[string]uint64{
+			crtBuiltinCalls: 5,
+			crtTransfers:    0,
+			crtTrieReads:    0,
+		}
+		assert.Equal(t, expectedMap, countersMap)
+
 		counter.ResetCounters()
 
 		assert.Nil(t, counter.ProcessMaxBuiltInCounters(vmInput)) // counter is now 1
+		countersMap = counter.GetCounterValues()
+		expectedMap = map[string]uint64{
+			crtBuiltinCalls: 1,
+			crtTransfers:    0,
+			crtTrieReads:    0,
+		}
+		assert.Equal(t, expectedMap, countersMap)
 	})
 	t.Run("number of transfers exceeded", func(t *testing.T) {
 		t.Parallel()
@@ -96,9 +126,23 @@ func TestUsageCounter_ProcessMaxBuiltInCounters(t *testing.T) {
 		assert.Nil(t, counter.ProcessMaxBuiltInCounters(vmInput))                                        // counter is now 6
 		assert.ErrorIs(t, counter.ProcessMaxBuiltInCounters(vmInput), process.ErrMaxBuiltInCallsReached) // counter is now 8, error signalled
 		assert.ErrorIs(t, counter.ProcessMaxBuiltInCounters(vmInput), process.ErrMaxBuiltInCallsReached) // counter is now 10, error signalled
+		countersMap := counter.GetCounterValues()
+		expectedMap := map[string]uint64{
+			crtBuiltinCalls: 5,
+			crtTransfers:    10,
+			crtTrieReads:    0,
+		}
+		assert.Equal(t, expectedMap, countersMap)
 
 		counter.ResetCounters()
 
 		assert.Nil(t, counter.ProcessMaxBuiltInCounters(vmInput)) // counter is now 2
+		countersMap = counter.GetCounterValues()
+		expectedMap = map[string]uint64{
+			crtBuiltinCalls: 1,
+			crtTransfers:    2,
+			crtTrieReads:    0,
+		}
+		assert.Equal(t, expectedMap, countersMap)
 	})
 }

--- a/process/smartContract/hooks/interface.go
+++ b/process/smartContract/hooks/interface.go
@@ -8,5 +8,6 @@ type BlockChainHookCounter interface {
 	ProcessMaxBuiltInCounters(input *vmcommon.ContractCallInput) error
 	ResetCounters()
 	SetMaximumValues(mapsOfValues map[string]uint64)
+	GetCounterValues() map[string]uint64
 	IsInterfaceNil() bool
 }

--- a/testscommon/blockChainHookCounterStub.go
+++ b/testscommon/blockChainHookCounterStub.go
@@ -8,6 +8,7 @@ type BlockChainHookCounterStub struct {
 	ProcessMaxBuiltInCountersCalled          func(input *vmcommon.ContractCallInput) error
 	ResetCountersCalled                      func()
 	SetMaximumValuesCalled                   func(mapsOfValues map[string]uint64)
+	GetCounterValuesCalled                   func() map[string]uint64
 }
 
 // ProcessCrtNumberOfTrieReadsCounter -
@@ -40,6 +41,15 @@ func (stub *BlockChainHookCounterStub) SetMaximumValues(mapsOfValues map[string]
 	if stub.SetMaximumValuesCalled != nil {
 		stub.SetMaximumValuesCalled(mapsOfValues)
 	}
+}
+
+// GetCounterValues -
+func (stub *BlockChainHookCounterStub) GetCounterValues() map[string]uint64 {
+	if stub.GetCounterValuesCalled != nil {
+		return stub.GetCounterValuesCalled()
+	}
+
+	return make(map[string]uint64)
 }
 
 // IsInterfaceNil -

--- a/testscommon/blockChainHookStub.go
+++ b/testscommon/blockChainHookStub.go
@@ -45,6 +45,7 @@ type BlockChainHookStub struct {
 	FilterCodeMetadataForUpgradeCalled   func(input []byte) ([]byte, error)
 	ApplyFiltersOnCodeMetadataCalled     func(codeMetadata vmcommon.CodeMetadata) vmcommon.CodeMetadata
 	ResetCountersCalled                  func()
+	GetCounterValuesCalled               func() map[string]uint64
 }
 
 // GetCode -
@@ -378,6 +379,15 @@ func (stub *BlockChainHookStub) ResetCounters() {
 	if stub.ResetCountersCalled != nil {
 		stub.ResetCountersCalled()
 	}
+}
+
+// GetCounterValues -
+func (stub *BlockChainHookStub) GetCounterValues() map[string]uint64 {
+	if stub.GetCounterValuesCalled != nil {
+		return stub.GetCounterValuesCalled()
+	}
+
+	return make(map[string]uint64)
 }
 
 // IsInterfaceNil -


### PR DESCRIPTION
## Reasoning behind the pull request
- blockchain hook prints did not contain execution context such as the transaction hash and other helpful information
  
## Proposed changes
- refactor code to provide more context whenever blockchain counters needed to be output as log prints

## Testing procedure
- run a system testnet with the following log level `*:DEBUG,blockchainHookCounters:TRACE`, analyze the logs, should find trace logs that start with `blockchain hook counters` that contain the 3 counters values.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
