### PR TITLE
Get from storage shard data creator

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -64,8 +64,8 @@
     ]
 
     ProcessConfigsByRound = [
-        { EnableRound = 0, MaxRoundsWithoutNewBlockReceived = 10, MaxRoundsWithoutCommittedBlock = 10, RoundModulusTriggerWhenSyncIsStuck = 20 },
-        { EnableRound = 440, MaxRoundsWithoutNewBlockReceived = 100, MaxRoundsWithoutCommittedBlock = 100, RoundModulusTriggerWhenSyncIsStuck = 200 },
+        { EnableRound = 0, MaxRoundsWithoutNewBlockReceived = 10, MaxRoundsWithoutCommittedBlock = 10, RoundModulusTriggerWhenSyncIsStuck = 20, MaxSyncWithErrorsAllowed = 10 },
+        { EnableRound = 440, MaxRoundsWithoutNewBlockReceived = 100, MaxRoundsWithoutCommittedBlock = 100, RoundModulusTriggerWhenSyncIsStuck = 200, MaxSyncWithErrorsAllowed = 100 },
     ]
 
     EpochStartConfigsByEpoch = [

--- a/common/configs/processConfigs.go
+++ b/common/configs/processConfigs.go
@@ -14,6 +14,7 @@ const (
 	defaultMaxRoundsWithoutNewBlockReceived   = 10
 	defaultMaxRoundsWithoutCommittedBlock     = 10
 	defaultRoundModulusTriggerWhenSyncIsStuck = 20
+	defaultMaxSyncWithErrorsAllowed           = 20
 )
 
 // ErrEmptyProcessConfigsByEpoch signals that an empty process configs by epoch has been provided
@@ -185,6 +186,17 @@ func (pce *processConfigsByEpoch) GetRoundModulusTriggerWhenSyncIsStuck(round ui
 	}
 
 	return defaultRoundModulusTriggerWhenSyncIsStuck // this should not happen
+}
+
+// GetMaxSyncWithErrorsAllowed returns max allowed sync errors until an error event is triggered
+func (pce *processConfigsByEpoch) GetMaxSyncWithErrorsAllowed(round uint64) uint32 {
+	for i := len(pce.orderedConfigByRound) - 1; i >= 0; i-- {
+		if pce.orderedConfigByRound[i].EnableRound <= round {
+			return pce.orderedConfigByRound[i].MaxSyncWithErrorsAllowed
+		}
+	}
+
+	return defaultMaxSyncWithErrorsAllowed
 }
 
 // IsInterfaceNil checks if the instance is nil

