### PR TITLE
fix: fix slice init length

### DIFF
--- a/process/smartContract/hooks/blockChainHook.go
+++ b/process/smartContract/hooks/blockChainHook.go
@@ -736,7 +736,7 @@ func hashFromAddressAndNonce(creatorAddress []byte, creatorNonce uint64) []byte 
 }
 
 func createPrefixMask(vmType []byte) []byte {
-	prefixMask := make([]byte, core.NumInitCharactersForScAddress-core.VMTypeLen)
+	prefixMask := make([]byte, 0, core.NumInitCharactersForScAddress-core.VMTypeLen)
 	prefixMask = append(prefixMask, vmType...)
 
 	return prefixMask


### PR DESCRIPTION
## Reasoning behind the pull request


The intention here should be to initialize a slice with a capacity of  `core.NumInitCharactersForScAddress-core.VMTypeLen` rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW


  
## Proposed changes
- 
- 
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
