### PR TITLE
fix num rounds and nonces passed in epoch for prometheus

### DIFF
--- a/statusHandler/statusMetricsProvider.go
+++ b/statusHandler/statusMetricsProvider.go
@@ -110,6 +110,19 @@ func (sm *statusMetrics) Close() {
 
 // StatusMetricsMapWithoutP2P will return the non-p2p metrics in a map
 func (sm *statusMetrics) StatusMetricsMapWithoutP2P() (map[string]interface{}, error) {
+	metrics, err := sm.getMetricsWithoutP2P()
+	if err != nil {
+		return nil, err
+	}
+
+	// remove these metrics, since they are computed at call time and would return 0 otherwise
+	delete(metrics, common.MetricNoncesPassedInCurrentEpoch)
+	delete(metrics, common.MetricRoundsPassedInCurrentEpoch)
+
+	return metrics, nil
+}
+
+func (sm *statusMetrics) getMetricsWithoutP2P() (map[string]interface{}, error) {
 	return sm.getMetricsWithKeyFilterMutexProtected(func(input string) bool {
 		return !strings.Contains(input, "_p2p_")
 	}), nil
@@ -160,7 +173,7 @@ func (sm *statusMetrics) getMetricsWithKeyFilterMutexProtected(filterFunc func(i
 
 // StatusMetricsWithoutP2PPrometheusString returns the metrics in a string format which respects prometheus style
 func (sm *statusMetrics) StatusMetricsWithoutP2PPrometheusString() (string, error) {
-	metrics, err := sm.StatusMetricsMapWithoutP2P()
+	metrics, err := sm.getMetricsWithoutP2P()
 	if err != nil {
 		return "", err
 	}

--- a/statusHandler/statusMetricsProvider.go
+++ b/statusHandler/statusMetricsProvider.go
@@ -171,15 +171,31 @@ func (sm *statusMetrics) StatusMetricsWithoutP2PPrometheusString() (string, erro
 
 	stringBuilder := strings.Builder{}
 	for key, value := range metrics {
-		_, isUint64 := value.(uint64)
-		_, isInt64 := value.(int64)
-		isNumericValue := isUint64 || isInt64
-		if isNumericValue {
-			stringBuilder.WriteString(fmt.Sprintf("%s{%s=\"%d\"} %v\n", key, common.MetricShardId, shardID, value))
-		}
+		sm.addPrometheusMetricToStringBuilder(&stringBuilder, shardID, key, value)
 	}
 
 	return stringBuilder.String(), nil
+}
+
+func (sm *statusMetrics) addPrometheusMetricToStringBuilder(builder *strings.Builder, shardID uint64, key string, value interface{}) {
+	// only numeric values are accepted for prometheus. return if the value is not int64 or uint64
+	switch value.(type) {
+	case int64, uint64:
+	default:
+		return
+	}
+
+	if key == common.MetricNoncesPassedInCurrentEpoch {
+		sm.mutUint64Operations.RLock()
+		value = computeDelta(sm.uint64Metrics[common.MetricNonce], sm.uint64Metrics[common.MetricNonceAtEpochStart])
+		sm.mutUint64Operations.RUnlock()
+	}
+	if key == common.MetricRoundsPassedInCurrentEpoch {
+		sm.mutUint64Operations.RLock()
+		value = computeDelta(sm.uint64Metrics[common.MetricCurrentRound], sm.uint64Metrics[common.MetricRoundAtEpochStart])
+		sm.mutUint64Operations.RUnlock()
+	}
+	builder.WriteString(fmt.Sprintf("%s{%s=\"%d\"} %v\n", key, common.MetricShardId, shardID, value))
 }
 
 // EconomicsMetrics returns the economics related metrics
@@ -290,13 +306,13 @@ func (sm *statusMetrics) EnableEpochsMetrics() (map[string]interface{}, error) {
 func (sm *statusMetrics) NetworkMetrics() (map[string]interface{}, error) {
 	networkMetrics := make(map[string]interface{})
 
-	sm.saveUint64MetricsInMap(networkMetrics)
-	sm.saveStringMetricsInMap(networkMetrics)
+	sm.saveUint64NetworkMetricsInMap(networkMetrics)
+	sm.saveStringNetworkMetricsInMap(networkMetrics)
 
 	return networkMetrics, nil
 }
 
-func (sm *statusMetrics) saveUint64MetricsInMap(networkMetrics map[string]interface{}) {
+func (sm *statusMetrics) saveUint64NetworkMetricsInMap(networkMetrics map[string]interface{}) {
 	sm.mutUint64Operations.RLock()
 	defer sm.mutUint64Operations.RUnlock()
 
@@ -312,20 +328,11 @@ func (sm *statusMetrics) saveUint64MetricsInMap(networkMetrics map[string]interf
 	networkMetrics[common.MetricNonceAtEpochStart] = nonceAtEpochStart
 	networkMetrics[common.MetricEpochNumber] = sm.uint64Metrics[common.MetricEpochNumber]
 	networkMetrics[common.MetricRoundsPerEpoch] = sm.uint64Metrics[common.MetricRoundsPerEpoch]
-	roundsPassedInEpoch := uint64(0)
-	if currentRound >= roundNumberAtEpochStart {
-		roundsPassedInEpoch = currentRound - roundNumberAtEpochStart
-	}
-	networkMetrics[common.MetricRoundsPassedInCurrentEpoch] = roundsPassedInEpoch
-
-	noncesPassedInEpoch := uint64(0)
-	if currentNonce >= nonceAtEpochStart {
-		noncesPassedInEpoch = currentNonce - nonceAtEpochStart
-	}
-	networkMetrics[common.MetricNoncesPassedInCurrentEpoch] = noncesPassedInEpoch
+	networkMetrics[common.MetricRoundsPassedInCurrentEpoch] = computeDelta(currentRound, roundNumberAtEpochStart)
+	networkMetrics[common.MetricNoncesPassedInCurrentEpoch] = computeDelta(currentNonce, nonceAtEpochStart)
 }
 
-func (sm *statusMetrics) saveStringMetricsInMap(networkMetrics map[string]interface{}) {
+func (sm *statusMetrics) saveStringNetworkMetricsInMap(networkMetrics map[string]interface{}) {
 	sm.mutStringOperations.RLock()
 	defer sm.mutStringOperations.RUnlock()
 
@@ -379,4 +386,12 @@ func (sm *statusMetrics) RatingsMetrics() (map[string]interface{}, error) {
 	sm.mutStringOperations.RUnlock()
 
 	return ratingsMetrics, nil
+}
+
+func computeDelta(biggerNum uint64, lowerNum uint64) uint64 {
+	if biggerNum >= lowerNum {
+		return biggerNum - lowerNum
+	}
+
+	return 0
 }

--- a/statusHandler/statusMetricsProvider_test.go
+++ b/statusHandler/statusMetricsProvider_test.go
@@ -147,6 +147,25 @@ func TestStatusMetrics_StatusMetricsWithoutP2PPrometheusStringShouldPutCorrectSh
 	assert.True(t, strings.Contains(strRes, expectedMetricOutput))
 }
 
+func TestStatusMetrics_StatusMetricsWithoutP2PPrometheusStringShouldComputeRoundsAndNoncesPassedInEpoch(t *testing.T) {
+	t.Parallel()
+
+	shardID := uint32(2)
+	sm := statusHandler.NewStatusMetrics()
+	sm.SetUInt64Value(common.MetricRoundsPassedInCurrentEpoch, 0)
+	sm.SetUInt64Value(common.MetricNoncesPassedInCurrentEpoch, 0)
+	sm.SetUInt64Value(common.MetricShardId, uint64(shardID))
+	sm.SetUInt64Value(common.MetricRoundAtEpochStart, 100)
+	sm.SetUInt64Value(common.MetricCurrentRound, 137)
+	sm.SetUInt64Value(common.MetricNonceAtEpochStart, 100)
+	sm.SetUInt64Value(common.MetricNonce, 138)
+
+	strRes, _ := sm.StatusMetricsWithoutP2PPrometheusString()
+
+	assert.Contains(t, strRes, `erd_rounds_passed_in_current_epoch{erd_shard_id="2"} 37`)
+	assert.Contains(t, strRes, `erd_nonces_passed_in_current_epoch{erd_shard_id="2"} 38`)
+}
+
 func TestStatusMetrics_NetworkConfig(t *testing.T) {
 	t.Parallel()
 

--- a/statusHandler/statusMetricsProvider_test.go
+++ b/statusHandler/statusMetricsProvider_test.go
@@ -260,6 +260,28 @@ func TestStatusMetrics_NetworkMetrics(t *testing.T) {
 	})
 }
 
+func TestStatusMetrics_StatusMetricsMapWithoutP2P(t *testing.T) {
+	t.Parallel()
+
+	sm := statusHandler.NewStatusMetrics()
+
+	sm.SetUInt64Value(common.MetricCurrentRound, 100)
+	sm.SetUInt64Value(common.MetricRoundAtEpochStart, 200)
+	sm.SetUInt64Value(common.MetricNonce, 300)
+	sm.SetStringValue(common.MetricAppVersion, "400")
+	sm.SetUInt64Value(common.MetricRoundsPassedInCurrentEpoch, 95)
+	sm.SetUInt64Value(common.MetricNoncesPassedInCurrentEpoch, 1)
+
+	res, _ := sm.StatusMetricsMapWithoutP2P()
+
+	require.Equal(t, uint64(100), res[common.MetricCurrentRound])
+	require.Equal(t, uint64(200), res[common.MetricRoundAtEpochStart])
+	require.Equal(t, uint64(300), res[common.MetricNonce])
+	require.Equal(t, "400", res[common.MetricAppVersion])
+	require.NotContains(t, res, common.MetricRoundsPassedInCurrentEpoch)
+	require.NotContains(t, res, common.MetricNoncesPassedInCurrentEpoch)
+}
+
 func TestStatusMetrics_EnableEpochMetrics(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Reasoning behind the pull request
- `erd_rounds_passed_in_current_epoch` and `erd_nonces_passed_in_current_epoch` were not set when calling the Prometheus metrics endpoint
  
## Proposed changes
- compute their values for that endpoint as well

## Testing procedure
- query `<node>:<port>/node/metrics` and search for the 2 metrics. They should have the same value as the ones found at `<node>:<port>/node/status`

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
