### PR TITLE
Fixed Epoch Start Round Leap 

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -45,9 +45,9 @@
 
     # ChainParametersByEpoch defines chain operation configurable values that can be modified based on epochs
     ChainParametersByEpoch = [
-        { EnableEpoch = 0, RoundDuration = 6000, RoundsPerEpoch = 200, MinRoundsBetweenEpochs = 20, ShardConsensusGroupSize = 7, ShardMinNumNodes = 10, MetachainConsensusGroupSize = 10, MetachainMinNumNodes = 10, Hysteresis = 0.2, Adaptivity = false },
-        { EnableEpoch = 1, RoundDuration = 6000, RoundsPerEpoch = 200, MinRoundsBetweenEpochs = 20, ShardConsensusGroupSize = 10, ShardMinNumNodes = 10, MetachainConsensusGroupSize = 10, MetachainMinNumNodes = 10, Hysteresis = 0.2, Adaptivity = false },
-        { EnableEpoch = 2, RoundDuration = 600, RoundsPerEpoch = 2000, MinRoundsBetweenEpochs = 50, ShardConsensusGroupSize = 10, ShardMinNumNodes = 10, MetachainConsensusGroupSize = 10, MetachainMinNumNodes = 10, Hysteresis = 0.2, Adaptivity = false }
+        { EnableEpoch = 0, RoundDuration = 6000, RoundsPerEpoch = 200, MinRoundsBetweenEpochs = 20, ShardConsensusGroupSize = 7, ShardMinNumNodes = 10, MetachainConsensusGroupSize = 10, MetachainMinNumNodes = 10, Hysteresis = 0.2, Adaptivity = false, Offset = 0 },
+        { EnableEpoch = 1, RoundDuration = 6000, RoundsPerEpoch = 200, MinRoundsBetweenEpochs = 20, ShardConsensusGroupSize = 10, ShardMinNumNodes = 10, MetachainConsensusGroupSize = 10, MetachainMinNumNodes = 10, Hysteresis = 0.2, Adaptivity = false, Offset = 0 },
+        { EnableEpoch = 2, RoundDuration = 600, RoundsPerEpoch = 2000, MinRoundsBetweenEpochs = 50, ShardConsensusGroupSize = 10, ShardMinNumNodes = 10, MetachainConsensusGroupSize = 10, MetachainMinNumNodes = 10, Hysteresis = 0.2, Adaptivity = false, Offset = 2 }
     ]
 
     # EpochChangeGracePeriodEnableEpoch represents the configuration of different grace periods for epoch change with their activation epochs

--- a/config/config.go
+++ b/config/config.go
@@ -803,6 +803,7 @@ type ChainParametersByEpochConfig struct {
 	MetachainConsensusGroupSize uint32
 	MetachainMinNumNodes        uint32
 	Adaptivity                  bool
+	Offset                      uint16
 }
 
 // IndexBroadcastDelay holds a pair of starting consensus index and the delay the nodes should wait before broadcasting final info

--- a/config/tomlConfig_test.go
+++ b/config/tomlConfig_test.go
@@ -59,6 +59,7 @@ func TestTomlParser(t *testing.T) {
 					MetachainConsensusGroupSize: 5,
 					Hysteresis:                  0.0,
 					Adaptivity:                  false,
+					Offset:                      2,
 				},
 			},
 		},
