### PR TITLE
In integration tests, when creating pools, use mock DB

### DIFF
--- a/testscommon/dataRetriever/poolFactory.go
+++ b/testscommon/dataRetriever/poolFactory.go
@@ -14,8 +14,8 @@ import (
 	"github.com/multiversx/mx-chain-go/dataRetriever/shardedData"
 	"github.com/multiversx/mx-chain-go/dataRetriever/txpool"
 	"github.com/multiversx/mx-chain-go/storage/cache"
-	"github.com/multiversx/mx-chain-go/storage/mock"
 	"github.com/multiversx/mx-chain-go/storage/storageunit"
+	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/txcachemocks"
 	"github.com/multiversx/mx-chain-go/trie/factory"
 )
@@ -85,12 +85,12 @@ func createPoolHolderArgs(numShards uint32, selfShard uint32) dataPool.DataPoolA
 	cacher, err := cache.NewCapacityLRU(10, 10000)
 	panicIfError("CreatePoolsHolder", err)
 
-	persister := &mock.PersisterStub{}
+	db := testscommon.NewMemDbMock()
 	tnf := factory.NewTrieNodeFactory()
 
 	adaptedTrieNodesStorage, err := storageunit.NewStorageCacherAdapter(
 		cacher,
-		persister,
+		db,
 		tnf,
 		&marshal.GogoProtoMarshalizer{},
 	)


### PR DESCRIPTION
## Reasoning behind the pull request
- When running tests on the self-hosted GitHub actions runner, the some temporary folders were not cleaned up. Specifically, in the integration tests, we didn't call `Destroy()` on the persister backing the `adaptedTrieNodesStorage`, the one created by `testscommon/dataRetriever/poolFactory.go`. 
  
## Proposed changes
- In integration tests, when creating pools, use a mock DB for the trie nodes storage cache - just like for other components used in the integration tests.

## Testing procedure
- Long tests should succeed. `/tmp` folder should not contain folders of the kind `integrationTests*`.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