--- a/common/configs/processConfigs_test.go
+++ b/common/configs/processConfigs_test.go
@@ -79,13 +79,29 @@ func TestProcessConfigsByEpoch_Getters(t *testing.T) {
 	t.Parallel()
 
 	conf := []config.ProcessConfigByEpoch{
-		{EnableEpoch: 0, MaxMetaNoncesBehind: 10, MaxMetaNoncesBehindForGlobalStuck: 11, MaxShardNoncesBehind: 12},
-		{EnableEpoch: 1, MaxMetaNoncesBehind: 20, MaxMetaNoncesBehindForGlobalStuck: 21, MaxShardNoncesBehind: 22},
+		{EnableEpoch: 0,
+			MaxMetaNoncesBehind:               10,
+			MaxMetaNoncesBehindForGlobalStuck: 11,
+			MaxShardNoncesBehind:              12,
+		},
+		{EnableEpoch: 1,
+			MaxMetaNoncesBehind:               20,
+			MaxMetaNoncesBehindForGlobalStuck: 21,
+			MaxShardNoncesBehind:              22,
+		},
 	}
 
 	confByRound := []config.ProcessConfigByRound{
-		{EnableRound: 0, MaxRoundsWithoutNewBlockReceived: 10, MaxRoundsWithoutCommittedBlock: 20},
-		{EnableRound: 1, MaxRoundsWithoutNewBlockReceived: 11, MaxRoundsWithoutCommittedBlock: 21},
+		{EnableRound: 0,
+			MaxRoundsWithoutNewBlockReceived: 10,
+			MaxRoundsWithoutCommittedBlock:   20,
+			MaxSyncWithErrorsAllowed:         30,
+		},
+		{EnableRound: 1,
+			MaxRoundsWithoutNewBlockReceived: 11,
+			MaxRoundsWithoutCommittedBlock:   21,
+			MaxSyncWithErrorsAllowed:         31,
+		},
 	}
 
 	t.Run("get max meta nonces behind", func(t *testing.T) {
@@ -146,5 +162,17 @@ func TestProcessConfigsByEpoch_Getters(t *testing.T) {
 
 		maxRoundsWithoutCommittedBlock = pce.GetMaxRoundsWithoutCommittedBlock(1)
 		require.Equal(t, uint32(21), maxRoundsWithoutCommittedBlock)
+	})
+
+	t.Run("get max allowed sync with errors", func(t *testing.T) {
+		t.Parallel()
+
+		pce, _ := configs.NewProcessConfigsHandler(conf, confByRound)
+
+		maxSyncWithErrorsAllowed := pce.GetMaxSyncWithErrorsAllowed(0)
+		require.Equal(t, uint32(30), maxSyncWithErrorsAllowed)
+
+		maxSyncWithErrorsAllowed = pce.GetMaxSyncWithErrorsAllowed(1)
+		require.Equal(t, uint32(31), maxSyncWithErrorsAllowed)
 	})
 }

--- a/common/interface.go
+++ b/common/interface.go
@@ -486,6 +486,7 @@ type ProcessConfigsHandler interface {
 	GetMaxRoundsWithoutNewBlockReceivedByRound(round uint64) uint32
 	GetMaxRoundsWithoutCommittedBlock(round uint64) uint32
 	GetRoundModulusTriggerWhenSyncIsStuck(round uint64) uint32
+	GetMaxSyncWithErrorsAllowed(round uint64) uint32
 
 	IsInterfaceNil() bool
 }

--- a/config/config.go
+++ b/config/config.go
@@ -194,14 +194,14 @@ type Config struct {
 	ProofsStorage           StorageConfig
 	ExecutionResultsStorage StorageConfig
 
-	AccountsTrieStorage      StorageConfig
-	PeerAccountsTrieStorage  StorageConfig
-	EvictionWaitingList      EvictionWaitingListConfig
-	StateTriesConfig         StateTriesConfig
+	AccountsTrieStorage          StorageConfig
+	PeerAccountsTrieStorage      StorageConfig
+	EvictionWaitingList          EvictionWaitingListConfig
+	StateTriesConfig             StateTriesConfig
 	StateAccessesCollectorConfig StateAccessesCollectorConfig
-	TrieStorageManagerConfig TrieStorageManagerConfig
-	TrieLeavesRetrieverConfig TrieLeavesRetrieverConfig
-	BadBlocksCache           CacheConfig
+	TrieStorageManagerConfig     TrieStorageManagerConfig
+	TrieLeavesRetrieverConfig    TrieLeavesRetrieverConfig
+	BadBlocksCache               CacheConfig
 
 	TxBlockBodyDataPool          CacheConfig
 	PeerBlockBodyDataPool        CacheConfig
@@ -382,6 +382,10 @@ type ProcessConfigByRound struct {
 
 	// RoundModulusTriggerWhenSyncIsStuck defines a round modulus on which a trigger for an action when sync is stuck will be released
 	RoundModulusTriggerWhenSyncIsStuck uint32
+
+	// MaxSyncWithErrorsAllowed defines the maximum allowed number of sync with errors,
+	// before a special action to be applied
+	MaxSyncWithErrorsAllowed uint32
 }
 
 // GeneralSettingsConfig will hold the general settings for a node

--- a/factory/processing/blockProcessorCreator.go
+++ b/factory/processing/blockProcessorCreator.go
@@ -1204,13 +1204,16 @@ func (pcf *processComponentsFactory) newMetaBlockProcessor(
 		return nil, err
 	}
 
-	shardInfoCreator, err := block.NewShardInfoCreateData(
-		pcf.coreData.EnableEpochsHandler(),
-		pcf.data.Datapool().Headers(),
-		pcf.data.Datapool().Proofs(),
-		pendingMiniBlocksHandler,
-		blockTracker,
-	)
+	shardInfoCreateDataArgs := block.ShardInfoCreateDataArgs{
+		EnableEpochsHandler:      pcf.coreData.EnableEpochsHandler(),
+		HeadersPool:              pcf.data.Datapool().Headers(),
+		ProofsPool:               pcf.data.Datapool().Proofs(),
+		PendingMiniBlocksHandler: pendingMiniBlocksHandler,
+		BlockTracker:             blockTracker,
+		Storage:                  pcf.data.StorageService(),
+		Marshaller:               pcf.coreData.InternalMarshalizer(),
+	}
+	shardInfoCreator, err := block.NewShardInfoCreateData(shardInfoCreateDataArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -637,6 +637,7 @@ func (pcf *processComponentsFactory) Create() (*processComponents, error) {
 		Headers:                 pcf.data.Datapool().Headers(),
 		StorageService:          pcf.data.StorageService(),
 		Marshaller:              pcf.coreData.InternalMarshalizer(),
+		ShardCoordinator:        pcf.bootstrapComponents.ShardCoordinator(),
 	}
 	execManager, err := executionManager.NewExecutionManager(argExecManager)
 	if err != nil {

--- a/integrationTests/testFullNode.go
+++ b/integrationTests/testFullNode.go
@@ -955,6 +955,7 @@ func (tpn *TestFullNode) initBlockProcessor(
 		Headers:                 tpn.DataPool.Headers(),
 		StorageService:          &storageStubs.ChainStorerStub{},
 		Marshaller:              TestMarshaller,
+		ShardCoordinator:        &testscommon.ShardsCoordinatorMock{},
 	}
 	tpn.ExecutionManager, err = executionManager.NewExecutionManager(argsExecutionManager)
 	if err != nil {
@@ -1190,13 +1191,16 @@ func (tpn *TestFullNode) initBlockProcessor(
 		epochStartSystemSCProcessor, _ := metachain.NewSystemSCProcessor(argsEpochSystemSC)
 		tpn.EpochStartSystemSCProcessor = epochStartSystemSCProcessor
 
-		shardInfoCreator, errShardInfoCreate := block.NewShardInfoCreateData(
-			tpn.EnableEpochsHandler,
-			tpn.DataPool.Headers(),
-			tpn.DataPool.Proofs(),
-			&mock.PendingMiniBlocksHandlerStub{},
-			argumentsBase.BlockTracker,
-		)
+		shardInfoCreateDataArgs := block.ShardInfoCreateDataArgs{
+			EnableEpochsHandler:      tpn.EnableEpochsHandler,
+			HeadersPool:              tpn.DataPool.Headers(),
+			ProofsPool:               tpn.DataPool.Proofs(),
+			PendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
+			BlockTracker:             argumentsBase.BlockTracker,
+			Storage:                  tpn.Storage,
+			Marshaller:               TestMarshalizer,
+		}
+		shardInfoCreator, errShardInfoCreate := block.NewShardInfoCreateData(shardInfoCreateDataArgs)
 		log.LogIfError(errShardInfoCreate)
 
 		arguments := block.ArgMetaProcessor{
@@ -1320,6 +1324,7 @@ func (tpn *TestFullNode) initBlockProcessorWithSync(
 		Headers:                 tpn.DataPool.Headers(),
 		StorageService:          &storageStubs.ChainStorerStub{},
 		Marshaller:              TestMarshaller,
+		ShardCoordinator:        &testscommon.ShardsCoordinatorMock{},
 	}
 	tpn.ExecutionManager, err = executionManager.NewExecutionManager(argsExecutionManager)
 	if err != nil {
@@ -1413,13 +1418,16 @@ func (tpn *TestFullNode) initBlockProcessorWithSync(
 		argumentsBase.ForkDetector = tpn.ForkDetector
 		argumentsBase.TxCoordinator = &mock.TransactionCoordinatorMock{}
 
-		shardInfoCreator, errShardInfoCreate := block.NewShardInfoCreateData(
-			coreComponents.EnableEpochsHandler(),
-			dataComponents.DataPool.Headers(),
-			dataComponents.DataPool.Proofs(),
-			&mock.PendingMiniBlocksHandlerStub{},
-			argumentsBase.BlockTracker,
-		)
+		shardInfoCreateDataArgs := block.ShardInfoCreateDataArgs{
+			EnableEpochsHandler:      tpn.EnableEpochsHandler,
+			HeadersPool:              tpn.DataPool.Headers(),
+			ProofsPool:               tpn.DataPool.Proofs(),
+			PendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
+			BlockTracker:             argumentsBase.BlockTracker,
+			Storage:                  tpn.Storage,
+			Marshaller:               TestMarshalizer,
+		}
+		shardInfoCreator, errShardInfoCreate := block.NewShardInfoCreateData(shardInfoCreateDataArgs)
 		log.LogIfError(errShardInfoCreate)
 
 		arguments := block.ArgMetaProcessor{

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -2525,6 +2525,7 @@ func (tpn *TestProcessorNode) initBlockProcessor() {
 		Headers:                 tpn.DataPool.Headers(),
 		StorageService:          &storageStubs.ChainStorerStub{},
 		Marshaller:              TestMarshaller,
+		ShardCoordinator:        &testscommon.ShardsCoordinatorMock{},
 	}
 	tpn.ExecutionManager, err = executionManager.NewExecutionManager(argsExecutionManager)
 	if err != nil {
@@ -2778,14 +2779,17 @@ func (tpn *TestProcessorNode) initBlockProcessor() {
 		epochStartSystemSCProcessor, _ := metachain.NewSystemSCProcessor(argsEpochSystemSC)
 		tpn.EpochStartSystemSCProcessor = epochStartSystemSCProcessor
 
-		shardInfoCreator, errShardInfoCreator := block.NewShardInfoCreateData(
-			tpn.EnableEpochsHandler,
-			tpn.DataPool.Headers(),
-			tpn.DataPool.Proofs(),
-			&mock.PendingMiniBlocksHandlerStub{},
-			argumentsBase.BlockTracker,
-		)
-		log.LogIfError(errShardInfoCreator)
+		shardInfoCreateDataArgs := block.ShardInfoCreateDataArgs{
+			EnableEpochsHandler:      tpn.EnableEpochsHandler,
+			HeadersPool:              tpn.DataPool.Headers(),
+			ProofsPool:               tpn.DataPool.Proofs(),
+			PendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
+			BlockTracker:             argumentsBase.BlockTracker,
+			Storage:                  tpn.Storage,
+			Marshaller:               TestMarshalizer,
+		}
+		shardInfoCreator, errShardInfoCreate := block.NewShardInfoCreateData(shardInfoCreateDataArgs)
+		log.LogIfError(errShardInfoCreate)
 
 		arguments := block.ArgMetaProcessor{
 			ArgBaseProcessor:             argumentsBase,

--- a/integrationTests/testSyncNode.go
+++ b/integrationTests/testSyncNode.go
@@ -134,6 +134,7 @@ func (tpn *TestProcessorNode) initBlockProcessorWithSync() {
 		Headers:                 tpn.DataPool.Headers(),
 		StorageService:          &storageStubs.ChainStorerStub{},
 		Marshaller:              TestMarshaller,
+		ShardCoordinator:        &testscommon.ShardsCoordinatorMock{},
 	}
 	tpn.ExecutionManager, err = executionManager.NewExecutionManager(argsExecutionManager)
 	if err != nil {
@@ -238,13 +239,16 @@ func (tpn *TestProcessorNode) initBlockProcessorWithSync() {
 		)
 		argumentsBase.ForkDetector = tpn.ForkDetector
 		argumentsBase.TxCoordinator = &mock.TransactionCoordinatorMock{}
-		shardInfoCreator, errShardInfoCreator := block.NewShardInfoCreateData(
-			tpn.EnableEpochsHandler,
-			tpn.DataPool.Headers(),
-			tpn.DataPool.Proofs(),
-			&mock.PendingMiniBlocksHandlerStub{},
-			argumentsBase.BlockTracker,
-		)
+		shardInfoCreateDataArgs := block.ShardInfoCreateDataArgs{
+			EnableEpochsHandler:      tpn.EnableEpochsHandler,
+			HeadersPool:              tpn.DataPool.Headers(),
+			ProofsPool:               tpn.DataPool.Proofs(),
+			PendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
+			BlockTracker:             argumentsBase.BlockTracker,
+			Storage:                  tpn.Storage,
+			Marshaller:               TestMarshalizer,
+		}
+		shardInfoCreator, errShardInfoCreator := block.NewShardInfoCreateData(shardInfoCreateDataArgs)
 		log.LogIfError(errShardInfoCreator)
 
 		arguments := block.ArgMetaProcessor{

--- a/integrationTests/vm/staking/metaBlockProcessorCreator.go
+++ b/integrationTests/vm/staking/metaBlockProcessorCreator.go
@@ -122,6 +122,7 @@ func createMetaBlockProcessor(
 		Headers:                 dataComponents.Datapool().Headers(),
 		StorageService:          dataComponents.StorageService(),
 		Marshaller:              coreComponents.InternalMarshalizer(),
+		ShardCoordinator:        bootstrapComponents.ShardCoordinator(),
 	})
 	execResultsVerifier, _ := blproc.NewExecutionResultsVerifier(dataComponents.Blockchain(), execManager)
 	inclusionEstimator := estimator.NewExecutionResultInclusionEstimator(
@@ -140,13 +141,16 @@ func createMetaBlockProcessor(
 	}
 	missingDataResolver, _ := missingData.NewMissingDataResolver(missingDataArgs)
 
-	shardInfoCreator, _ := blproc.NewShardInfoCreateData(
-		coreComponents.EnableEpochsHandler(),
-		dataComponents.Datapool().Headers(),
-		dataComponents.Datapool().Proofs(),
-		&mock.PendingMiniBlocksHandlerStub{},
-		blockTracker,
-	)
+	shardInfoCreateDataArgs := blproc.ShardInfoCreateDataArgs{
+		EnableEpochsHandler:      coreComponents.EnableEpochsHandler(),
+		HeadersPool:              dataComponents.Datapool().Headers(),
+		ProofsPool:               dataComponents.Datapool().Proofs(),
+		PendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
+		BlockTracker:             blockTracker,
+		Storage:                  dataComponents.StorageService(),
+		Marshaller:               coreComponents.InternalMarshalizer(),
+	}
+	shardInfoCreator, _ := blproc.NewShardInfoCreateData(shardInfoCreateDataArgs)
 
 	args := blproc.ArgMetaProcessor{
 		ArgBaseProcessor: blproc.ArgBaseProcessor{

--- a/process/asyncExecution/executionManager/executionManager.go
+++ b/process/asyncExecution/executionManager/executionManager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/asyncExecution/disabled"
+	"github.com/multiversx/mx-chain-go/sharding"
 
 	"github.com/multiversx/mx-chain-go/process/asyncExecution/queue"
 )
@@ -27,6 +28,7 @@ type ArgsExecutionManager struct {
 	Headers                 common.HeadersPool
 	StorageService          dataRetriever.StorageService
 	Marshaller              marshal.Marshalizer
+	ShardCoordinator        sharding.Coordinator
 }
 
 type executionManager struct {
@@ -38,6 +40,7 @@ type executionManager struct {
 	headers                 common.HeadersPool
 	storageService          dataRetriever.StorageService
 	marshaller              marshal.Marshalizer
+	shardCoordinator        sharding.Coordinator
 }
 
 // NewExecutionManager creates a new instance of executionManager
@@ -60,6 +63,9 @@ func NewExecutionManager(args ArgsExecutionManager) (*executionManager, error) {
 	if check.IfNil(args.Marshaller) {
 		return nil, process.ErrNilMarshalizer
 	}
+	if check.IfNil(args.ShardCoordinator) {
+		return nil, process.ErrNilShardCoordinator
+	}
 
 	instance := &executionManager{
 		headersExecutor:         disabled.NewHeadersExecutor(),
@@ -69,6 +75,7 @@ func NewExecutionManager(args ArgsExecutionManager) (*executionManager, error) {
 		headers:                 args.Headers,
 		storageService:          args.StorageService,
 		marshaller:              args.Marshaller,
+		shardCoordinator:        args.ShardCoordinator,
 	}
 
 	return instance, nil
@@ -322,14 +329,7 @@ func (em *executionManager) getHeaderFromPoolOrStorage(
 		return header, nil
 	}
 
-	// chain handler header is set for self shard id
-	// TODO: add use shard coordinator
-	currentBlockHeader := em.blockChain.GetCurrentBlockHeader()
-	if check.IfNil(currentBlockHeader) {
-		return nil, common.ErrNilHeaderHandler
-	}
-
-	shardID := currentBlockHeader.GetShardID()
+	shardID := em.shardCoordinator.SelfId()
 
 	return process.GetHeaderFromStorage(
 		shardID,

--- a/process/asyncExecution/executionManager/executionManager_test.go
+++ b/process/asyncExecution/executionManager/executionManager_test.go
@@ -31,6 +31,7 @@ func createMockArgs() executionManager.ArgsExecutionManager {
 		Headers:                 &pool.HeadersPoolStub{},
 		StorageService:          &storageStubs.ChainStorerStub{},
 		Marshaller:              &mock.MarshalizerMock{},
+		ShardCoordinator:        &mock.ShardCoordinatorStub{},
 	}
 }
 
@@ -79,6 +80,39 @@ func TestNewExecutionManager(t *testing.T) {
 		em, err := executionManager.NewExecutionManager(args)
 		require.Nil(t, em)
 		require.Equal(t, executionManager.ErrNilHeadersPool, err)
+	})
+
+	t.Run("nil storage service should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgs()
+		args.StorageService = nil
+
+		em, err := executionManager.NewExecutionManager(args)
+		require.Nil(t, em)
+		require.Equal(t, process.ErrNilStorage, err)
+	})
+
+	t.Run("nil marshaller should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgs()
+		args.Marshaller = nil
+
+		em, err := executionManager.NewExecutionManager(args)
+		require.Nil(t, em)
+		require.Equal(t, process.ErrNilMarshalizer, err)
+	})
+
+	t.Run("nil shard coordinator should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgs()
+		args.ShardCoordinator = nil
+
+		em, err := executionManager.NewExecutionManager(args)
+		require.Nil(t, em)
+		require.Equal(t, process.ErrNilShardCoordinator, err)
 	})
 
 	t.Run("should work", func(t *testing.T) {

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -178,6 +178,7 @@ func createArgBaseProcessor(
 			Headers:                 dataComponents.DataPool.Headers(),
 			StorageService:          dataComponents.StorageService(),
 			Marshaller:              coreComponents.InternalMarshalizer(),
+			ShardCoordinator:        bootstrapComponents.ShardCoordinator(),
 		})
 		execResultsVerifier, _ = blproc.NewExecutionResultsVerifier(dataComponents.BlockChain, execManager)
 		inclusionEstimator = estimator.NewExecutionResultInclusionEstimator(

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -214,6 +214,7 @@ func NewShardProcessorEmptyWith3shards(
 		Headers:                 dataComponents.Datapool().Headers(),
 		StorageService:          dataComponents.StorageService(),
 		Marshaller:              coreComponents.InternalMarshalizer(),
+		ShardCoordinator:        boostrapComponents.ShardCoordinator(),
 	})
 	execResultsVerifier, _ := NewExecutionResultsVerifier(dataComponents.BlockChain, execManager)
 	inclusionEstimator := estimator.NewExecutionResultInclusionEstimator(

--- a/process/block/metablock_test.go
+++ b/process/block/metablock_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/multiversx/mx-chain-go/process/asyncExecution/executionManager"
 	"github.com/multiversx/mx-chain-go/process/asyncExecution/executionTrack"
 	blproc "github.com/multiversx/mx-chain-go/process/block"
+	processBlock "github.com/multiversx/mx-chain-go/process/block"
 	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
 	"github.com/multiversx/mx-chain-go/process/block/headerForBlock"
 	"github.com/multiversx/mx-chain-go/process/block/processedMb"
@@ -176,6 +177,7 @@ func createMockMetaArguments(
 		Headers:                 dataComponents.DataPool.Headers(),
 		StorageService:          dataComponents.StorageService(),
 		Marshaller:              coreComponents.InternalMarshalizer(),
+		ShardCoordinator:        bootstrapComponents.ShardCoordinator(),
 	})
 	execResultsVerifier, _ := blproc.NewExecutionResultsVerifier(dataComponents.BlockChain, execManager)
 	_ = executionResultsTracker.SetLastNotarizedResult(&block.ExecutionResult{})
@@ -204,13 +206,16 @@ func createMockMetaArguments(
 	}
 	gasComputation, _ := blproc.NewGasConsumption(argsGasConsumption)
 
-	shardInfoCreator, _ := blproc.NewShardInfoCreateData(
-		coreComponents.EnableEpochsHandler(),
-		dataComponents.Datapool().Headers(),
-		dataComponents.Datapool().Proofs(),
-		&mock.PendingMiniBlocksHandlerStub{},
-		blockTracker,
-	)
+	shardInfoCreateDataArgs := processBlock.ShardInfoCreateDataArgs{
+		EnableEpochsHandler:      coreComponents.EnableEpochsHandler(),
+		HeadersPool:              dataComponents.Datapool().Headers(),
+		ProofsPool:               dataComponents.Datapool().Proofs(),
+		PendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
+		BlockTracker:             blockTracker,
+		Storage:                  dataComponents.StorageService(),
+		Marshaller:               coreComponents.InternalMarshalizer(),
+	}
+	shardInfoCreator, _ := blproc.NewShardInfoCreateData(shardInfoCreateDataArgs)
 
 	arguments := blproc.ArgMetaProcessor{
 		ArgBaseProcessor: blproc.ArgBaseProcessor{

--- a/process/block/shardInfo.go
+++ b/process/block/shardInfo.go
@@ -7,11 +7,23 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/marshal"
 
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
 )
+
+// ShardInfoCreateDataArgs defines the arguments needed to create shard info creator
+type ShardInfoCreateDataArgs struct {
+	EnableEpochsHandler      common.EnableEpochsHandler
+	HeadersPool              dataRetriever.HeadersPool
+	ProofsPool               dataRetriever.ProofsPool
+	PendingMiniBlocksHandler process.PendingMiniBlocksHandler
+	BlockTracker             process.BlockTracker
+	Storage                  dataRetriever.StorageService
+	Marshaller               marshal.Marshalizer
+}
 
 // ShardInfoCreateData is a component used to create shard info from shard headers
 type ShardInfoCreateData struct {
@@ -20,38 +32,44 @@ type ShardInfoCreateData struct {
 	proofsPool               dataRetriever.ProofsPool
 	pendingMiniBlocksHandler process.PendingMiniBlocksHandler
 	blockTracker             process.BlockTracker
+	storage                  dataRetriever.StorageService
+	marshaller               marshal.Marshalizer
 }
 
 // NewShardInfoCreateData creates a new ShardInfoCreateData instance
 func NewShardInfoCreateData(
-	enableEpochsHandler common.EnableEpochsHandler,
-	headersPool dataRetriever.HeadersPool,
-	proofsPool dataRetriever.ProofsPool,
-	pendingMiniBlocksHandler process.PendingMiniBlocksHandler,
-	blockTracker process.BlockTracker,
+	args ShardInfoCreateDataArgs,
 ) (*ShardInfoCreateData, error) {
-	if check.IfNil(enableEpochsHandler) {
+	if check.IfNil(args.EnableEpochsHandler) {
 		return nil, process.ErrNilEnableEpochsHandler
 	}
-	if check.IfNil(headersPool) {
+	if check.IfNil(args.HeadersPool) {
 		return nil, process.ErrNilHeadersDataPool
 	}
-	if check.IfNil(proofsPool) {
+	if check.IfNil(args.ProofsPool) {
 		return nil, process.ErrNilProofsPool
 	}
-	if check.IfNil(pendingMiniBlocksHandler) {
+	if check.IfNil(args.PendingMiniBlocksHandler) {
 		return nil, process.ErrNilPendingMiniBlocksHandler
 	}
-	if check.IfNil(blockTracker) {
+	if check.IfNil(args.BlockTracker) {
 		return nil, process.ErrNilBlockTracker
+	}
+	if check.IfNil(args.Storage) {
+		return nil, process.ErrNilStorageService
+	}
+	if check.IfNil(args.Marshaller) {
+		return nil, process.ErrNilMarshalizer
 	}
 
 	return &ShardInfoCreateData{
-		enableEpochsHandler:      enableEpochsHandler,
-		headersPool:              headersPool,
-		proofsPool:               proofsPool,
-		pendingMiniBlocksHandler: pendingMiniBlocksHandler,
-		blockTracker:             blockTracker,
+		enableEpochsHandler:      args.EnableEpochsHandler,
+		headersPool:              args.HeadersPool,
+		proofsPool:               args.ProofsPool,
+		pendingMiniBlocksHandler: args.PendingMiniBlocksHandler,
+		blockTracker:             args.BlockTracker,
+		storage:                  args.Storage,
+		marshaller:               args.Marshaller,
 	}, nil
 }
 
@@ -180,7 +198,7 @@ func (sic *ShardInfoCreateData) createShardDataFromV3Header(
 
 	shardDataHandlers := make([]data.ShardDataHandler, len(executionResults))
 	for i, execResult := range executionResults {
-		shardData, err := sic.createShardDataFromExecutionResult(execResult)
+		shardData, err := sic.createShardDataFromExecutionResult(execResult, shardHeader.GetShardID())
 		if err != nil {
 			return nil, nil, err
 		}
@@ -206,6 +224,7 @@ func (sic *ShardInfoCreateData) createShardDataProposalFromHeader(
 
 func (sic *ShardInfoCreateData) createShardDataFromExecutionResult(
 	execResult data.BaseExecutionResultHandler,
+	shardID uint32,
 ) (data.ShardDataHandler, error) {
 	if check.IfNil(execResult) {
 		return nil, process.ErrNilExecutionResultHandler
@@ -216,8 +235,13 @@ func (sic *ShardInfoCreateData) createShardDataFromExecutionResult(
 		return nil, process.ErrWrongTypeAssertion
 	}
 
-	// TODO: search also in storage: at bootstrap the header might not be in pool
-	header, err := sic.headersPool.GetHeaderByHash(execResultHandler.GetHeaderHash())
+	header, err := process.GetHeader(
+		execResultHandler.GetHeaderHash(),
+		sic.headersPool,
+		sic.storage,
+		sic.marshaller,
+		shardID,
+	)
 	if err != nil {
 		log.Debug("createShardDataFromExecutionResult: failed to get header with hash", "hash", execResultHandler.GetHeaderHash(), "error", err)
 		return nil, err

--- a/process/block/shardblockProposal_test.go
+++ b/process/block/shardblockProposal_test.go
@@ -2052,6 +2052,7 @@ func TestShardBlockProposal_CreateAndVerifyProposal(t *testing.T) {
 		Headers:                 dataComponents.DataPool.Headers(),
 		StorageService:          dataComponents.StorageService(),
 		Marshaller:              coreComponents.InternalMarshalizer(),
+		ShardCoordinator:        bootstrapComponents.ShardCoordinator(),
 	})
 	execResultsVerifier, _ := blproc.NewExecutionResultsVerifier(dataComponents.BlockChain, execManager)
 
@@ -2202,6 +2203,7 @@ func TestShardBlockProposal_CreateAndVerifyProposal_WithTransactions(t *testing.
 		Headers:                 dataComponents.DataPool.Headers(),
 		StorageService:          dataComponents.StorageService(),
 		Marshaller:              coreComponents.InternalMarshalizer(),
+		ShardCoordinator:        bootstrapComponents.ShardCoordinator(),
 	})
 	execResultsVerifier, _ := blproc.NewExecutionResultsVerifier(dataComponents.BlockChain, execManager)
 

--- a/process/block/shardinfo_test.go
+++ b/process/block/shardinfo_test.go
@@ -9,11 +9,14 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 
 	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/mock"
+	"github.com/multiversx/mx-chain-go/storage"
 	dataRetrieverMock "github.com/multiversx/mx-chain-go/testscommon/dataRetriever"
 	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
 	poolMock "github.com/multiversx/mx-chain-go/testscommon/pool"
+	mockStorage "github.com/multiversx/mx-chain-go/testscommon/storage"
 
 	"github.com/stretchr/testify/require"
 )
@@ -33,27 +36,20 @@ func TestShardInfo_NewShardInfoCreateData(t *testing.T) {
 		t.Parallel()
 
 		args := createDefaultShardInfoCreateDataArgs()
-		sicd, err := NewShardInfoCreateData(
-			nil,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		args.EnableEpochsHandler = nil
+
+		sicd, err := NewShardInfoCreateData(args)
 		require.Nil(t, sicd)
 		require.Equal(t, process.ErrNilEnableEpochsHandler, err)
 	})
 
 	t.Run("nil headersPool", func(t *testing.T) {
 		t.Parallel()
+
 		args := createDefaultShardInfoCreateDataArgs()
-		sicd, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			nil,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		args.HeadersPool = nil
+
+		sicd, err := NewShardInfoCreateData(args)
 		require.Nil(t, sicd)
 		require.Equal(t, process.ErrNilHeadersDataPool, err)
 	})
@@ -62,14 +58,9 @@ func TestShardInfo_NewShardInfoCreateData(t *testing.T) {
 		t.Parallel()
 
 		args := createDefaultShardInfoCreateDataArgs()
+		args.ProofsPool = nil
 
-		sicd, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			nil,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sicd, err := NewShardInfoCreateData(args)
 		require.Nil(t, sicd)
 		require.Equal(t, process.ErrNilProofsPool, err)
 	})
@@ -78,14 +69,9 @@ func TestShardInfo_NewShardInfoCreateData(t *testing.T) {
 		t.Parallel()
 
 		args := createDefaultShardInfoCreateDataArgs()
+		args.PendingMiniBlocksHandler = nil
 
-		sicd, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			nil,
-			args.blockTracker,
-		)
+		sicd, err := NewShardInfoCreateData(args)
 		require.Nil(t, sicd)
 		require.Equal(t, process.ErrNilPendingMiniBlocksHandler, err)
 	})
@@ -94,13 +80,9 @@ func TestShardInfo_NewShardInfoCreateData(t *testing.T) {
 		t.Parallel()
 
 		args := createDefaultShardInfoCreateDataArgs()
-		sicd, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			nil,
-		)
+		args.BlockTracker = nil
+
+		sicd, err := NewShardInfoCreateData(args)
 		require.Nil(t, sicd)
 		require.Equal(t, process.ErrNilBlockTracker, err)
 	})
@@ -109,13 +91,7 @@ func TestShardInfo_NewShardInfoCreateData(t *testing.T) {
 
 		args := createDefaultShardInfoCreateDataArgs()
 
-		sicd, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sicd, err := NewShardInfoCreateData(args)
 		require.NotNil(t, sicd)
 		require.Nil(t, err)
 	})
@@ -145,14 +121,11 @@ func TestShardInfoCreateData_CreateShardInfoV3(t *testing.T) {
 
 	round := uint64(10)
 	metaHdrV3 := &block.MetaBlockV3{Round: round}
+
 	args := createDefaultShardInfoCreateDataArgs()
-	sic, err := NewShardInfoCreateData(
-		args.enableEpochsHandler,
-		pool.Headers(),
-		args.proofsPool,
-		args.pendingMiniBlocksHandler,
-		args.blockTracker,
-	)
+	args.HeadersPool = pool.Headers()
+
+	sic, err := NewShardInfoCreateData(args)
 	require.Nil(t, err)
 
 	t.Run("should fail with nil meta header", func(t *testing.T) {
@@ -194,26 +167,29 @@ func TestShardInfoCreateData_CreateShardInfoV3(t *testing.T) {
 		t.Parallel()
 
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.HeadersPool = pool.Headers()
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: headers[shardID].GetNonce()}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: headers[shardID].GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
 		}
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return true
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return true
+			},
 		}
 
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			pool.Headers(),
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		shardDataProposalHandlers, shardDataHandlers, err := sic.CreateShardInfoV3(metaHdrV3, headers, headerHashes)
 		require.Nil(t, err)
@@ -271,13 +247,7 @@ func TestShardInfoCreateData_CreateShardInfoFromLegacyMeta(t *testing.T) {
 	metaHdr := &block.MetaBlock{Round: round}
 
 	args := createDefaultShardInfoCreateDataArgs()
-	sic, err := NewShardInfoCreateData(
-		args.enableEpochsHandler,
-		args.headersPool,
-		args.proofsPool,
-		args.pendingMiniBlocksHandler,
-		args.blockTracker,
-	)
+	sic, err := NewShardInfoCreateData(args)
 	require.Nil(t, err)
 	t.Run("should fail with nil meta header", func(t *testing.T) {
 		t.Parallel()
@@ -306,25 +276,29 @@ func TestShardInfoCreateData_CreateShardInfoFromLegacyMeta(t *testing.T) {
 		t.Parallel()
 
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.HeadersPool = pool.Headers()
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return nil, nil, errExpected
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return nil, nil, errExpected
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
 		}
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return true
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return true
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			pool.Headers(),
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		shardInfo, err := sic.CreateShardInfoFromLegacyMeta(metaHdr, headers, headerHashes)
 		require.NotNil(t, err)
@@ -334,25 +308,29 @@ func TestShardInfoCreateData_CreateShardInfoFromLegacyMeta(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.HeadersPool = pool.Headers()
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: headers[shardID].GetNonce()}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: headers[shardID].GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
 		}
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return true
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return true
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			pool.Headers(),
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		shardInfo, err := sic.CreateShardInfoFromLegacyMeta(metaHdr, headers, headerHashes)
 		require.Nil(t, err)
@@ -367,13 +345,7 @@ func TestShardInfoCreateData_createShardInfoFromHeader(t *testing.T) {
 	t.Run("should fail with nil header", func(t *testing.T) {
 		t.Parallel()
 		args := createDefaultShardInfoCreateDataArgs()
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 
 		shardDataProposalHandlers, shardDataHandlers, err := sic.createShardInfoFromHeader(nil, nil)
@@ -384,13 +356,7 @@ func TestShardInfoCreateData_createShardInfoFromHeader(t *testing.T) {
 	t.Run("should fail with invalid hash", func(t *testing.T) {
 		t.Parallel()
 		args := createDefaultShardInfoCreateDataArgs()
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 
 		shardDataProposalHandlers, shardDataHandlers, err := sic.createShardInfoFromHeader(&block.Header{}, []byte{})
@@ -401,17 +367,15 @@ func TestShardInfoCreateData_createShardInfoFromHeader(t *testing.T) {
 
 	t.Run("should fail with missing shard header proof", func(t *testing.T) {
 		t.Parallel()
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return false
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return false
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 
 		shardDataProposalHandlers, shardDataHandlers, err := sic.createShardInfoFromHeader(&block.Header{Nonce: 1}, []byte("hash"))
@@ -423,25 +387,28 @@ func TestShardInfoCreateData_createShardInfoFromHeader(t *testing.T) {
 		t.Parallel()
 		header := getShardHeaderForShard(uint32(1))
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
 		}
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return true
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return true
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		expectedProposalHandler := &block.ShardDataProposal{
 			HeaderHash:           []byte("hash"),
@@ -463,25 +430,28 @@ func TestShardInfoCreateData_createShardInfoFromHeader(t *testing.T) {
 		header := getShardHeaderForShard(uint32(1))
 		_ = header.SetNonce(0)
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
 		}
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return false
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return true
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		expectedProposalHandler := &block.ShardDataProposal{
 			HeaderHash:           []byte("hash"),
@@ -501,30 +471,35 @@ func TestShardInfoCreateData_createShardInfoFromHeader(t *testing.T) {
 	t.Run("should work with V3", func(t *testing.T) {
 		t.Parallel()
 		header := getHeaderV3ForShard(uint32(1), []byte("header hash for shard 1"))
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.headersPool.GetHeaderByHashCalled = func(hash []byte) (data.HeaderHandler, error) {
-			return header, nil
+		args.HeadersPool = &poolMock.HeadersPoolStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				return header, nil
+			},
+		}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
+		}
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
+		}
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
+		}
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return true
+			},
 		}
 
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
-		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
-		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
-		}
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return true
-		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		expectedProposalHandler := &block.ShardDataProposal{
 			HeaderHash:           []byte("hash"),
@@ -543,32 +518,39 @@ func TestShardInfoCreateData_createShardInfoFromHeader(t *testing.T) {
 	})
 	t.Run("should work with V3 no proof for nonce < 1", func(t *testing.T) {
 		t.Parallel()
+
 		header := getHeaderV3ForShard(uint32(1), []byte("header hash for shard 1"))
 		expectedNonce := uint64(0)
 		_ = header.SetNonce(expectedNonce)
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.headersPool.GetHeaderByHashCalled = func(hash []byte) (data.HeaderHandler, error) {
-			return header, nil
+		args.HeadersPool = &poolMock.HeadersPoolStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				return header, nil
+			},
 		}
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
 		}
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return false
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return false
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		expectedProposalHandler := &block.ShardDataProposal{
 			HeaderHash:           []byte("hash"),
@@ -594,22 +576,24 @@ func TestShardInfoCreateData_createShardDataFromLegacyHeader(t *testing.T) {
 		t.Parallel()
 		header := getShardHeaderForShard(uint32(1))
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return nil, nil, fmt.Errorf("GetLastSelfNotarizedHeader error")
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return nil, nil, fmt.Errorf("GetLastSelfNotarizedHeader error")
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return false
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return false
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
+
 		require.Nil(t, err)
 		shardDataList, err := sic.createShardDataFromLegacyHeader(header, []byte("headerHash"))
 		require.Contains(t, err.Error(), "GetLastSelfNotarizedHeader error")
@@ -619,24 +603,27 @@ func TestShardInfoCreateData_createShardDataFromLegacyHeader(t *testing.T) {
 	t.Run("should work with enable epoch flag disabled", func(t *testing.T) {
 		t.Parallel()
 		header := getShardHeaderForShard(uint32(1))
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return false
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return false
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		shardDataList, err := sic.createShardDataFromLegacyHeader(header, []byte("headerHash"))
 		require.Nil(t, err)
 		require.NotNil(t, shardDataList)
@@ -646,25 +633,29 @@ func TestShardInfoCreateData_createShardDataFromLegacyHeader(t *testing.T) {
 	})
 	t.Run("should work with enable epoch flag enabled", func(t *testing.T) {
 		t.Parallel()
+
 		header := getShardHeaderForShard(uint32(1))
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		shardDataList, err := sic.createShardDataFromLegacyHeader(header, []byte("headerHash"))
 		require.Nil(t, err)
 		require.NotNil(t, shardDataList)
@@ -679,13 +670,7 @@ func TestShardInfoCreateData_createShardDataFromV3Header(t *testing.T) {
 	t.Run("should fail with nil header", func(t *testing.T) {
 		t.Parallel()
 		args := createDefaultShardInfoCreateDataArgs()
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		shardDataProposalHandler, shardDataHandlers, err := sic.createShardDataFromV3Header(nil, nil)
 		require.Nil(t, shardDataHandlers)
@@ -698,13 +683,7 @@ func TestShardInfoCreateData_createShardDataFromV3Header(t *testing.T) {
 			Nonce: 0,
 		}
 		args := createDefaultShardInfoCreateDataArgs()
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		shardDataProposalHandler, shardDataHandlers, err := sic.createShardDataFromV3Header(header, []byte("headerHash"))
 		require.Nil(t, err)
@@ -714,56 +693,71 @@ func TestShardInfoCreateData_createShardDataFromV3Header(t *testing.T) {
 	})
 	t.Run("should fail with createShardDataFromExecutionResult error", func(t *testing.T) {
 		t.Parallel()
+
 		expectedNonce := uint64(12345)
 		header := getHeaderV3ForShard(uint32(1), []byte("header hash for shard 1"))
-		args := createDefaultShardInfoCreateDataArgs()
 		// GetHeaderByHash error will fail createShardDataFromExecutionResult
-		args.headersPool.GetHeaderByHashCalled = func(hash []byte) (data.HeaderHandler, error) {
-			return nil, fmt.Errorf("GetHeaderByHash error")
+		args := createDefaultShardInfoCreateDataArgs()
+		args.HeadersPool = &poolMock.HeadersPoolStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				return nil, fmt.Errorf("GetHeaderByHash error")
+			},
+		}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
+		}
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
+			},
+		}
+		args.Storage = &mockStorage.ChainStorerStub{
+			GetStorerCalled: func(unitType dataRetriever.UnitType) (storage.Storer, error) {
+				return &mockStorage.StorerStub{
+					GetCalled: func(key []byte) ([]byte, error) {
+						return nil, fmt.Errorf("GetHeaderByHash error from storage")
+					},
+				}, nil
+			},
 		}
 
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
-		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
-		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		shardDataProposalHandler, shardDataHandlers, err := sic.createShardDataFromV3Header(header, []byte("headerHash"))
 		require.Nil(t, shardDataHandlers)
 		require.Nil(t, shardDataProposalHandler)
-		require.Equal(t, fmt.Errorf("GetHeaderByHash error"), err)
+		require.ErrorIs(t, err, process.ErrMissingHeader)
 	})
 
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
+
 		expectedNonce := uint64(12345)
 		header := getHeaderV3ForShard(uint32(1), []byte("header hash for shard 1"))
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.headersPool.GetHeaderByHashCalled = func(hash []byte) (data.HeaderHandler, error) {
-			return header, nil
+		args.HeadersPool = &poolMock.HeadersPoolStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				return header, nil
+			},
 		}
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		shardDataProposalHandler, shardDataHandlers, err := sic.createShardDataFromV3Header(header, []byte("headerHash"))
 		require.Nil(t, err)
 		require.NotNil(t, shardDataHandlers)
@@ -779,102 +773,102 @@ func TestShardInfoCreateData_createShardDataFromExecutionResult(t *testing.T) {
 
 	t.Run("should fail with nil execution result", func(t *testing.T) {
 		t.Parallel()
+
 		args := createDefaultShardInfoCreateDataArgs()
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
-		shardData, err := sic.createShardDataFromExecutionResult(nil)
+
+		shardData, err := sic.createShardDataFromExecutionResult(nil, 0)
 		require.ErrorIs(t, err, process.ErrNilExecutionResultHandler)
 		require.Nil(t, shardData)
 	})
 
 	t.Run("should fail with wrong type of execution result", func(t *testing.T) {
 		t.Parallel()
+
 		args := createDefaultShardInfoCreateDataArgs()
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
-		shardData, err := sic.createShardDataFromExecutionResult(&block.BaseExecutionResult{})
+
+		shardData, err := sic.createShardDataFromExecutionResult(&block.BaseExecutionResult{}, 0)
 		require.ErrorIs(t, err, process.ErrWrongTypeAssertion)
 		require.Nil(t, shardData)
 	})
 
-	t.Run("should fail when GetHeaderByHash errors", func(t *testing.T) {
+	t.Run("should fail when getting header from pool and storage fails", func(t *testing.T) {
 		t.Parallel()
 		args := createDefaultShardInfoCreateDataArgs()
-		args.headersPool.GetHeaderByHashCalled = func(hash []byte) (data.HeaderHandler, error) {
-			return nil, fmt.Errorf("GetHeaderByHash error")
+		args.HeadersPool = &poolMock.HeadersPoolStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				return nil, fmt.Errorf("GetHeaderByHash error")
+			},
+		}
+		args.Storage = &mockStorage.ChainStorerStub{
+			GetStorerCalled: func(unitType dataRetriever.UnitType) (storage.Storer, error) {
+				return &mockStorage.StorerStub{
+					GetCalled: func(key []byte) ([]byte, error) {
+						return nil, fmt.Errorf("GetHeaderByHash error from storage")
+					},
+				}, nil
+			},
 		}
 
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		execResult := getExecutionResultForShard(uint32(1), []byte("header hash for shard 1"))
-		shardData, err := sic.createShardDataFromExecutionResult(execResult)
-		require.Equal(t, fmt.Errorf("GetHeaderByHash error"), err)
+		shardData, err := sic.createShardDataFromExecutionResult(execResult, uint32(1))
+		require.ErrorIs(t, err, process.ErrMissingHeader)
 		require.Nil(t, shardData)
 	})
 
 	t.Run("should fail when updateShardDataWithCrossShardInfo fails", func(t *testing.T) {
 		t.Parallel()
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.headersPool.GetHeaderByHashCalled = func(hash []byte) (data.HeaderHandler, error) {
-			return getShardHeaderForShard(uint32(1)), nil
+		args.HeadersPool = &poolMock.HeadersPoolStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				return getShardHeaderForShard(uint32(1)), nil
+			},
 		}
 
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		execResult := getExecutionResultForShard(uint32(1), []byte("header hash for shard 1"))
-		shardData, err := sic.createShardDataFromExecutionResult(execResult)
+		shardData, err := sic.createShardDataFromExecutionResult(execResult, uint32(1))
 		require.Equal(t, process.ErrNotarizedHeadersSliceIsNil, err)
 		require.Nil(t, shardData)
 	})
 
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
+
 		expectedNonce := uint64(1)
 		header := getShardHeaderForShard(uint32(1))
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.headersPool.GetHeaderByHashCalled = func(hash []byte) (data.HeaderHandler, error) {
-			return header, nil
+		args.HeadersPool = &poolMock.HeadersPoolStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				return header, nil
+			},
 		}
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		execResult := getExecutionResultForShard(uint32(1), []byte("header hash for shard 1"))
-		shardData, err := sic.createShardDataFromExecutionResult(execResult)
+		shardData, err := sic.createShardDataFromExecutionResult(execResult, uint32(1))
 		require.Nil(t, err)
 		require.NotNil(t, shardData)
 		require.Equal(t, uint32(2), shardData.GetNumPendingMiniBlocks())
@@ -984,17 +978,15 @@ func TestShardInfoCreateData_updateShardDataWithCrossShardInfo(t *testing.T) {
 		shardData := &block.ShardData{}
 
 		args := createDefaultShardInfoCreateDataArgs()
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return nil, nil, fmt.Errorf("GetLastSelfNotarizedHeader error")
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return nil, nil, fmt.Errorf("GetLastSelfNotarizedHeader error")
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		err = sic.updateShardDataWithCrossShardInfo(shardData, &header)
 		require.Contains(t, err.Error(), "GetLastSelfNotarizedHeader error")
 	})
@@ -1004,23 +996,23 @@ func TestShardInfoCreateData_updateShardDataWithCrossShardInfo(t *testing.T) {
 
 		header := block.Header{ShardID: 1}
 		shardData := &block.ShardData{}
-
 		expectedNonce := uint64(12345)
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		err = sic.updateShardDataWithCrossShardInfo(shardData, &header)
 		require.NotNil(t, shardData)
 		require.Nil(t, err)
@@ -1037,13 +1029,15 @@ type shardInfoCreateDataTestArgs struct {
 	enableEpochsHandler      *enableEpochsHandlerMock.EnableEpochsHandlerStub
 }
 
-func createDefaultShardInfoCreateDataArgs() *shardInfoCreateDataTestArgs {
-	return &shardInfoCreateDataTestArgs{
-		headersPool:              &poolMock.HeadersPoolStub{},
-		proofsPool:               &dataRetrieverMock.ProofsPoolMock{},
-		pendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
-		blockTracker:             &mock.BlockTrackerMock{},
-		enableEpochsHandler:      enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
+func createDefaultShardInfoCreateDataArgs() ShardInfoCreateDataArgs {
+	return ShardInfoCreateDataArgs{
+		EnableEpochsHandler:      &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
+		HeadersPool:              &poolMock.HeadersPoolStub{},
+		ProofsPool:               &dataRetrieverMock.ProofsPoolMock{},
+		PendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
+		BlockTracker:             &mock.BlockTrackerMock{},
+		Storage:                  &mockStorage.ChainStorerStub{},
+		Marshaller:               &mock.MarshalizerMock{},
 	}
 }
 

--- a/process/constants.go
+++ b/process/constants.go
@@ -81,10 +81,6 @@ const MaxHeaderRequestsAllowed = 20
 // committed block nonce, after which, node is considered himself not synced
 const NonceDifferenceWhenSynced = 0
 
-// MaxSyncWithErrorsAllowed defines the maximum allowed number of sync with errors,
-// before a special action to be applied
-const MaxSyncWithErrorsAllowed = 10
-
 // MaxHeadersToRequestInAdvance defines the maximum number of headers which will be requested in advance,
 // if they are missing
 const MaxHeadersToRequestInAdvance = 20

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -40,7 +40,7 @@ var log = logger.GetOrCreate("process/sync")
 var _ closing.Closer = (*baseBootstrap)(nil)
 
 // sleepTime defines the time in milliseconds between each iteration made in syncBlocks method
-const sleepTime = 5 * time.Millisecond
+const sleepTime = 50 * time.Millisecond
 const minimumProcessWaitTime = time.Millisecond * 100
 
 // hdrInfo hold the data related to a header
@@ -730,12 +730,23 @@ func (boot *baseBootstrap) syncBlocks(ctx context.Context) {
 	}
 }
 
+func (boot *baseBootstrap) getMaxSyncWithErrorsAllowed(
+	header data.HeaderHandler,
+) uint32 {
+	round := uint64(0)
+	if !check.IfNil(header) {
+		round = header.GetRound()
+	}
+
+	return boot.processConfigsHandler.GetMaxSyncWithErrorsAllowed(round)
+}
+
 func (boot *baseBootstrap) doJobOnSyncBlockFail(bodyHandler data.BodyHandler, headerHandler data.HeaderHandler, err error) {
 	processBlockStarted := !check.IfNil(bodyHandler) && !check.IfNil(headerHandler)
 	isProcessWithError := processBlockStarted && err != process.ErrTimeIsOut
 
 	numSyncedWithErrors := boot.incrementSyncedWithErrorsForNonce(boot.getNonceForNextBlock())
-	allowedSyncWithErrorsLimitReached := numSyncedWithErrors >= process.MaxSyncWithErrorsAllowed
+	allowedSyncWithErrorsLimitReached := numSyncedWithErrors >= boot.getMaxSyncWithErrorsAllowed(headerHandler)
 	isInProperRound := process.IsInProperRound(boot.roundHandler.Index())
 	isSyncWithErrorsLimitReachedInProperRound := allowedSyncWithErrorsLimitReached && isInProperRound
 

--- a/testscommon/processConfigsHandlerStub.go
+++ b/testscommon/processConfigsHandlerStub.go
@@ -20,6 +20,7 @@ func GetDefaultProcessConfigsHandler() common.ProcessConfigsHandler {
 				MaxRoundsWithoutNewBlockReceived:   10,
 				MaxRoundsWithoutCommittedBlock:     10,
 				RoundModulusTriggerWhenSyncIsStuck: 20,
+				MaxSyncWithErrorsAllowed:           10,
 			},
 		},
 	)
@@ -35,6 +36,7 @@ type ProcessConfigsHandlerStub struct {
 	GetMaxRoundsWithoutNewBlockReceivedByRoundCalled  func(round uint64) uint32
 	GetMaxRoundsWithoutCommittedBlockCalled           func(round uint64) uint32
 	GetRoundModulusTriggerWhenSyncIsStuckCalled       func(round uint64) uint32
+	GetMaxSyncWithErrorsAllowedCalled                 func(round uint64) uint32
 }
 
 // GetMaxMetaNoncesBehindByEpoch -
@@ -86,6 +88,15 @@ func (p *ProcessConfigsHandlerStub) GetMaxRoundsWithoutCommittedBlock(round uint
 func (p *ProcessConfigsHandlerStub) GetRoundModulusTriggerWhenSyncIsStuck(round uint64) uint32 {
 	if p.GetRoundModulusTriggerWhenSyncIsStuckCalled != nil {
 		return p.GetRoundModulusTriggerWhenSyncIsStuckCalled(round)
+	}
+
+	return 0
+}
+
+// GetMaxSyncWithErrorsAllowed -
+func (p *ProcessConfigsHandlerStub) GetMaxSyncWithErrorsAllowed(round uint64) uint32 {
+	if p.GetMaxSyncWithErrorsAllowedCalled != nil {
+		return p.GetMaxSyncWithErrorsAllowedCalled(round)
 	}
 
 	return 0


### PR DESCRIPTION
## Reasoning behind the pull request
- Implement fallback to search header in storage if not found in pool, for shard data creator
- added shardCoordinator in execution manager

## Testing procedure
- Standard system testing with restarts

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
