### PR TITLE
Cache transaction execution order and ourport fixes

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -64,8 +64,8 @@
     ]
 
     ProcessConfigsByRound = [
-        { EnableRound = 0, MaxRoundsWithoutNewBlockReceived = 10, MaxRoundsWithoutCommittedBlock = 10, RoundModulusTriggerWhenSyncIsStuck = 20 },
-        { EnableRound = 440, MaxRoundsWithoutNewBlockReceived = 100, MaxRoundsWithoutCommittedBlock = 100, RoundModulusTriggerWhenSyncIsStuck = 200 },
+        { EnableRound = 0, MaxRoundsWithoutNewBlockReceived = 10, MaxRoundsWithoutCommittedBlock = 10, RoundModulusTriggerWhenSyncIsStuck = 20, MaxSyncWithErrorsAllowed = 10 },
+        { EnableRound = 440, MaxRoundsWithoutNewBlockReceived = 100, MaxRoundsWithoutCommittedBlock = 100, RoundModulusTriggerWhenSyncIsStuck = 200, MaxSyncWithErrorsAllowed = 100 },
     ]
 
     EpochStartConfigsByEpoch = [

--- a/common/common.go
+++ b/common/common.go
@@ -43,6 +43,11 @@ func PrepareLogEventsKey(headerHash []byte) []byte {
 	return append([]byte("logs"), headerHash...)
 }
 
+// PrepareOrderedTxHashesKey will prepare transactions execution order key for cacher
+func PrepareOrderedTxHashesKey(headerHash []byte) []byte {
+	return append([]byte("execution"), headerHash...)
+}
+
 // IsValidRelayedTxV3 returns true if the provided transaction is a valid transaction of type relayed v3
 func IsValidRelayedTxV3(tx data.TransactionHandler) bool {
 	relayedTx, isRelayedV3 := tx.(data.RelayedTransactionHandler)

--- a/common/commonCachedData.go
+++ b/common/commonCachedData.go
@@ -46,6 +46,23 @@ func GetCachedLogs(cache storage.Cacher, headerHash []byte) ([]data.LogDataHandl
 	return cachedLogsSlice, nil
 }
 
+// GetCachedOrderedTxHashes wil return the cached ordered tx hashes from the provided cache
+func GetCachedOrderedTxHashes(cache storage.Cacher, headerHash []byte) ([][]byte, error) {
+	orderedTxHashesKey := PrepareOrderedTxHashesKey(headerHash)
+	cachedData, ok := cache.Get(orderedTxHashesKey)
+	if !ok {
+		log.Warn("orderedTxHashes not found in dataPool", "hash", headerHash)
+		return nil, fmt.Errorf("%w for header %s", ErrMissingOrderedTxHashes, hex.EncodeToString(headerHash))
+	}
+
+	cachedDataSlice, ok := cachedData.([][]byte)
+	if !ok {
+		return nil, fmt.Errorf("%w for cached logs %s", ErrWrongTypeAssertion, hex.EncodeToString(headerHash))
+	}
+
+	return cachedDataSlice, nil
+}
+
 // GetCachedMbs will return the cached miniblocks from provided cache
 func GetCachedMbs(cache storage.Cacher, marshaller marshal.Marshalizer, headerHash []byte) ([]*block.MiniBlock, error) {
 	cachedIntraMBs, ok := cache.Get(headerHash)

--- a/common/commonCachedData_test.go
+++ b/common/commonCachedData_test.go
@@ -264,3 +264,40 @@ func TestGetBody(t *testing.T) {
 		require.Equal(t, &block.Body{MiniBlocks: []*block.MiniBlock{mb1, mb2}}, res)
 	})
 }
+
+func TestGetCachedOrderedTxHashes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cannot find in cache should error", func(t *testing.T) {
+		t.Parallel()
+
+		cacher := cache.NewCacherMock()
+
+		headerHash := []byte("h")
+
+		_, err := GetCachedOrderedTxHashes(cacher, headerHash)
+		require.True(t, errors.Is(err, ErrMissingOrderedTxHashes))
+	})
+
+	t.Run("wrong type in cache should error", func(t *testing.T) {
+		cacher := cache.NewCacherMock()
+
+		headerHash := []byte("h")
+		cacher.Put(PrepareOrderedTxHashesKey(headerHash), []byte("a"), 0)
+
+		_, err := GetCachedOrderedTxHashes(cacher, headerHash)
+		require.True(t, errors.Is(err, ErrWrongTypeAssertion))
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		cacher := cache.NewCacherMock()
+
+		headerHash := []byte("h")
+		hashes := [][]byte{[]byte("a"), []byte("b"), []byte("c")}
+		cacher.Put(PrepareOrderedTxHashesKey(headerHash), hashes, 0)
+
+		res, err := GetCachedOrderedTxHashes(cacher, headerHash)
+		require.Nil(t, err)
+		require.Equal(t, hashes, res)
+	})
+}

--- a/common/configs/processConfigs.go
+++ b/common/configs/processConfigs.go
@@ -14,6 +14,7 @@ const (
 	defaultMaxRoundsWithoutNewBlockReceived   = 10
 	defaultMaxRoundsWithoutCommittedBlock     = 10
 	defaultRoundModulusTriggerWhenSyncIsStuck = 20
+	defaultMaxSyncWithErrorsAllowed           = 20
 )
 
 // ErrEmptyProcessConfigsByEpoch signals that an empty process configs by epoch has been provided
@@ -185,6 +186,17 @@ func (pce *processConfigsByEpoch) GetRoundModulusTriggerWhenSyncIsStuck(round ui
 	}
 
 	return defaultRoundModulusTriggerWhenSyncIsStuck // this should not happen
+}
+
+// GetMaxSyncWithErrorsAllowed returns max allowed sync errors until an error event is triggered
+func (pce *processConfigsByEpoch) GetMaxSyncWithErrorsAllowed(round uint64) uint32 {
+	for i := len(pce.orderedConfigByRound) - 1; i >= 0; i-- {
+		if pce.orderedConfigByRound[i].EnableRound <= round {
+			return pce.orderedConfigByRound[i].MaxSyncWithErrorsAllowed
+		}
+	}
+
+	return defaultMaxSyncWithErrorsAllowed
 }
 
 // IsInterfaceNil checks if the instance is nil

