### PR TITLE
Epoch nodes config cacher

### DIFF
--- a/epochStart/bootstrap/syncValidatorStatus.go
+++ b/epochStart/bootstrap/syncValidatorStatus.go
@@ -23,6 +23,7 @@ import (
 )
 
 const consensusGroupCacheSize = 50
+const nodesConfigCacheSize = 10
 
 type syncValidatorStatus struct {
 	miniBlocksSyncer    epochStart.PendingMiniBlocksSyncHandler
@@ -109,6 +110,11 @@ func NewSyncValidatorStatus(args ArgsNewSyncValidatorStatus) (*syncValidatorStat
 		return nil, err
 	}
 
+	nodesConfigCache, err := cache.NewLRUCache(nodesConfigCacheSize)
+	if err != nil {
+		return nil, err
+	}
+
 	s.memDB = disabled.CreateMemUnit()
 
 	argsNodesCoordinator := nodesCoordinator.ArgNodesCoordinator{
@@ -132,6 +138,7 @@ func NewSyncValidatorStatus(args ArgsNewSyncValidatorStatus) (*syncValidatorStat
 		EnableEpochsHandler:     args.EnableEpochsHandler,
 		ValidatorInfoCacher:     s.dataPool.CurrentEpochValidatorInfo(),
 		NumStoredEpochs:         args.NumStoredEpochs,
+		NodesConfigCache:        nodesConfigCache,
 	}
 	baseNodesCoordinator, err := nodesCoordinator.NewIndexHashedNodesCoordinator(argsNodesCoordinator)
 	if err != nil {

--- a/factory/bootstrap/shardingFactory.go
+++ b/factory/bootstrap/shardingFactory.go
@@ -171,6 +171,11 @@ func CreateNodesCoordinator(
 		return nil, err
 	}
 
+	nodesConfigCache, err := cache.NewLRUCache(25000)
+	if err != nil {
+		return nil, err
+	}
+
 	shuffledOutHandler, err := sharding.NewShuffledOutTrigger(pubKeyBytes, currentShardID, nodeShufflerOut.EndOfProcessingHandler)
 	if err != nil {
 		return nil, err
@@ -199,6 +204,7 @@ func CreateNodesCoordinator(
 		EnableEpochsHandler:     enableEpochsHandler,
 		ValidatorInfoCacher:     validatorInfoCacher,
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        nodesConfigCache,
 	}
 
 	baseNodesCoordinator, err := nodesCoordinator.NewIndexHashedNodesCoordinator(argumentsNodesCoordinator)

--- a/factory/bootstrap/shardingFactory.go
+++ b/factory/bootstrap/shardingFactory.go
@@ -22,6 +22,9 @@ import (
 	"github.com/ElrondNetwork/elrond-go/storage/cache"
 )
 
+const consensusGroupCacheSize = 25000
+const nodesConfigCacheSize = 10
+
 // CreateShardCoordinator is the shard coordinator factory
 func CreateShardCoordinator(
 	nodesConfig sharding.GenesisNodesSetupHandler,
@@ -166,12 +169,12 @@ func CreateNodesCoordinator(
 		return nil, err
 	}
 
-	consensusGroupCache, err := cache.NewLRUCache(25000)
+	consensusGroupCache, err := cache.NewLRUCache(consensusGroupCacheSize)
 	if err != nil {
 		return nil, err
 	}
 
-	nodesConfigCache, err := cache.NewLRUCache(25000)
+	nodesConfigCache, err := cache.NewLRUCache(nodesConfigCacheSize)
 	if err != nil {
 		return nil, err
 	}

--- a/sharding/mock/nodesCoordinatorCacheMock.go
+++ b/sharding/mock/nodesCoordinatorCacheMock.go
@@ -29,3 +29,8 @@ func (rm *NodesCoordinatorCacheMock) Get(key []byte) (value interface{}, ok bool
 	}
 	return nil, false
 }
+
+// IsInterfaceNil -
+func (rm *NodesCoordinatorCacheMock) IsInterfaceNil() bool {
+	return rm == nil
+}

--- a/sharding/nodesCoordinator/errors.go
+++ b/sharding/nodesCoordinator/errors.go
@@ -114,3 +114,6 @@ var ErrNilNodesCoordinatorRegistry = errors.New("nil nodes coordinator registry"
 
 // ErrInvalidNumberOfStoredEpochs signals that an invalid number of stored epochs has been provided
 var ErrInvalidNumberOfStoredEpochs = errors.New("invalid number of stored epochs")
+
+// ErrNilNodesConfigCacher signals that a nil value for the nodes config cacher has been provided
+var ErrNilNodesConfigCacher = errors.New("nodes config cacher is nil")

--- a/sharding/nodesCoordinator/indexHashedNodesCoordinator.go
+++ b/sharding/nodesCoordinator/indexHashedNodesCoordinator.go
@@ -229,6 +229,9 @@ func checkArguments(args ArgNodesCoordinator) error {
 	if args.NumStoredEpochs < minStoredEpochs {
 		return ErrInvalidNumberOfStoredEpochs
 	}
+	if check.IfNilReflect(args.NodesConfigCache) {
+		return ErrNilNodesConfigCacher
+	}
 
 	return nil
 }

--- a/sharding/nodesCoordinator/indexHashedNodesCoordinator.go
+++ b/sharding/nodesCoordinator/indexHashedNodesCoordinator.go
@@ -253,7 +253,7 @@ func (ihnc *indexHashedNodesCoordinator) getNodesConfig(epoch uint32) (*epochNod
 	}
 
 	ncInternalkey := append([]byte(common.NodesCoordinatorRegistryKeyPrefix), []byte(fmt.Sprint(epoch))...)
-	epochConfigBytes, err := ihnc.bootStorer.SearchFirst(ncInternalkey)
+	epochConfigBytes, err := ihnc.bootStorer.GetFromEpoch(ncInternalkey, epoch)
 	if err != nil {
 		return nil, false
 	}

--- a/sharding/nodesCoordinator/indexHashedNodesCoordinatorLite.go
+++ b/sharding/nodesCoordinator/indexHashedNodesCoordinatorLite.go
@@ -54,7 +54,7 @@ func (ihnc *indexHashedNodesCoordinator) SetNodesConfigFromValidatorsInfo(epoch 
 // IsEpochInConfig checks whether the specified epoch is already in map
 func (ihnc *indexHashedNodesCoordinator) IsEpochInConfig(epoch uint32) bool {
 	ihnc.mutNodesConfig.RLock()
-	_, exists := ihnc.nodesConfig[epoch]
+	_, exists := ihnc.getNodesConfig(epoch)
 	ihnc.mutNodesConfig.RUnlock()
 
 	return exists

--- a/sharding/nodesCoordinator/indexHashedNodesCoordinatorRegistry.go
+++ b/sharding/nodesCoordinator/indexHashedNodesCoordinatorRegistry.go
@@ -202,6 +202,16 @@ func (ihnc *indexHashedNodesCoordinator) NodesCoordinatorToRegistry() *NodesCoor
 	return registry
 }
 
+func epochNodesConfigToRegistryBytes(epoch uint32, nodesConfig *epochNodesConfig) ([]byte, error) {
+	registry := &NodesCoordinatorRegistry{
+		CurrentEpoch: epoch,
+		EpochsConfig: make(map[string]*EpochValidators),
+	}
+	registry.EpochsConfig[fmt.Sprint(epoch)] = epochNodesConfigToEpochValidators(nodesConfig)
+
+	return json.Marshal(registry)
+}
+
 // SaveNodesCoordinatorRegistry will save the nodes coordinator registry to storage
 func SaveNodesCoordinatorRegistry(
 	nodesConfig *NodesCoordinatorRegistry,

--- a/sharding/nodesCoordinator/indexHashedNodesCoordinatorRegistry.go
+++ b/sharding/nodesCoordinator/indexHashedNodesCoordinatorRegistry.go
@@ -202,16 +202,6 @@ func (ihnc *indexHashedNodesCoordinator) NodesCoordinatorToRegistry() *NodesCoor
 	return registry
 }
 
-func epochNodesConfigToRegistryBytes(epoch uint32, nodesConfig *epochNodesConfig) ([]byte, error) {
-	registry := &NodesCoordinatorRegistry{
-		CurrentEpoch: epoch,
-		EpochsConfig: make(map[string]*EpochValidators),
-	}
-	registry.EpochsConfig[fmt.Sprint(epoch)] = epochNodesConfigToEpochValidators(nodesConfig)
-
-	return json.Marshal(registry)
-}
-
 // SaveNodesCoordinatorRegistry will save the nodes coordinator registry to storage
 func SaveNodesCoordinatorRegistry(
 	nodesConfig *NodesCoordinatorRegistry,

--- a/sharding/nodesCoordinator/indexHashedNodesCoordinatorWithRater_test.go
+++ b/sharding/nodesCoordinator/indexHashedNodesCoordinatorWithRater_test.go
@@ -98,6 +98,7 @@ func TestIndexHashedGroupSelectorWithRater_OkValShouldWork(t *testing.T) {
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 	nc, err := NewIndexHashedNodesCoordinator(arguments)
 	assert.Nil(t, err)
@@ -195,6 +196,7 @@ func BenchmarkIndexHashedGroupSelectorWithRater_ComputeValidatorsGroup63of400(b 
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 	ihnc, err := NewIndexHashedNodesCoordinator(arguments)
 	require.Nil(b, err)
@@ -271,6 +273,7 @@ func Test_ComputeValidatorsGroup63of400(t *testing.T) {
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 	ihnc, _ := NewIndexHashedNodesCoordinator(arguments)
 	numRounds := uint64(1000000)
@@ -347,6 +350,7 @@ func TestIndexHashedGroupSelectorWithRater_GetValidatorWithPublicKeyShouldReturn
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 	nc, _ := NewIndexHashedNodesCoordinator(arguments)
 	ihnc, _ := NewIndexHashedNodesCoordinatorWithRater(nc, &mock.RaterMock{})
@@ -402,6 +406,7 @@ func TestIndexHashedGroupSelectorWithRater_GetValidatorWithPublicKeyShouldReturn
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 	nc, _ := NewIndexHashedNodesCoordinator(arguments)
 	ihnc, _ := NewIndexHashedNodesCoordinatorWithRater(nc, &mock.RaterMock{})
@@ -471,6 +476,7 @@ func TestIndexHashedGroupSelectorWithRater_GetValidatorWithPublicKeyShouldWork(t
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 	nc, _ := NewIndexHashedNodesCoordinator(arguments)
 	ihnc, _ := NewIndexHashedNodesCoordinatorWithRater(nc, &mock.RaterMock{})
@@ -557,6 +563,7 @@ func TestIndexHashedGroupSelectorWithRater_GetAllEligibleValidatorsPublicKeys(t 
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 
 	nc, err := NewIndexHashedNodesCoordinator(arguments)
@@ -865,6 +872,7 @@ func BenchmarkIndexHashedWithRaterGroupSelector_ComputeValidatorsGroup21of400(b 
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 	ihnc, err := NewIndexHashedNodesCoordinator(arguments)
 	require.Nil(b, err)

--- a/sharding/nodesCoordinator/indexHashedNodesCoordinator_test.go
+++ b/sharding/nodesCoordinator/indexHashedNodesCoordinator_test.go
@@ -123,6 +123,7 @@ func createArguments() ArgNodesCoordinator {
 		},
 		ValidatorInfoCacher: &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:     numStoredEpochs,
+		NodesConfigCache:    &mock.NodesCoordinatorCacheMock{},
 	}
 	return arguments
 }
@@ -292,6 +293,7 @@ func TestIndexHashedNodesCoordinator_OkValShouldWork(t *testing.T) {
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 
 	ihnc, err := NewIndexHashedNodesCoordinator(arguments)
@@ -353,6 +355,7 @@ func TestIndexHashedNodesCoordinator_NewCoordinatorTooFewNodesShouldErr(t *testi
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 	ihnc, err := NewIndexHashedNodesCoordinator(arguments)
 
@@ -428,6 +431,7 @@ func TestIndexHashedNodesCoordinator_ComputeValidatorsGroup1ValidatorShouldRetur
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 	ihnc, _ := NewIndexHashedNodesCoordinator(arguments)
 	list2, err := ihnc.ComputeConsensusGroup([]byte("randomness"), 0, 0, 0)
@@ -489,6 +493,7 @@ func TestIndexHashedNodesCoordinator_ComputeValidatorsGroup400of400For10locksNoM
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 
 	ihnc, err := NewIndexHashedNodesCoordinator(arguments)
@@ -578,6 +583,7 @@ func TestIndexHashedNodesCoordinator_ComputeValidatorsGroup400of400For10BlocksMe
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 
 	ihnc, err := NewIndexHashedNodesCoordinator(arguments)
@@ -650,6 +656,7 @@ func TestIndexHashedNodesCoordinator_ComputeValidatorsGroup63of400TestEqualSameP
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 
 	ihnc, err := NewIndexHashedNodesCoordinator(arguments)
@@ -715,6 +722,7 @@ func BenchmarkIndexHashedGroupSelector_ComputeValidatorsGroup21of400(b *testing.
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 	ihnc, _ := NewIndexHashedNodesCoordinator(arguments)
 
@@ -789,6 +797,7 @@ func runBenchmark(consensusGroupCache Cacher, consensusGroupSize int, nodesMap m
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 	ihnc, _ := NewIndexHashedNodesCoordinator(arguments)
 
@@ -840,6 +849,7 @@ func computeMemoryRequirements(consensusGroupCache Cacher, consensusGroupSize in
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 	ihnc, err := NewIndexHashedNodesCoordinator(arguments)
 	require.Nil(b, err)
@@ -981,6 +991,7 @@ func TestIndexHashedNodesCoordinator_GetValidatorWithPublicKeyShouldWork(t *test
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 	ihnc, _ := NewIndexHashedNodesCoordinator(arguments)
 
@@ -1066,6 +1077,7 @@ func TestIndexHashedGroupSelector_GetAllEligibleValidatorsPublicKeys(t *testing.
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 
 	ihnc, _ := NewIndexHashedNodesCoordinator(arguments)
@@ -1146,6 +1158,7 @@ func TestIndexHashedGroupSelector_GetAllWaitingValidatorsPublicKeys(t *testing.T
 		EnableEpochsHandler:     &mock.EnableEpochsHandlerMock{},
 		ValidatorInfoCacher:     &vic.ValidatorInfoCacherStub{},
 		NumStoredEpochs:         numStoredEpochs,
+		NodesConfigCache:        &mock.NodesCoordinatorCacheMock{},
 	}
 
 	ihnc, _ := NewIndexHashedNodesCoordinator(arguments)
@@ -1508,6 +1521,7 @@ func TestIndexHashedNodesCoordinator_EpochStart_EligibleSortedAscendingByIndex(t
 		},
 		ValidatorInfoCacher: dataPool.NewCurrentEpochValidatorInfoPool(),
 		NumStoredEpochs:     numStoredEpochs,
+		NodesConfigCache:    &mock.NodesCoordinatorCacheMock{},
 	}
 
 	ihnc, err := NewIndexHashedNodesCoordinator(arguments)

--- a/sharding/nodesCoordinator/indexHashedNodesCoordinator_test.go
+++ b/sharding/nodesCoordinator/indexHashedNodesCoordinator_test.go
@@ -2565,7 +2565,7 @@ func TestIndexHashedNodesCoordinator_GetNodesConfig(t *testing.T) {
 		require.NotNil(t, nc)
 	})
 
-	t.Run("should work will old epochs", func(t *testing.T) {
+	t.Run("should work with old epochs", func(t *testing.T) {
 		t.Parallel()
 
 		epochKey := []byte(fmt.Sprint(1))

--- a/sharding/nodesCoordinator/interface.go
+++ b/sharding/nodesCoordinator/interface.go
@@ -63,11 +63,11 @@ type NodesCoordinatorHelper interface {
 	GetChance(uint32) uint32
 }
 
-//ChanceComputer provides chance computation capabilities based on a rating
+// ChanceComputer provides chance computation capabilities based on a rating
 type ChanceComputer interface {
-	//GetChance returns the chances for the rating
+	// GetChance returns the chances for the rating
 	GetChance(uint32) uint32
-	//IsInterfaceNil verifies if the interface is nil
+	// IsInterfaceNil verifies if the interface is nil
 	IsInterfaceNil() bool
 }
 
@@ -79,6 +79,8 @@ type Cacher interface {
 	Put(key []byte, value interface{}, sizeInBytes int) (evicted bool)
 	// Get looks up a key's value from the cache.
 	Get(key []byte) (value interface{}, ok bool)
+	// IsInterfaceNil verifies if the interface is nil
+	IsInterfaceNil() bool
 }
 
 // ShuffledOutHandler defines the methods needed for the computation of a shuffled out event

--- a/sharding/nodesCoordinator/shardingArgs.go
+++ b/sharding/nodesCoordinator/shardingArgs.go
@@ -33,4 +33,5 @@ type ArgNodesCoordinator struct {
 	EnableEpochsHandler     common.EnableEpochsHandler
 	ValidatorInfoCacher     epochStart.ValidatorInfoCacher
 	NumStoredEpochs         uint32
+	NodesConfigCache        Cacher
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- Cacher for epoch nodes config, in order to keep more nodes configuration in a cacher if needed.
  
## Proposed changes
- add a separate cacher for epoch nodes config
- separate operation for getting nodes config

## Testing procedure
- Standard system test

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
