### PR TITLE
Fixes blocks queue

### DIFF
--- a/integrationTests/chainSimulator/mempool/mempool_test.go
+++ b/integrationTests/chainSimulator/mempool/mempool_test.go
@@ -600,8 +600,8 @@ func Test_Selection_ShouldNotSelectSameTransactionsWithSameSender(t *testing.T) 
 	require.Nil(t, err)
 
 	// do the second selection. should not return same txs
-	// the currentNonce should represent here the nonce of the block on which the selection is built
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 1)
+	// the currentNonce should represent here the nonce of the block for which the selection is built
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
 	require.Nil(t, err)
 	require.Equal(t, 2, len(selectedTransactions))
 	require.Equal(t, "txHash2", string(selectedTransactions[0].TxHash))
@@ -744,8 +744,8 @@ func Test_Selection_ShouldNotSelectSameTransactionsWithDifferentSenders(t *testi
 	require.Nil(t, err)
 
 	// do the second selection. should not return same txs
-	// the currentNonce should represent here the nonce of the block on which the selection is built
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 1)
+	// the currentNonce should represent here the nonce of the block for which the selection is built
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
 	require.Nil(t, err)
 	require.Equal(t, 2, len(selectedTransactions))
 	require.Equal(t, "txHash2", string(selectedTransactions[0].TxHash))
@@ -825,8 +825,8 @@ func Test_Selection_ShouldNotSelectSameTransactionsWithManyTransactions(t *testi
 	require.Nil(t, err)
 
 	// do the second selection (the rest of the transactions should be selected)
-	// the currentNonce should represent here the nonce of the block on which the selection is built
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 1)
+	// the currentNonce should represent here the nonce of the block for which the selection is built
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
 	require.Nil(t, err)
 	require.Equal(t, numTxsPerSender, len(selectedTransactions))
 
@@ -844,8 +844,8 @@ func Test_Selection_ShouldNotSelectSameTransactionsWithManyTransactions(t *testi
 	require.Nil(t, err)
 
 	// do the last selection (no tx should be returned)
-	// the currentNonce should represent here the nonce of the block on which the selection is built
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
+	// the currentNonce should represent here the nonce of the block for which the selection is built
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 3)
 	require.Nil(t, err)
 	require.Equal(t, 0, len(selectedTransactions))
 }
@@ -946,8 +946,8 @@ func Test_Selection_ProposeEmptyBlocks(t *testing.T) {
 	require.Nil(t, err)
 
 	// do the second selection (the rest of the transactions should be selected)
-	// the currentNonce should represent here the nonce of the block on which the selection is built
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 3)
+	// the currentNonce should represent here the nonce of the block for which the selection is built
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 4)
 	require.Nil(t, err)
 	require.Equal(t, numTxsPerSender, len(selectedTransactions))
 
@@ -965,8 +965,8 @@ func Test_Selection_ProposeEmptyBlocks(t *testing.T) {
 	require.Nil(t, err)
 
 	// do the last selection (no tx should be returned)
-	// the currentNonce should represent here the nonce of the block on which the selection is built
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 4)
+	// the currentNonce should represent here the nonce of the block for which the selection is built
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 5)
 	require.Nil(t, err)
 	require.Equal(t, 0, len(selectedTransactions))
 }
@@ -1057,8 +1057,8 @@ func Test_Selection_ProposeBlocksWithSameNonceToTriggerForkScenarios(t *testing.
 		require.Nil(t, err)
 
 		// because the first one was replaced, the same transactions should be selected again
-		// the currentNonce should represent here the nonce of the block on which the selection is built
-		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 1)
+		// the currentNonce should represent here the nonce of the block for which the selection is built
+		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
 		require.Nil(t, err)
 		require.Equal(t, numTxsPerSender, len(selectedTransactions))
 
@@ -1075,8 +1075,8 @@ func Test_Selection_ProposeBlocksWithSameNonceToTriggerForkScenarios(t *testing.
 		require.Nil(t, err)
 
 		// do the second selection (the rest of the transactions should be selected)
-		// the currentNonce should represent here the nonce of the block on which the selection is built
-		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
+		// the currentNonce should represent here the nonce of the block for which the selection is built
+		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 3)
 		require.Nil(t, err)
 		require.Equal(t, numTxsPerSender, len(selectedTransactions))
 
