### PR TITLE
added tail inflation enable epoch metric

### DIFF
--- a/.github/workflows/build_and_run_chain_simulator_and_execute_system_test.yml
+++ b/.github/workflows/build_and_run_chain_simulator_and_execute_system_test.yml
@@ -437,6 +437,7 @@ jobs:
             const exitCode                  = process.env.PYTEST_EXIT_CODE;
 
             const simulatorCommitHash = process.env.SIMULATOR_COMMIT_HASH || 'N/A';
+            const testingSuiteCommitHash = process.env.CURRENT_COMMIT_HASH || 'N/A';
             const r2Url            = process.env.R2_REPORT_URL || 'N/A';
 
             const issue_number = context.issue.number;
@@ -465,8 +466,9 @@ jobs:
               - **Current Branch:** \`${currentBranch}\`
               - **mx-chain-go Target Branch:** \`${goTargetBranch}\`
               - **mx-chain-simulator-go Target Branch:** \`${simulatorTargetBranch}\`
-              - **mx-chain-testing-suite Target Branch:** \`${testingSuiteTargetBranch}\`
               - **mx-chain-simulator-go Commit Hash:** \`${simulatorCommitHash}\`
+              - **mx-chain-testing-suite Target Branch:** \`${testingSuiteTargetBranch}\`
+              - **mx-chain-testing-suite Commit Hash:** \`${testingSuiteCommitHash}\`
 
               🚀 **Environment Variables:**
               - **TIMESTAMP:** \`${ts}\`

--- a/common/constants.go
+++ b/common/constants.go
@@ -801,6 +801,9 @@ const (
 	// MetricRelayedTransactionsV1V2DisableEpoch represents the epoch when relayed transactions v1 and v2 are disabled
 	MetricRelayedTransactionsV1V2DisableEpoch = "erd_relayed_transactions_v1_v2_disable_epoch"
 
+	// MetricTailInflationEnableEpoch represents the epoch when tail inflation is enabled
+	MetricTailInflationEnableEpoch = "erd_tail_inflation_enable_epoch"
+
 	// MetricEpochEnable represents the epoch when the max nodes change configuration is applied
 	MetricEpochEnable = "erd_epoch_enable"
 

--- a/node/metrics/metrics.go
+++ b/node/metrics/metrics.go
@@ -212,6 +212,7 @@ func InitConfigMetrics(
 	appStatusHandler.SetUInt64Value(common.MetricAutomaticActivationOfNodesDisableEpoch, uint64(enableEpochs.AutomaticActivationOfNodesDisableEpoch))
 	appStatusHandler.SetUInt64Value(common.MetricFixGetBalanceEnableEpoch, uint64(enableEpochs.FixGetBalanceEnableEpoch))
 	appStatusHandler.SetUInt64Value(common.MetricRelayedTransactionsV1V2DisableEpoch, uint64(enableEpochs.RelayedTransactionsV1V2DisableEpoch))
+	appStatusHandler.SetUInt64Value(common.MetricTailInflationEnableEpoch, uint64(economicsConfig.GlobalSettings.TailInflation.EnableEpoch))
 
 	for i, nodesChangeConfig := range enableEpochs.MaxNodesChangeEnableEpoch {
 		epochEnable := fmt.Sprintf("%s%d%s", common.MetricMaxNodesChangeEnableEpoch, i, common.EpochEnableSuffix)

--- a/node/metrics/metrics_test.go
+++ b/node/metrics/metrics_test.go
@@ -353,6 +353,7 @@ func TestInitConfigMetrics(t *testing.T) {
 		"erd_automatic_activation_of_nodes_disable_epoch":                      uint32(114),
 		"erd_fix_get_balance_enable_epoch":                                     uint32(115),
 		"erd_relayed_transactions_v1_v2_disable_epoch":                         uint32(116),
+		"erd_tail_inflation_enable_epoch":                                      uint32(117),
 		"erd_max_nodes_change_enable_epoch":                                    nil,
 		"erd_total_supply":                                                     "12345",
 		"erd_hysteresis":                                                       "0.100000",
@@ -366,6 +367,9 @@ func TestInitConfigMetrics(t *testing.T) {
 	economicsConfig := config.EconomicsConfig{
 		GlobalSettings: config.GlobalSettings{
 			GenesisTotalSupply: "12345",
+			TailInflation: config.TailInflationSettings{
+				EnableEpoch: 117,
+			},
 		},
 	}
 

--- a/statusHandler/statusMetricsProvider.go
+++ b/statusHandler/statusMetricsProvider.go
@@ -389,6 +389,7 @@ func (sm *statusMetrics) EnableEpochsMetrics() (map[string]interface{}, error) {
 	enableEpochsMetrics[common.MetricBarnardOpcodesEnableEpoch] = sm.uint64Metrics[common.MetricBarnardOpcodesEnableEpoch]
 	enableEpochsMetrics[common.MetricAutomaticActivationOfNodesDisableEpoch] = sm.uint64Metrics[common.MetricAutomaticActivationOfNodesDisableEpoch]
 	enableEpochsMetrics[common.MetricFixGetBalanceEnableEpoch] = sm.uint64Metrics[common.MetricFixGetBalanceEnableEpoch]
+	enableEpochsMetrics[common.MetricTailInflationEnableEpoch] = sm.uint64Metrics[common.MetricTailInflationEnableEpoch]
 
 	numNodesChangeConfig := sm.uint64Metrics[common.MetricMaxNodesChangeEnableEpoch+"_count"]
 

--- a/statusHandler/statusMetricsProvider_test.go
+++ b/statusHandler/statusMetricsProvider_test.go
@@ -416,7 +416,7 @@ func TestStatusMetrics_EnableEpochMetrics(t *testing.T) {
 	sm.SetUInt64Value(common.MetricBarnardOpcodesEnableEpoch, uint64(4))
 	sm.SetUInt64Value(common.MetricAutomaticActivationOfNodesDisableEpoch, uint64(4))
 	sm.SetUInt64Value(common.MetricFixGetBalanceEnableEpoch, uint64(4))
-
+	sm.SetUInt64Value(common.MetricTailInflationEnableEpoch, uint64(4))
 	maxNodesChangeConfig := []map[string]uint64{
 		{
 			"EpochEnable":            0,
@@ -556,6 +556,7 @@ func TestStatusMetrics_EnableEpochMetrics(t *testing.T) {
 		common.MetricBarnardOpcodesEnableEpoch:                                uint64(4),
 		common.MetricAutomaticActivationOfNodesDisableEpoch:                   uint64(4),
 		common.MetricFixGetBalanceEnableEpoch:                                 uint64(4),
+		common.MetricTailInflationEnableEpoch:                                 uint64(4),
 		common.MetricMaxNodesChangeEnableEpoch: []map[string]interface{}{
 			{
 				common.MetricEpochEnable:            uint64(0),


### PR DESCRIPTION
## Reasoning behind the pull request
- for stakingV5 testing the tail inflation enable epoch has to be queried
  
## Proposed changes
- added the tail inflation enable epoch on the network/enable-epochs endpoint

## Testing procedure
- run an internal testnet and query the network/enable-epochs and search for erd_tail_inflation_enable_epoch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
