### PR TITLE
Updated block.MetaBlock usages to use interface instead

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -455,7 +455,7 @@ func CreateLastExecutionResultFromPrevHeader(prevHeader data.HeaderHandler, prev
 		}, nil
 	}
 
-	prevMetaHeader, ok := prevHeader.(*block.MetaBlock)
+	prevMetaHeader, ok := prevHeader.(data.MetaHeaderHandler)
 	if !ok {
 		return nil, ErrWrongTypeAssertion
 	}

--- a/dataRetriever/blockchain/metachain.go
+++ b/dataRetriever/blockchain/metachain.go
@@ -4,7 +4,6 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
-	"github.com/multiversx/mx-chain-core-go/data/block"
 )
 
 var _ data.ChainHandler = (*metaChain)(nil)
@@ -40,7 +39,7 @@ func (mc *metaChain) SetGenesisHeader(header data.HeaderHandler) error {
 		return nil
 	}
 
-	genBlock, ok := header.(*block.MetaBlock)
+	genBlock, ok := header.(data.MetaHeaderHandler)
 	if !ok {
 		return ErrWrongTypeInSet
 	}

--- a/epochStart/bootstrap/fromLocalStorage.go
+++ b/epochStart/bootstrap/fromLocalStorage.go
@@ -155,7 +155,7 @@ func (e *epochStartBootstrap) prepareEpochFromStorage() (Parameters, error) {
 	}
 
 	prevEpochStartMetaHash := e.epochStartMeta.GetEpochStartHandler().GetEconomicsHandler().GetPrevEpochStartHash()
-	prevEpochStartMeta, ok := e.syncedHeaders[string(prevEpochStartMetaHash)].(*block.MetaBlock)
+	prevEpochStartMeta, ok := e.syncedHeaders[string(prevEpochStartMetaHash)].(data.MetaHeaderHandler)
 	if !ok {
 		return Parameters{}, epochStart.ErrWrongTypeAssertion
 	}

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -850,7 +850,7 @@ func (e *epochStartBootstrap) requestAndProcessing() (Parameters, error) {
 	log.Debug("start in epoch bootstrap: got shard headers and previous epoch start meta block")
 
 	prevEpochStartMetaHash := e.epochStartMeta.GetEpochStartHandler().GetEconomicsHandler().GetPrevEpochStartHash()
-	prevEpochStartMeta, ok := e.syncedHeaders[string(prevEpochStartMetaHash)].(*block.MetaBlock)
+	prevEpochStartMeta, ok := e.syncedHeaders[string(prevEpochStartMetaHash)].(data.MetaHeaderHandler)
 	if !ok {
 		return Parameters{}, epochStart.ErrWrongTypeAssertion
 	}

--- a/epochStart/bootstrap/shardStorageHandler.go
+++ b/epochStart/bootstrap/shardStorageHandler.go
@@ -470,7 +470,7 @@ func getProcessedMiniBlockHashesForMetaBlockHash(
 			epochStart.ErrMissingHeader,
 			hex.EncodeToString(metaBlockHash))
 	}
-	neededMeta, ok := metaHeaderHandler.(*block.MetaBlock)
+	neededMeta, ok := metaHeaderHandler.(data.MetaHeaderHandler)
 	if !ok {
 		return nil, epochStart.ErrWrongTypeAssertion
 	}