@@ -1094,8 +1094,8 @@ func Test_Selection_ProposeBlocksWithSameNonceToTriggerForkScenarios(t *testing.
 		require.Nil(t, err)
 
 		// do the last selection (no tx should be returned)
-		// the currentNonce should represent here the nonce of the block on which the selection is built
-		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 3)
+		// the currentNonce should represent here the nonce of the block for which the selection is built
+		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 4)
 		require.Nil(t, err)
 		require.Equal(t, 0, len(selectedTransactions))
 	})
@@ -1175,8 +1175,8 @@ func Test_Selection_ProposeBlocksWithSameNonceToTriggerForkScenarios(t *testing.
 		require.Nil(t, err)
 
 		// do the second selection
-		// the currentNonce should represent here the nonce of the block on which the selection is built
-		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 1)
+		// the currentNonce should represent here the nonce of the block for which the selection is built
+		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
 		require.Nil(t, err)
 		require.Equal(t, numTxsPerSender, len(selectedTransactions))
 
@@ -1193,8 +1193,8 @@ func Test_Selection_ProposeBlocksWithSameNonceToTriggerForkScenarios(t *testing.
 		require.Nil(t, err)
 
 		// do the third selection (the rest of the transactions should be selected)
-		// the currentNonce should represent here the nonce of the block on which the selection is built
-		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
+		// the currentNonce should represent here the nonce of the block for which the selection is built
+		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 3)
 		require.Nil(t, err)
 		require.Equal(t, numTxsPerSender, len(selectedTransactions))
 
@@ -1212,8 +1212,8 @@ func Test_Selection_ProposeBlocksWithSameNonceToTriggerForkScenarios(t *testing.
 		require.Nil(t, err)
 
 		// do the last selection (no tx should be returned)
-		// the currentNonce should represent here the nonce of the block on which the selection is built
-		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 3)
+		// the currentNonce should represent here the nonce of the block for which the selection is built
+		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 4)
 		require.Nil(t, err)
 		require.Equal(t, 0, len(selectedTransactions))
 
@@ -1229,8 +1229,8 @@ func Test_Selection_ProposeBlocksWithSameNonceToTriggerForkScenarios(t *testing.
 		require.Nil(t, err)
 
 		// because the block with nonce 2 was replaced, we expect to still have two non-empty selections
-		// the currentNonce should represent here the nonce of the block on which the selection is built
-		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
+		// the currentNonce should represent here the nonce of the block for which the selection is built
+		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 3)
 		require.Nil(t, err)
 		require.Equal(t, numTxsPerSender, len(selectedTransactions))
 
@@ -1248,8 +1248,8 @@ func Test_Selection_ProposeBlocksWithSameNonceToTriggerForkScenarios(t *testing.
 		require.Nil(t, err)
 
 		// expect one more non-empty selection
-		// the currentNonce should represent here the nonce of the block on which the selection is built
-		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 3)
+		// the currentNonce should represent here the nonce of the block for which the selection is built
+		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 4)
 		require.Nil(t, err)
 		require.Equal(t, numTxsPerSender, len(selectedTransactions))
 
@@ -1267,8 +1267,8 @@ func Test_Selection_ProposeBlocksWithSameNonceToTriggerForkScenarios(t *testing.
 		require.Nil(t, err)
 
 		// no txs should be returned for the last selection
-		// the currentNonce should represent here the nonce of the block on which the selection is built
-		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 4)
+		// the currentNonce should represent here the nonce of the block for which the selection is built
+		selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 5)
 		require.Nil(t, err)
 		require.Equal(t, 0, len(selectedTransactions))
 	})
@@ -1346,8 +1346,8 @@ func Test_Selection_ShouldNotSelectSameTransactionsWithManyTransactionsAndExecut
 	require.Nil(t, err)
 
 	// do the second selection (the rest of the transactions should be selected)
-	// the currentNonce should represent here the nonce of the block on which the selection is built
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 1)
+	// the currentNonce should represent here the nonce of the block for which the selection is built
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
 	require.Nil(t, err)
 	require.Equal(t, 30_000, len(selectedTransactions))
 
