### PR TITLE
Select Transactions Endpoint: Return PPU info

### DIFF
--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -430,6 +430,7 @@ func (atp *apiTransactionProcessor) getFieldGettersForTx(wrappedTx *txcache.Wrap
 		receiverField:    atp.addressPubKeyConverter.SilentEncode(wrappedTx.Tx.GetRcvAddr(), log),
 		gasLimitField:    wrappedTx.Tx.GetGasLimit(),
 		gasPriceField:    wrappedTx.Tx.GetGasPrice(),
+		ppu:              wrappedTx.PricePerUnit,
 		rcvUsernameField: wrappedTx.Tx.GetRcvUserName(),
 		dataField:        wrappedTx.Tx.GetData(),
 		valueField:       getTxValue(wrappedTx),

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -1322,7 +1322,7 @@ func TestApiTransactionProcessor_GetSelectedTransactions(t *testing.T) {
 
 		selectionOptionsAPI := holders.NewTxSelectionOptionsAPI(
 			options,
-			"hash,sender,relayer,nonce",
+			"hash,sender,relayer,nonce,ppu",
 		)
 
 		selectedTxs, err := atp.GetSelectedTransactions(selectionOptionsAPI, blockchainMock, accountsAdapter)
@@ -1337,6 +1337,9 @@ func TestApiTransactionProcessor_GetSelectedTransactions(t *testing.T) {
 			require.False(t, ok)
 
 			_, ok = tx.TxFields["nonce"]
+			require.True(t, ok)
+
+			_, ok = tx.TxFields["ppu"]
 			require.True(t, ok)
 		}
 	})

--- a/node/external/transactionAPI/fieldsHandler.go
+++ b/node/external/transactionAPI/fieldsHandler.go
@@ -11,6 +11,7 @@ const (
 	receiverField          = "receiver"
 	gasLimitField          = "gaslimit"
 	gasPriceField          = "gasprice"
+	ppu                    = "ppu"
 	rcvUsernameField       = "receiverusername"
 	dataField              = "data"
 	valueField             = "value"

--- a/node/external/transactionAPI/fieldsHandler_test.go
+++ b/node/external/transactionAPI/fieldsHandler_test.go
@@ -14,7 +14,7 @@ func Test_newFieldsHandler(t *testing.T) {
 	fh := newFieldsHandler("")
 	require.Equal(t, fieldsHandler{map[string]struct{}{hashField: {}}}, fh)
 
-	providedFields := "nOnCe,sender,receiver,gasLimit,GASprice,receiverusername,data,value,signature,guardian,guardiansignature,sendershard,receivershard"
+	providedFields := "nOnCe,sender,receiver,gasLimit,GASprice,receiverusername,data,value,signature,guardian,guardiansignature,sendershard,receivershard,ppu"
 	splitFields := strings.Split(providedFields, separator)
 	fh = newFieldsHandler(providedFields)
 	for _, field := range splitFields {


### PR DESCRIPTION
## Reasoning behind the pull request
- At the moment, there is no option for user to ask for PPU field when trying a simulation of transactions selection. 
This PR fixes this issue.
  
## Proposed changes
- add field
- modify unit test

## Testing procedure
- local testing

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
