### PR TITLE
refactor to use storer ids for dataRetriever

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -834,9 +834,3 @@ const MetricTrieSyncNumReceivedBytes = "erd_trie_sync_num_bytes_received"
 
 // MetricTrieSyncNumProcessedNodes is the metric that outputs the number of trie nodes processed for accounts during trie sync
 const MetricTrieSyncNumProcessedNodes = "erd_trie_sync_num_nodes_processed"
-
-// AccountsTrieIdentifier defines the identifier for accounts trie storer
-const AccountsTrieIdentifier = "AccountsTrie"
-
-// PeerAccountsTrieIdentifier defines the identifier for peer accounts storer
-const PeerAccountsTrieIdentifier = "PeerAccountsTrie"

--- a/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/factory/containers"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/resolvers"
-	triesFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
 
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/process/factory"
@@ -151,7 +150,7 @@ func (mrcf *metaResolversContainerFactory) AddShardTrieNodeResolvers(container d
 		identifierTrieNodes := factory.AccountTrieNodesTopic + shardC.CommunicationIdentifier(idx)
 		resolver, err := mrcf.createTrieNodesResolver(
 			identifierTrieNodes,
-			triesFactory.UserAccountTrie,
+			dataRetriever.UserAccountsUnit.String(),
 			mrcf.numCrossShardPeers,
 			mrcf.numTotalPeers-mrcf.numCrossShardPeers,
 			idx,
@@ -310,7 +309,7 @@ func (mrcf *metaResolversContainerFactory) generateTrieNodesResolvers() error {
 	identifierTrieNodes := factory.AccountTrieNodesTopic + core.CommunicationIdentifierBetweenShards(core.MetachainShardId, core.MetachainShardId)
 	resolver, err := mrcf.createTrieNodesResolver(
 		identifierTrieNodes,
-		triesFactory.UserAccountTrie,
+		dataRetriever.UserAccountsUnit.String(),
 		0,
 		mrcf.numTotalPeers,
 		core.MetachainShardId,
@@ -325,7 +324,7 @@ func (mrcf *metaResolversContainerFactory) generateTrieNodesResolvers() error {
 	identifierTrieNodes = factory.ValidatorTrieNodesTopic + core.CommunicationIdentifierBetweenShards(core.MetachainShardId, core.MetachainShardId)
 	resolver, err = mrcf.createTrieNodesResolver(
 		identifierTrieNodes,
-		triesFactory.PeerAccountTrie,
+		dataRetriever.PeerAccountsUnit.String(),
 		0,
 		mrcf.numTotalPeers,
 		core.MetachainShardId,

--- a/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory_test.go
+++ b/dataRetriever/factory/resolverscontainer/metaResolversContainerFactory_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	storageStubs "github.com/ElrondNetwork/elrond-go/testscommon/storage"
 	trieMock "github.com/ElrondNetwork/elrond-go/testscommon/trie"
-	triesFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -84,8 +83,8 @@ func createStoreForMeta() dataRetriever.StorageService {
 
 func createTriesHolderForMeta() common.TriesHolder {
 	triesHolder := state.NewDataTriesHolder()
-	triesHolder.Put([]byte(triesFactory.UserAccountTrie), &trieMock.TrieStub{})
-	triesHolder.Put([]byte(triesFactory.PeerAccountTrie), &trieMock.TrieStub{})
+	triesHolder.Put([]byte(dataRetriever.UserAccountsUnit.String()), &trieMock.TrieStub{})
+	triesHolder.Put([]byte(dataRetriever.PeerAccountsUnit.String()), &trieMock.TrieStub{})
 	return triesHolder
 }
 

--- a/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory.go
+++ b/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/factory/containers"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever/resolvers"
 	"github.com/ElrondNetwork/elrond-go/process/factory"
-	triesFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
 )
 
 var _ dataRetriever.ResolversContainerFactory = (*shardResolversContainerFactory)(nil)
@@ -241,7 +240,7 @@ func (srcf *shardResolversContainerFactory) generateTrieNodesResolvers() error {
 	identifierTrieNodes := factory.AccountTrieNodesTopic + shardC.CommunicationIdentifier(core.MetachainShardId)
 	resolver, err := srcf.createTrieNodesResolver(
 		identifierTrieNodes,
-		triesFactory.UserAccountTrie,
+		dataRetriever.UserAccountsUnit.String(),
 		0,
 		srcf.numTotalPeers,
 		core.MetachainShardId,

--- a/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory_test.go
+++ b/dataRetriever/factory/resolverscontainer/shardResolversContainerFactory_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon/p2pmocks"
 	storageStubs "github.com/ElrondNetwork/elrond-go/testscommon/storage"
 	trieMock "github.com/ElrondNetwork/elrond-go/testscommon/trie"
-	triesFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -90,8 +89,8 @@ func createStoreForShard() dataRetriever.StorageService {
 
 func createTriesHolderForShard() common.TriesHolder {
 	triesHolder := state.NewDataTriesHolder()
-	triesHolder.Put([]byte(triesFactory.UserAccountTrie), &trieMock.TrieStub{})
-	triesHolder.Put([]byte(triesFactory.PeerAccountTrie), &trieMock.TrieStub{})
+	triesHolder.Put([]byte(dataRetriever.UserAccountsUnit.String()), &trieMock.TrieStub{})
+	triesHolder.Put([]byte(dataRetriever.PeerAccountsUnit.String()), &trieMock.TrieStub{})
 	return triesHolder
 }
 

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -1046,7 +1046,7 @@ func (e *epochStartBootstrap) syncUserAccountsState(rootHash []byte) error {
 	}
 
 	e.mutTrieStorageManagers.RLock()
-	trieStorageManager := e.trieStorageManagers[factory.UserAccountTrie]
+	trieStorageManager := e.trieStorageManagers[dataRetriever.UserAccountsUnit.String()]
 	e.mutTrieStorageManagers.RUnlock()
 
 	argsUserAccountsSyncer := syncer.ArgsNewUserAccountsSyncer{
@@ -1115,7 +1115,7 @@ func (e *epochStartBootstrap) createStorageService(
 
 func (e *epochStartBootstrap) syncValidatorAccountsState(rootHash []byte) error {
 	e.mutTrieStorageManagers.RLock()
-	peerTrieStorageManager := e.trieStorageManagers[factory.PeerAccountTrie]
+	peerTrieStorageManager := e.trieStorageManagers[dataRetriever.PeerAccountsUnit.String()]
 	e.mutTrieStorageManagers.RUnlock()
 
 	argsValidatorAccountsSyncer := syncer.ArgsNewValidatorAccountsSyncer{

--- a/factory/consensus/consensusComponents.go
+++ b/factory/consensus/consensusComponents.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/consensus/signing"
 	"github.com/ElrondNetwork/elrond-go/consensus/spos"
 	"github.com/ElrondNetwork/elrond-go/consensus/spos/sposFactory"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/errors"
 	"github.com/ElrondNetwork/elrond-go/factory"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -24,7 +25,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process/sync/storageBootstrap"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 	"github.com/ElrondNetwork/elrond-go/state/syncer"
-	trieFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
 	"github.com/ElrondNetwork/elrond-go/trie/statistics"
 	"github.com/ElrondNetwork/elrond-go/trie/storageMarker"
 	"github.com/ElrondNetwork/elrond-go/update"
@@ -516,7 +516,7 @@ func (ccf *consensusComponentsFactory) createArgsBaseAccountsSyncer(trieStorageM
 }
 
 func (ccf *consensusComponentsFactory) createValidatorAccountsSyncer() (process.AccountsDBSyncer, error) {
-	trieStorageManager, ok := ccf.stateComponents.TrieStorageManagers()[trieFactory.PeerAccountTrie]
+	trieStorageManager, ok := ccf.stateComponents.TrieStorageManagers()[dataRetriever.PeerAccountsUnit.String()]
 	if !ok {
 		return nil, errors.ErrNilTrieStorageManager
 	}
@@ -528,7 +528,7 @@ func (ccf *consensusComponentsFactory) createValidatorAccountsSyncer() (process.
 }
 
 func (ccf *consensusComponentsFactory) createUserAccountsSyncer() (process.AccountsDBSyncer, error) {
-	trieStorageManager, ok := ccf.stateComponents.TrieStorageManagers()[trieFactory.UserAccountTrie]
+	trieStorageManager, ok := ccf.stateComponents.TrieStorageManagers()[dataRetriever.UserAccountsUnit.String()]
 	if !ok {
 		return nil, errors.ErrNilTrieStorageManager
 	}

--- a/factory/processing/blockProcessorCreator_test.go
+++ b/factory/processing/blockProcessorCreator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-go/common"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	dataComp "github.com/ElrondNetwork/elrond-go/factory/data"
 	"github.com/ElrondNetwork/elrond-go/factory/mock"
 	processComp "github.com/ElrondNetwork/elrond-go/factory/processing"
@@ -24,7 +25,6 @@ import (
 	storageManager "github.com/ElrondNetwork/elrond-go/testscommon/storage"
 	trieMock "github.com/ElrondNetwork/elrond-go/testscommon/trie"
 	"github.com/ElrondNetwork/elrond-go/trie"
-	trieFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/stretchr/testify/require"
 )
@@ -104,14 +104,14 @@ func Test_newBlockProcessorCreatorForMeta(t *testing.T) {
 	storageManagerPeer, _ := trie.CreateTrieStorageManager(storageManagerArgs, options)
 
 	trieStorageManagers := make(map[string]common.StorageManager)
-	trieStorageManagers[trieFactory.UserAccountTrie] = storageManagerUser
-	trieStorageManagers[trieFactory.PeerAccountTrie] = storageManagerPeer
+	trieStorageManagers[dataRetriever.UserAccountsUnit.String()] = storageManagerUser
+	trieStorageManagers[dataRetriever.PeerAccountsUnit.String()] = storageManagerPeer
 
 	accounts, err := createAccountAdapter(
 		&mock.MarshalizerMock{},
 		&hashingMocks.HasherMock{},
 		factoryState.NewAccountCreator(),
-		trieStorageManagers[trieFactory.UserAccountTrie],
+		trieStorageManagers[dataRetriever.UserAccountsUnit.String()],
 	)
 	require.Nil(t, err)
 

--- a/factory/state/stateComponents.go
+++ b/factory/state/stateComponents.go
@@ -128,7 +128,7 @@ func (scf *stateComponentsFactory) Create() (*stateComponents, error) {
 
 func (scf *stateComponentsFactory) createAccountsAdapters(triesContainer common.TriesHolder) (state.AccountsAdapter, state.AccountsAdapter, state.AccountsRepository, error) {
 	accountFactory := factoryState.NewAccountCreator()
-	merkleTrie := triesContainer.Get([]byte(trieFactory.UserAccountTrie))
+	merkleTrie := triesContainer.Get([]byte(dataRetriever.UserAccountsUnit.String()))
 	storagePruning, err := scf.newStoragePruningManager()
 	if err != nil {
 		return nil, nil, nil, err
@@ -192,7 +192,7 @@ func (scf *stateComponentsFactory) createAccountsAdapters(triesContainer common.
 
 func (scf *stateComponentsFactory) createPeerAdapter(triesContainer common.TriesHolder) (state.AccountsAdapter, error) {
 	accountFactory := factoryState.NewPeerAccountCreator()
-	merkleTrie := triesContainer.Get([]byte(trieFactory.PeerAccountTrie))
+	merkleTrie := triesContainer.Get([]byte(dataRetriever.PeerAccountsUnit.String()))
 	storagePruning, err := scf.newStoragePruningManager()
 	if err != nil {
 		return nil, err

--- a/genesis/process/genesisBlockCreator.go
+++ b/genesis/process/genesisBlockCreator.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/storage"
 	"github.com/ElrondNetwork/elrond-go/storage/factory"
 	"github.com/ElrondNetwork/elrond-go/storage/storageunit"
-	triesFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
 	"github.com/ElrondNetwork/elrond-go/update"
 	hardfork "github.com/ElrondNetwork/elrond-go/update/genesis"
 	hardForkProcess "github.com/ElrondNetwork/elrond-go/update/process"
@@ -481,7 +480,7 @@ func (gbc *genesisBlockCreator) getNewArgForShard(shardID uint32) (ArgsGenesisBl
 		newArgument.Core.InternalMarshalizer(),
 		newArgument.Core.Hasher(),
 		factoryState.NewAccountCreator(),
-		gbc.arg.TrieStorageManagers[triesFactory.UserAccountTrie],
+		gbc.arg.TrieStorageManagers[dataRetriever.UserAccountsUnit.String()],
 	)
 	if err != nil {
 		return ArgsGenesisBlockCreator{}, fmt.Errorf("'%w' while generating an in-memory accounts adapter for shard %d",

--- a/genesis/process/genesisBlockCreator_test.go
+++ b/genesis/process/genesisBlockCreator_test.go
@@ -28,7 +28,6 @@ import (
 	stateMock "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	storageCommon "github.com/ElrondNetwork/elrond-go/testscommon/storage"
 	"github.com/ElrondNetwork/elrond-go/trie"
-	"github.com/ElrondNetwork/elrond-go/trie/factory"
 	"github.com/ElrondNetwork/elrond-go/update"
 	updateMock "github.com/ElrondNetwork/elrond-go/update/mock"
 	"github.com/ElrondNetwork/elrond-go/vm/systemSmartContracts/defaults"
@@ -52,8 +51,8 @@ func createMockArgument(
 	storageManager, _ := trie.CreateTrieStorageManager(storageManagerArgs, options)
 
 	trieStorageManagers := make(map[string]common.StorageManager)
-	trieStorageManagers[factory.UserAccountTrie] = storageManager
-	trieStorageManagers[factory.PeerAccountTrie] = storageManager
+	trieStorageManagers[dataRetriever.UserAccountsUnit.String()] = storageManager
+	trieStorageManagers[dataRetriever.PeerAccountsUnit.String()] = storageManager
 
 	arg := ArgsGenesisBlockCreator{
 		GenesisTime:   0,
@@ -146,7 +145,7 @@ func createMockArgument(
 		&mock.MarshalizerMock{},
 		&hashingMocks.HasherMock{},
 		factoryState.NewAccountCreator(),
-		trieStorageManagers[factory.UserAccountTrie],
+		trieStorageManagers[dataRetriever.UserAccountsUnit.String()],
 	)
 	require.Nil(t, err)
 

--- a/integrationTests/state/stateTrie/stateTrie_test.go
+++ b/integrationTests/state/stateTrie/stateTrie_test.go
@@ -25,6 +25,7 @@ import (
 	crypto "github.com/ElrondNetwork/elrond-go-crypto"
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/integrationTests"
 	"github.com/ElrondNetwork/elrond-go/integrationTests/mock"
 	"github.com/ElrondNetwork/elrond-go/sharding"
@@ -39,7 +40,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon/statusHandler"
 	trieMock "github.com/ElrondNetwork/elrond-go/testscommon/trie"
 	"github.com/ElrondNetwork/elrond-go/trie"
-	trieFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1574,7 +1574,7 @@ func TestStatePruningIsBuffered(t *testing.T) {
 	round, nonce = integrationTests.ProposeAndSyncOneBlock(t, nodes, idxProposers, round, nonce)
 
 	rootHash := shardNode.BlockChain.GetCurrentBlockHeader().GetRootHash()
-	stateTrie := shardNode.TrieContainer.Get([]byte(trieFactory.UserAccountTrie))
+	stateTrie := shardNode.TrieContainer.Get([]byte(dataRetriever.UserAccountsUnit.String()))
 
 	delayRounds := 10
 	for i := 0; i < delayRounds; i++ {
@@ -1764,7 +1764,7 @@ func testNodeStateCheckpointSnapshotAndPruning(
 	prunedRootHashes [][]byte,
 ) {
 
-	stateTrie := node.TrieContainer.Get([]byte(trieFactory.UserAccountTrie))
+	stateTrie := node.TrieContainer.Get([]byte(dataRetriever.UserAccountsUnit.String()))
 	assert.Equal(t, 6, len(checkpointsRootHashes))
 	for i := range checkpointsRootHashes {
 		tr, err := stateTrie.Recreate(checkpointsRootHashes[i])
@@ -1945,7 +1945,7 @@ func checkCodeConsistency(
 ) {
 	for code := range codeMap {
 		codeHash := integrationTests.TestHasher.Compute(code)
-		tr := shardNode.TrieContainer.Get([]byte(trieFactory.UserAccountTrie))
+		tr := shardNode.TrieContainer.Get([]byte(dataRetriever.UserAccountsUnit.String()))
 
 		if codeMap[code] != 0 {
 			val, _, err := tr.Get(codeHash)

--- a/integrationTests/state/stateTrieSync/stateTrieSync_test.go
+++ b/integrationTests/state/stateTrieSync/stateTrieSync_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/throttler"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/common"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/epochStart/notifier"
 	"github.com/ElrondNetwork/elrond-go/integrationTests"
 	"github.com/ElrondNetwork/elrond-go/process/factory"
@@ -21,7 +22,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 	testStorage "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	"github.com/ElrondNetwork/elrond-go/trie"
-	trieFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
 	"github.com/ElrondNetwork/elrond-go/trie/keyBuilder"
 	"github.com/ElrondNetwork/elrond-go/trie/statistics"
 	"github.com/ElrondNetwork/elrond-go/trie/storageMarker"
@@ -94,7 +94,7 @@ func testNodeRequestInterceptTrieNodesWithMessenger(t *testing.T, version int) {
 
 	time.Sleep(integrationTests.SyncDelay)
 
-	resolverTrie := nResolver.TrieContainer.Get([]byte(trieFactory.UserAccountTrie))
+	resolverTrie := nResolver.TrieContainer.Get([]byte(dataRetriever.UserAccountsUnit.String()))
 	// we have tested even with the 1000000 value and found out that it worked in a reasonable amount of time ~3.5 minutes
 	numTrieLeaves := 10000
 	for i := 0; i < numTrieLeaves; i++ {
@@ -116,7 +116,7 @@ func testNodeRequestInterceptTrieNodesWithMessenger(t *testing.T, version int) {
 	numLeaves := getNumLeaves(t, resolverTrie, rootHash)
 	assert.Equal(t, numTrieLeaves, numLeaves)
 
-	requesterTrie := nRequester.TrieContainer.Get([]byte(trieFactory.UserAccountTrie))
+	requesterTrie := nRequester.TrieContainer.Get([]byte(dataRetriever.UserAccountsUnit.String()))
 	nilRootHash, _ := requesterTrie.RootHash()
 
 	tss := statistics.NewTrieSyncStatistics()
@@ -224,7 +224,7 @@ func testNodeRequestInterceptTrieNodesWithMessengerNotSyncingShouldErr(t *testin
 
 	time.Sleep(integrationTests.SyncDelay)
 
-	resolverTrie := nResolver.TrieContainer.Get([]byte(trieFactory.UserAccountTrie))
+	resolverTrie := nResolver.TrieContainer.Get([]byte(dataRetriever.UserAccountsUnit.String()))
 	// we have tested even with the 1000000 value and found out that it worked in a reasonable amount of time ~3.5 minutes
 	numTrieLeaves := 10000
 	for i := 0; i < numTrieLeaves; i++ {
@@ -246,7 +246,7 @@ func testNodeRequestInterceptTrieNodesWithMessengerNotSyncingShouldErr(t *testin
 	numLeaves := getNumLeaves(t, resolverTrie, rootHash)
 	assert.Equal(t, numTrieLeaves, numLeaves)
 
-	requesterTrie := nRequester.TrieContainer.Get([]byte(trieFactory.UserAccountTrie))
+	requesterTrie := nRequester.TrieContainer.Get([]byte(dataRetriever.UserAccountsUnit.String()))
 
 	tss := statistics.NewTrieSyncStatistics()
 	arg := trie.ArgTrieSyncer{
@@ -356,7 +356,7 @@ func testMultipleDataTriesSync(t *testing.T, numAccounts int, numDataTrieLeaves 
 	err = common.GetErrorFromChanNonBlocking(leavesChannel.ErrChan)
 	require.Nil(t, err)
 
-	requesterTrie := nRequester.TrieContainer.Get([]byte(trieFactory.UserAccountTrie))
+	requesterTrie := nRequester.TrieContainer.Get([]byte(dataRetriever.UserAccountsUnit.String()))
 	nilRootHash, _ := requesterTrie.RootHash()
 
 	syncerArgs := getUserAccountSyncerArgs(nRequester, version)
@@ -483,14 +483,14 @@ func testSyncMissingSnapshotNodes(t *testing.T, version int) {
 		time.Sleep(integrationTests.StepDelay)
 	}
 
-	resolverTrie := nResolver.TrieContainer.Get([]byte(trieFactory.UserAccountTrie))
+	resolverTrie := nResolver.TrieContainer.Get([]byte(dataRetriever.UserAccountsUnit.String()))
 	accState := nResolver.AccntState
 	dataTrieRootHashes := addAccountsToState(t, numAccounts, numDataTrieLeaves, accState, valSize)
 	rootHash, _ := accState.RootHash()
 	numLeaves := getNumLeaves(t, resolverTrie, rootHash)
 	require.Equal(t, numAccounts+numSystemAccounts, numLeaves)
 
-	requesterTrie := nRequester.TrieContainer.Get([]byte(trieFactory.UserAccountTrie))
+	requesterTrie := nRequester.TrieContainer.Get([]byte(dataRetriever.UserAccountsUnit.String()))
 	nilRootHash, _ := requesterTrie.RootHash()
 
 	copyPartialState(t, nResolver, nRequester, dataTrieRootHashes)
@@ -504,7 +504,7 @@ func testSyncMissingSnapshotNodes(t *testing.T, version int) {
 	err = nRequester.AccntState.StartSnapshotIfNeeded()
 	assert.Nil(t, err)
 
-	tsm := nRequester.TrieStorageManagers[trieFactory.UserAccountTrie]
+	tsm := nRequester.TrieStorageManagers[dataRetriever.UserAccountsUnit.String()]
 	_ = tsm.PutInEpoch([]byte(common.ActiveDBKey), []byte(common.ActiveDBVal), 0)
 	nRequester.AccntState.SnapshotState(rootHash)
 	for tsm.IsPruningBlocked() {
@@ -522,12 +522,12 @@ func testSyncMissingSnapshotNodes(t *testing.T, version int) {
 }
 
 func copyPartialState(t *testing.T, sourceNode, destinationNode *integrationTests.TestProcessorNode, dataTriesRootHashes [][]byte) {
-	resolverTrie := sourceNode.TrieContainer.Get([]byte(trieFactory.UserAccountTrie))
+	resolverTrie := sourceNode.TrieContainer.Get([]byte(dataRetriever.UserAccountsUnit.String()))
 	hashes, _ := resolverTrie.GetAllHashes()
 	assert.NotEqual(t, 0, len(hashes))
 
 	hashes = append(hashes, getDataTriesHashes(t, resolverTrie, dataTriesRootHashes)...)
-	destStorage := destinationNode.TrieContainer.Get([]byte(trieFactory.UserAccountTrie)).GetStorageManager()
+	destStorage := destinationNode.TrieContainer.Get([]byte(dataRetriever.UserAccountsUnit.String())).GetStorageManager()
 
 	for i, hash := range hashes {
 		if i%1000 == 0 {
@@ -599,7 +599,7 @@ func getUserAccountSyncerArgs(node *integrationTests.TestProcessorNode, version 
 		ArgsNewBaseAccountsSyncer: syncer.ArgsNewBaseAccountsSyncer{
 			Hasher:                            integrationTests.TestHasher,
 			Marshalizer:                       integrationTests.TestMarshalizer,
-			TrieStorageManager:                node.TrieStorageManagers[trieFactory.UserAccountTrie],
+			TrieStorageManager:                node.TrieStorageManagers[dataRetriever.UserAccountsUnit.String()],
 			RequestHandler:                    node.RequestHandler,
 			Timeout:                           common.TimeoutGettingTrieNodes,
 			Cacher:                            node.DataPool.TrieNodes(),

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -110,7 +110,6 @@ import (
 	statusHandlerMock "github.com/ElrondNetwork/elrond-go/testscommon/statusHandler"
 	storageStubs "github.com/ElrondNetwork/elrond-go/testscommon/storage"
 	trieMock "github.com/ElrondNetwork/elrond-go/testscommon/trie"
-	trieFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
 	"github.com/ElrondNetwork/elrond-go/trie/keyBuilder"
 	"github.com/ElrondNetwork/elrond-go/update"
 	"github.com/ElrondNetwork/elrond-go/update/trigger"
@@ -525,15 +524,15 @@ func (tpn *TestProcessorNode) initAccountDBsWithPruningStorer() {
 	tpn.TrieContainer = state.NewDataTriesHolder()
 	var stateTrie common.Trie
 	tpn.AccntState, stateTrie = CreateAccountsDB(UserAccount, trieStorageManager)
-	tpn.TrieContainer.Put([]byte(trieFactory.UserAccountTrie), stateTrie)
+	tpn.TrieContainer.Put([]byte(dataRetriever.UserAccountsUnit.String()), stateTrie)
 
 	var peerTrie common.Trie
 	tpn.PeerState, peerTrie = CreateAccountsDB(ValidatorAccount, trieStorageManager)
-	tpn.TrieContainer.Put([]byte(trieFactory.PeerAccountTrie), peerTrie)
+	tpn.TrieContainer.Put([]byte(dataRetriever.PeerAccountsUnit.String()), peerTrie)
 
 	tpn.TrieStorageManagers = make(map[string]common.StorageManager)
-	tpn.TrieStorageManagers[trieFactory.UserAccountTrie] = trieStorageManager
-	tpn.TrieStorageManagers[trieFactory.PeerAccountTrie] = trieStorageManager
+	tpn.TrieStorageManagers[dataRetriever.UserAccountsUnit.String()] = trieStorageManager
+	tpn.TrieStorageManagers[dataRetriever.PeerAccountsUnit.String()] = trieStorageManager
 }
 
 func (tpn *TestProcessorNode) initAccountDBs(store storage.Storer) {
@@ -541,15 +540,15 @@ func (tpn *TestProcessorNode) initAccountDBs(store storage.Storer) {
 	tpn.TrieContainer = state.NewDataTriesHolder()
 	var stateTrie common.Trie
 	tpn.AccntState, stateTrie = CreateAccountsDB(UserAccount, trieStorageManager)
-	tpn.TrieContainer.Put([]byte(trieFactory.UserAccountTrie), stateTrie)
+	tpn.TrieContainer.Put([]byte(dataRetriever.UserAccountsUnit.String()), stateTrie)
 
 	var peerTrie common.Trie
 	tpn.PeerState, peerTrie = CreateAccountsDB(ValidatorAccount, trieStorageManager)
-	tpn.TrieContainer.Put([]byte(trieFactory.PeerAccountTrie), peerTrie)
+	tpn.TrieContainer.Put([]byte(dataRetriever.PeerAccountsUnit.String()), peerTrie)
 
 	tpn.TrieStorageManagers = make(map[string]common.StorageManager)
-	tpn.TrieStorageManagers[trieFactory.UserAccountTrie] = trieStorageManager
-	tpn.TrieStorageManagers[trieFactory.PeerAccountTrie] = trieStorageManager
+	tpn.TrieStorageManagers[dataRetriever.UserAccountsUnit.String()] = trieStorageManager
+	tpn.TrieStorageManagers[dataRetriever.PeerAccountsUnit.String()] = trieStorageManager
 }
 
 func (tpn *TestProcessorNode) initValidatorStatistics() {
@@ -3064,9 +3063,9 @@ func GetDefaultStateComponents() *testscommon.StateComponentsMock {
 		AccountsRepo: &stateMock.AccountsRepositoryStub{},
 		Tries:        &trieMock.TriesHolderStub{},
 		StorageManagers: map[string]common.StorageManager{
-			"0":                         &testscommon.StorageManagerStub{},
-			trieFactory.UserAccountTrie: &testscommon.StorageManagerStub{},
-			trieFactory.PeerAccountTrie: &testscommon.StorageManagerStub{},
+			"0":                                     &testscommon.StorageManagerStub{},
+			dataRetriever.UserAccountsUnit.String(): &testscommon.StorageManagerStub{},
+			dataRetriever.PeerAccountsUnit.String(): &testscommon.StorageManagerStub{},
 		},
 	}
 }

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -59,7 +59,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/storage/cache"
 	storageFactory "github.com/ElrondNetwork/elrond-go/storage/factory"
 	"github.com/ElrondNetwork/elrond-go/storage/storageunit"
-	trieFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
 	trieStatistics "github.com/ElrondNetwork/elrond-go/trie/statistics"
 	"github.com/ElrondNetwork/elrond-go/trie/storageMarker"
 	"github.com/ElrondNetwork/elrond-go/update/trigger"
@@ -600,7 +599,7 @@ func getUserAccountSyncer(
 	processComponents mainFactory.ProcessComponentsHolder,
 ) (process.AccountsDBSyncer, error) {
 	maxTrieLevelInMemory := config.StateTriesConfig.MaxStateTrieLevelInMemory
-	userTrie := stateComponents.TriesContainer().Get([]byte(trieFactory.UserAccountTrie))
+	userTrie := stateComponents.TriesContainer().Get([]byte(dataRetriever.UserAccountsUnit.String()))
 	storageManager := userTrie.GetStorageManager()
 
 	thr, err := throttler.NewNumGoRoutinesThrottler(int32(config.TrieSync.NumConcurrentTrieSyncers))
@@ -633,7 +632,7 @@ func getValidatorAccountSyncer(
 	processComponents mainFactory.ProcessComponentsHolder,
 ) (process.AccountsDBSyncer, error) {
 	maxTrieLevelInMemory := config.StateTriesConfig.MaxPeerTrieLevelInMemory
-	peerTrie := stateComponents.TriesContainer().Get([]byte(trieFactory.PeerAccountTrie))
+	peerTrie := stateComponents.TriesContainer().Get([]byte(dataRetriever.PeerAccountsUnit.String()))
 	storageManager := peerTrie.GetStorageManager()
 
 	args := syncer.ArgsNewValidatorAccountsSyncer{

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -124,9 +124,6 @@ type baseBootstrap struct {
 	isInImportMode               bool
 	scheduledTxsExecutionHandler process.ScheduledTxsExecutionHandler
 	processWaitTime              time.Duration
-
-	userAccountsStorerIdentifier string
-	peerAccountsStorerIdentifier string
 }
 
 // setRequestedHeaderNonce method sets the header nonce requested by the sync mechanism
@@ -1127,29 +1124,17 @@ func (boot *baseBootstrap) waitForMiniBlocks() error {
 	}
 }
 
-func (boot *baseBootstrap) setAccountsStorerIdentifiers() error {
-	userStorer, err := boot.store.GetStorer(dataRetriever.UserAccountsUnit)
+func (boot *baseBootstrap) getStorerIdentifier(unitType dataRetriever.UnitType) (string, error) {
+	storer, err := boot.store.GetStorer(unitType)
 	if err != nil {
-		return err
+		return "", err
 	}
-	dbWithID, ok := userStorer.(dbStorerWithIdentifier)
+	dbWithID, ok := storer.(dbStorerWithIdentifier)
 	if !ok {
-		return errors.ErrWrongTypeAssertion
-	}
-	boot.userAccountsStorerIdentifier = dbWithID.GetIdentifier()
-
-	peerStorer, err := boot.store.GetStorer(dataRetriever.PeerAccountsUnit)
-	if err != nil {
-		return err
-	}
-	dbPeerWithID, ok := peerStorer.(dbStorerWithIdentifier)
-	if !ok {
-		return errors.ErrWrongTypeAssertion
+		return "", errors.ErrWrongTypeAssertion
 	}
 
-	boot.peerAccountsStorerIdentifier = dbPeerWithID.GetIdentifier()
-
-	return nil
+	return dbWithID.GetIdentifier(), nil
 }
 
 func (boot *baseBootstrap) init() {

--- a/process/sync/interface.go
+++ b/process/sync/interface.go
@@ -35,3 +35,7 @@ type getKeyHandler interface {
 	GetKey() []byte
 	GetIdentifier() string
 }
+
+type dbStorerWithIdentifier interface {
+	GetIdentifier() string
+}

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
-	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/errors"
 	"github.com/ElrondNetwork/elrond-go/process"
@@ -108,6 +107,11 @@ func NewMetaBootstrap(arguments ArgMetaBootstrapper) (*MetaBootstrap, error) {
 		return nil, err
 	}
 
+	err = base.setAccountsStorerIdentifiers()
+	if err != nil {
+		return nil, err
+	}
+
 	base.init()
 
 	return &boot, nil
@@ -195,11 +199,12 @@ func (boot *MetaBootstrap) SyncBlock(ctx context.Context) error {
 }
 
 func (boot *MetaBootstrap) syncAccountsDBs(key []byte, id string) error {
+
 	// TODO: refactor this in order to avoid treatment based on identifier
 	switch id {
-	case common.AccountsTrieIdentifier:
+	case boot.userAccountsStorerIdentifier:
 		return boot.syncUserAccountsState(key)
-	case common.PeerAccountsTrieIdentifier:
+	case boot.peerAccountsStorerIdentifier:
 		return boot.syncValidatorAccountsState(key)
 	default:
 		return fmt.Errorf("invalid trie identifier, id: %s", id)

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -107,11 +107,6 @@ func NewMetaBootstrap(arguments ArgMetaBootstrapper) (*MetaBootstrap, error) {
 		return nil, err
 	}
 
-	err = base.setAccountsStorerIdentifiers()
-	if err != nil {
-		return nil, err
-	}
-
 	base.init()
 
 	return &boot, nil
@@ -199,6 +194,10 @@ func (boot *MetaBootstrap) SyncBlock(ctx context.Context) error {
 }
 
 func (boot *MetaBootstrap) syncAccountsDBs(key []byte, id string) error {
+	err := boot.setAccountsStorerIdentifiers()
+	if err != nil {
+		return err
+	}
 
 	// TODO: refactor this in order to avoid treatment based on identifier
 	switch id {

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -194,16 +194,21 @@ func (boot *MetaBootstrap) SyncBlock(ctx context.Context) error {
 }
 
 func (boot *MetaBootstrap) syncAccountsDBs(key []byte, id string) error {
-	err := boot.setAccountsStorerIdentifiers()
+	userAccountsStorerIdentifier, err := boot.getStorerIdentifier(dataRetriever.UserAccountsUnit)
+	if err != nil {
+		return err
+	}
+
+	peerAccountsStorerIdentifier, err := boot.getStorerIdentifier(dataRetriever.PeerAccountsUnit)
 	if err != nil {
 		return err
 	}
 
 	// TODO: refactor this in order to avoid treatment based on identifier
 	switch id {
-	case boot.userAccountsStorerIdentifier:
+	case userAccountsStorerIdentifier:
 		return boot.syncUserAccountsState(key)
-	case boot.peerAccountsStorerIdentifier:
+	case peerAccountsStorerIdentifier:
 		return boot.syncValidatorAccountsState(key)
 	default:
 		return fmt.Errorf("invalid trie identifier, id: %s", id)

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -92,6 +92,11 @@ func NewShardBootstrap(arguments ArgShardBootstrapper) (*ShardBootstrap, error) 
 		return nil, err
 	}
 
+	err = base.setAccountsStorerIdentifiers()
+	if err != nil {
+		return nil, err
+	}
+
 	base.init()
 
 	return &boot, nil

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -92,11 +92,6 @@ func NewShardBootstrap(arguments ArgShardBootstrapper) (*ShardBootstrap, error) 
 		return nil, err
 	}
 
-	err = base.setAccountsStorerIdentifiers()
-	if err != nil {
-		return nil, err
-	}
-
 	base.init()
 
 	return &boot, nil

--- a/process/sync/shardblock_test.go
+++ b/process/sync/shardblock_test.go
@@ -107,6 +107,8 @@ func createFullStore() dataRetriever.StorageService {
 	store.AddStorer(dataRetriever.ShardHdrNonceHashDataUnit, generateTestUnit())
 	store.AddStorer(dataRetriever.ReceiptsUnit, generateTestUnit())
 	store.AddStorer(dataRetriever.ScheduledSCRsUnit, generateTestUnit())
+	store.AddStorer(dataRetriever.UserAccountsUnit, generateTestUnit())
+	store.AddStorer(dataRetriever.PeerAccountsUnit, generateTestUnit())
 	return store
 }
 
@@ -1739,7 +1741,8 @@ func TestBootstrap_GetTxBodyHavingHashNotFoundInCacherOrStorageShouldRetEmptySli
 	args.Store = createFullStore()
 	args.Store.AddStorer(dataRetriever.TransactionUnit, txBlockUnit)
 
-	bs, _ := sync.NewShardBootstrap(args)
+	bs, err := sync.NewShardBootstrap(args)
+	require.Nil(t, err)
 	gotMbsAndHashes, _ := bs.GetMiniBlocks(requestedHash)
 
 	assert.Equal(t, 0, len(gotMbsAndHashes))

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -13,6 +13,7 @@ import (
 	commonFactory "github.com/ElrondNetwork/elrond-go/common/factory"
 	"github.com/ElrondNetwork/elrond-go/config"
 	"github.com/ElrondNetwork/elrond-go/consensus/spos"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/epochStart/bootstrap/disabled"
 	"github.com/ElrondNetwork/elrond-go/factory"
 	bootstrapComp "github.com/ElrondNetwork/elrond-go/factory/bootstrap"
@@ -40,7 +41,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon/shardingMocks"
 	statusHandlerMock "github.com/ElrondNetwork/elrond-go/testscommon/statusHandler"
 	"github.com/ElrondNetwork/elrond-go/trie"
-	trieFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
 	"github.com/ElrondNetwork/elrond-go/trie/hashesHolder"
 	arwenConfig "github.com/ElrondNetwork/wasm-vm-v1_4/config"
 	"github.com/stretchr/testify/require"
@@ -334,14 +334,14 @@ func GetStateFactoryArgs(coreComponents factory.CoreComponentsHolder, shardCoord
 	storageManagerPeer, _ := trie.NewTrieStorageManagerWithoutPruning(tsm)
 
 	trieStorageManagers := make(map[string]common.StorageManager)
-	trieStorageManagers[trieFactory.UserAccountTrie] = storageManagerUser
-	trieStorageManagers[trieFactory.PeerAccountTrie] = storageManagerPeer
+	trieStorageManagers[dataRetriever.UserAccountsUnit.String()] = storageManagerUser
+	trieStorageManagers[dataRetriever.PeerAccountsUnit.String()] = storageManagerPeer
 
 	triesHolder := state.NewDataTriesHolder()
 	trieUsers, _ := trie.NewTrie(storageManagerUser, coreComponents.InternalMarshalizer(), coreComponents.Hasher(), 5)
 	triePeers, _ := trie.NewTrie(storageManagerPeer, coreComponents.InternalMarshalizer(), coreComponents.Hasher(), 5)
-	triesHolder.Put([]byte(trieFactory.UserAccountTrie), trieUsers)
-	triesHolder.Put([]byte(trieFactory.PeerAccountTrie), triePeers)
+	triesHolder.Put([]byte(dataRetriever.UserAccountsUnit.String()), trieUsers)
+	triesHolder.Put([]byte(dataRetriever.PeerAccountsUnit.String()), triePeers)
 
 	stateComponentsFactoryArgs := stateComp.StateComponentsFactoryArgs{
 		Config:           GetGeneralConfig(),

--- a/testscommon/components/default.go
+++ b/testscommon/components/default.go
@@ -5,6 +5,7 @@ import (
 
 	crypto "github.com/ElrondNetwork/elrond-go-crypto"
 	"github.com/ElrondNetwork/elrond-go/common"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/factory/mock"
 	"github.com/ElrondNetwork/elrond-go/sharding"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
@@ -17,7 +18,6 @@ import (
 	stateMock "github.com/ElrondNetwork/elrond-go/testscommon/state"
 	"github.com/ElrondNetwork/elrond-go/testscommon/storage"
 	trieMock "github.com/ElrondNetwork/elrond-go/testscommon/trie"
-	trieFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
 )
 
 // GetDefaultCoreComponents -
@@ -85,9 +85,9 @@ func GetDefaultStateComponents() *testscommon.StateComponentsMock {
 		Accounts: &stateMock.AccountsStub{},
 		Tries:    &trieMock.TriesHolderStub{},
 		StorageManagers: map[string]common.StorageManager{
-			"0":                         &testscommon.StorageManagerStub{},
-			trieFactory.UserAccountTrie: &testscommon.StorageManagerStub{},
-			trieFactory.PeerAccountTrie: &testscommon.StorageManagerStub{},
+			"0":                                     &testscommon.StorageManagerStub{},
+			dataRetriever.UserAccountsUnit.String(): &testscommon.StorageManagerStub{},
+			dataRetriever.PeerAccountsUnit.String(): &testscommon.StorageManagerStub{},
 		},
 	}
 }

--- a/testscommon/storage/storerStub.go
+++ b/testscommon/storage/storerStub.go
@@ -19,6 +19,7 @@ type StorerStub struct {
 	GetBulkFromEpochCalled       func(keys [][]byte, epoch uint32) ([]storage.KeyValuePair, error)
 	GetOldestEpochCalled         func() (uint32, error)
 	RangeKeysCalled              func(handler func(key []byte, val []byte) bool)
+	GetIdentifierCalled          func() string
 	CloseCalled                  func() error
 }
 
@@ -122,6 +123,14 @@ func (ss *StorerStub) RangeKeys(handler func(key []byte, val []byte) bool) {
 	if ss.RangeKeysCalled != nil {
 		ss.RangeKeysCalled(handler)
 	}
+}
+
+// GetIdentifier -
+func (ss *StorerStub) GetIdentifier() string {
+	if ss.GetIdentifierCalled != nil {
+		return ss.GetIdentifierCalled()
+	}
+	return ""
 }
 
 // Close -

--- a/trie/factory/trieCreator.go
+++ b/trie/factory/trieCreator.go
@@ -148,8 +148,8 @@ func CreateTriesComponentsForShardId(
 	trieContainer := state.NewDataTriesHolder()
 	trieStorageManagers := make(map[string]common.StorageManager)
 
-	trieContainer.Put([]byte(UserAccountTrie), userAccountTrie)
-	trieStorageManagers[UserAccountTrie] = userStorageManager
+	trieContainer.Put([]byte(dataRetriever.UserAccountsUnit.String()), userAccountTrie)
+	trieStorageManagers[dataRetriever.UserAccountsUnit.String()] = userStorageManager
 
 	mainStorer, err = storageService.GetStorer(dataRetriever.PeerAccountsUnit)
 	if err != nil {
@@ -175,8 +175,8 @@ func CreateTriesComponentsForShardId(
 		return nil, nil, err
 	}
 
-	trieContainer.Put([]byte(PeerAccountTrie), peerAccountsTrie)
-	trieStorageManagers[PeerAccountTrie] = peerStorageManager
+	trieContainer.Put([]byte(dataRetriever.PeerAccountsUnit.String()), peerAccountsTrie)
+	trieStorageManagers[dataRetriever.PeerAccountsUnit.String()] = peerStorageManager
 
 	return trieContainer, trieStorageManagers, nil
 }

--- a/trie/factory/trieFactoryArgs.go
+++ b/trie/factory/trieFactoryArgs.go
@@ -7,14 +7,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/storage"
 )
 
-// TODO: refactor to align these constants with db filepath identifier
-
-// UserAccountTrie represents the use account identifier
-const UserAccountTrie = "userAccount"
-
-// PeerAccountTrie represents the peer account identifier
-const PeerAccountTrie = "peerAccount"
-
 // TrieFactoryArgs holds the arguments for creating a trie factory
 type TrieFactoryArgs struct {
 	Marshalizer              marshal.Marshalizer

--- a/update/genesis/import.go
+++ b/update/genesis/import.go
@@ -16,11 +16,11 @@ import (
 	"github.com/ElrondNetwork/elrond-go/common"
 	commonDisabled "github.com/ElrondNetwork/elrond-go/common/disabled"
 	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/state"
 	"github.com/ElrondNetwork/elrond-go/state/factory"
 	"github.com/ElrondNetwork/elrond-go/state/storagePruningManager/disabled"
 	"github.com/ElrondNetwork/elrond-go/trie"
-	triesFactory "github.com/ElrondNetwork/elrond-go/trie/factory"
 	"github.com/ElrondNetwork/elrond-go/update"
 )
 
@@ -286,9 +286,9 @@ func (si *stateImport) getTrie(shardID uint32, accType Type) (common.Trie, error
 		return trieForShard, nil
 	}
 
-	trieStorageManager := si.trieStorageManagers[triesFactory.UserAccountTrie]
+	trieStorageManager := si.trieStorageManagers[dataRetriever.PeerAccountsUnit.String()]
 	if accType == ValidatorAccount {
-		trieStorageManager = si.trieStorageManagers[triesFactory.PeerAccountTrie]
+		trieStorageManager = si.trieStorageManagers[dataRetriever.PeerAccountsUnit.String()]
 	}
 
 	trieForShard, err := trie.NewTrie(trieStorageManager, si.marshalizer, si.hasher, maxTrieLevelInMemory)
@@ -323,7 +323,7 @@ func (si *stateImport) importDataTrie(identifier string, shID uint32, keys [][]b
 		return fmt.Errorf("%w wanted a roothash", update.ErrWrongTypeAssertion)
 	}
 
-	dataTrie, err := trie.NewTrie(si.trieStorageManagers[triesFactory.UserAccountTrie], si.marshalizer, si.hasher, maxTrieLevelInMemory)
+	dataTrie, err := trie.NewTrie(si.trieStorageManagers[dataRetriever.UserAccountsUnit.String()], si.marshalizer, si.hasher, maxTrieLevelInMemory)
 	if err != nil {
 		return err
 	}

--- a/update/genesis/import_test.go
+++ b/update/genesis/import_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go/common"
 	"github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/dataRetriever"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/testscommon/hashingMocks"
-	"github.com/ElrondNetwork/elrond-go/trie/factory"
 	"github.com/ElrondNetwork/elrond-go/update"
 	"github.com/ElrondNetwork/elrond-go/update/mock"
 	"github.com/stretchr/testify/assert"
@@ -23,7 +23,7 @@ import (
 
 func TestNewStateImport(t *testing.T) {
 	trieStorageManagers := make(map[string]common.StorageManager)
-	trieStorageManagers[factory.UserAccountTrie] = &testscommon.StorageManagerStub{}
+	trieStorageManagers[dataRetriever.UserAccountsUnit.String()] = &testscommon.StorageManagerStub{}
 	tests := []struct {
 		name    string
 		args    ArgsNewStateImport
@@ -82,8 +82,8 @@ func TestImportAll(t *testing.T) {
 	t.Parallel()
 
 	trieStorageManagers := make(map[string]common.StorageManager)
-	trieStorageManagers[factory.UserAccountTrie] = &testscommon.StorageManagerStub{}
-	trieStorageManagers[factory.PeerAccountTrie] = &testscommon.StorageManagerStub{}
+	trieStorageManagers[dataRetriever.UserAccountsUnit.String()] = &testscommon.StorageManagerStub{}
+	trieStorageManagers[dataRetriever.PeerAccountsUnit.String()] = &testscommon.StorageManagerStub{}
 
 	args := ArgsNewStateImport{
 		HardforkStorer:      &mock.HardforkStorerStub{},
@@ -105,7 +105,7 @@ func TestStateImport_ImportUnFinishedMetaBlocksShouldWork(t *testing.T) {
 	t.Parallel()
 
 	trieStorageManagers := make(map[string]common.StorageManager)
-	trieStorageManagers[factory.UserAccountTrie] = &testscommon.StorageManagerStub{}
+	trieStorageManagers[dataRetriever.UserAccountsUnit.String()] = &testscommon.StorageManagerStub{}
 
 	hasher := &hashingMocks.HasherMock{}
 	marshahlizer := &mock.MarshalizerMock{}


### PR DESCRIPTION
## Reasoning behind the pull request
- Duplicate constants for db identifier
  
## Proposed changes
- remove constants for peer and user accounts key
- use constant from dataRetriever storage units

## Testing procedure
- N/A

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