@@ -1385,9 +1385,9 @@ func Test_Selection_ShouldNotSelectSameTransactionsWithManyTransactionsAndExecut
 	)
 	require.Nil(t, err)
 
-	// the currentNonce should represent here the nonce of the block on which the selection is built
+	// the currentNonce should represent here the nonce of the block for which the selection is built
 	// no transactions should be returned
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 3)
 	require.Nil(t, err)
 	require.Equal(t, 0, len(selectedTransactions))
 
@@ -1488,8 +1488,8 @@ func Test_Selection_ProposeEmptyBlocksAndExecutedBlockNotification(t *testing.T)
 	require.Nil(t, err)
 
 	// do the second selection (the rest of the transactions should be selected)
-	// the currentNonce should represent here the nonce of the block on which the selection is built
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 3)
+	// the currentNonce should represent here the nonce of the block for which the selection is built
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 4)
 	require.Nil(t, err)
 	require.Equal(t, 30_000, len(selectedTransactions))
 
@@ -1542,9 +1542,9 @@ func Test_Selection_ProposeEmptyBlocksAndExecutedBlockNotification(t *testing.T)
 		return []byte("rootHash1"), nil
 	}
 
-	// the currentNonce should represent here the nonce of the block on which the selection is built
+	// the currentNonce should represent here the nonce of the block for which the selection is built
 	// no transactions should be returned
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 4)
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 5)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(selectedTransactions))
 
@@ -1648,8 +1648,7 @@ func Test_Selection_WithRemovingProposedBlocks(t *testing.T) {
 
 	// now, suppose we want to re-select again for the block with nonce 2
 	// this means we do not want to use the second proposed block
-	// to do this, we have to call the SelectTransactions with other nonce - 1.
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 1)
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
 	require.Nil(t, err)
 	require.Equal(t, numTxsPerSender, len(selectedTransactions))
 
@@ -1666,7 +1665,7 @@ func Test_Selection_WithRemovingProposedBlocks(t *testing.T) {
 	require.Nil(t, err)
 
 	// now, we should have one more non-empty selection
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 3)
 	require.Nil(t, err)
 	require.Equal(t, numTxsPerSender, len(selectedTransactions))
 
@@ -1683,7 +1682,7 @@ func Test_Selection_WithRemovingProposedBlocks(t *testing.T) {
 	require.Nil(t, err)
 
 	// now, do the last selection and expect an empty one
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 3)
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 4)
 	require.Nil(t, err)
 	require.Equal(t, 0, len(selectedTransactions))
 }
@@ -1890,8 +1889,8 @@ func Test_Selection_MaxTrackedBlocksReached(t *testing.T) {
 	require.Nil(t, err)
 
 	// do the second selection (the rest of the transactions should be selected)
-	// the currentNonce should represent here the nonce of the block on which the selection is built
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 1)
+	// the currentNonce should represent here the nonce of the block for which the selection is built
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
 	require.Nil(t, err)
 	require.Equal(t, numTxsPerSender, len(selectedTransactions))
 
@@ -1909,8 +1908,8 @@ func Test_Selection_MaxTrackedBlocksReached(t *testing.T) {
 	require.Nil(t, err)
 
 	// do the last selection (no tx should be returned)
-	// the currentNonce should represent here the nonce of the block on which the selection is built
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
+	// the currentNonce should represent here the nonce of the block for which the selection is built
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 3)
 	require.Nil(t, err)
 	require.Equal(t, 0, len(selectedTransactions))
 
@@ -2103,8 +2102,8 @@ func Test_SelectionWhenFeeExceedsBalanceWithMax3TxsSelected(t *testing.T) {
 	require.Equal(t, txpool.CountTx(), uint64(4))
 
 	// do the first selection: first 3 transactions should be returned
-	// the currentNonce should represent here the nonce of the block on which the selection is built
-	selectedTransactions, _, err := txpool.SelectTransactions(selectionSession, options, 0)
+	// the currentNonce should represent here the nonce of the block for which the selection is built
+	selectedTransactions, _, err := txpool.SelectTransactions(selectionSession, options, 1)
 	require.Nil(t, err)
 	require.Equal(t, 3, len(selectedTransactions))
 	require.Equal(t, "relayer", string(selectedTransactions[0].Tx.GetSndAddr()))
@@ -2125,8 +2124,8 @@ func Test_SelectionWhenFeeExceedsBalanceWithMax3TxsSelected(t *testing.T) {
 	require.Nil(t, err)
 
 	// do the second selection, last tx should not be returned (relayer has insufficient balance)
-	// the currentNonce should represent here the nonce of the block on which the selection is built
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 1)
+	// the currentNonce should represent here the nonce of the block for which the selection is built
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
 	require.Nil(t, err)
 	require.Equal(t, 0, len(selectedTransactions))
 }