--- a/common/configs/processConfigs_test.go
+++ b/common/configs/processConfigs_test.go
@@ -79,13 +79,29 @@ func TestProcessConfigsByEpoch_Getters(t *testing.T) {
 	t.Parallel()
 
 	conf := []config.ProcessConfigByEpoch{
-		{EnableEpoch: 0, MaxMetaNoncesBehind: 10, MaxMetaNoncesBehindForGlobalStuck: 11, MaxShardNoncesBehind: 12},
-		{EnableEpoch: 1, MaxMetaNoncesBehind: 20, MaxMetaNoncesBehindForGlobalStuck: 21, MaxShardNoncesBehind: 22},
+		{EnableEpoch: 0,
+			MaxMetaNoncesBehind:               10,
+			MaxMetaNoncesBehindForGlobalStuck: 11,
+			MaxShardNoncesBehind:              12,
+		},
+		{EnableEpoch: 1,
+			MaxMetaNoncesBehind:               20,
+			MaxMetaNoncesBehindForGlobalStuck: 21,
+			MaxShardNoncesBehind:              22,
+		},
 	}
 
 	confByRound := []config.ProcessConfigByRound{
-		{EnableRound: 0, MaxRoundsWithoutNewBlockReceived: 10, MaxRoundsWithoutCommittedBlock: 20},
-		{EnableRound: 1, MaxRoundsWithoutNewBlockReceived: 11, MaxRoundsWithoutCommittedBlock: 21},
+		{EnableRound: 0,
+			MaxRoundsWithoutNewBlockReceived: 10,
+			MaxRoundsWithoutCommittedBlock:   20,
+			MaxSyncWithErrorsAllowed:         30,
+		},
+		{EnableRound: 1,
+			MaxRoundsWithoutNewBlockReceived: 11,
+			MaxRoundsWithoutCommittedBlock:   21,
+			MaxSyncWithErrorsAllowed:         31,
+		},
 	}
 
 	t.Run("get max meta nonces behind", func(t *testing.T) {
@@ -146,5 +162,17 @@ func TestProcessConfigsByEpoch_Getters(t *testing.T) {
 
 		maxRoundsWithoutCommittedBlock = pce.GetMaxRoundsWithoutCommittedBlock(1)
 		require.Equal(t, uint32(21), maxRoundsWithoutCommittedBlock)
+	})
+
+	t.Run("get max allowed sync with errors", func(t *testing.T) {
+		t.Parallel()
+
+		pce, _ := configs.NewProcessConfigsHandler(conf, confByRound)
+
+		maxSyncWithErrorsAllowed := pce.GetMaxSyncWithErrorsAllowed(0)
+		require.Equal(t, uint32(30), maxSyncWithErrorsAllowed)
+
+		maxSyncWithErrorsAllowed = pce.GetMaxSyncWithErrorsAllowed(1)
+		require.Equal(t, uint32(31), maxSyncWithErrorsAllowed)
 	})
 }

--- a/common/constants.go
+++ b/common/constants.go
@@ -1322,3 +1322,6 @@ const (
 	DisableAsyncCallV1Flag EnableRoundFlag = "DisableAsyncCallV1"
 	SupernovaRoundFlag     EnableRoundFlag = "SupernovaEnableRound"
 )
+
+// HashSize defines  const for the hash length
+const HashSize = 32

--- a/common/errors.go
+++ b/common/errors.go
@@ -62,5 +62,8 @@ var ErrMissingCachedTransactions = errors.New("missing cached transactions")
 // ErrMissingCachedLogs signals that cached logs events are missing
 var ErrMissingCachedLogs = errors.New("missing cached logs")
 
+// ErrMissingOrderedTxHashes signals that ordered tx hashes are missing
+var ErrMissingOrderedTxHashes = errors.New("missing ordered tx hashes")
+
 // ErrInvalidHeader signals that an invalid header has been provided
 var ErrInvalidHeader = errors.New("invalid header")

--- a/common/interface.go
+++ b/common/interface.go
@@ -486,6 +486,7 @@ type ProcessConfigsHandler interface {
 	GetMaxRoundsWithoutNewBlockReceivedByRound(round uint64) uint32
 	GetMaxRoundsWithoutCommittedBlock(round uint64) uint32
 	GetRoundModulusTriggerWhenSyncIsStuck(round uint64) uint32
+	GetMaxSyncWithErrorsAllowed(round uint64) uint32
 
 	IsInterfaceNil() bool
 }

--- a/config/config.go
+++ b/config/config.go
@@ -194,14 +194,14 @@ type Config struct {
 	ProofsStorage           StorageConfig
 	ExecutionResultsStorage StorageConfig
 
-	AccountsTrieStorage      StorageConfig
-	PeerAccountsTrieStorage  StorageConfig
-	EvictionWaitingList      EvictionWaitingListConfig
-	StateTriesConfig         StateTriesConfig
+	AccountsTrieStorage          StorageConfig
+	PeerAccountsTrieStorage      StorageConfig
+	EvictionWaitingList          EvictionWaitingListConfig
+	StateTriesConfig             StateTriesConfig
 	StateAccessesCollectorConfig StateAccessesCollectorConfig
-	TrieStorageManagerConfig TrieStorageManagerConfig
-	TrieLeavesRetrieverConfig TrieLeavesRetrieverConfig
-	BadBlocksCache           CacheConfig
+	TrieStorageManagerConfig     TrieStorageManagerConfig
+	TrieLeavesRetrieverConfig    TrieLeavesRetrieverConfig
+	BadBlocksCache               CacheConfig
 
 	TxBlockBodyDataPool          CacheConfig
 	PeerBlockBodyDataPool        CacheConfig
@@ -382,6 +382,10 @@ type ProcessConfigByRound struct {
 
 	// RoundModulusTriggerWhenSyncIsStuck defines a round modulus on which a trigger for an action when sync is stuck will be released
 	RoundModulusTriggerWhenSyncIsStuck uint32
+
+	// MaxSyncWithErrorsAllowed defines the maximum allowed number of sync with errors,
+	// before a special action to be applied
+	MaxSyncWithErrorsAllowed uint32
 }
 
 // GeneralSettingsConfig will hold the general settings for a node

--- a/factory/processing/blockProcessorCreator.go
+++ b/factory/processing/blockProcessorCreator.go
@@ -565,6 +565,7 @@ func (pcf *processComponentsFactory) newShardBlockProcessor(
 		ExecutionResultsInclusionEstimator: inclusionEstimator,
 		GasComputation:                     gasConsumption,
 		ExecutionManager:                   executionManager,
+		TxExecutionOrderHandler:            pcf.txExecutionOrderHandler,
 	}
 	arguments := block.ArgShardProcessor{
 		ArgBaseProcessor: argumentsBaseProcessor,
@@ -1118,6 +1119,7 @@ func (pcf *processComponentsFactory) newMetaBlockProcessor(
 		ExecutionResultsInclusionEstimator: inclusionEstimator,
 		GasComputation:                     gasConsumption,
 		ExecutionManager:                   executionManager,
+		TxExecutionOrderHandler:            pcf.txExecutionOrderHandler,
 	}
 
 	esdtOwnerAddress, err := pcf.coreData.AddressPubKeyConverter().Decode(pcf.systemSCConfig.ESDTSystemSCConfig.OwnerAddress)

--- a/factory/processing/blockProcessorCreator.go
+++ b/factory/processing/blockProcessorCreator.go
@@ -1204,13 +1204,16 @@ func (pcf *processComponentsFactory) newMetaBlockProcessor(
 		return nil, err
 	}
 
-	shardInfoCreator, err := block.NewShardInfoCreateData(
-		pcf.coreData.EnableEpochsHandler(),
-		pcf.data.Datapool().Headers(),
-		pcf.data.Datapool().Proofs(),
-		pendingMiniBlocksHandler,
-		blockTracker,
-	)
+	shardInfoCreateDataArgs := block.ShardInfoCreateDataArgs{
+		EnableEpochsHandler:      pcf.coreData.EnableEpochsHandler(),
+		HeadersPool:              pcf.data.Datapool().Headers(),
+		ProofsPool:               pcf.data.Datapool().Proofs(),
+		PendingMiniBlocksHandler: pendingMiniBlocksHandler,
+		BlockTracker:             blockTracker,
+		Storage:                  pcf.data.StorageService(),
+		Marshaller:               pcf.coreData.InternalMarshalizer(),
+	}
+	shardInfoCreator, err := block.NewShardInfoCreateData(shardInfoCreateDataArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -637,6 +637,7 @@ func (pcf *processComponentsFactory) Create() (*processComponents, error) {
 		Headers:                 pcf.data.Datapool().Headers(),
 		StorageService:          pcf.data.StorageService(),
 		Marshaller:              pcf.coreData.InternalMarshalizer(),
+		ShardCoordinator:        pcf.bootstrapComponents.ShardCoordinator(),
 	}
 	execManager, err := executionManager.NewExecutionManager(argExecManager)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/multiversx/mx-chain-communication-go v1.3.0
 	github.com/multiversx/mx-chain-core-go v1.4.2-0.20251208114845-28456d47841d
 	github.com/multiversx/mx-chain-crypto-go v1.3.0
-	github.com/multiversx/mx-chain-es-indexer-go v1.9.3-0.20251208115629-86278c61b0c8
+	github.com/multiversx/mx-chain-es-indexer-go v1.9.3-0.20251209110302-3b451942b7f9
 	github.com/multiversx/mx-chain-logger-go v1.1.0
 	github.com/multiversx/mx-chain-scenario-go v1.6.0
 	github.com/multiversx/mx-chain-storage-go v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/multiversx/mx-chain-core-go v1.4.2-0.20251208114845-28456d47841d h1:B
 github.com/multiversx/mx-chain-core-go v1.4.2-0.20251208114845-28456d47841d/go.mod h1:IO+vspNan+gT0WOHnJ95uvWygiziHZvfXpff6KnxV7g=
 github.com/multiversx/mx-chain-crypto-go v1.3.0 h1:0eK2bkDOMi8VbSPrB1/vGJSYT81IBtfL4zw+C4sWe/k=
 github.com/multiversx/mx-chain-crypto-go v1.3.0/go.mod h1:nPIkxxzyTP8IquWKds+22Q2OJ9W7LtusC7cAosz7ojM=
-github.com/multiversx/mx-chain-es-indexer-go v1.9.3-0.20251208115629-86278c61b0c8 h1:kYw/GwFE+iv8jmQvqtLgzGNzlLNbH+C9YzDJFv/QqWU=
-github.com/multiversx/mx-chain-es-indexer-go v1.9.3-0.20251208115629-86278c61b0c8/go.mod h1:F/BpaYVPuHN7POJN6gwvJfZ22diYtvz2576a+PWiPvw=
+github.com/multiversx/mx-chain-es-indexer-go v1.9.3-0.20251209110302-3b451942b7f9 h1:lywsKESTxcEC+RnmXzF/6T444DVyhl/ft52Rh4JMPyQ=
+github.com/multiversx/mx-chain-es-indexer-go v1.9.3-0.20251209110302-3b451942b7f9/go.mod h1:F/BpaYVPuHN7POJN6gwvJfZ22diYtvz2576a+PWiPvw=
 github.com/multiversx/mx-chain-logger-go v1.1.0 h1:97x84A6L4RfCa6YOx1HpAFxZp1cf/WI0Qh112whgZNM=
 github.com/multiversx/mx-chain-logger-go v1.1.0/go.mod h1:K9XgiohLwOsNACETMNL0LItJMREuEvTH6NsoXWXWg7g=
 github.com/multiversx/mx-chain-scenario-go v1.6.0 h1:cwDFuS1pSc4YXnfiKKDTEb+QDY4fulPQaiRgIebnKxI=

--- a/integrationTests/testFullNode.go
+++ b/integrationTests/testFullNode.go
@@ -1041,6 +1041,7 @@ func (tpn *TestFullNode) initBlockProcessor(
 		ExecutionResultsInclusionEstimator: inclusionEstimator,
 		GasComputation:                     gasConsumption,
 		ExecutionManager:                   tpn.ExecutionManager,
+		TxExecutionOrderHandler:            tpn.TxExecutionOrderHandler,
 	}
 
 	if check.IfNil(tpn.EpochStartNotifier) {
@@ -1407,6 +1408,7 @@ func (tpn *TestFullNode) initBlockProcessorWithSync(
 		ExecutionResultsInclusionEstimator: inclusionEstimator,
 		GasComputation:                     gasConsumption,
 		ExecutionManager:                   tpn.ExecutionManager,
+		TxExecutionOrderHandler:            tpn.TxExecutionOrderHandler,
 	}
 
 	if tpn.ShardCoordinator.SelfId() == core.MetachainShardId {

--- a/integrationTests/testFullNode.go
+++ b/integrationTests/testFullNode.go
@@ -955,6 +955,7 @@ func (tpn *TestFullNode) initBlockProcessor(
 		Headers:                 tpn.DataPool.Headers(),
 		StorageService:          &storageStubs.ChainStorerStub{},
 		Marshaller:              TestMarshaller,
+		ShardCoordinator:        &testscommon.ShardsCoordinatorMock{},
 	}
 	tpn.ExecutionManager, err = executionManager.NewExecutionManager(argsExecutionManager)
 	if err != nil {
@@ -1190,13 +1191,16 @@ func (tpn *TestFullNode) initBlockProcessor(
 		epochStartSystemSCProcessor, _ := metachain.NewSystemSCProcessor(argsEpochSystemSC)
 		tpn.EpochStartSystemSCProcessor = epochStartSystemSCProcessor
 
-		shardInfoCreator, errShardInfoCreate := block.NewShardInfoCreateData(
-			tpn.EnableEpochsHandler,
-			tpn.DataPool.Headers(),
-			tpn.DataPool.Proofs(),
-			&mock.PendingMiniBlocksHandlerStub{},
-			argumentsBase.BlockTracker,
-		)
+		shardInfoCreateDataArgs := block.ShardInfoCreateDataArgs{
+			EnableEpochsHandler:      tpn.EnableEpochsHandler,
+			HeadersPool:              tpn.DataPool.Headers(),
+			ProofsPool:               tpn.DataPool.Proofs(),
+			PendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
+			BlockTracker:             argumentsBase.BlockTracker,
+			Storage:                  tpn.Storage,
+			Marshaller:               TestMarshalizer,
+		}
+		shardInfoCreator, errShardInfoCreate := block.NewShardInfoCreateData(shardInfoCreateDataArgs)
 		log.LogIfError(errShardInfoCreate)
 
 		arguments := block.ArgMetaProcessor{
@@ -1320,6 +1324,7 @@ func (tpn *TestFullNode) initBlockProcessorWithSync(
 		Headers:                 tpn.DataPool.Headers(),
 		StorageService:          &storageStubs.ChainStorerStub{},
 		Marshaller:              TestMarshaller,
+		ShardCoordinator:        &testscommon.ShardsCoordinatorMock{},
 	}
 	tpn.ExecutionManager, err = executionManager.NewExecutionManager(argsExecutionManager)
 	if err != nil {
@@ -1413,13 +1418,16 @@ func (tpn *TestFullNode) initBlockProcessorWithSync(
 		argumentsBase.ForkDetector = tpn.ForkDetector
 		argumentsBase.TxCoordinator = &mock.TransactionCoordinatorMock{}
 
-		shardInfoCreator, errShardInfoCreate := block.NewShardInfoCreateData(
-			coreComponents.EnableEpochsHandler(),
-			dataComponents.DataPool.Headers(),
-			dataComponents.DataPool.Proofs(),
-			&mock.PendingMiniBlocksHandlerStub{},
-			argumentsBase.BlockTracker,
-		)
+		shardInfoCreateDataArgs := block.ShardInfoCreateDataArgs{
+			EnableEpochsHandler:      tpn.EnableEpochsHandler,
+			HeadersPool:              tpn.DataPool.Headers(),
+			ProofsPool:               tpn.DataPool.Proofs(),
+			PendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
+			BlockTracker:             argumentsBase.BlockTracker,
+			Storage:                  tpn.Storage,
+			Marshaller:               TestMarshalizer,
+		}
+		shardInfoCreator, errShardInfoCreate := block.NewShardInfoCreateData(shardInfoCreateDataArgs)
 		log.LogIfError(errShardInfoCreate)
 
 		arguments := block.ArgMetaProcessor{

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -2610,6 +2610,7 @@ func (tpn *TestProcessorNode) initBlockProcessor() {
 		ExecutionResultsInclusionEstimator: inclusionEstimator,
 		GasComputation:                     gasConsumption,
 		ExecutionManager:                   tpn.ExecutionManager,
+		TxExecutionOrderHandler:            tpn.TxExecutionOrderHandler,
 	}
 
 	if check.IfNil(tpn.EpochStartNotifier) {

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -2525,6 +2525,7 @@ func (tpn *TestProcessorNode) initBlockProcessor() {
 		Headers:                 tpn.DataPool.Headers(),
 		StorageService:          &storageStubs.ChainStorerStub{},
 		Marshaller:              TestMarshaller,
+		ShardCoordinator:        &testscommon.ShardsCoordinatorMock{},
 	}
 	tpn.ExecutionManager, err = executionManager.NewExecutionManager(argsExecutionManager)
 	if err != nil {
@@ -2778,14 +2779,17 @@ func (tpn *TestProcessorNode) initBlockProcessor() {
 		epochStartSystemSCProcessor, _ := metachain.NewSystemSCProcessor(argsEpochSystemSC)
 		tpn.EpochStartSystemSCProcessor = epochStartSystemSCProcessor
 
-		shardInfoCreator, errShardInfoCreator := block.NewShardInfoCreateData(
-			tpn.EnableEpochsHandler,
-			tpn.DataPool.Headers(),
-			tpn.DataPool.Proofs(),
-			&mock.PendingMiniBlocksHandlerStub{},
-			argumentsBase.BlockTracker,
-		)
-		log.LogIfError(errShardInfoCreator)
+		shardInfoCreateDataArgs := block.ShardInfoCreateDataArgs{
+			EnableEpochsHandler:      tpn.EnableEpochsHandler,
+			HeadersPool:              tpn.DataPool.Headers(),
+			ProofsPool:               tpn.DataPool.Proofs(),
+			PendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
+			BlockTracker:             argumentsBase.BlockTracker,
+			Storage:                  tpn.Storage,
+			Marshaller:               TestMarshalizer,
+		}
+		shardInfoCreator, errShardInfoCreate := block.NewShardInfoCreateData(shardInfoCreateDataArgs)
+		log.LogIfError(errShardInfoCreate)
 
 		arguments := block.ArgMetaProcessor{
 			ArgBaseProcessor:             argumentsBase,

--- a/integrationTests/testSyncNode.go
+++ b/integrationTests/testSyncNode.go
@@ -221,6 +221,7 @@ func (tpn *TestProcessorNode) initBlockProcessorWithSync() {
 		ExecutionResultsInclusionEstimator: inclusionEstimator,
 		GasComputation:                     gasConsumption,
 		ExecutionManager:                   tpn.ExecutionManager,
+		TxExecutionOrderHandler:            tpn.TxExecutionOrderHandler,
 	}
 
 	if tpn.ShardCoordinator.SelfId() == core.MetachainShardId {

--- a/integrationTests/testSyncNode.go
+++ b/integrationTests/testSyncNode.go
@@ -134,6 +134,7 @@ func (tpn *TestProcessorNode) initBlockProcessorWithSync() {
 		Headers:                 tpn.DataPool.Headers(),
 		StorageService:          &storageStubs.ChainStorerStub{},
 		Marshaller:              TestMarshaller,
+		ShardCoordinator:        &testscommon.ShardsCoordinatorMock{},
 	}
 	tpn.ExecutionManager, err = executionManager.NewExecutionManager(argsExecutionManager)
 	if err != nil {
@@ -238,13 +239,16 @@ func (tpn *TestProcessorNode) initBlockProcessorWithSync() {
 		)
 		argumentsBase.ForkDetector = tpn.ForkDetector
 		argumentsBase.TxCoordinator = &mock.TransactionCoordinatorMock{}
-		shardInfoCreator, errShardInfoCreator := block.NewShardInfoCreateData(
-			tpn.EnableEpochsHandler,
-			tpn.DataPool.Headers(),
-			tpn.DataPool.Proofs(),
-			&mock.PendingMiniBlocksHandlerStub{},
-			argumentsBase.BlockTracker,
-		)
+		shardInfoCreateDataArgs := block.ShardInfoCreateDataArgs{
+			EnableEpochsHandler:      tpn.EnableEpochsHandler,
+			HeadersPool:              tpn.DataPool.Headers(),
+			ProofsPool:               tpn.DataPool.Proofs(),
+			PendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
+			BlockTracker:             argumentsBase.BlockTracker,
+			Storage:                  tpn.Storage,
+			Marshaller:               TestMarshalizer,
+		}
+		shardInfoCreator, errShardInfoCreator := block.NewShardInfoCreateData(shardInfoCreateDataArgs)
 		log.LogIfError(errShardInfoCreator)
 
 		arguments := block.ArgMetaProcessor{

--- a/integrationTests/vm/staking/metaBlockProcessorCreator.go
+++ b/integrationTests/vm/staking/metaBlockProcessorCreator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/multiversx/mx-chain-go/process/asyncExecution"
 	"github.com/multiversx/mx-chain-go/process/asyncExecution/executionManager"
 	"github.com/multiversx/mx-chain-go/process/asyncExecution/queue"
+	commonMock "github.com/multiversx/mx-chain-go/testscommon/common"
 
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/process/asyncExecution/executionTrack"
@@ -190,6 +191,7 @@ func createMetaBlockProcessor(
 			ExecutionResultsInclusionEstimator: inclusionEstimator,
 			GasComputation:                     &testscommon.GasComputationMock{},
 			ExecutionManager:                   execManager,
+			TxExecutionOrderHandler:            &commonMock.TxExecutionOrderHandlerStub{},
 		},
 		SCToProtocol:             stakingToPeer,
 		PendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},

--- a/integrationTests/vm/staking/metaBlockProcessorCreator.go
+++ b/integrationTests/vm/staking/metaBlockProcessorCreator.go
@@ -122,6 +122,7 @@ func createMetaBlockProcessor(
 		Headers:                 dataComponents.Datapool().Headers(),
 		StorageService:          dataComponents.StorageService(),
 		Marshaller:              coreComponents.InternalMarshalizer(),
+		ShardCoordinator:        bootstrapComponents.ShardCoordinator(),
 	})
 	execResultsVerifier, _ := blproc.NewExecutionResultsVerifier(dataComponents.Blockchain(), execManager)
 	inclusionEstimator := estimator.NewExecutionResultInclusionEstimator(
@@ -140,13 +141,16 @@ func createMetaBlockProcessor(
 	}
 	missingDataResolver, _ := missingData.NewMissingDataResolver(missingDataArgs)
 
-	shardInfoCreator, _ := blproc.NewShardInfoCreateData(
-		coreComponents.EnableEpochsHandler(),
-		dataComponents.Datapool().Headers(),
-		dataComponents.Datapool().Proofs(),
-		&mock.PendingMiniBlocksHandlerStub{},
-		blockTracker,
-	)
+	shardInfoCreateDataArgs := blproc.ShardInfoCreateDataArgs{
+		EnableEpochsHandler:      coreComponents.EnableEpochsHandler(),
+		HeadersPool:              dataComponents.Datapool().Headers(),
+		ProofsPool:               dataComponents.Datapool().Proofs(),
+		PendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
+		BlockTracker:             blockTracker,
+		Storage:                  dataComponents.StorageService(),
+		Marshaller:               coreComponents.InternalMarshalizer(),
+	}
+	shardInfoCreator, _ := blproc.NewShardInfoCreateData(shardInfoCreateDataArgs)
 
 	args := blproc.ArgMetaProcessor{
 		ArgBaseProcessor: blproc.ArgBaseProcessor{

--- a/outport/process/outportDataProvider.go
+++ b/outport/process/outportDataProvider.go
@@ -656,7 +656,11 @@ func putInMapTxsFromBody(
 			continue
 		}
 
-		storeByType := getDataStoreForType(dataPool, mb.Type)
+		storeByType, found := getDataStoreForType(dataPool, mb.Type)
+		if !found {
+			continue
+		}
+
 		strCache := process.ShardCacherIdentifier(mb.SenderShardID, mb.ReceiverShardID)
 		cache := storeByType.ShardDataStore(strCache)
 
@@ -674,15 +678,15 @@ func putInMapTxsFromBody(
 func getDataStoreForType(
 	dataPool dataRetriever.PoolsHolder,
 	mbType block.Type,
-) dataRetriever.ShardedDataCacherNotifier {
+) (dataRetriever.ShardedDataCacherNotifier, bool) {
 	switch mbType {
 	case block.SmartContractResultBlock:
-		return dataPool.UnsignedTransactions()
+		return dataPool.UnsignedTransactions(), true
 	case block.TxBlock:
-		return dataPool.Transactions()
+		return dataPool.Transactions(), true
 	case block.RewardsBlock:
-		return dataPool.RewardTransactions()
+		return dataPool.RewardTransactions(), true
 	default:
-		return nil
+		return nil, false
 	}
 }

--- a/outport/process/outportDataProvider.go
+++ b/outport/process/outportDataProvider.go
@@ -222,9 +222,6 @@ func (odp *outportDataProvider) prepareExecutionResultsData(args ArgPrepareOutpo
 		if err != nil {
 			return nil, err
 		}
-		if len(cachedTxs[block.SmartContractResultBlock]) > 0 {
-			fmt.Println("aa")
-		}
 
 		putInMapTxsFromBody(odp.dataPool, body, odp.shardID, cachedTxs)
 
@@ -243,6 +240,9 @@ func (odp *outportDataProvider) prepareExecutionResultsData(args ArgPrepareOutpo
 		}
 
 		orderedTxHashes, err := common.GetCachedOrderedTxHashes(odp.dataPool.PostProcessTransactions(), headerHash)
+		if err != nil {
+			return nil, err
+		}
 		_, _ = odp.setExecutionOrderInTransactionPool(pool, orderedTxHashes)
 
 		alteredAccounts, err := odp.alteredAccountsProvider.ExtractAlteredAccountsFromPool(pool, shared.AlteredAccountsOptions{

--- a/outport/process/outportDataProvider.go
+++ b/outport/process/outportDataProvider.go
@@ -120,16 +120,19 @@ func (odp *outportDataProvider) PrepareOutportSaveBlockData(arg ArgPrepareOutpor
 		return nil, fmt.Errorf("transactionsFeeProcessor.PutFeeAndGasUsed %w", err)
 	}
 
-	orderedTxHashes, foundTxHashes := odp.setExecutionOrderInTransactionPool(pool)
+	if !arg.Header.IsHeaderV3() {
+		items := odp.executionOrderHandler.GetItems()
+		orderedTxHashes, foundTxHashes := odp.setExecutionOrderInTransactionPool(pool, items)
 
-	executedTxs, err := collectExecutedTxHashes(arg.Body, arg.Header)
-	if err != nil {
-		log.Warn("PrepareOutportSaveBlockData - collectExecutedTxHashes", "error", err)
-	}
+		executedTxs, errC := collectExecutedTxHashes(arg.Body, arg.Header)
+		if errC != nil {
+			log.Warn("PrepareOutportSaveBlockData - collectExecutedTxHashes", "error", errC)
+		}
 
-	err = checkTxOrder(orderedTxHashes, executedTxs, foundTxHashes)
-	if err != nil {
-		log.Warn("PrepareOutportSaveBlockData - checkTxOrder", "error", err.Error())
+		err = checkTxOrder(orderedTxHashes, executedTxs, foundTxHashes)
+		if err != nil {
+			log.Warn("PrepareOutportSaveBlockData - checkTxOrder", "error", err.Error())
+		}
 	}
 
 	alteredAccounts, err := odp.alteredAccountsProvider.ExtractAlteredAccountsFromPool(pool, shared.AlteredAccountsOptions{
@@ -219,6 +222,12 @@ func (odp *outportDataProvider) prepareExecutionResultsData(args ArgPrepareOutpo
 		if err != nil {
 			return nil, err
 		}
+		if len(cachedTxs[block.SmartContractResultBlock]) > 0 {
+			fmt.Println("aa")
+		}
+
+		putInMapTxsFromBody(odp.dataPool, body, odp.shardID, cachedTxs)
+
 		cachedLogs, err := common.GetCachedLogs(odp.dataPool.PostProcessTransactions(), headerHash)
 		if err != nil {
 			return nil, err
@@ -233,7 +242,8 @@ func (odp *outportDataProvider) prepareExecutionResultsData(args ArgPrepareOutpo
 			return nil, fmt.Errorf("transactionsFeeProcessor.PutFeeAndGasUsed %w", err)
 		}
 
-		_, _ = odp.setExecutionOrderInTransactionPool(pool)
+		orderedTxHashes, err := common.GetCachedOrderedTxHashes(odp.dataPool.PostProcessTransactions(), headerHash)
+		_, _ = odp.setExecutionOrderInTransactionPool(pool, orderedTxHashes)
 
 		alteredAccounts, err := odp.alteredAccountsProvider.ExtractAlteredAccountsFromPool(pool, shared.AlteredAccountsOptions{
 			WithAdditionalOutportData: true,
@@ -312,8 +322,8 @@ func extractExecutedTxsFromMb(mbHeader data.MiniBlockHeaderHandler, miniBlock *b
 
 func (odp *outportDataProvider) setExecutionOrderInTransactionPool(
 	pool *outportcore.TransactionPool,
+	orderedTxHashes [][]byte,
 ) ([][]byte, int) {
-	orderedTxHashes := odp.executionOrderHandler.GetItems()
 	if pool == nil {
 		return orderedTxHashes, 0
 	}
@@ -626,4 +636,53 @@ func (odp *outportDataProvider) filterOutDuplicatedMiniBlocks(miniBlocksFromBody
 	}
 
 	return filteredMiniBlocks, nil
+}
+
+func putInMapTxsFromBody(
+	dataPool dataRetriever.PoolsHolder,
+	body *block.Body,
+	selfShardID uint32,
+	txs map[block.Type]map[string]data.TransactionHandler,
+) {
+	for _, t := range []block.Type{block.TxBlock, block.SmartContractResultBlock, block.RewardsBlock} {
+		if txs[t] == nil {
+			txs[t] = make(map[string]data.TransactionHandler)
+		}
+	}
+
+	for _, mb := range body.MiniBlocks {
+		isCrossSCRBlockFromMe := mb.Type == block.SmartContractResultBlock && mb.SenderShardID == selfShardID
+		if isCrossSCRBlockFromMe {
+			continue
+		}
+
+		storeByType := getDataStoreForType(dataPool, mb.Type)
+		strCache := process.ShardCacherIdentifier(mb.SenderShardID, mb.ReceiverShardID)
+		cache := storeByType.ShardDataStore(strCache)
+
+		for _, txHash := range mb.TxHashes {
+			txI, found := cache.Get(txHash)
+			if !found {
+				continue
+			}
+
+			txs[mb.Type][string(txHash)] = txI.(data.TransactionHandler)
+		}
+	}
+}
+
+func getDataStoreForType(
+	dataPool dataRetriever.PoolsHolder,
+	mbType block.Type,
+) dataRetriever.ShardedDataCacherNotifier {
+	switch mbType {
+	case block.SmartContractResultBlock:
+		return dataPool.UnsignedTransactions()
+	case block.TxBlock:
+		return dataPool.Transactions()
+	case block.RewardsBlock:
+		return dataPool.RewardTransactions()
+	default:
+		return nil
+	}
 }

--- a/outport/process/outportDataProvider_test.go
+++ b/outport/process/outportDataProvider_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/alteredAccount"
 	"github.com/multiversx/mx-chain-core-go/data/block"
@@ -16,6 +17,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/outport/process/alteredaccounts/shared"
+	"github.com/multiversx/mx-chain-go/process"
 	"github.com/stretchr/testify/require"
 
 	"github.com/multiversx/mx-chain-go/outport/mock"
@@ -279,7 +281,7 @@ func Test_setExecutionOrderInTransactionPool(t *testing.T) {
 			},
 		}
 
-		orderedHashes, numProcessed := odp.setExecutionOrderInTransactionPool(nil)
+		orderedHashes, numProcessed := odp.setExecutionOrderInTransactionPool(nil, txHashes)
 		require.Equal(t, 0, numProcessed)
 		require.Equal(t, len(txHashes), len(orderedHashes))
 		for i := 0; i < len(txHashes); i++ {
@@ -296,13 +298,8 @@ func Test_setExecutionOrderInTransactionPool(t *testing.T) {
 		}
 
 		txHashes := createRandTxHashes(10)
-		odp.executionOrderHandler = &commonMocks.TxExecutionOrderHandlerStub{
-			GetItemsCalled: func() [][]byte {
-				return txHashes
-			},
-		}
 
-		orderedHashes, numProcessed := odp.setExecutionOrderInTransactionPool(pool)
+		orderedHashes, numProcessed := odp.setExecutionOrderInTransactionPool(pool, txHashes)
 		require.Equal(t, 0, numProcessed)
 		require.Equal(t, len(txHashes), len(orderedHashes))
 	})
@@ -334,13 +331,8 @@ func Test_setExecutionOrderInTransactionPool(t *testing.T) {
 		}
 
 		txHashes := createRandTxHashes(10)
-		odp.executionOrderHandler = &commonMocks.TxExecutionOrderHandlerStub{
-			GetItemsCalled: func() [][]byte {
-				return txHashes
-			},
-		}
 
-		orderedHashes, numProcessed := odp.setExecutionOrderInTransactionPool(pool)
+		orderedHashes, numProcessed := odp.setExecutionOrderInTransactionPool(pool, txHashes)
 		require.Equal(t, 0, numProcessed)
 		require.Equal(t, len(txHashes), len(orderedHashes))
 	})
@@ -373,13 +365,7 @@ func Test_setExecutionOrderInTransactionPool(t *testing.T) {
 			},
 		}
 
-		odp.executionOrderHandler = &commonMocks.TxExecutionOrderHandlerStub{
-			GetItemsCalled: func() [][]byte {
-				return txHashes
-			},
-		}
-
-		orderedHashes, numProcessed := odp.setExecutionOrderInTransactionPool(pool)
+		orderedHashes, numProcessed := odp.setExecutionOrderInTransactionPool(pool, txHashes)
 		require.Equal(t, 3, numProcessed)
 		require.Equal(t, uint32(0), pool.Transactions[hex.EncodeToString(txHashes[0])].GetExecutionOrder())
 		require.Equal(t, uint32(1), pool.SmartContractResults[hex.EncodeToString(txHashes[1])].GetExecutionOrder())
@@ -414,13 +400,7 @@ func Test_setExecutionOrderInTransactionPool(t *testing.T) {
 			},
 		}
 
-		odp.executionOrderHandler = &commonMocks.TxExecutionOrderHandlerStub{
-			GetItemsCalled: func() [][]byte {
-				return txHashes
-			},
-		}
-
-		orderedHashes, numProcessed := odp.setExecutionOrderInTransactionPool(pool)
+		orderedHashes, numProcessed := odp.setExecutionOrderInTransactionPool(pool, txHashes)
 		require.Equal(t, 3, numProcessed)
 		require.Equal(t, uint32(7), pool.Transactions[hex.EncodeToString(txHashes[7])].GetExecutionOrder())
 		require.Equal(t, uint32(8), pool.SmartContractResults[hex.EncodeToString(txHashes[8])].GetExecutionOrder())
@@ -917,4 +897,67 @@ func TestPrepareExecutionResultsData(t *testing.T) {
 		require.Len(t, results[hex.EncodeToString(headerHash)].AlteredAccounts, 1)
 		require.Equal(t, uint64(10), results[hex.EncodeToString(headerHash)].HeaderNonce)
 	})
+}
+
+func TestPutInMapTxsFromBody(t *testing.T) {
+	t.Parallel()
+
+	dataPool := dataRetriever.NewPoolsHolderMock()
+	txsMap := make(map[block.Type]map[string]data.TransactionHandler)
+	shardID := uint32(0)
+
+	tx1H, tx2H, tx3H := []byte("tx1"), []byte("tx2"), []byte("tx3")
+
+	tx1 := &transaction.Transaction{}
+	cacheID := process.ShardCacherIdentifier(0, 1)
+	dataPool.Transactions().AddData(tx1H, tx1, 1, cacheID)
+
+	tx2 := &rewardTx.RewardTx{}
+	cacheID = process.ShardCacherIdentifier(core.MetachainShardId, 0)
+	dataPool.RewardTransactions().AddData(tx2H, tx2, 1, cacheID)
+
+	tx3 := &smartContractResult.SmartContractResult{}
+	cacheID = process.ShardCacherIdentifier(2, 0)
+	dataPool.UnsignedTransactions().AddData(tx3H, tx3, 1, cacheID)
+
+	body := &block.Body{
+		MiniBlocks: []*block.MiniBlock{
+			{
+				SenderShardID:   shardID,
+				ReceiverShardID: 2,
+				Type:            block.SmartContractResultBlock,
+				// this will be ignored
+			},
+			{
+				SenderShardID:   shardID,
+				ReceiverShardID: 1,
+				Type:            block.TxBlock,
+				TxHashes:        [][]byte{tx1H},
+			},
+			{
+				SenderShardID:   core.MetachainShardId,
+				ReceiverShardID: shardID,
+				TxHashes:        [][]byte{tx2H},
+				Type:            block.RewardsBlock,
+			},
+			{
+				SenderShardID:   2,
+				ReceiverShardID: shardID,
+				Type:            block.SmartContractResultBlock,
+				TxHashes:        [][]byte{tx3H},
+			},
+		},
+	}
+
+	putInMapTxsFromBody(dataPool, body, shardID, txsMap)
+
+	txPool, scrPool, rewardPool := txsMap[block.TxBlock], txsMap[block.SmartContractResultBlock], txsMap[block.RewardsBlock]
+	txFromPool := txPool[string(tx1H)].(*transaction.Transaction)
+	require.Equal(t, tx1, txFromPool)
+
+	rewordFromPool := rewardPool[string(tx2H)].(*rewardTx.RewardTx)
+	require.Equal(t, tx2, rewordFromPool)
+
+	scrFromPool := scrPool[string(tx3H)].(*smartContractResult.SmartContractResult)
+	require.Equal(t, tx3, scrFromPool)
 }

--- a/outport/process/outportDataProvider_test.go
+++ b/outport/process/outportDataProvider_test.go
@@ -836,6 +836,9 @@ func TestPrepareExecutionResultsData(t *testing.T) {
 		cachedTxs[block.TxBlock] = make(map[string]data.TransactionHandler)
 		arg.DataPool.PostProcessTransactions().Put(headerHash, cachedTxs, 1)
 
+		key := common.PrepareOrderedTxHashesKey(headerHash)
+		arg.DataPool.PostProcessTransactions().Put(key, [][]byte{[]byte("a")}, 1)
+
 		outportDataP, _ := NewOutportDataProvider(arg)
 
 		results, err := outportDataP.prepareExecutionResultsData(ArgPrepareOutportSaveBlockData{
@@ -876,6 +879,9 @@ func TestPrepareExecutionResultsData(t *testing.T) {
 		cachedTxs := make(map[block.Type]map[string]data.TransactionHandler)
 		cachedTxs[block.TxBlock] = make(map[string]data.TransactionHandler)
 		arg.DataPool.PostProcessTransactions().Put(headerHash, cachedTxs, 1)
+
+		key := common.PrepareOrderedTxHashesKey(headerHash)
+		arg.DataPool.PostProcessTransactions().Put(key, [][]byte{[]byte("a")}, 1)
 
 		outportDataP, _ := NewOutportDataProvider(arg)
 

--- a/process/asyncExecution/executionManager/executionManager.go
+++ b/process/asyncExecution/executionManager/executionManager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/asyncExecution/disabled"
+	"github.com/multiversx/mx-chain-go/sharding"
 
 	"github.com/multiversx/mx-chain-go/process/asyncExecution/queue"
 )
@@ -27,6 +28,7 @@ type ArgsExecutionManager struct {
 	Headers                 common.HeadersPool
 	StorageService          dataRetriever.StorageService
 	Marshaller              marshal.Marshalizer
+	ShardCoordinator        sharding.Coordinator
 }
 
 type executionManager struct {
@@ -38,6 +40,7 @@ type executionManager struct {
 	headers                 common.HeadersPool
 	storageService          dataRetriever.StorageService
 	marshaller              marshal.Marshalizer
+	shardCoordinator        sharding.Coordinator
 }
 
 // NewExecutionManager creates a new instance of executionManager
@@ -60,6 +63,9 @@ func NewExecutionManager(args ArgsExecutionManager) (*executionManager, error) {
 	if check.IfNil(args.Marshaller) {
 		return nil, process.ErrNilMarshalizer
 	}
+	if check.IfNil(args.ShardCoordinator) {
+		return nil, process.ErrNilShardCoordinator
+	}
 
 	instance := &executionManager{
 		headersExecutor:         disabled.NewHeadersExecutor(),
@@ -69,6 +75,7 @@ func NewExecutionManager(args ArgsExecutionManager) (*executionManager, error) {
 		headers:                 args.Headers,
 		storageService:          args.StorageService,
 		marshaller:              args.Marshaller,
+		shardCoordinator:        args.ShardCoordinator,
 	}
 
 	return instance, nil
@@ -322,14 +329,7 @@ func (em *executionManager) getHeaderFromPoolOrStorage(
 		return header, nil
 	}
 
-	// chain handler header is set for self shard id
-	// TODO: add use shard coordinator
-	currentBlockHeader := em.blockChain.GetCurrentBlockHeader()
-	if check.IfNil(currentBlockHeader) {
-		return nil, common.ErrNilHeaderHandler
-	}
-
-	shardID := currentBlockHeader.GetShardID()
+	shardID := em.shardCoordinator.SelfId()
 
 	return process.GetHeaderFromStorage(
 		shardID,

--- a/process/asyncExecution/executionManager/executionManager_test.go
+++ b/process/asyncExecution/executionManager/executionManager_test.go
@@ -31,6 +31,7 @@ func createMockArgs() executionManager.ArgsExecutionManager {
 		Headers:                 &pool.HeadersPoolStub{},
 		StorageService:          &storageStubs.ChainStorerStub{},
 		Marshaller:              &mock.MarshalizerMock{},
+		ShardCoordinator:        &mock.ShardCoordinatorStub{},
 	}
 }
 
@@ -79,6 +80,39 @@ func TestNewExecutionManager(t *testing.T) {
 		em, err := executionManager.NewExecutionManager(args)
 		require.Nil(t, em)
 		require.Equal(t, executionManager.ErrNilHeadersPool, err)
+	})
+
+	t.Run("nil storage service should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgs()
+		args.StorageService = nil
+
+		em, err := executionManager.NewExecutionManager(args)
+		require.Nil(t, em)
+		require.Equal(t, process.ErrNilStorage, err)
+	})
+
+	t.Run("nil marshaller should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgs()
+		args.Marshaller = nil
+
+		em, err := executionManager.NewExecutionManager(args)
+		require.Nil(t, em)
+		require.Equal(t, process.ErrNilMarshalizer, err)
+	})
+
+	t.Run("nil shard coordinator should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgs()
+		args.ShardCoordinator = nil
+
+		em, err := executionManager.NewExecutionManager(args)
+		require.Nil(t, em)
+		require.Equal(t, process.ErrNilShardCoordinator, err)
 	})
 
 	t.Run("should work", func(t *testing.T) {

--- a/process/block/argProcessor.go
+++ b/process/block/argProcessor.go
@@ -106,6 +106,7 @@ type ArgBaseProcessor struct {
 	MissingDataResolver                MissingDataResolver
 	GasComputation                     process.GasComputation
 	ExecutionManager                   process.ExecutionManager
+	TxExecutionOrderHandler            common.TxExecutionOrderHandler
 }
 
 // ArgShardProcessor holds all dependencies required by the process data factory in order to create

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -144,6 +144,7 @@ type baseProcessor struct {
 	missingDataResolver                MissingDataResolver
 	gasComputation                     process.GasComputation
 	executionManager                   process.ExecutionManager
+	txExecutionOrderHandler            common.TxExecutionOrderHandler
 }
 
 type bootStorerDataArgs struct {
@@ -232,6 +233,7 @@ func NewBaseProcessor(arguments ArgBaseProcessor) (*baseProcessor, error) {
 		missingDataResolver:                arguments.MissingDataResolver,
 		gasComputation:                     arguments.GasComputation,
 		executionManager:                   arguments.ExecutionManager,
+		txExecutionOrderHandler:            arguments.TxExecutionOrderHandler,
 	}
 
 	err = base.OnExecutedBlock(genesisHdr, genesisHdr.GetRootHash())
@@ -788,6 +790,9 @@ func checkProcessorParameters(arguments ArgBaseProcessor) error {
 	}
 	if check.IfNil(arguments.ExecutionManager) {
 		return process.ErrNilExecutionManager
+	}
+	if check.IfNil(arguments.TxExecutionOrderHandler) {
+		return process.ErrNilTxExecutionOrderHandler
 	}
 
 	return nil
@@ -2983,6 +2988,12 @@ func (bp *baseProcessor) cacheIntermediateTxsForHeader(headerHash []byte) error 
 
 	bp.dataPool.PostProcessTransactions().Put(headerHash, intermediateTxs, intermediateTxsSize)
 
+	executionOrderKey := common.PrepareOrderedTxHashesKey(headerHash)
+	items := bp.txExecutionOrderHandler.GetItems()
+
+	size := len(items) * 32 // number of items * length of a transaction hash
+	bp.dataPool.PostProcessTransactions().Put(executionOrderKey, items, size)
+
 	return nil
 }
 
@@ -3051,6 +3062,8 @@ func (bp *baseProcessor) saveIntermediateTxs(headerHash []byte) error {
 
 	// all transactions moved, cleaning the cache
 	postProcessTxsCache.Remove(headerHash)
+	// remove execution order data
+	postProcessTxsCache.Remove(common.PrepareOrderedTxHashesKey(headerHash))
 
 	return nil
 }

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -2987,13 +2987,6 @@ func (bp *baseProcessor) cacheIntermediateTxsForHeader(headerHash []byte) error 
 	}
 
 	bp.dataPool.PostProcessTransactions().Put(headerHash, intermediateTxs, intermediateTxsSize)
-
-	executionOrderKey := common.PrepareOrderedTxHashesKey(headerHash)
-	items := bp.txExecutionOrderHandler.GetItems()
-
-	size := len(items) * 32 // number of items * length of a transaction hash
-	bp.dataPool.PostProcessTransactions().Put(executionOrderKey, items, size)
-
 	return nil
 }
 
@@ -3679,6 +3672,14 @@ func (bp *baseProcessor) collectMiniBlocks(
 	}
 
 	return miniBlockHeaderHandlers, totalTxCount, receiptHash, nil
+}
+
+func (bp *baseProcessor) cacheOrderedTxHashes(headerHash []byte) {
+	executionOrderKey := common.PrepareOrderedTxHashesKey(headerHash)
+	items := bp.txExecutionOrderHandler.GetItems()
+
+	size := len(items) * common.HashSize // number of items * length of a transaction hash
+	bp.dataPool.PostProcessTransactions().Put(executionOrderKey, items, size)
 }
 
 func (bp *baseProcessor) getBlockBodyFromPool(

--- a/process/block/baseProcessHeaderV3_test.go
+++ b/process/block/baseProcessHeaderV3_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-core-go/marshal"
+	commonMocks "github.com/multiversx/mx-chain-go/testscommon/common"
 	"github.com/stretchr/testify/require"
 
 	"github.com/multiversx/mx-chain-go/common"
@@ -200,6 +201,7 @@ func TestBaseProcessor_cacheIntermediateTxsForHeader(t *testing.T) {
 					}
 				},
 			},
+			txExecutionOrderHandler: &commonMocks.TxExecutionOrderHandlerStub{},
 		}
 
 		err := bp.cacheIntermediateTxsForHeader(headerHash)
@@ -224,6 +226,7 @@ func TestBaseProcessor_cacheIntermediateTxsForHeader(t *testing.T) {
 					}
 				},
 			},
+			txExecutionOrderHandler: &commonMocks.TxExecutionOrderHandlerStub{},
 		}
 
 		err := bp.cacheIntermediateTxsForHeader(headerHash)

--- a/process/block/baseProcessHeaderV3_test.go
+++ b/process/block/baseProcessHeaderV3_test.go
@@ -772,6 +772,8 @@ func TestBaseProcessor_cleanPostProcessCache(t *testing.T) {
 			},
 		}
 
+		expectedRemovedKeys := []string{"hash1", "executionhash1", "hash2", "executionhash2"}
+
 		bp := getDefaultBaseProcessor()
 		removedKeys := make([]string, 0)
 		cacher := &cache.CacherStub{
@@ -786,6 +788,6 @@ func TestBaseProcessor_cleanPostProcessCache(t *testing.T) {
 		}
 
 		bp.cleanPostProcessCache(header)
-		require.Equal(t, headerHashes, removedKeys)
+		require.Equal(t, expectedRemovedKeys, removedKeys)
 	})
 }

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -246,7 +246,8 @@ func createArgBaseProcessor(
 				return txHashes, nil, nil
 			},
 		},
-		ExecutionManager: execManager,
+		ExecutionManager:        execManager,
+		TxExecutionOrderHandler: &commonMocks.TxExecutionOrderHandlerStub{},
 	}
 }
 

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -178,6 +178,7 @@ func createArgBaseProcessor(
 			Headers:                 dataComponents.DataPool.Headers(),
 			StorageService:          dataComponents.StorageService(),
 			Marshaller:              coreComponents.InternalMarshalizer(),
+			ShardCoordinator:        bootstrapComponents.ShardCoordinator(),
 		})
 		execResultsVerifier, _ = blproc.NewExecutionResultsVerifier(dataComponents.BlockChain, execManager)
 		inclusionEstimator = estimator.NewExecutionResultInclusionEstimator(

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/display"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
+	commonMocks "github.com/multiversx/mx-chain-go/testscommon/common"
 
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/configs"
@@ -283,6 +284,7 @@ func NewShardProcessorEmptyWith3shards(
 			ExecutionResultsInclusionEstimator: inclusionEstimator,
 			GasComputation:                     gasComputation,
 			ExecutionManager:                   execManager,
+			TxExecutionOrderHandler:            &commonMocks.TxExecutionOrderHandlerStub{},
 		},
 	}
 	shardProc, err := NewShardProcessor(arguments)

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -214,6 +214,7 @@ func NewShardProcessorEmptyWith3shards(
 		Headers:                 dataComponents.Datapool().Headers(),
 		StorageService:          dataComponents.StorageService(),
 		Marshaller:              coreComponents.InternalMarshalizer(),
+		ShardCoordinator:        boostrapComponents.ShardCoordinator(),
 	})
 	execResultsVerifier, _ := NewExecutionResultsVerifier(dataComponents.BlockChain, execManager)
 	inclusionEstimator := estimator.NewExecutionResultInclusionEstimator(

--- a/process/block/metablockProposal.go
+++ b/process/block/metablockProposal.go
@@ -588,6 +588,8 @@ func (mp *metaProcessor) createExecutionResult(
 		return nil, err
 	}
 
+	mp.cacheOrderedTxHashes(headerHash)
+
 	return executionResult, nil
 }
 

--- a/process/block/metablock_test.go
+++ b/process/block/metablock_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-go/testscommon/cache"
+	commonMocks "github.com/multiversx/mx-chain-go/testscommon/common"
 	"github.com/multiversx/mx-chain-go/trie"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -253,6 +254,7 @@ func createMockMetaArguments(
 			ExecutionResultsInclusionEstimator: inclusionEstimator,
 			GasComputation:                     gasComputation,
 			ExecutionManager:                   execManager,
+			TxExecutionOrderHandler:            &commonMocks.TxExecutionOrderHandlerStub{},
 		},
 		SCToProtocol:                 &mock.SCToProtocolStub{},
 		PendingMiniBlocksHandler:     &mock.PendingMiniBlocksHandlerStub{},

--- a/process/block/metablock_test.go
+++ b/process/block/metablock_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/multiversx/mx-chain-go/process/asyncExecution/executionManager"
 	"github.com/multiversx/mx-chain-go/process/asyncExecution/executionTrack"
 	blproc "github.com/multiversx/mx-chain-go/process/block"
+	processBlock "github.com/multiversx/mx-chain-go/process/block"
 	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
 	"github.com/multiversx/mx-chain-go/process/block/headerForBlock"
 	"github.com/multiversx/mx-chain-go/process/block/processedMb"
@@ -176,6 +177,7 @@ func createMockMetaArguments(
 		Headers:                 dataComponents.DataPool.Headers(),
 		StorageService:          dataComponents.StorageService(),
 		Marshaller:              coreComponents.InternalMarshalizer(),
+		ShardCoordinator:        bootstrapComponents.ShardCoordinator(),
 	})
 	execResultsVerifier, _ := blproc.NewExecutionResultsVerifier(dataComponents.BlockChain, execManager)
 	_ = executionResultsTracker.SetLastNotarizedResult(&block.ExecutionResult{})
@@ -204,13 +206,16 @@ func createMockMetaArguments(
 	}
 	gasComputation, _ := blproc.NewGasConsumption(argsGasConsumption)
 
-	shardInfoCreator, _ := blproc.NewShardInfoCreateData(
-		coreComponents.EnableEpochsHandler(),
-		dataComponents.Datapool().Headers(),
-		dataComponents.Datapool().Proofs(),
-		&mock.PendingMiniBlocksHandlerStub{},
-		blockTracker,
-	)
+	shardInfoCreateDataArgs := processBlock.ShardInfoCreateDataArgs{
+		EnableEpochsHandler:      coreComponents.EnableEpochsHandler(),
+		HeadersPool:              dataComponents.Datapool().Headers(),
+		ProofsPool:               dataComponents.Datapool().Proofs(),
+		PendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
+		BlockTracker:             blockTracker,
+		Storage:                  dataComponents.StorageService(),
+		Marshaller:               coreComponents.InternalMarshalizer(),
+	}
+	shardInfoCreator, _ := blproc.NewShardInfoCreateData(shardInfoCreateDataArgs)
 
 	arguments := blproc.ArgMetaProcessor{
 		ArgBaseProcessor: blproc.ArgBaseProcessor{

--- a/process/block/shardInfo.go
+++ b/process/block/shardInfo.go
@@ -7,11 +7,23 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/marshal"
 
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
 )
+
+// ShardInfoCreateDataArgs defines the arguments needed to create shard info creator
+type ShardInfoCreateDataArgs struct {
+	EnableEpochsHandler      common.EnableEpochsHandler
+	HeadersPool              dataRetriever.HeadersPool
+	ProofsPool               dataRetriever.ProofsPool
+	PendingMiniBlocksHandler process.PendingMiniBlocksHandler
+	BlockTracker             process.BlockTracker
+	Storage                  dataRetriever.StorageService
+	Marshaller               marshal.Marshalizer
+}
 
 // ShardInfoCreateData is a component used to create shard info from shard headers
 type ShardInfoCreateData struct {
@@ -20,38 +32,44 @@ type ShardInfoCreateData struct {
 	proofsPool               dataRetriever.ProofsPool
 	pendingMiniBlocksHandler process.PendingMiniBlocksHandler
 	blockTracker             process.BlockTracker
+	storage                  dataRetriever.StorageService
+	marshaller               marshal.Marshalizer
 }
 
 // NewShardInfoCreateData creates a new ShardInfoCreateData instance
 func NewShardInfoCreateData(
-	enableEpochsHandler common.EnableEpochsHandler,
-	headersPool dataRetriever.HeadersPool,
-	proofsPool dataRetriever.ProofsPool,
-	pendingMiniBlocksHandler process.PendingMiniBlocksHandler,
-	blockTracker process.BlockTracker,
+	args ShardInfoCreateDataArgs,
 ) (*ShardInfoCreateData, error) {
-	if check.IfNil(enableEpochsHandler) {
+	if check.IfNil(args.EnableEpochsHandler) {
 		return nil, process.ErrNilEnableEpochsHandler
 	}
-	if check.IfNil(headersPool) {
+	if check.IfNil(args.HeadersPool) {
 		return nil, process.ErrNilHeadersDataPool
 	}
-	if check.IfNil(proofsPool) {
+	if check.IfNil(args.ProofsPool) {
 		return nil, process.ErrNilProofsPool
 	}
-	if check.IfNil(pendingMiniBlocksHandler) {
+	if check.IfNil(args.PendingMiniBlocksHandler) {
 		return nil, process.ErrNilPendingMiniBlocksHandler
 	}
-	if check.IfNil(blockTracker) {
+	if check.IfNil(args.BlockTracker) {
 		return nil, process.ErrNilBlockTracker
+	}
+	if check.IfNil(args.Storage) {
+		return nil, process.ErrNilStorageService
+	}
+	if check.IfNil(args.Marshaller) {
+		return nil, process.ErrNilMarshalizer
 	}
 
 	return &ShardInfoCreateData{
-		enableEpochsHandler:      enableEpochsHandler,
-		headersPool:              headersPool,
-		proofsPool:               proofsPool,
-		pendingMiniBlocksHandler: pendingMiniBlocksHandler,
-		blockTracker:             blockTracker,
+		enableEpochsHandler:      args.EnableEpochsHandler,
+		headersPool:              args.HeadersPool,
+		proofsPool:               args.ProofsPool,
+		pendingMiniBlocksHandler: args.PendingMiniBlocksHandler,
+		blockTracker:             args.BlockTracker,
+		storage:                  args.Storage,
+		marshaller:               args.Marshaller,
 	}, nil
 }
 
@@ -180,7 +198,7 @@ func (sic *ShardInfoCreateData) createShardDataFromV3Header(
 
 	shardDataHandlers := make([]data.ShardDataHandler, len(executionResults))
 	for i, execResult := range executionResults {
-		shardData, err := sic.createShardDataFromExecutionResult(execResult)
+		shardData, err := sic.createShardDataFromExecutionResult(execResult, shardHeader.GetShardID())
 		if err != nil {
 			return nil, nil, err
 		}
@@ -206,6 +224,7 @@ func (sic *ShardInfoCreateData) createShardDataProposalFromHeader(
 
 func (sic *ShardInfoCreateData) createShardDataFromExecutionResult(
 	execResult data.BaseExecutionResultHandler,
+	shardID uint32,
 ) (data.ShardDataHandler, error) {
 	if check.IfNil(execResult) {
 		return nil, process.ErrNilExecutionResultHandler
@@ -216,8 +235,13 @@ func (sic *ShardInfoCreateData) createShardDataFromExecutionResult(
 		return nil, process.ErrWrongTypeAssertion
 	}
 
-	// TODO: search also in storage: at bootstrap the header might not be in pool
-	header, err := sic.headersPool.GetHeaderByHash(execResultHandler.GetHeaderHash())
+	header, err := process.GetHeader(
+		execResultHandler.GetHeaderHash(),
+		sic.headersPool,
+		sic.storage,
+		sic.marshaller,
+		shardID,
+	)
 	if err != nil {
 		log.Debug("createShardDataFromExecutionResult: failed to get header with hash", "hash", execResultHandler.GetHeaderHash(), "error", err)
 		return nil, err

--- a/process/block/shardblockProposal.go
+++ b/process/block/shardblockProposal.go
@@ -726,6 +726,8 @@ func (sp *shardProcessor) collectExecutionResults(headerHash []byte, header data
 		return nil, err
 	}
 
+	sp.cacheOrderedTxHashes(headerHash)
+
 	return executionResult, nil
 }
 

--- a/process/block/shardblockProposal_test.go
+++ b/process/block/shardblockProposal_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	commonMocks "github.com/multiversx/mx-chain-go/testscommon/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -3659,13 +3660,14 @@ func createSubComponentsForCollectExecutionResultsTest() (map[string]interface{}
 				return 0
 			},
 		},
-		"feeHandler":          feeHandler,
-		"gasConsumedProvider": gasConsumedProvider,
-		"marshalizer":         &mock.MarshalizerMock{},
-		"hasher":              &hashingMocks.HasherMock{},
-		"enableEpochsHandler": enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
-		"dataPool":            initDataPool(),
-		"accountsDB":          accounts,
+		"feeHandler":              feeHandler,
+		"gasConsumedProvider":     gasConsumedProvider,
+		"marshalizer":             &mock.MarshalizerMock{},
+		"hasher":                  &hashingMocks.HasherMock{},
+		"enableEpochsHandler":     enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
+		"dataPool":                initDataPool(),
+		"accountsDB":              accounts,
+		"txExecutionOrderHandler": &commonMocks.TxExecutionOrderHandlerStub{},
 	}
 
 	header, body := createHeaderAndBodyForTestingProcessBlockProposal()

--- a/process/block/shardblockProposal_test.go
+++ b/process/block/shardblockProposal_test.go
@@ -2052,6 +2052,7 @@ func TestShardBlockProposal_CreateAndVerifyProposal(t *testing.T) {
 		Headers:                 dataComponents.DataPool.Headers(),
 		StorageService:          dataComponents.StorageService(),
 		Marshaller:              coreComponents.InternalMarshalizer(),
+		ShardCoordinator:        bootstrapComponents.ShardCoordinator(),
 	})
 	execResultsVerifier, _ := blproc.NewExecutionResultsVerifier(dataComponents.BlockChain, execManager)
 
@@ -2202,6 +2203,7 @@ func TestShardBlockProposal_CreateAndVerifyProposal_WithTransactions(t *testing.
 		Headers:                 dataComponents.DataPool.Headers(),
 		StorageService:          dataComponents.StorageService(),
 		Marshaller:              coreComponents.InternalMarshalizer(),
+		ShardCoordinator:        bootstrapComponents.ShardCoordinator(),
 	})
 	execResultsVerifier, _ := blproc.NewExecutionResultsVerifier(dataComponents.BlockChain, execManager)
 

--- a/process/block/shardinfo_test.go
+++ b/process/block/shardinfo_test.go
@@ -9,11 +9,14 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 
 	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/mock"
+	"github.com/multiversx/mx-chain-go/storage"
 	dataRetrieverMock "github.com/multiversx/mx-chain-go/testscommon/dataRetriever"
 	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
 	poolMock "github.com/multiversx/mx-chain-go/testscommon/pool"
+	mockStorage "github.com/multiversx/mx-chain-go/testscommon/storage"
 
 	"github.com/stretchr/testify/require"
 )
@@ -33,27 +36,20 @@ func TestShardInfo_NewShardInfoCreateData(t *testing.T) {
 		t.Parallel()
 
 		args := createDefaultShardInfoCreateDataArgs()
-		sicd, err := NewShardInfoCreateData(
-			nil,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		args.EnableEpochsHandler = nil
+
+		sicd, err := NewShardInfoCreateData(args)
 		require.Nil(t, sicd)
 		require.Equal(t, process.ErrNilEnableEpochsHandler, err)
 	})
 
 	t.Run("nil headersPool", func(t *testing.T) {
 		t.Parallel()
+
 		args := createDefaultShardInfoCreateDataArgs()
-		sicd, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			nil,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		args.HeadersPool = nil
+
+		sicd, err := NewShardInfoCreateData(args)
 		require.Nil(t, sicd)
 		require.Equal(t, process.ErrNilHeadersDataPool, err)
 	})
@@ -62,14 +58,9 @@ func TestShardInfo_NewShardInfoCreateData(t *testing.T) {
 		t.Parallel()
 
 		args := createDefaultShardInfoCreateDataArgs()
+		args.ProofsPool = nil
 
-		sicd, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			nil,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sicd, err := NewShardInfoCreateData(args)
 		require.Nil(t, sicd)
 		require.Equal(t, process.ErrNilProofsPool, err)
 	})
@@ -78,14 +69,9 @@ func TestShardInfo_NewShardInfoCreateData(t *testing.T) {
 		t.Parallel()
 
 		args := createDefaultShardInfoCreateDataArgs()
+		args.PendingMiniBlocksHandler = nil
 
-		sicd, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			nil,
-			args.blockTracker,
-		)
+		sicd, err := NewShardInfoCreateData(args)
 		require.Nil(t, sicd)
 		require.Equal(t, process.ErrNilPendingMiniBlocksHandler, err)
 	})
@@ -94,13 +80,9 @@ func TestShardInfo_NewShardInfoCreateData(t *testing.T) {
 		t.Parallel()
 
 		args := createDefaultShardInfoCreateDataArgs()
-		sicd, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			nil,
-		)
+		args.BlockTracker = nil
+
+		sicd, err := NewShardInfoCreateData(args)
 		require.Nil(t, sicd)
 		require.Equal(t, process.ErrNilBlockTracker, err)
 	})
@@ -109,13 +91,7 @@ func TestShardInfo_NewShardInfoCreateData(t *testing.T) {
 
 		args := createDefaultShardInfoCreateDataArgs()
 
-		sicd, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sicd, err := NewShardInfoCreateData(args)
 		require.NotNil(t, sicd)
 		require.Nil(t, err)
 	})
@@ -145,14 +121,11 @@ func TestShardInfoCreateData_CreateShardInfoV3(t *testing.T) {
 
 	round := uint64(10)
 	metaHdrV3 := &block.MetaBlockV3{Round: round}
+
 	args := createDefaultShardInfoCreateDataArgs()
-	sic, err := NewShardInfoCreateData(
-		args.enableEpochsHandler,
-		pool.Headers(),
-		args.proofsPool,
-		args.pendingMiniBlocksHandler,
-		args.blockTracker,
-	)
+	args.HeadersPool = pool.Headers()
+
+	sic, err := NewShardInfoCreateData(args)
 	require.Nil(t, err)
 
 	t.Run("should fail with nil meta header", func(t *testing.T) {
@@ -194,26 +167,29 @@ func TestShardInfoCreateData_CreateShardInfoV3(t *testing.T) {
 		t.Parallel()
 
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.HeadersPool = pool.Headers()
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: headers[shardID].GetNonce()}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: headers[shardID].GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
 		}
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return true
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return true
+			},
 		}
 
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			pool.Headers(),
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		shardDataProposalHandlers, shardDataHandlers, err := sic.CreateShardInfoV3(metaHdrV3, headers, headerHashes)
 		require.Nil(t, err)
@@ -271,13 +247,7 @@ func TestShardInfoCreateData_CreateShardInfoFromLegacyMeta(t *testing.T) {
 	metaHdr := &block.MetaBlock{Round: round}
 
 	args := createDefaultShardInfoCreateDataArgs()
-	sic, err := NewShardInfoCreateData(
-		args.enableEpochsHandler,
-		args.headersPool,
-		args.proofsPool,
-		args.pendingMiniBlocksHandler,
-		args.blockTracker,
-	)
+	sic, err := NewShardInfoCreateData(args)
 	require.Nil(t, err)
 	t.Run("should fail with nil meta header", func(t *testing.T) {
 		t.Parallel()
@@ -306,25 +276,29 @@ func TestShardInfoCreateData_CreateShardInfoFromLegacyMeta(t *testing.T) {
 		t.Parallel()
 
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.HeadersPool = pool.Headers()
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return nil, nil, errExpected
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return nil, nil, errExpected
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
 		}
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return true
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return true
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			pool.Headers(),
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		shardInfo, err := sic.CreateShardInfoFromLegacyMeta(metaHdr, headers, headerHashes)
 		require.NotNil(t, err)
@@ -334,25 +308,29 @@ func TestShardInfoCreateData_CreateShardInfoFromLegacyMeta(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.HeadersPool = pool.Headers()
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: headers[shardID].GetNonce()}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: headers[shardID].GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
 		}
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return true
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return true
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			pool.Headers(),
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		shardInfo, err := sic.CreateShardInfoFromLegacyMeta(metaHdr, headers, headerHashes)
 		require.Nil(t, err)
@@ -367,13 +345,7 @@ func TestShardInfoCreateData_createShardInfoFromHeader(t *testing.T) {
 	t.Run("should fail with nil header", func(t *testing.T) {
 		t.Parallel()
 		args := createDefaultShardInfoCreateDataArgs()
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 
 		shardDataProposalHandlers, shardDataHandlers, err := sic.createShardInfoFromHeader(nil, nil)
@@ -384,13 +356,7 @@ func TestShardInfoCreateData_createShardInfoFromHeader(t *testing.T) {
 	t.Run("should fail with invalid hash", func(t *testing.T) {
 		t.Parallel()
 		args := createDefaultShardInfoCreateDataArgs()
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 
 		shardDataProposalHandlers, shardDataHandlers, err := sic.createShardInfoFromHeader(&block.Header{}, []byte{})
@@ -401,17 +367,15 @@ func TestShardInfoCreateData_createShardInfoFromHeader(t *testing.T) {
 
 	t.Run("should fail with missing shard header proof", func(t *testing.T) {
 		t.Parallel()
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return false
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return false
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 
 		shardDataProposalHandlers, shardDataHandlers, err := sic.createShardInfoFromHeader(&block.Header{Nonce: 1}, []byte("hash"))
@@ -423,25 +387,28 @@ func TestShardInfoCreateData_createShardInfoFromHeader(t *testing.T) {
 		t.Parallel()
 		header := getShardHeaderForShard(uint32(1))
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
 		}
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return true
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return true
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		expectedProposalHandler := &block.ShardDataProposal{
 			HeaderHash:           []byte("hash"),
@@ -463,25 +430,28 @@ func TestShardInfoCreateData_createShardInfoFromHeader(t *testing.T) {
 		header := getShardHeaderForShard(uint32(1))
 		_ = header.SetNonce(0)
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
 		}
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return false
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return true
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		expectedProposalHandler := &block.ShardDataProposal{
 			HeaderHash:           []byte("hash"),
@@ -501,30 +471,35 @@ func TestShardInfoCreateData_createShardInfoFromHeader(t *testing.T) {
 	t.Run("should work with V3", func(t *testing.T) {
 		t.Parallel()
 		header := getHeaderV3ForShard(uint32(1), []byte("header hash for shard 1"))
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.headersPool.GetHeaderByHashCalled = func(hash []byte) (data.HeaderHandler, error) {
-			return header, nil
+		args.HeadersPool = &poolMock.HeadersPoolStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				return header, nil
+			},
+		}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
+		}
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
+		}
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
+		}
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return true
+			},
 		}
 
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
-		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
-		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
-		}
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return true
-		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		expectedProposalHandler := &block.ShardDataProposal{
 			HeaderHash:           []byte("hash"),
@@ -543,32 +518,39 @@ func TestShardInfoCreateData_createShardInfoFromHeader(t *testing.T) {
 	})
 	t.Run("should work with V3 no proof for nonce < 1", func(t *testing.T) {
 		t.Parallel()
+
 		header := getHeaderV3ForShard(uint32(1), []byte("header hash for shard 1"))
 		expectedNonce := uint64(0)
 		_ = header.SetNonce(expectedNonce)
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.headersPool.GetHeaderByHashCalled = func(hash []byte) (data.HeaderHandler, error) {
-			return header, nil
+		args.HeadersPool = &poolMock.HeadersPoolStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				return header, nil
+			},
 		}
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
 		}
-		args.proofsPool.HasProofCalled = func(shardID uint32, headerHash []byte) bool {
-			return false
+		args.ProofsPool = &dataRetrieverMock.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return false
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		expectedProposalHandler := &block.ShardDataProposal{
 			HeaderHash:           []byte("hash"),
@@ -594,22 +576,24 @@ func TestShardInfoCreateData_createShardDataFromLegacyHeader(t *testing.T) {
 		t.Parallel()
 		header := getShardHeaderForShard(uint32(1))
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return nil, nil, fmt.Errorf("GetLastSelfNotarizedHeader error")
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return nil, nil, fmt.Errorf("GetLastSelfNotarizedHeader error")
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return false
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return false
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
+
 		require.Nil(t, err)
 		shardDataList, err := sic.createShardDataFromLegacyHeader(header, []byte("headerHash"))
 		require.Contains(t, err.Error(), "GetLastSelfNotarizedHeader error")
@@ -619,24 +603,27 @@ func TestShardInfoCreateData_createShardDataFromLegacyHeader(t *testing.T) {
 	t.Run("should work with enable epoch flag disabled", func(t *testing.T) {
 		t.Parallel()
 		header := getShardHeaderForShard(uint32(1))
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return false
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return false
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		shardDataList, err := sic.createShardDataFromLegacyHeader(header, []byte("headerHash"))
 		require.Nil(t, err)
 		require.NotNil(t, shardDataList)
@@ -646,25 +633,29 @@ func TestShardInfoCreateData_createShardDataFromLegacyHeader(t *testing.T) {
 	})
 	t.Run("should work with enable epoch flag enabled", func(t *testing.T) {
 		t.Parallel()
+
 		header := getShardHeaderForShard(uint32(1))
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: header.GetNonce()}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		args.enableEpochsHandler.IsFlagEnabledInEpochCalled = func(flag core.EnableEpochFlag, epoch uint32) bool {
-			return true
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return true
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		shardDataList, err := sic.createShardDataFromLegacyHeader(header, []byte("headerHash"))
 		require.Nil(t, err)
 		require.NotNil(t, shardDataList)
@@ -679,13 +670,7 @@ func TestShardInfoCreateData_createShardDataFromV3Header(t *testing.T) {
 	t.Run("should fail with nil header", func(t *testing.T) {
 		t.Parallel()
 		args := createDefaultShardInfoCreateDataArgs()
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		shardDataProposalHandler, shardDataHandlers, err := sic.createShardDataFromV3Header(nil, nil)
 		require.Nil(t, shardDataHandlers)
@@ -698,13 +683,7 @@ func TestShardInfoCreateData_createShardDataFromV3Header(t *testing.T) {
 			Nonce: 0,
 		}
 		args := createDefaultShardInfoCreateDataArgs()
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
 		shardDataProposalHandler, shardDataHandlers, err := sic.createShardDataFromV3Header(header, []byte("headerHash"))
 		require.Nil(t, err)
@@ -714,56 +693,71 @@ func TestShardInfoCreateData_createShardDataFromV3Header(t *testing.T) {
 	})
 	t.Run("should fail with createShardDataFromExecutionResult error", func(t *testing.T) {
 		t.Parallel()
+
 		expectedNonce := uint64(12345)
 		header := getHeaderV3ForShard(uint32(1), []byte("header hash for shard 1"))
-		args := createDefaultShardInfoCreateDataArgs()
 		// GetHeaderByHash error will fail createShardDataFromExecutionResult
-		args.headersPool.GetHeaderByHashCalled = func(hash []byte) (data.HeaderHandler, error) {
-			return nil, fmt.Errorf("GetHeaderByHash error")
+		args := createDefaultShardInfoCreateDataArgs()
+		args.HeadersPool = &poolMock.HeadersPoolStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				return nil, fmt.Errorf("GetHeaderByHash error")
+			},
+		}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
+		}
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
+			},
+		}
+		args.Storage = &mockStorage.ChainStorerStub{
+			GetStorerCalled: func(unitType dataRetriever.UnitType) (storage.Storer, error) {
+				return &mockStorage.StorerStub{
+					GetCalled: func(key []byte) ([]byte, error) {
+						return nil, fmt.Errorf("GetHeaderByHash error from storage")
+					},
+				}, nil
+			},
 		}
 
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
-		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
-		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		shardDataProposalHandler, shardDataHandlers, err := sic.createShardDataFromV3Header(header, []byte("headerHash"))
 		require.Nil(t, shardDataHandlers)
 		require.Nil(t, shardDataProposalHandler)
-		require.Equal(t, fmt.Errorf("GetHeaderByHash error"), err)
+		require.ErrorIs(t, err, process.ErrMissingHeader)
 	})
 
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
+
 		expectedNonce := uint64(12345)
 		header := getHeaderV3ForShard(uint32(1), []byte("header hash for shard 1"))
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.headersPool.GetHeaderByHashCalled = func(hash []byte) (data.HeaderHandler, error) {
-			return header, nil
+		args.HeadersPool = &poolMock.HeadersPoolStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				return header, nil
+			},
 		}
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		shardDataProposalHandler, shardDataHandlers, err := sic.createShardDataFromV3Header(header, []byte("headerHash"))
 		require.Nil(t, err)
 		require.NotNil(t, shardDataHandlers)
@@ -779,102 +773,102 @@ func TestShardInfoCreateData_createShardDataFromExecutionResult(t *testing.T) {
 
 	t.Run("should fail with nil execution result", func(t *testing.T) {
 		t.Parallel()
+
 		args := createDefaultShardInfoCreateDataArgs()
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
-		shardData, err := sic.createShardDataFromExecutionResult(nil)
+
+		shardData, err := sic.createShardDataFromExecutionResult(nil, 0)
 		require.ErrorIs(t, err, process.ErrNilExecutionResultHandler)
 		require.Nil(t, shardData)
 	})
 
 	t.Run("should fail with wrong type of execution result", func(t *testing.T) {
 		t.Parallel()
+
 		args := createDefaultShardInfoCreateDataArgs()
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
-		shardData, err := sic.createShardDataFromExecutionResult(&block.BaseExecutionResult{})
+
+		shardData, err := sic.createShardDataFromExecutionResult(&block.BaseExecutionResult{}, 0)
 		require.ErrorIs(t, err, process.ErrWrongTypeAssertion)
 		require.Nil(t, shardData)
 	})
 
-	t.Run("should fail when GetHeaderByHash errors", func(t *testing.T) {
+	t.Run("should fail when getting header from pool and storage fails", func(t *testing.T) {
 		t.Parallel()
 		args := createDefaultShardInfoCreateDataArgs()
-		args.headersPool.GetHeaderByHashCalled = func(hash []byte) (data.HeaderHandler, error) {
-			return nil, fmt.Errorf("GetHeaderByHash error")
+		args.HeadersPool = &poolMock.HeadersPoolStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				return nil, fmt.Errorf("GetHeaderByHash error")
+			},
+		}
+		args.Storage = &mockStorage.ChainStorerStub{
+			GetStorerCalled: func(unitType dataRetriever.UnitType) (storage.Storer, error) {
+				return &mockStorage.StorerStub{
+					GetCalled: func(key []byte) ([]byte, error) {
+						return nil, fmt.Errorf("GetHeaderByHash error from storage")
+					},
+				}, nil
+			},
 		}
 
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		execResult := getExecutionResultForShard(uint32(1), []byte("header hash for shard 1"))
-		shardData, err := sic.createShardDataFromExecutionResult(execResult)
-		require.Equal(t, fmt.Errorf("GetHeaderByHash error"), err)
+		shardData, err := sic.createShardDataFromExecutionResult(execResult, uint32(1))
+		require.ErrorIs(t, err, process.ErrMissingHeader)
 		require.Nil(t, shardData)
 	})
 
 	t.Run("should fail when updateShardDataWithCrossShardInfo fails", func(t *testing.T) {
 		t.Parallel()
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.headersPool.GetHeaderByHashCalled = func(hash []byte) (data.HeaderHandler, error) {
-			return getShardHeaderForShard(uint32(1)), nil
+		args.HeadersPool = &poolMock.HeadersPoolStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				return getShardHeaderForShard(uint32(1)), nil
+			},
 		}
 
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		execResult := getExecutionResultForShard(uint32(1), []byte("header hash for shard 1"))
-		shardData, err := sic.createShardDataFromExecutionResult(execResult)
+		shardData, err := sic.createShardDataFromExecutionResult(execResult, uint32(1))
 		require.Equal(t, process.ErrNotarizedHeadersSliceIsNil, err)
 		require.Nil(t, shardData)
 	})
 
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
+
 		expectedNonce := uint64(1)
 		header := getShardHeaderForShard(uint32(1))
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.headersPool.GetHeaderByHashCalled = func(hash []byte) (data.HeaderHandler, error) {
-			return header, nil
+		args.HeadersPool = &poolMock.HeadersPoolStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				return header, nil
+			},
 		}
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		execResult := getExecutionResultForShard(uint32(1), []byte("header hash for shard 1"))
-		shardData, err := sic.createShardDataFromExecutionResult(execResult)
+		shardData, err := sic.createShardDataFromExecutionResult(execResult, uint32(1))
 		require.Nil(t, err)
 		require.NotNil(t, shardData)
 		require.Equal(t, uint32(2), shardData.GetNumPendingMiniBlocks())
@@ -984,17 +978,15 @@ func TestShardInfoCreateData_updateShardDataWithCrossShardInfo(t *testing.T) {
 		shardData := &block.ShardData{}
 
 		args := createDefaultShardInfoCreateDataArgs()
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return nil, nil, fmt.Errorf("GetLastSelfNotarizedHeader error")
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return nil, nil, fmt.Errorf("GetLastSelfNotarizedHeader error")
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		err = sic.updateShardDataWithCrossShardInfo(shardData, &header)
 		require.Contains(t, err.Error(), "GetLastSelfNotarizedHeader error")
 	})
@@ -1004,23 +996,23 @@ func TestShardInfoCreateData_updateShardDataWithCrossShardInfo(t *testing.T) {
 
 		header := block.Header{ShardID: 1}
 		shardData := &block.ShardData{}
-
 		expectedNonce := uint64(12345)
+
 		args := createDefaultShardInfoCreateDataArgs()
-		args.pendingMiniBlocksHandler.GetPendingMiniBlocksCalled = func(shardID uint32) [][]byte {
-			return [][]byte{[]byte("hash1"), []byte("hash2")}
+		args.PendingMiniBlocksHandler = &mock.PendingMiniBlocksHandlerStub{
+			GetPendingMiniBlocksCalled: func(shardID uint32) [][]byte {
+				return [][]byte{[]byte("hash1"), []byte("hash2")}
+			},
 		}
-		args.blockTracker.GetLastSelfNotarizedHeaderCalled = func(shardID uint32) (data.HeaderHandler, []byte, error) {
-			return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
+		args.BlockTracker = &mock.BlockTrackerMock{
+			GetLastSelfNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+				return &block.Header{Nonce: expectedNonce}, []byte("selfNotarizedHash"), nil
+			},
 		}
-		sic, err := NewShardInfoCreateData(
-			args.enableEpochsHandler,
-			args.headersPool,
-			args.proofsPool,
-			args.pendingMiniBlocksHandler,
-			args.blockTracker,
-		)
+
+		sic, err := NewShardInfoCreateData(args)
 		require.Nil(t, err)
+
 		err = sic.updateShardDataWithCrossShardInfo(shardData, &header)
 		require.NotNil(t, shardData)
 		require.Nil(t, err)
@@ -1037,13 +1029,15 @@ type shardInfoCreateDataTestArgs struct {
 	enableEpochsHandler      *enableEpochsHandlerMock.EnableEpochsHandlerStub
 }
 
-func createDefaultShardInfoCreateDataArgs() *shardInfoCreateDataTestArgs {
-	return &shardInfoCreateDataTestArgs{
-		headersPool:              &poolMock.HeadersPoolStub{},
-		proofsPool:               &dataRetrieverMock.ProofsPoolMock{},
-		pendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
-		blockTracker:             &mock.BlockTrackerMock{},
-		enableEpochsHandler:      enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
+func createDefaultShardInfoCreateDataArgs() ShardInfoCreateDataArgs {
+	return ShardInfoCreateDataArgs{
+		EnableEpochsHandler:      &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
+		HeadersPool:              &poolMock.HeadersPoolStub{},
+		ProofsPool:               &dataRetrieverMock.ProofsPoolMock{},
+		PendingMiniBlocksHandler: &mock.PendingMiniBlocksHandlerStub{},
+		BlockTracker:             &mock.BlockTrackerMock{},
+		Storage:                  &mockStorage.ChainStorerStub{},
+		Marshaller:               &mock.MarshalizerMock{},
 	}
 }
 

--- a/process/constants.go
+++ b/process/constants.go
@@ -81,10 +81,6 @@ const MaxHeaderRequestsAllowed = 20
 // committed block nonce, after which, node is considered himself not synced
 const NonceDifferenceWhenSynced = 0
 
-// MaxSyncWithErrorsAllowed defines the maximum allowed number of sync with errors,
-// before a special action to be applied
-const MaxSyncWithErrorsAllowed = 10
-
 // MaxHeadersToRequestInAdvance defines the maximum number of headers which will be requested in advance,
 // if they are missing
 const MaxHeadersToRequestInAdvance = 20

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -40,7 +40,7 @@ var log = logger.GetOrCreate("process/sync")
 var _ closing.Closer = (*baseBootstrap)(nil)
 
 // sleepTime defines the time in milliseconds between each iteration made in syncBlocks method
-const sleepTime = 5 * time.Millisecond
+const sleepTime = 50 * time.Millisecond
 const minimumProcessWaitTime = time.Millisecond * 100
 
 // hdrInfo hold the data related to a header
@@ -730,12 +730,23 @@ func (boot *baseBootstrap) syncBlocks(ctx context.Context) {
 	}
 }
 
+func (boot *baseBootstrap) getMaxSyncWithErrorsAllowed(
+	header data.HeaderHandler,
+) uint32 {
+	round := uint64(0)
+	if !check.IfNil(header) {
+		round = header.GetRound()
+	}
+
+	return boot.processConfigsHandler.GetMaxSyncWithErrorsAllowed(round)
+}
+
 func (boot *baseBootstrap) doJobOnSyncBlockFail(bodyHandler data.BodyHandler, headerHandler data.HeaderHandler, err error) {
 	processBlockStarted := !check.IfNil(bodyHandler) && !check.IfNil(headerHandler)
 	isProcessWithError := processBlockStarted && err != process.ErrTimeIsOut
 
 	numSyncedWithErrors := boot.incrementSyncedWithErrorsForNonce(boot.getNonceForNextBlock())
-	allowedSyncWithErrorsLimitReached := numSyncedWithErrors >= process.MaxSyncWithErrorsAllowed
+	allowedSyncWithErrorsLimitReached := numSyncedWithErrors >= boot.getMaxSyncWithErrorsAllowed(headerHandler)
 	isInProperRound := process.IsInProperRound(boot.roundHandler.Index())
 	isSyncWithErrorsLimitReachedInProperRound := allowedSyncWithErrorsLimitReached && isInProperRound
 

--- a/testscommon/processConfigsHandlerStub.go
+++ b/testscommon/processConfigsHandlerStub.go
@@ -20,6 +20,7 @@ func GetDefaultProcessConfigsHandler() common.ProcessConfigsHandler {
 				MaxRoundsWithoutNewBlockReceived:   10,
 				MaxRoundsWithoutCommittedBlock:     10,
 				RoundModulusTriggerWhenSyncIsStuck: 20,
+				MaxSyncWithErrorsAllowed:           10,
 			},
 		},
 	)
@@ -35,6 +36,7 @@ type ProcessConfigsHandlerStub struct {
 	GetMaxRoundsWithoutNewBlockReceivedByRoundCalled  func(round uint64) uint32
 	GetMaxRoundsWithoutCommittedBlockCalled           func(round uint64) uint32
 	GetRoundModulusTriggerWhenSyncIsStuckCalled       func(round uint64) uint32
+	GetMaxSyncWithErrorsAllowedCalled                 func(round uint64) uint32
 }
 
 // GetMaxMetaNoncesBehindByEpoch -
@@ -86,6 +88,15 @@ func (p *ProcessConfigsHandlerStub) GetMaxRoundsWithoutCommittedBlock(round uint
 func (p *ProcessConfigsHandlerStub) GetRoundModulusTriggerWhenSyncIsStuck(round uint64) uint32 {
 	if p.GetRoundModulusTriggerWhenSyncIsStuckCalled != nil {
 		return p.GetRoundModulusTriggerWhenSyncIsStuckCalled(round)
+	}
+
+	return 0
+}
+
+// GetMaxSyncWithErrorsAllowed -
+func (p *ProcessConfigsHandlerStub) GetMaxSyncWithErrorsAllowed(round uint64) uint32 {
+	if p.GetMaxSyncWithErrorsAllowedCalled != nil {
+		return p.GetMaxSyncWithErrorsAllowedCalled(round)
 	}
 
 	return 0


### PR DESCRIPTION
## Reasoning behind the pull request
- Cached the transaction execution order
- Ourport fixes
- New indexer version
- PR from mx-chain-es-indexer-go: https://github.com/multiversx/mx-chain-es-indexer-go/pull/359 


## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