@@ -178,7 +179,7 @@ func TestTomlParser(t *testing.T) {
 	testString := `
 [GeneralSettings]
 	ChainParametersByEpoch = [
-        { EnableEpoch = 0, RoundDuration = 4000, ShardConsensusGroupSize = 3, ShardMinNumNodes = 4, MetachainConsensusGroupSize = 5, MetachainMinNumNodes = 6, Hysteresis = 0.0, Adaptivity = false }
+        { EnableEpoch = 0, RoundDuration = 4000, ShardConsensusGroupSize = 3, ShardMinNumNodes = 4, MetachainConsensusGroupSize = 5, MetachainMinNumNodes = 6, Hysteresis = 0.0, Adaptivity = false, Offset = 2 }
     ]
 [MiniBlocksStorage]
     [MiniBlocksStorage.Cache]

--- a/epochStart/metachain/trigger.go
+++ b/epochStart/metachain/trigger.go
@@ -203,6 +203,16 @@ func (t *trigger) getRoundsPerEpoch(epoch uint32) uint64 {
 	return uint64(chainParametersForEpoch.RoundsPerEpoch)
 }
 
+func (t *trigger) getOffsetPerEpoch(epoch uint32) uint64 {
+	chainParametersForEpoch, err := t.chainParametersHandler.ChainParametersForEpoch(epoch)
+	if err != nil {
+		log.Warn("could not get rounds per epoch for epoch, returned current chain parameters", "epoch", epoch, "error", err)
+		chainParametersForEpoch = t.chainParametersHandler.CurrentChainParameters()
+	}
+
+	return uint64(chainParametersForEpoch.Offset)
+}
+
 func (t *trigger) getMinRoundsBetweenEpochs(epoch uint32) uint64 {
 	chainParametersForEpoch, err := t.chainParametersHandler.ChainParametersForEpoch(epoch)
 	if err != nil {
@@ -235,7 +245,7 @@ func (t *trigger) SetEpochChangeProposed(value bool) {
 
 func (t *trigger) shouldTriggerEpochStart(currentRound uint64, currentNonce uint64) bool {
 	isZeroEpochEdgeCase := currentNonce < minimumNonceToStartEpoch
-	isNormalEpochStart := currentRound > t.currEpochStartRound+t.getRoundsPerEpoch(t.epoch)
+	isNormalEpochStart := currentRound > t.currEpochStartRound+t.getRoundsPerEpoch(t.epoch)-t.getOffsetPerEpoch(t.epoch)
 	isWithEarlyEndOfEpoch := currentRound >= t.nextEpochStartRound
 	shouldTriggerEpochStart := (isNormalEpochStart || isWithEarlyEndOfEpoch) && !isZeroEpochEdgeCase
 

--- a/epochStart/metachain/trigger.go
+++ b/epochStart/metachain/trigger.go
@@ -176,7 +176,7 @@ func (t *trigger) ForceEpochStart(round uint64) {
 	defer t.mutTrigger.Unlock()
 
 	t.nextEpochStartRound = round
-	if t.nextEpochStartRound > t.currEpochStartRound+t.getRoundsPerEpoch(t.epoch) {
+	if t.nextEpochStartRound > t.currEpochStartRound+t.getRoundsPerEpoch(t.epoch)-t.getOffsetPerEpoch(t.epoch) {
 		t.nextEpochStartRound = disabledRoundForForceEpochStart
 		log.Debug("can not force epoch start because the resulting round is in the next epoch")
 

--- a/epochStart/metachain/trigger_test.go
+++ b/epochStart/metachain/trigger_test.go
@@ -310,6 +310,34 @@ func TestTrigger_ForceEpochStartShouldOk(t *testing.T) {
 	assert.True(t, isEpochStart)
 }
 
+func TestTrigger_ForceEpochStartShouldWorkForSupernovaEpoch(t *testing.T) {
+	t.Parallel()
+
+	epoch := uint32(2)
+	roundsPerEpoch := 200
+	arguments := createMockEpochStartTriggerArguments()
+	arguments.ChainParametersHandler = &chainParameters.ChainParametersHandlerStub{
+		ChainParametersForEpochCalled: func(epoch uint32) (config.ChainParametersByEpochConfig, error) {
+			return config.ChainParametersByEpochConfig{
+				MinRoundsBetweenEpochs: 20,
+				RoundsPerEpoch:         int64(roundsPerEpoch),
+				Offset:                 2,
+			}, nil
+		},
+	}
+
+	arguments.Epoch = epoch
+	arguments.EpochStartRound = 100
+	epochStartTrigger, err := NewEpochStartTrigger(arguments)
+	require.Nil(t, err)
+
+	epochStartTrigger.ForceEpochStart(298)
+	assert.Equal(t, uint64(298), epochStartTrigger.nextEpochStartRound)
+
+	epochStartTrigger.ForceEpochStart(299)
+	assert.Equal(t, uint64(disabledRoundForForceEpochStart), epochStartTrigger.nextEpochStartRound)
+}
+
 func TestTrigger_LastCommitedMetaEpochStartBlock(t *testing.T) {
 	t.Parallel()
 

--- a/epochStart/metachain/trigger_test.go
+++ b/epochStart/metachain/trigger_test.go
@@ -164,22 +164,54 @@ func TestNewEpochStartTrigger_ShouldProposeEpochChange(t *testing.T) {
 	t.Parallel()
 
 	arguments := createMockEpochStartTriggerArguments()
+	arguments.ChainParametersHandler = &chainParameters.ChainParametersHandlerStub{
+		CurrentChainParametersCalled: func() config.ChainParametersByEpochConfig {
+			return config.ChainParametersByEpochConfig{
+				RoundsPerEpoch:         200,
+				MinRoundsBetweenEpochs: 1,
+				Offset:                 2,
+			}
+		},
+		ChainParametersForEpochCalled: func(epoch uint32) (config.ChainParametersByEpochConfig, error) {
+			if epoch == 1 {
+				return config.ChainParametersByEpochConfig{
+					RoundsPerEpoch: 200,
+					Offset:         0,
+				}, nil
+			}
+			if epoch == 2 {
+				return config.ChainParametersByEpochConfig{
+					RoundsPerEpoch: 200,
+					Offset:         2,
+				}, nil
+			}
+			return config.ChainParametersByEpochConfig{}, errExpected
+		},
+	}
+
+	arguments.EpochStartRound = 100
+	arguments.Epoch = 1
 
 	epochStartTrigger, err := NewEpochStartTrigger(arguments)
 	require.NotNil(t, epochStartTrigger)
 	require.Nil(t, err)
 
-	epoch := uint32(0)
-	round := uint64(2)
 	nonce := uint64(100)
 
+	round := uint64(300)
 	shouldProposeEpochChange := epochStartTrigger.ShouldProposeEpochChange(round, nonce)
-	require.True(t, shouldProposeEpochChange)
+	require.False(t, shouldProposeEpochChange)
 
-	currentEpoch := epochStartTrigger.epoch
+	round = uint64(301)
 	shouldProposeEpochChange = epochStartTrigger.ShouldProposeEpochChange(round, nonce)
 	require.True(t, shouldProposeEpochChange)
-	require.Equal(t, epoch, currentEpoch)
+
+	epochStartTrigger.epoch = 2
+	epochStartTrigger.currEpochStartRound = 301
+
+	round = 500
+	shouldProposeEpochChange = epochStartTrigger.ShouldProposeEpochChange(round, nonce)
+	require.True(t, shouldProposeEpochChange)
 	require.False(t, epochStartTrigger.IsEpochStart())
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request


At the moment, there is **a leap round on each epoch.** To avoid this for supernova epoch, we added an **Offset** in the **ChainParametersByEpoch** config. For Supernova epoch this Offset is 2 (we also have the propose of epoch change), for the others is 0. In this way, for the rest of epochs this remains the same, while for Supernova there will be no leap round.
  
## Proposed changes
## Testing procedure
## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
