### PR TITLE
Supernova TxPool: removed diagnose counters

### DIFF
--- a/txcache/diagnosis.go
+++ b/txcache/diagnosis.go
@@ -23,38 +23,7 @@ type printedTransaction struct {
 
 // Diagnose checks the state of the cache for inconsistencies and displays a summary, senders and transactions.
 func (cache *TxCache) Diagnose(_ bool) {
-	cache.diagnoseCounters()
 	cache.diagnoseTransactions()
-}
-
-func (cache *TxCache) diagnoseCounters() {
-	if log.GetLevel() > logger.LogDebug {
-		return
-	}
-
-	sizeInBytes := cache.NumBytes()
-	numTxsEstimate := int(cache.CountTx())
-	numTxsInChunks := cache.txByHash.backingMap.Count()
-	txsKeys := cache.txByHash.backingMap.Keys()
-	numSendersEstimate := int(cache.CountSenders())
-	numSendersInChunks := cache.txListBySender.backingMap.Count()
-	sendersKeys := cache.txListBySender.backingMap.Keys()
-
-	fine := numSendersEstimate == numSendersInChunks
-	fine = fine && (int(numSendersEstimate) == len(sendersKeys))
-	fine = fine && (numTxsEstimate == numTxsInChunks && numTxsEstimate == len(txsKeys))
-
-	log.Debug("diagnoseCounters",
-		"fine", fine,
-		"numTxsEstimate", numTxsEstimate,
-		"numTxsInChunks", numTxsInChunks,
-		"len(txsKeys)", len(txsKeys),
-		"sizeInBytes", sizeInBytes,
-		"numBytesThreshold", cache.config.NumBytesThreshold,
-		"numSendersEstimate", numSendersEstimate,
-		"numSendersInChunks", numSendersInChunks,
-		"len(sendersKeys)", len(sendersKeys),
-	)
 }
 
 func (cache *TxCache) diagnoseTransactions() {

--- a/txcache/txCache.go
+++ b/txcache/txCache.go
@@ -151,8 +151,6 @@ func (cache *TxCache) SelectTransactions(
 		"gas", accumulatedGas,
 	)
 
-	// TODO drop the diagnoseCounters
-	go cache.diagnoseCounters()
 	go displaySelectionOutcome(logSelect, "selection", transactions)
 
 	return transactions, accumulatedGas


### PR DESCRIPTION
## Reasoning behind the pull request
 Solved one of the **TODOs** from **TxPool** - **removing the diagnoseCounters** - a debugging step useful in the past, **but not useful anymore**.
  
## Proposed changes
- **removed diagnose counters**

## Testing procedure

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
