### PR TITLE
Send dummy firehose block

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/ElrondNetwork/elastic-indexer-go v1.3.3
-	github.com/ElrondNetwork/elrond-go-core v1.1.26
+	github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221215140953-889ae4c74255
 	github.com/ElrondNetwork/elrond-go-crypto v1.2.2
 	github.com/ElrondNetwork/elrond-go-logger v1.0.10
 	github.com/ElrondNetwork/elrond-go-p2p v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,9 @@ github.com/ElrondNetwork/concurrent-map v0.1.3 h1:j2LtPrNJuerannC1cQDE79STvi/P04
 github.com/ElrondNetwork/concurrent-map v0.1.3/go.mod h1:3XwSwn4JHI0lrKxWLZvtp53Emr8BXYTmNQGwcukHJEE=
 github.com/ElrondNetwork/elastic-indexer-go v1.3.3 h1:RgJ043yt92PUWMbSAQHRrC+GiyNnFdwdM/kseHlpLoo=
 github.com/ElrondNetwork/elastic-indexer-go v1.3.3/go.mod h1:E3VO5712GkGSGYnOTJ+0wxW74JXgjV6XCRPlcHiTTK0=
-github.com/ElrondNetwork/elrond-go-core v1.1.26 h1:5syiJMlkWlH7HHnuiOafJJzeI+oUfYqL8mXREqrFerY=
 github.com/ElrondNetwork/elrond-go-core v1.1.26/go.mod h1:N/RI++YU2M6OlnD1GSZepc1wPhI84ykRDQ1IyD3B0wk=
+github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221215140953-889ae4c74255 h1:p/jhYM8rrA9mwiXPqlBDO9CDWpAvCjOuzk4Hvts1Qu0=
+github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221215140953-889ae4c74255/go.mod h1:N/RI++YU2M6OlnD1GSZepc1wPhI84ykRDQ1IyD3B0wk=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.2 h1:Q59dZUeyibuskq5vjgk3ng/87ifOcd9YZMTnlYJAuIU=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.2/go.mod h1:MyQPKUKti7Axnx/eihhL0F2jLTalvSV/Ytv1mIxvYyM=
 github.com/ElrondNetwork/elrond-go-logger v1.0.10 h1:2xQOWZErcHW5sl9qSRO+7mGNw+QhFhqiUlLLtOgvuuk=

--- a/outport/firehose/errors.go
+++ b/outport/firehose/errors.go
@@ -3,3 +3,7 @@ package firehose
 import "errors"
 
 var errNilWriter = errors.New("nil writer provided")
+
+var errNilHeader = errors.New("received nil header")
+
+var errInvalidHeaderType = errors.New("received invalid/unknown header type")

--- a/outport/firehose/firehoseIndexer.go
+++ b/outport/firehose/firehoseIndexer.go
@@ -63,14 +63,14 @@ func (fi *firehoseIndexer) SaveBlock(args *outportcore.ArgsSaveBlockData) error 
 
 	switch header := args.Header.(type) {
 	case *block.MetaBlock:
-		headerBytes, err = fi.marshaller.Marshal(header)
 		headerType = core.MetaHeader
+		headerBytes, err = fi.marshaller.Marshal(header)
 	case *block.Header:
-		headerBytes, err = fi.marshaller.Marshal(header)
 		headerType = core.ShardHeaderV1
-	case *block.HeaderV2:
 		headerBytes, err = fi.marshaller.Marshal(header)
+	case *block.HeaderV2:
 		headerType = core.ShardHeaderV2
+		headerBytes, err = fi.marshaller.Marshal(header)
 	default:
 		return errInvalidHeaderType
 	}

