### PR TITLE
Trie leaf data unmarshal

### DIFF
--- a/state/parsers/dataTrieLeafParser.go
+++ b/state/parsers/dataTrieLeafParser.go
@@ -37,7 +37,7 @@ func (tlp *dataTrieLeafParser) ParseLeaf(trieKey []byte, trieVal []byte) (core.K
 	if tlp.enableEpochsHandler.IsAutoBalanceDataTriesEnabled() {
 		data := &dataTrieValue.TrieLeafData{}
 		err := tlp.marshaller.Unmarshal(data, trieVal)
-		if err == nil {
+		if err == nil && !isEmptyTrieData(data) {
 			return keyValStorage.NewKeyValStorage(data.Key, data.Value), nil
 		}
 	}
@@ -49,6 +49,18 @@ func (tlp *dataTrieLeafParser) ParseLeaf(trieKey []byte, trieVal []byte) (core.K
 	}
 
 	return keyValStorage.NewKeyValStorage(trieKey, value), nil
+}
+
+func isEmptyTrieData(data *dataTrieValue.TrieLeafData) bool {
+	if data == nil {
+		return true
+	}
+
+	if len(data.Value) == 0 && len(data.Key) == 0 && len(data.Address) == 0 {
+		return true
+	}
+
+	return false
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/state/parsers/dataTrieLeafParser.go
+++ b/state/parsers/dataTrieLeafParser.go
@@ -51,6 +51,7 @@ func (tlp *dataTrieLeafParser) ParseLeaf(trieKey []byte, trieVal []byte) (core.K
 	return keyValStorage.NewKeyValStorage(trieKey, value), nil
 }
 
+// TODO remove this after proper marshaller fix
 func isEmptyTrieData(data *dataTrieValue.TrieLeafData) bool {
 	if data == nil {
 		return true

--- a/state/parsers/dataTrieLeafParser_test.go
+++ b/state/parsers/dataTrieLeafParser_test.go
@@ -2,10 +2,10 @@ package parsers
 
 import (
 	"encoding/hex"
-	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/errors"
 	"github.com/ElrondNetwork/elrond-go/state/dataTrieValue"
 	"github.com/ElrondNetwork/elrond-go/testscommon/enableEpochsHandlerMock"

--- a/state/parsers/dataTrieLeafParser_test.go
+++ b/state/parsers/dataTrieLeafParser_test.go
@@ -1,6 +1,8 @@
 package parsers
 
 import (
+	"encoding/hex"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
@@ -99,5 +101,29 @@ func TestTrieLeafParser_ParseLeaf(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, key, keyVal.Key())
 		assert.Equal(t, val, keyVal.Value())
+	})
+
+	t.Run("unmarshall bytes with appended data should not return empty data", func(t *testing.T) {
+		t.Parallel()
+
+		marshaller := &marshal.GogoProtoMarshalizer{}
+
+		keyBytes := []byte("eth")
+		valBytes := []byte("0xA2AA67319062488CAFfc7E52802a3308cAF78a54")
+		addrBytes, err := hex.DecodeString("b080fe7e47edd5f32b619a7a439a0174ebda49ac27a5b112dd685470ae008001")
+		assert.Nil(t, err)
+
+		valWithAppendedData := append(valBytes, keyBytes...)
+		valWithAppendedData = append(valWithAppendedData, addrBytes...)
+
+		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsAutoBalanceDataTriesEnabledField: true,
+		}
+		tlp, _ := NewDataTrieLeafParser(addrBytes, marshaller, enableEpochsHandler)
+
+		keyVal, err := tlp.ParseLeaf(keyBytes, valWithAppendedData)
+		assert.Nil(t, err)
+		assert.Equal(t, keyBytes, keyVal.Key())
+		assert.Equal(t, valBytes, keyVal.Value())
 	})
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- When parsing a data trie leaf, if the leaf value was not migrated to the new version, the unmarshal should err. There are some cases in which the unmarshall does not err, but the data is still nil.
  
## Proposed changes
- After unmarshal, also check that the trieData is not empty.

## Testing procedure
- added unit test

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