@@ -2261,8 +2260,8 @@ func Test_SelectionWhenFeeExceedsBalanceWithMax2TxsSelected(t *testing.T) {
 	require.Equal(t, txpool.CountTx(), uint64(4))
 
 	// do the first selection: first 3 transactions should be returned
-	// the currentNonce should represent here the nonce of the block on which the selection is built
-	selectedTransactions, _, err := txpool.SelectTransactions(selectionSession, options, 0)
+	// the currentNonce should represent here the nonce of the block for which the selection is built
+	selectedTransactions, _, err := txpool.SelectTransactions(selectionSession, options, 1)
 	require.Nil(t, err)
 	require.Equal(t, 2, len(selectedTransactions))
 	require.Equal(t, "relayer", string(selectedTransactions[0].Tx.GetSndAddr()))
@@ -2282,8 +2281,8 @@ func Test_SelectionWhenFeeExceedsBalanceWithMax2TxsSelected(t *testing.T) {
 	require.Nil(t, err)
 
 	// do the second selection, last tx should not be returned (relayer has insufficient balance)
-	// the currentNonce should represent here the nonce of the block on which the selection is built
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 1)
+	// the currentNonce should represent here the nonce of the block for which the selection is built
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
 	require.Nil(t, err)
 	require.Equal(t, 1, len(selectedTransactions))
 	require.Equal(t, "bob", string(selectedTransactions[0].Tx.GetSndAddr()))
@@ -2460,7 +2459,7 @@ func Test_SelectionWithAliceRelayerAndSenderOnSameTxs(t *testing.T) {
 	)
 
 	// do the first selection
-	selectedTransactions, _, err := txpool.SelectTransactions(selectionSession, options, 0)
+	selectedTransactions, _, err := txpool.SelectTransactions(selectionSession, options, 1)
 	require.Nil(t, err)
 	require.Len(t, selectedTransactions, 1)
 	require.Equal(t, selectedTransactions[0].TxHash, []byte("txHash1"))
@@ -2479,7 +2478,7 @@ func Test_SelectionWithAliceRelayerAndSenderOnSameTxs(t *testing.T) {
 	require.Nil(t, err)
 
 	// the second tx should not be selected, because alice has insufficient funds
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 1)
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
 	require.Nil(t, err)
 	require.Len(t, selectedTransactions, 0)
 }
@@ -2574,7 +2573,7 @@ func Test_SelectionWithAliceSenderAndThenRelayerOnDifferentTxs(t *testing.T) {
 
 	// do the first selection
 	// only one should be selected
-	selectedTransactions, _, err := txpool.SelectTransactions(selectionSession, options, 0)
+	selectedTransactions, _, err := txpool.SelectTransactions(selectionSession, options, 1)
 	require.Nil(t, err)
 	require.Len(t, selectedTransactions, 1)
 	require.Equal(t, selectedTransactions[0].TxHash, []byte("txHash1"))
@@ -2593,7 +2592,7 @@ func Test_SelectionWithAliceSenderAndThenRelayerOnDifferentTxs(t *testing.T) {
 	require.Nil(t, err)
 
 	// the second tx should not be selected, because alice has insufficient funds
-	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 1)
+	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
 	require.Nil(t, err)
 	require.Len(t, selectedTransactions, 0)
 }