@@ -610,7 +610,7 @@ func getEpochShardDataAndNeededMetaBlock(
 	shardID uint32,
 	meta data.MetaHeaderHandler,
 	headers map[string]data.HeaderHandler,
-) (data.EpochStartShardDataHandler, *block.MetaBlock, error) {
+) (data.EpochStartShardDataHandler, data.MetaHeaderHandler, error) {
 
 	epochShardData, err := getEpochStartShardData(meta, shardID)
 	if err != nil {
@@ -624,7 +624,7 @@ func getEpochShardDataAndNeededMetaBlock(
 			hex.EncodeToString(epochShardData.GetFirstPendingMetaBlock()))
 	}
 
-	neededMeta, ok := header.(*block.MetaBlock)
+	neededMeta, ok := header.(data.MetaHeaderHandler)
 	if !ok {
 		return nil, nil, epochStart.ErrWrongTypeAssertion
 	}
@@ -635,7 +635,7 @@ func getEpochShardDataAndNeededMetaBlock(
 	return epochShardData, neededMeta, nil
 }
 
-func getMiniBlocksInfo(epochShardData data.EpochStartShardDataHandler, neededMeta *block.MetaBlock, shardID uint32) *miniBlocksInfo {
+func getMiniBlocksInfo(epochShardData data.EpochStartShardDataHandler, neededMeta data.MetaHeaderHandler, shardID uint32) *miniBlocksInfo {
 	mbsInfo := &miniBlocksInfo{
 		miniBlockHashes:              make([][]byte, 0),
 		fullyProcessed:               make([]bool, 0),
@@ -673,7 +673,7 @@ func setMiniBlocksInfoWithPendingMiniBlocks(epochShardData data.EpochStartShardD
 	}
 }
 
-func setMiniBlocksInfoWithProcessedMiniBlocks(neededMeta *block.MetaBlock, shardID uint32, mbsInfo *miniBlocksInfo) {
+func setMiniBlocksInfoWithProcessedMiniBlocks(neededMeta data.MetaHeaderHandler, shardID uint32, mbsInfo *miniBlocksInfo) {
 	miniBlockHeaders := getProcessedMiniBlockHeaders(neededMeta, shardID, mbsInfo.pendingMiniBlocksMap)
 	for mbHash, mbHeader := range miniBlockHeaders {
 		log.Debug("shardStorageHandler.setMiniBlocksInfoWithProcessedMiniBlocks",
@@ -715,7 +715,7 @@ func createProcessedAndPendingMiniBlocks(
 	return processedMiniBlocks, pendingMiniBlocks
 }
 
-func getProcessedMiniBlockHeaders(metaBlock *block.MetaBlock, destShardID uint32, pendingMBsMap map[string]struct{}) map[string]block.MiniBlockHeader {
+func getProcessedMiniBlockHeaders(metaBlock data.MetaHeaderHandler, destShardID uint32, pendingMBsMap map[string]struct{}) map[string]block.MiniBlockHeader {
 	processedMiniBlockHeaders := make(map[string]block.MiniBlockHeader)
 	miniBlockHeadersDestMe := getMiniBlockHeadersForDest(metaBlock, destShardID)
 	for hash, mbh := range miniBlockHeadersDestMe {
@@ -762,7 +762,7 @@ func (ssh *shardStorageHandler) saveLastCrossNotarizedHeaders(
 			hex.EncodeToString(lastCrossMetaHdrHash))
 	}
 
-	neededMeta, ok := neededHdr.(*block.MetaBlock)
+	neededMeta, ok := neededHdr.(data.MetaHeaderHandler)
 	if !ok {
 		return nil, epochStart.ErrWrongTypeAssertion
 	}

--- a/epochStart/bootstrap/storageEpochStartMetaBlockProcessor.go
+++ b/epochStart/bootstrap/storageEpochStartMetaBlockProcessor.go
@@ -8,8 +8,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
-	"github.com/multiversx/mx-chain-core-go/data"
-	"github.com/multiversx/mx-chain-core-go/data/block"
+	coreData "github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/epochStart"
@@ -25,7 +24,7 @@ type storageEpochStartMetaBlockProcessor struct {
 	hasher         hashing.Hasher
 	chanReceived   chan struct{}
 	mutMetablock   sync.Mutex
-	metaBlock      data.MetaHeaderHandler
+	metaBlock      coreData.MetaHeaderHandler
 }
 
 // NewStorageEpochStartMetaBlockProcessor will return an interceptor processor for epoch start meta block when importing
@@ -81,7 +80,7 @@ func (ses *storageEpochStartMetaBlockProcessor) Save(data process.InterceptedDat
 		return false, nil
 	}
 
-	metaBlock, ok := interceptedHdr.HeaderHandler().(*block.MetaBlock)
+	metaBlock, ok := interceptedHdr.HeaderHandler().(coreData.MetaHeaderHandler)
 	if !ok {
 		log.Warn("saving epoch start meta block error", "error", epochStart.ErrWrongTypeAssertion,
 			"header", interceptedHdr.HeaderHandler())
@@ -108,7 +107,7 @@ func (ses *storageEpochStartMetaBlockProcessor) Save(data process.InterceptedDat
 
 // GetEpochStartMetaBlock will return the metablock after it is confirmed or an error if the number of tries was exceeded
 // This is a blocking method which will end after the consensus for the meta block is obtained or the context is done
-func (ses *storageEpochStartMetaBlockProcessor) GetEpochStartMetaBlock(ctx context.Context) (data.MetaHeaderHandler, error) {
+func (ses *storageEpochStartMetaBlockProcessor) GetEpochStartMetaBlock(ctx context.Context) (coreData.MetaHeaderHandler, error) {
 	ses.requestMetaBlock()
 
 	chanRequests := time.After(durationBetweenReRequests)
@@ -125,7 +124,7 @@ func (ses *storageEpochStartMetaBlockProcessor) GetEpochStartMetaBlock(ctx conte
 	}
 }
 
-func (ses *storageEpochStartMetaBlockProcessor) getMetablock() (data.MetaHeaderHandler, error) {
+func (ses *storageEpochStartMetaBlockProcessor) getMetablock() (coreData.MetaHeaderHandler, error) {
 	ses.mutMetablock.Lock()
 	defer ses.mutMetablock.Unlock()
 

--- a/epochStart/bootstrap/storageProcess.go
+++ b/epochStart/bootstrap/storageProcess.go
@@ -310,7 +310,7 @@ func (sesb *storageEpochStartBootstrap) requestAndProcessFromStorage() (Paramete
 	log.Debug("start in epoch bootstrap: got shard header and previous epoch start meta block")
 
 	prevEpochStartMetaHash := sesb.epochStartMeta.GetEpochStartHandler().GetEconomicsHandler().GetPrevEpochStartHash()
-	prevEpochStartMeta, ok := sesb.syncedHeaders[string(prevEpochStartMetaHash)].(*block.MetaBlock)
+	prevEpochStartMeta, ok := sesb.syncedHeaders[string(prevEpochStartMetaHash)].(data.MetaHeaderHandler)
 	if !ok {
 		return Parameters{}, epochStart.ErrWrongTypeAssertion
 	}
@@ -431,7 +431,7 @@ func (sesb *storageEpochStartBootstrap) processNodesConfig(pubKey []byte) error 
 	}
 
 	clonedHeader := sesb.epochStartMeta.ShallowClone()
-	clonedEpochStartMeta, ok := clonedHeader.(*block.MetaBlock)
+	clonedEpochStartMeta, ok := clonedHeader.(data.MetaHeaderHandler)
 	if !ok {
 		return fmt.Errorf("%w while trying to assert clonedHeader to *block.MetaBlock", epochStart.ErrWrongTypeAssertion)
 	}
@@ -441,7 +441,7 @@ func (sesb *storageEpochStartBootstrap) processNodesConfig(pubKey []byte) error 
 	}
 
 	clonedHeader = sesb.prevEpochStartMeta.ShallowClone()
-	clonedPrevEpochStartMeta, ok := clonedHeader.(*block.MetaBlock)
+	clonedPrevEpochStartMeta, ok := clonedHeader.(data.MetaHeaderHandler)
 	if !ok {
 		return fmt.Errorf("%w while trying to assert prevClonedHeader to *block.MetaBlock", epochStart.ErrWrongTypeAssertion)
 	}

--- a/epochStart/metachain/trigger.go
+++ b/epochStart/metachain/trigger.go
@@ -372,7 +372,7 @@ func (t *trigger) revert(header data.HeaderHandler) error {
 		return nil
 	}
 
-	metaHdr, ok := header.(*block.MetaBlock)
+	metaHdr, ok := header.(data.MetaHeaderHandler)
 	if !ok {
 		log.Warn("wrong type assertion in Revert metachain trigger")
 		return epochStart.ErrWrongTypeAssertion
@@ -381,7 +381,7 @@ func (t *trigger) revert(header data.HeaderHandler) error {
 	t.mutTrigger.Lock()
 	defer t.mutTrigger.Unlock()
 
-	prevEpochStartIdentifier := core.EpochStartIdentifier(metaHdr.Epoch - 1)
+	prevEpochStartIdentifier := core.EpochStartIdentifier(metaHdr.GetEpoch() - 1)
 	epochStartMetaBuff, err := t.metaHeaderStorage.SearchFirst([]byte(prevEpochStartIdentifier))
 	if err != nil {
 		log.Warn("Revert get previous meta from storage", "error", err)
@@ -395,7 +395,7 @@ func (t *trigger) revert(header data.HeaderHandler) error {
 		return err
 	}
 
-	epochStartIdentifier := core.EpochStartIdentifier(metaHdr.Epoch)
+	epochStartIdentifier := core.EpochStartIdentifier(metaHdr.GetEpoch())
 	errNotCritical := t.triggerStorage.Remove([]byte(epochStartIdentifier))
 	if errNotCritical != nil {
 		log.Debug("Revert remove from triggerStorage", "error", errNotCritical.Error())
@@ -406,8 +406,8 @@ func (t *trigger) revert(header data.HeaderHandler) error {
 		log.Debug("Revert remove from triggerStorage", "error", errNotCritical.Error())
 	}
 
-	t.currEpochStartRound = metaHdr.EpochStart.Economics.PrevEpochStartRound
-	t.epoch = metaHdr.Epoch - 1
+	t.currEpochStartRound = metaHdr.GetEpochStartHandler().GetEconomicsHandler().GetPrevEpochStartRound()
+	t.epoch = metaHdr.GetEpoch() - 1
 	t.isEpochStart = false
 	t.epochStartMeta = epochStartMeta
 

--- a/epochStart/metachain/triggerRegistry.go
+++ b/epochStart/metachain/triggerRegistry.go
@@ -59,6 +59,7 @@ func UnmarshalTrigger(marshaller marshal.Marshalizer, data []byte) (*block.MetaT
 
 // saveState saves the trigger state. Needs to be called under mutex
 func (t *trigger) saveState(key []byte) error {
+	// TODO: add new structures for the new headers and update this component
 	metaHeader, ok := t.epochStartMeta.(*block.MetaBlock)
 	if !ok {
 		return epochStart.ErrWrongTypeAssertion

--- a/epochStart/metachain/triggerRegistry_test.go
+++ b/epochStart/metachain/triggerRegistry_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/data"
-	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/stretchr/testify/require"
 
 	"github.com/multiversx/mx-chain-go/common"
@@ -119,7 +118,7 @@ type legacyTriggerRegistry struct {
 }
 
 func createLegacyTriggerRegistryFromTrigger(t *trigger) *legacyTriggerRegistry {
-	metaBlock, _ := t.epochStartMeta.(*block.MetaBlock)
+	metaBlock, _ := t.epochStartMeta.(data.MetaHeaderHandler)
 	return &legacyTriggerRegistry{
 		Epoch:                       t.epoch,
 		EpochFinalityAttestingRound: t.epochFinalityAttestingRound,

--- a/epochStart/shardchain/trigger.go
+++ b/epochStart/shardchain/trigger.go
@@ -489,7 +489,7 @@ func (t *trigger) RequestEpochStartIfNeeded(interceptedHeader data.HeaderHandler
 	if interceptedHeader.GetEpoch() <= t.Epoch() {
 		return
 	}
-	_, ok := interceptedHeader.(*block.MetaBlock)
+	_, ok := interceptedHeader.(data.MetaHeaderHandler)
 	if !ok {
 		return
 	}
@@ -511,18 +511,18 @@ func (t *trigger) RequestEpochStartIfNeeded(interceptedHeader data.HeaderHandler
 }
 
 func (t *trigger) changeEpochFinalityAttestingRoundIfNeeded(
-	metaHdr *block.MetaBlock,
+	metaHdr data.MetaHeaderHandler,
 	receivedHash []byte,
 ) {
-	hash := t.mapFinalizedEpochs[metaHdr.Epoch]
+	hash := t.mapFinalizedEpochs[metaHdr.GetEpoch()]
 	epochStartMetaHdr := t.mapEpochStartHdrs[hash]
 	if check.IfNil(epochStartMetaHdr) {
 		return
 	}
 
-	isHeaderOnTopOfFinalityAttestingRound := metaHdr.Nonce == epochStartMetaHdr.GetNonce()+t.finality+1
+	isHeaderOnTopOfFinalityAttestingRound := metaHdr.GetNonce() == epochStartMetaHdr.GetNonce()+t.finality+1
 	if isHeaderOnTopOfFinalityAttestingRound {
-		metaHdrWithFinalityAttestingRound, err := t.getHeaderWithNonceAndHash(epochStartMetaHdr.GetNonce()+t.finality, metaHdr.PrevHash)
+		metaHdrWithFinalityAttestingRound, err := t.getHeaderWithNonceAndHash(epochStartMetaHdr.GetNonce()+t.finality, metaHdr.GetPrevHash())
 		if err != nil {
 			log.Debug("searched metaHeader was not found")
 			_ = t.requestedFinalityAttestingBlock.SetReturningPrevious()
@@ -533,7 +533,7 @@ func (t *trigger) changeEpochFinalityAttestingRoundIfNeeded(
 		return
 	}
 
-	isFinalityAttestingBlock := metaHdr.Nonce == epochStartMetaHdr.GetNonce()+t.finality
+	isFinalityAttestingBlock := metaHdr.GetNonce() == epochStartMetaHdr.GetNonce()+t.finality
 	if !isFinalityAttestingBlock {
 		return
 	}
@@ -544,7 +544,7 @@ func (t *trigger) changeEpochFinalityAttestingRoundIfNeeded(
 	}
 
 	if t.requestedFinalityAttestingBlock.IsSet() {
-		_, err = t.getHeaderWithNonceAndPrevHash(metaHdr.Nonce+1, receivedHash)
+		_, err = t.getHeaderWithNonceAndPrevHash(metaHdr.GetNonce()+1, receivedHash)
 		if err != nil {
 			return
 		}
@@ -608,7 +608,7 @@ func (t *trigger) receivedMetaBlock(headerHandler data.HeaderHandler, metaBlockH
 }
 
 func (t *trigger) checkMetaHeaderForEpochTriggerEquivalentProofs(headerHandler data.HeaderHandler, metaBlockHash []byte) {
-	metaHdr, ok := headerHandler.(*block.MetaBlock)
+	metaHdr, ok := headerHandler.(data.MetaHeaderHandler)
 	if !ok {
 		return
 	}
@@ -623,13 +623,13 @@ func (t *trigger) checkMetaHeaderForEpochTriggerEquivalentProofs(headerHandler d
 }
 
 func (t *trigger) checkMetaHeaderForEpochTriggerLegacy(headerHandler data.HeaderHandler, metaBlockHash []byte) {
-	metaHdr, ok := headerHandler.(*block.MetaBlock)
+	metaHdr, ok := headerHandler.(data.MetaHeaderHandler)
 	if !ok {
 		return
 	}
 
 	if !t.isPreviousEpochStartMetaBlock(metaHdr, metaBlockHash) {
-		_, ok = t.mapFinalizedEpochs[metaHdr.Epoch]
+		_, ok = t.mapFinalizedEpochs[metaHdr.GetEpoch()]
 		if t.metaEpoch == headerHandler.GetEpoch() && ok {
 			t.changeEpochFinalityAttestingRoundIfNeeded(metaHdr, metaBlockHash)
 			return
@@ -644,12 +644,12 @@ func (t *trigger) checkMetaHeaderForEpochTriggerLegacy(headerHandler data.Header
 	t.updateTriggerFromMeta()
 }
 
-func (t *trigger) shouldUpdateTrigger(metaHdr *block.MetaBlock, metaBlockHash []byte) bool {
+func (t *trigger) shouldUpdateTrigger(metaHdr data.MetaHeaderHandler, metaBlockHash []byte) bool {
 	if !t.newEpochHdrReceived && !metaHdr.IsStartOfEpochBlock() {
 		return false
 	}
 
-	isMetaStartOfEpochForCurrentOrOlderEpoch := metaHdr.Epoch <= t.epoch && metaHdr.IsStartOfEpochBlock()
+	isMetaStartOfEpochForCurrentOrOlderEpoch := metaHdr.GetEpoch() <= t.epoch && metaHdr.IsStartOfEpochBlock()
 	if isMetaStartOfEpochForCurrentOrOlderEpoch {
 		return false
 	}
@@ -657,7 +657,7 @@ func (t *trigger) shouldUpdateTrigger(metaHdr *block.MetaBlock, metaBlockHash []
 	_, foundHdrInMap := t.mapHashHdr[string(metaBlockHash)]
 	_, foundHdrInEpochStartMap := t.mapEpochStartHdrs[string(metaBlockHash)]
 
-	finalizedMetaBlockHash, ok := t.mapFinalizedEpochs[metaHdr.Epoch]
+	finalizedMetaBlockHash, ok := t.mapFinalizedEpochs[metaHdr.GetEpoch()]
 	foundHdrInFinalizedMap := ok && bytes.Equal(metaBlockHash, []byte(finalizedMetaBlockHash))
 
 	if foundHdrInMap && foundHdrInEpochStartMap && foundHdrInFinalizedMap {
@@ -667,7 +667,7 @@ func (t *trigger) shouldUpdateTrigger(metaHdr *block.MetaBlock, metaBlockHash []
 	return true
 }
 
-func (t *trigger) updateTriggerHeaderData(metaHdr *block.MetaBlock, metaBlockHash []byte) {
+func (t *trigger) updateTriggerHeaderData(metaHdr data.MetaHeaderHandler, metaBlockHash []byte) {
 	if metaHdr.IsStartOfEpochBlock() {
 		t.newEpochHdrReceived = true
 		t.mapEpochStartHdrs[string(metaBlockHash)] = metaHdr
@@ -686,12 +686,12 @@ func (t *trigger) updateTriggerHeaderData(metaHdr *block.MetaBlock, metaBlockHas
 	}
 
 	t.mapHashHdr[string(metaBlockHash)] = metaHdr
-	t.mapNonceHashes[metaHdr.Nonce] = append(t.mapNonceHashes[metaHdr.Nonce], string(metaBlockHash))
+	t.mapNonceHashes[metaHdr.GetNonce()] = append(t.mapNonceHashes[metaHdr.GetNonce()], string(metaBlockHash))
 }
 
 // call only if mutex is locked before
-func (t *trigger) isPreviousEpochStartMetaBlock(metaBlock *block.MetaBlock, metaBlockHash []byte) bool {
-	metaHdrHashesWithNonce := t.mapNonceHashes[metaBlock.Nonce+1]
+func (t *trigger) isPreviousEpochStartMetaBlock(metaBlock data.MetaHeaderHandler, metaBlockHash []byte) bool {
+	metaHdrHashesWithNonce := t.mapNonceHashes[metaBlock.GetNonce()+1]
 	for _, hash := range metaHdrHashesWithNonce {
 		epochStartMetaBlock, ok := t.mapEpochStartHdrs[hash]
 		if !ok {
@@ -922,10 +922,10 @@ func (t *trigger) getHeaderWithNonceAndHashFromMaps(nonce uint64, neededHash []b
 // call only if mutex is locked before
 func (t *trigger) getHeaderWithHashFromPool(neededHash []byte) data.HeaderHandler {
 	peekedData, _ := t.headersPool.GetHeaderByHash(neededHash)
-	neededHdr, ok := peekedData.(*block.MetaBlock)
+	neededHdr, ok := peekedData.(data.MetaHeaderHandler)
 	if ok {
 		t.mapHashHdr[string(neededHash)] = neededHdr
-		t.mapNonceHashes[neededHdr.Nonce] = append(t.mapNonceHashes[neededHdr.Nonce], string(neededHash))
+		t.mapNonceHashes[neededHdr.GetNonce()] = append(t.mapNonceHashes[neededHdr.GetNonce()], string(neededHash))
 		return neededHdr
 	}
 
@@ -1006,13 +1006,13 @@ func (t *trigger) getHeaderWithNonceAndPrevHashFromCache(nonce uint64, prevHash 
 	}
 
 	lowestRound := uint64(math.MaxUint64)
-	chosenMeta := &block.MetaBlock{}
+	var chosenMeta data.MetaHeaderHandler
 	for i, header := range headers {
 		if !bytes.Equal(header.GetPrevHash(), prevHash) {
 			continue
 		}
 
-		hdrWithNonce, ok := header.(*block.MetaBlock)
+		hdrWithNonce, ok := header.(data.MetaHeaderHandler)
 		if !ok {
 			continue
 		}
@@ -1023,7 +1023,7 @@ func (t *trigger) getHeaderWithNonceAndPrevHashFromCache(nonce uint64, prevHash 
 		}
 
 		t.mapHashHdr[string(hashes[i])] = hdrWithNonce
-		t.mapNonceHashes[hdrWithNonce.Nonce] = append(t.mapNonceHashes[hdrWithNonce.Nonce], string(hashes[i]))
+		t.mapNonceHashes[hdrWithNonce.GetNonce()] = append(t.mapNonceHashes[hdrWithNonce.GetNonce()], string(hashes[i]))
 	}
 
 	if lowestRound == uint64(math.MaxUint64) {

--- a/epochStart/shardchain/triggerRegistry.go
+++ b/epochStart/shardchain/triggerRegistry.go
@@ -107,6 +107,7 @@ func unmarshalTriggerV1(marshaller marshal.Marshalizer, data []byte) (data.Trigg
 
 // saveState saves the trigger state. Needs to be called under mutex
 func (t *trigger) saveState(key []byte) error {
+	// TODO: add new structures for the new headers and update this component
 	registryV2 := &block.ShardTriggerRegistryV2{
 		EpochStartShardHeader: &block.HeaderV2{},
 	}

--- a/genesis/process/metaGenesisBlockCreator.go
+++ b/genesis/process/metaGenesisBlockCreator.go
@@ -190,7 +190,7 @@ func createMetaGenesisBlockAfterHardFork(
 		return nil, nil, nil, err
 	}
 
-	metaHdr, ok := hdrHandler.(*block.MetaBlock)
+	metaHdr, ok := hdrHandler.(data.MetaHeaderHandler)
 	if !ok {
 		return nil, nil, nil, process.ErrWrongTypeAssertion
 	}

--- a/node/chainSimulator/chainSimulator.go
+++ b/node/chainSimulator/chainSimulator.go
@@ -193,13 +193,11 @@ func (s *simulator) createChainHandlers(args ArgsBaseChainSimulator) error {
 				TimeStamp: uint64(node.GetCoreComponents().RoundHandler().TimeStamp().Unix()),
 			}
 		} else {
-			epochStartBlockHeader = &block.HeaderV2{
-				Header: &block.Header{
-					Nonce:     args.InitialNonce,
-					Epoch:     args.InitialEpoch,
-					Round:     uint64(args.InitialRound),
-					TimeStamp: uint64(node.GetCoreComponents().RoundHandler().TimeStamp().Unix()),
-				},
+			epochStartBlockHeader = &block.MetaBlockV3{
+				Nonce:       args.InitialNonce,
+				Epoch:       args.InitialEpoch,
+				Round:       uint64(args.InitialRound),
+				TimestampMs: uint64(node.GetCoreComponents().RoundHandler().TimeStamp().Unix()),
 			}
 		}
 

--- a/node/external/blockAPI/internalBlock.go
+++ b/node/external/blockAPI/internalBlock.go
@@ -188,8 +188,7 @@ func (ibp *internalBlockProcessor) GetInternalStartOfEpochValidatorsInfo(epoch u
 		return nil, err
 	}
 
-	metaBlock := &block.MetaBlock{}
-	err = ibp.marshalizer.Unmarshal(metaBlock, blockBytes)
+	metaBlock, err := process.UnmarshalHeader(core.MetachainShardId, ibp.marshalizer, blockBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -279,9 +278,8 @@ func (ibp *internalBlockProcessor) getMiniBlockByHash(hash []byte, epoch uint32)
 	return miniBlock, nil
 }
 
-func (ibp *internalBlockProcessor) convertMetaBlockBytesToInternalBlock(blockBytes []byte) (*block.MetaBlock, error) {
-	blockHeader := &block.MetaBlock{}
-	err := ibp.marshalizer.Unmarshal(blockHeader, blockBytes)
+func (ibp *internalBlockProcessor) convertMetaBlockBytesToInternalBlock(blockBytes []byte) (data.HeaderHandler, error) {
+	blockHeader, err := process.UnmarshalHeader(core.MetachainShardId, ibp.marshalizer, blockBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/node/external/blockAPI/metaBlock.go
+++ b/node/external/blockAPI/metaBlock.go
@@ -94,8 +94,7 @@ func (mbp *metaAPIBlockProcessor) GetBlockByHash(hash []byte, options api.BlockQ
 		return nil, err
 	}
 
-	blockHeader := &block.MetaBlock{}
-	err = mbp.marshalizer.Unmarshal(blockHeader, blockBytes)
+	blockHeader, err := process.UnmarshalHeader(core.MetachainShardId, mbp.marshalizer, blockBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/process/sync/metablock_test.go
+++ b/process/sync/metablock_test.go
@@ -43,7 +43,7 @@ import (
 func createMetaBlockProcessor(blk data.ChainHandler) *testscommon.BlockProcessorStub {
 	blockProcessorMock := &testscommon.BlockProcessorStub{
 		ProcessBlockCalled: func(hdr data.HeaderHandler, bdy data.BodyHandler, haveTime func() time.Duration) error {
-			_ = blk.SetCurrentBlockHeaderAndRootHash(hdr.(*block.MetaBlock), hdr.GetRootHash())
+			_ = blk.SetCurrentBlockHeaderAndRootHash(hdr.(data.MetaHeaderHandler), hdr.GetRootHash())
 			return nil
 		},
 		RevertCurrentBlockCalled: func(_ data.HeaderHandler) {

--- a/update/genesis/import.go
+++ b/update/genesis/import.go
@@ -151,7 +151,7 @@ func (si *stateImport) importEpochStartMetaBlock(identifier string, keys [][]byt
 		return err
 	}
 
-	metaBlock, ok := object.(*block.MetaBlock)
+	metaBlock, ok := object.(data.MetaHeaderHandler)
 	if !ok {
 		return update.ErrWrongTypeAssertion
 	}
@@ -170,7 +170,7 @@ func (si *stateImport) importUnFinishedMetaBlocks(identifier string, keys [][]by
 			break
 		}
 
-		metaBlock, ok := object.(*block.MetaBlock)
+		metaBlock, ok := object.(data.MetaHeaderHandler)
 		if !ok {
 			return update.ErrWrongTypeAssertion
 		}

--- a/update/sync/syncHeaders.go
+++ b/update/sync/syncHeaders.go
@@ -115,7 +115,7 @@ func (h *headersToSync) receivedMetaBlockFirstPending(headerHandler data.HeaderH
 		return
 	}
 
-	metaHeader, ok := headerHandler.(*block.MetaBlock)
+	metaHeader, ok := headerHandler.(data.MetaHeaderHandler)
 	if !ok {
 		h.mutMeta.Unlock()
 		return
@@ -145,7 +145,7 @@ func (h *headersToSync) receivedUnFinishedMetaBlocks(headerHandler data.HeaderHa
 		return
 	}
 
-	meta, ok := headerHandler.(*block.MetaBlock)
+	meta, ok := headerHandler.(data.MetaHeaderHandler)
 	if !ok {
 		h.mutMeta.Unlock()
 		return


### PR DESCRIPTION
## Reasoning behind the pull request
- multiple common places still cast to block.MetaBlock
  
## Proposed changes
- update casts to use the MetsaHeaderHandler interface

## Testing procedure
- with feat branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
