### PR TITLE
Fix `MetricReceivedProposedBlock` overflow

### DIFF
--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -514,6 +514,9 @@ func (wrk *Worker) processReceivedHeaderMetric(cnsDta *consensus.Message) {
 	}
 
 	sinceRoundStart := time.Since(wrk.roundHandler.TimeStamp())
+	if sinceRoundStart < 0 {
+		sinceRoundStart = 0
+	}
 	percent := sinceRoundStart * 100 / wrk.roundHandler.TimeDuration()
 	wrk.appStatusHandler.SetUInt64Value(common.MetricReceivedProposedBlock, uint64(percent))
 	wrk.appStatusHandler.SetStringValue(common.MetricRedundancyIsMainActive, strconv.FormatBool(wrk.nodeRedundancyHandler.IsMainMachineActive()))


### PR DESCRIPTION
## Reasoning behind the pull request
- there were situations when the MetricReceivedProposedBlock was improperly computed
  
## Proposed changes
- fix MetricReceivedProposedBlock overflow by disallowing a negative value

## Testing procedure
- standard system test + system test without transactions 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