--- a/process/asyncExecution/queue/blocksQueue.go
+++ b/process/asyncExecution/queue/blocksQueue.go
@@ -138,7 +138,7 @@ func (bq *blocksQueue) add(pair HeaderBodyPair) error {
 // If the queue is empty, the method blocks until a new item is available.
 func (bq *blocksQueue) Pop() (HeaderBodyPair, bool) {
 	bq.mutex.Lock()
-	if len(bq.headerBodyPairs) > 0 {
+	if len(bq.headerBodyPairs) > 1 {
 		item := bq.headerBodyPairs[0]
 		bq.headerBodyPairs = bq.headerBodyPairs[1:]
 		bq.mutex.Unlock()

--- a/process/asyncExecution/queue/blocksQueue_test.go
+++ b/process/asyncExecution/queue/blocksQueue_test.go
@@ -535,3 +535,35 @@ func TestBlocksQueue_RemoveAtNonceAndHigher(t *testing.T) {
 		hq.RemoveAtNonceAndHigher(10) // coverage only, should early exit
 	})
 }
+
+func TestBlocksQueue_AddAndPop(t *testing.T) {
+	t.Parallel()
+
+	hq := NewBlocksQueue()
+
+	pair := HeaderBodyPair{
+		Header: &block.Header{Nonce: 0, Round: 1},
+		Body:   &block.Body{},
+	}
+
+	err := hq.AddOrReplace(pair)
+	require.NoError(t, err)
+
+	_, ok := hq.Pop()
+	require.True(t, ok)
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		_, okP := hq.Pop()
+		require.True(t, okP)
+	}()
+
+	select {
+	case <-done:
+		t.Fatalf("expected hq.Pop() to block, but it returned")
+	case <-time.After(1 * time.Second):
+		t.Log("expected hq.Pop() to block, success")
+	}
+}

--- a/txcache/selectionTracker.go
+++ b/txcache/selectionTracker.go
@@ -414,7 +414,7 @@ func (st *selectionTracker) deriveVirtualSelectionSession(
 	defer st.mutTracker.Unlock()
 
 	if !shouldRemoveTrackedBlocks {
-		err := st.removeBlocksAboveNonceNoLock(nonce)
+		err := st.removeBlocksAboveOrEqualToNonceNoLock(nonce)
 		if err != nil {
 			return nil, err
 		}
@@ -449,9 +449,9 @@ func (st *selectionTracker) deriveVirtualSelectionSession(
 	return computer.createVirtualSelectionSession(globalAccountsBreadcrumbs)
 }
 
-// removeBlocksAboveNonceNoLock removes blocks with nonce higher or equal than the given nonce.
-// The removeBlocksAboveNonceNoLock is used on the deriveVirtualSelectionSession flow.
-func (st *selectionTracker) removeBlocksAboveNonceNoLock(nonce uint64) error {
+// removeBlocksAboveOrEqualToNonceNoLock removes blocks with nonce higher or equal than the given nonce.
+// The removeBlocksAboveOrEqualToNonceNoLock is used on the deriveVirtualSelectionSession flow.
+func (st *selectionTracker) removeBlocksAboveOrEqualToNonceNoLock(nonce uint64) error {
 	for blockHash, tb := range st.blocks {
 		if tb.hasSameNonceOrHigherThanGivenNonce(nonce) {
 			// first delete, then update the global breadcrumbs
@@ -462,7 +462,7 @@ func (st *selectionTracker) removeBlocksAboveNonceNoLock(nonce uint64) error {
 				return err
 			}
 
-			log.Trace("selectionTracker.removeBlocksAboveNonceNoLock",
+			log.Trace("selectionTracker.removeBlocksAboveOrEqualToNonceNoLock",
 				"nonce", nonce,
 				"nonce of deleted block", tb.nonce,
 				"hash of deleted block", blockHash,

--- a/txcache/selectionTracker.go
+++ b/txcache/selectionTracker.go
@@ -403,7 +403,8 @@ func (st *selectionTracker) ResetTrackedBlocks() {
 }
 
 // deriveVirtualSelectionSession creates a virtual selection session by transforming the global accounts breadcrumbs into virtual records
-// The deriveVirtualSelectionSession methods needs a SelectionSession and the nonce of the block on which the selection is built.
+// The deriveVirtualSelectionSession methods needs a SelectionSession and the nonce of the block for which the selection is built.
+// Before the actual selection, all tracked blocks with greater or equal nonce are removed from the tracker.
 func (st *selectionTracker) deriveVirtualSelectionSession(
 	session SelectionSession,
 	nonce uint64,
@@ -448,11 +449,11 @@ func (st *selectionTracker) deriveVirtualSelectionSession(
 	return computer.createVirtualSelectionSession(globalAccountsBreadcrumbs)
 }
 
-// removeBlocksAboveNonceNoLock removes blocks with nonce higher than the given nonce.
+// removeBlocksAboveNonceNoLock removes blocks with nonce higher or equal than the given nonce.
 // The removeBlocksAboveNonceNoLock is used on the deriveVirtualSelectionSession flow.
 func (st *selectionTracker) removeBlocksAboveNonceNoLock(nonce uint64) error {
 	for blockHash, tb := range st.blocks {
-		if tb.hasHigherNonce(nonce) {
+		if tb.hasSameNonceOrHigherThanGivenNonce(nonce) {
 			// first delete, then update the global breadcrumbs
 			delete(st.blocks, blockHash)
 

--- a/txcache/selectionTracker_test.go
+++ b/txcache/selectionTracker_test.go
@@ -1602,5 +1602,5 @@ func TestSelectionTracker_removeBlocksAboveNonce(t *testing.T) {
 	err = tracker.removeBlocksAboveNonceNoLock(1)
 	require.Nil(t, err)
 
-	require.Equal(t, 1, len(txCache.tracker.blocks))
+	require.Equal(t, 0, len(txCache.tracker.blocks))
 }

--- a/txcache/selectionTracker_test.go
+++ b/txcache/selectionTracker_test.go
@@ -1599,7 +1599,7 @@ func TestSelectionTracker_removeBlocksAboveNonce(t *testing.T) {
 	}
 
 	require.Equal(t, 3, len(txCache.tracker.blocks))
-	err = tracker.removeBlocksAboveNonceNoLock(1)
+	err = tracker.removeBlocksAboveOrEqualToNonceNoLock(1)
 	require.Nil(t, err)
 
 	require.Equal(t, 0, len(txCache.tracker.blocks))

--- a/txcache/trackedBlock.go
+++ b/txcache/trackedBlock.go
@@ -34,8 +34,8 @@ func (tb *trackedBlock) hasSameNonceOrHigher(otherBlock *trackedBlock) bool {
 	return tb.nonce >= otherBlock.nonce
 }
 
-func (tb *trackedBlock) hasHigherNonce(nonce uint64) bool {
-	return tb.nonce > nonce
+func (tb *trackedBlock) hasSameNonceOrHigherThanGivenNonce(nonce uint64) bool {
+	return tb.nonce >= nonce
 }
 
 func (tb *trackedBlock) compileBreadcrumbs(txs []*WrappedTransaction) error {

--- a/txcache/txCache.go
+++ b/txcache/txCache.go
@@ -112,14 +112,14 @@ func (cache *TxCache) GetByTxHash(txHash []byte) (*WrappedTransaction, bool) {
 // SelectTransactions selects the best transactions to be included in the next miniblock.
 // It returns up to "options.maxNumTxs" transactions, with total gas <= "options.gasRequested".
 // The selection takes into consideration the proposed blocks which were not yet executed.
-// The SelectTransactions should receive the nonce of the block on which the selection is built.
-// The blocks with a nonce greater than the given one will be removed.
+// The SelectTransactions should receive the nonce of the block for which the selection is built.
+// The blocks with a nonce equal or greater than the given one will be removed.
 func (cache *TxCache) SelectTransactions(
 	session SelectionSession,
 	options common.TxSelectionOptions,
-	currentBlockNonce uint64,
+	blockNonce uint64,
 ) ([]*WrappedTransaction, uint64, error) {
-	return cache.selectTransactions(session, options, currentBlockNonce, false)
+	return cache.selectTransactions(session, options, blockNonce, false)
 }
 
 // SimulateSelectTransactions simulates a selection of transaction and does not affect the internal state of the tracker


### PR DESCRIPTION
## Reasoning behind the pull request
- Fix blocks queue 
- Fixed the bug related with `WARN [2025-12-12 10:08:49.980]   blocksQueue.Pop - blocks queue is empty  `

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