--- a/outport/firehose/firehoseIndexer_test.go
+++ b/outport/firehose/firehoseIndexer_test.go
@@ -2,32 +2,169 @@ package firehose
 
 import (
 	"encoding/hex"
+	"fmt"
 	"testing"
 
-	"github.com/ElrondNetwork/elrond-go-core/data/alteredAccount"
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/firehose"
+	outportcore "github.com/ElrondNetwork/elrond-go-core/data/outport"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFirehoseIndexer_SaveBlock(t *testing.T) {
-	marshaller := &marshal.GogoProtoMarshalizer{}
+	t.Parallel()
 
-	blk := &firehose.FirehoseBlock{
-		HeaderHash:      []byte("hasdsada2132131h"),
-		HeaderType:      "879bdsajhk3",
-		AlteredAccounts: []*alteredAccount.AlteredAccount{{Nonce: 4444}},
-	}
-	blkBytes, err := marshaller.Marshal(blk)
-	require.Nil(t, err)
+	protoMarshaller := &marshal.GogoProtoMarshalizer{}
+	t.Run("nil header, should return error", func(t *testing.T) {
+		t.Parallel()
 
-	_ = blkBytes
-	//_, err = fmt.Fprintf(os.Stdout, "%x", blkBytes)
-	hexDecodedBytes, err := hex.DecodeString("120b383739626473616a686b331a10686173647361646132313332313331682a0610dc221a0100")
-	require.Nil(t, err)
+		fi, _ := NewFirehoseIndexer(&testscommon.IoWriterStub{})
+		err := fi.SaveBlock(&outportcore.ArgsSaveBlockData{Header: nil})
+		require.Equal(t, errNilHeader, err)
+	})
 
-	newBlk := &firehose.FirehoseBlock{}
-	err = marshaller.Unmarshal(newBlk, hexDecodedBytes)
-	require.Nil(t, err)
+	t.Run("invalid header type, should return error", func(t *testing.T) {
+		t.Parallel()
 
+		fi, _ := NewFirehoseIndexer(&testscommon.IoWriterStub{})
+		err := fi.SaveBlock(&outportcore.ArgsSaveBlockData{Header: &testscommon.HeaderHandlerStub{}})
+		require.Equal(t, errInvalidHeaderType, err)
+	})
+
+	t.Run("meta header", func(t *testing.T) {
+		t.Parallel()
+
+		metaBlockHeader := &block.MetaBlock{
+			Nonce:     1,
+			PrevHash:  []byte("prevHashMeta"),
+			TimeStamp: 100,
+		}
+		marshalledHeader, err := protoMarshaller.Marshal(metaBlockHeader)
+		require.Nil(t, err)
+
+		headerHashMeta := []byte("headerHashMeta")
+		firehoseBlock := &firehose.FirehoseBlock{
+			HeaderHash:  headerHashMeta,
+			HeaderType:  string(core.MetaHeader),
+			HeaderBytes: marshalledHeader,
+		}
+		marshalledFirehoseBlock, err := protoMarshaller.Marshal(firehoseBlock)
+		require.Nil(t, err)
+
+		ioWriterCalledCt := 0
+		ioWriter := &testscommon.IoWriterStub{
+			WriteCalled: func(p []byte) (n int, err error) {
+				ioWriterCalledCt++
+				switch ioWriterCalledCt {
+				case 1:
+					require.Equal(t, []byte("FIRE BLOCK_BEGIN 1\n"), p)
+				case 2:
+
+					require.Equal(t, []byte(fmt.Sprintf("FIRE BLOCK_END 1 %s 100 %x\n",
+						hex.EncodeToString(metaBlockHeader.PrevHash),
+						marshalledFirehoseBlock)), p)
+				default:
+					require.Fail(t, "should not write again")
+				}
+				return 0, nil
+			},
+		}
+
+		fi, _ := NewFirehoseIndexer(ioWriter)
+		err = fi.SaveBlock(&outportcore.ArgsSaveBlockData{HeaderHash: headerHashMeta, Header: metaBlockHeader})
+		require.Nil(t, err)
+	})
+
+	t.Run("shard header v1", func(t *testing.T) {
+		t.Parallel()
+
+		shardHeaderV1 := &block.Header{
+			Nonce:     2,
+			PrevHash:  []byte("prevHashV1"),
+			TimeStamp: 200,
+		}
+		marshalledHeader, err := protoMarshaller.Marshal(shardHeaderV1)
+		require.Nil(t, err)
+
+		headerHashShardV1 := []byte("headerHashShardV1")
+		firehoseBlock := &firehose.FirehoseBlock{
+			HeaderHash:  headerHashShardV1,
+			HeaderType:  string(core.ShardHeaderV1),
+			HeaderBytes: marshalledHeader,
+		}
+		marshalledFirehoseBlock, err := protoMarshaller.Marshal(firehoseBlock)
+		require.Nil(t, err)
+
+		ioWriterCalledCt := 0
+		ioWriter := &testscommon.IoWriterStub{
+			WriteCalled: func(p []byte) (n int, err error) {
+				ioWriterCalledCt++
+				switch ioWriterCalledCt {
+				case 1:
+					require.Equal(t, []byte("FIRE BLOCK_BEGIN 2\n"), p)
+				case 2:
+
+					require.Equal(t, []byte(fmt.Sprintf("FIRE BLOCK_END 2 %s 200 %x\n",
+						hex.EncodeToString(shardHeaderV1.PrevHash),
+						marshalledFirehoseBlock)), p)
+				default:
+					require.Fail(t, "should not write again")
+				}
+				return 0, nil
+			},
+		}
+
+		fi, _ := NewFirehoseIndexer(ioWriter)
+		err = fi.SaveBlock(&outportcore.ArgsSaveBlockData{HeaderHash: headerHashShardV1, Header: shardHeaderV1})
+		require.Nil(t, err)
+	})
+
+	t.Run("shard header v2", func(t *testing.T) {
+		t.Parallel()
+
+		shardHeaderV2 := &block.HeaderV2{
+			Header: &block.Header{
+				Nonce:     3,
+				PrevHash:  []byte("prevHashV2"),
+				TimeStamp: 300,
+			},
+		}
+		marshalledHeader, err := protoMarshaller.Marshal(shardHeaderV2)
+		require.Nil(t, err)
+
+		headerHashShardV2 := []byte("headerHashShardV2")
+		firehoseBlock := &firehose.FirehoseBlock{
+			HeaderHash:  headerHashShardV2,
+			HeaderType:  string(core.ShardHeaderV2),
+			HeaderBytes: marshalledHeader,
+		}
+		marshalledFirehoseBlock, err := protoMarshaller.Marshal(firehoseBlock)
+		require.Nil(t, err)
+
+		ioWriterCalledCt := 0
+		ioWriter := &testscommon.IoWriterStub{
+			WriteCalled: func(p []byte) (n int, err error) {
+				ioWriterCalledCt++
+				switch ioWriterCalledCt {
+				case 1:
+					require.Equal(t, []byte("FIRE BLOCK_BEGIN 3\n"), p)
+				case 2:
+
+					require.Equal(t, []byte(fmt.Sprintf("FIRE BLOCK_END 3 %s 300 %x\n",
+						hex.EncodeToString(shardHeaderV2.Header.PrevHash),
+						marshalledFirehoseBlock)), p)
+				default:
+					require.Fail(t, "should not write again")
+				}
+				return 0, nil
+			},
+		}
+
+		fi, _ := NewFirehoseIndexer(ioWriter)
+		err = fi.SaveBlock(&outportcore.ArgsSaveBlockData{HeaderHash: headerHashShardV2, Header: shardHeaderV2})
+		require.Nil(t, err)
+	})
 }

--- a/outport/firehose/firehoseIndexer_test.go
+++ b/outport/firehose/firehoseIndexer_test.go
@@ -1,0 +1,33 @@
+package firehose
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/data/alteredAccount"
+	"github.com/ElrondNetwork/elrond-go-core/data/firehose"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFirehoseIndexer_SaveBlock(t *testing.T) {
+	marshaller := &marshal.GogoProtoMarshalizer{}
+
+	blk := &firehose.FirehoseBlock{
+		HeaderHash:      []byte("hasdsada2132131h"),
+		HeaderType:      "879bdsajhk3",
+		AlteredAccounts: []*alteredAccount.AlteredAccount{{Nonce: 4444}},
+	}
+	blkBytes, err := marshaller.Marshal(blk)
+	require.Nil(t, err)
+
+	_ = blkBytes
+	//_, err = fmt.Fprintf(os.Stdout, "%x", blkBytes)
+	hexDecodedBytes, err := hex.DecodeString("120b383739626473616a686b331a10686173647361646132313332313331682a0610dc221a0100")
+	require.Nil(t, err)
+
+	newBlk := &firehose.FirehoseBlock{}
+	err = marshaller.Unmarshal(newBlk, hexDecodedBytes)
+	require.Nil(t, err)
+
+}

--- a/testscommon/ioWriterStub.go
+++ b/testscommon/ioWriterStub.go
@@ -1,0 +1,15 @@
+package testscommon
+
+// IoWriterStub -
+type IoWriterStub struct {
+	WriteCalled func(p []byte) (n int, err error)
+}
+
+// Write -
+func (iws *IoWriterStub) Write(p []byte) (n int, err error) {
+	if iws.WriteCalled != nil {
+		return iws.WriteCalled(p)
+	}
+
+	return 0, err
+}


### PR DESCRIPTION
## Reasoning behind the pull request
- Proto firehose block communication between elrond-go node and firehose node
  
## Proposed changes
- Added support for "dummy" block firehose console writing for firehose node reader. 

**NOTE:** Intentionally initialized internal marshaller of `firehoseIndexer` with `&GogoProtoMarshalizer` instead of passing a marshaller interface.

## Testing procedure
- Local testnet with firehose block ingestion process

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
