### PR TITLE
fetch txs from storage and save into corresponding pool

### DIFF
--- a/epochStart/shardchain/triggerRegistry_test.go
+++ b/epochStart/shardchain/triggerRegistry_test.go
@@ -141,8 +141,6 @@ func TestTrigger_LoadStateBackwardsCompatibility(t *testing.T) {
 	arguments.Epoch = epoch
 
 	t.Run("backwards compatibility", func(t *testing.T) {
-		t.Parallel()
-
 		bootStorer := genericMocks.NewStorerMock()
 		arguments.Storage = &storageStubs.ChainStorerStub{
 			GetStorerCalled: func(unitType dataRetriever.UnitType) (storage.Storer, error) {
@@ -165,8 +163,6 @@ func TestTrigger_LoadStateBackwardsCompatibility(t *testing.T) {
 	})
 
 	t.Run("header v1", func(t *testing.T) {
-		t.Parallel()
-
 		triggerRegistry := &block.ShardTriggerRegistry{
 			Epoch:                 epoch,
 			MetaEpoch:             epoch,
@@ -200,8 +196,6 @@ func TestTrigger_LoadStateBackwardsCompatibility(t *testing.T) {
 	})
 
 	t.Run("header v2", func(t *testing.T) {
-		t.Parallel()
-
 		triggerRegistry := &block.ShardTriggerRegistryV2{
 			Epoch:     epoch,
 			MetaEpoch: epoch,
@@ -240,8 +234,6 @@ func TestTrigger_LoadStateBackwardsCompatibility(t *testing.T) {
 	})
 
 	t.Run("header v3", func(t *testing.T) {
-		t.Parallel()
-
 		triggerRegistry := &block.ShardTriggerRegistryV3{
 			Epoch:                 epoch,
 			MetaEpoch:             epoch,

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -1716,12 +1716,12 @@ func (bp *baseProcessor) saveProposedTxsToStorage(header data.HeaderHandler, bod
 
 	separatedBodies := process.SeparateBodyByType(body)
 	for blockType, blockBody := range separatedBodies {
-		dataPool, err := bp.getDataPoolByBlockType(blockType)
+		dataPool, err := process.GetDataPoolByBlockType(blockType, bp.dataPool)
 		if err != nil {
 			return err
 		}
 
-		unit, err := getStorageForProposedTxsFromBlockType(blockType)
+		unit, err := process.GetStorageForProposedTxsFromBlockType(blockType)
 		if err != nil {
 			return err
 		}
@@ -1799,37 +1799,6 @@ func (bp *baseProcessor) savePeerInfoToStorage(dataPool dataRetriever.ShardedDat
 	}
 
 	return nil
-}
-
-func (bp *baseProcessor) getDataPoolByBlockType(blockType block.Type) (dataRetriever.ShardedDataCacherNotifier, error) {
-	switch blockType {
-	case block.TxBlock, block.InvalidBlock:
-		return bp.dataPool.Transactions(), nil
-	case block.SmartContractResultBlock:
-		return bp.dataPool.UnsignedTransactions(), nil
-	case block.RewardsBlock:
-		return bp.dataPool.RewardTransactions(), nil
-	case block.PeerBlock:
-		return bp.dataPool.ValidatorsInfo(), nil
-	default:
-		return nil, fmt.Errorf("unsupported block type for dataPool: %d", blockType)
-	}
-}
-
-func getStorageForProposedTxsFromBlockType(blockType block.Type) (dataRetriever.UnitType, error) {
-	switch blockType {
-	case block.TxBlock, block.InvalidBlock:
-		return dataRetriever.TransactionUnit, nil
-	case block.SmartContractResultBlock:
-		return dataRetriever.UnsignedTransactionUnit, nil
-	case block.ReceiptBlock:
-		return dataRetriever.ReceiptsUnit, nil
-	case block.RewardsBlock:
-		return dataRetriever.RewardTransactionUnit, nil
-	case block.PeerBlock:
-		return dataRetriever.UnsignedTransactionUnit, nil
-	}
-	return 0, process.ErrInvalidBlockType
 }
 
 func (bp *baseProcessor) saveShardHeader(header data.HeaderHandler, headerHash []byte, marshalizedHeader []byte) {
@@ -3474,7 +3443,7 @@ func (bp *baseProcessor) getTransactionsForMiniBlock(
 		return make([]data.TransactionHandler, 0), nil
 	}
 
-	pool, err := bp.getDataPoolByBlockType(block.Type(miniBlock.GetTypeInt32()))
+	pool, err := process.GetDataPoolByBlockType(block.Type(miniBlock.GetTypeInt32()), bp.dataPool)
 	if err != nil {
 		return nil, err
 	}

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -1721,7 +1721,7 @@ func (bp *baseProcessor) saveProposedTxsToStorage(header data.HeaderHandler, bod
 			return err
 		}
 
-		unit, err := process.GetStorageForProposedTxsFromBlockType(blockType)
+		unit, err := process.GetStorageUnitByBlockType(blockType)
 		if err != nil {
 			return err
 		}

--- a/process/common.go
+++ b/process/common.go
@@ -1241,6 +1241,7 @@ func GetMarshaledSliceSize[T any](items []T, marshaller marshal.Marshalizer) (in
 	return size, nil
 }
 
+// GetDataPoolByBlockType returns data pool by type
 func GetDataPoolByBlockType(
 	blockType block.Type,
 	dataPool dataRetriever.PoolsHolder,
@@ -1259,7 +1260,8 @@ func GetDataPoolByBlockType(
 	}
 }
 
-func GetStorageForProposedTxsFromBlockType(blockType block.Type) (dataRetriever.UnitType, error) {
+// GetStorageUnitByBlockType returns storage by type
+func GetStorageUnitByBlockType(blockType block.Type) (dataRetriever.UnitType, error) {
 	switch blockType {
 	case block.TxBlock, block.InvalidBlock:
 		return dataRetriever.TransactionUnit, nil

--- a/process/common.go
+++ b/process/common.go
@@ -1240,3 +1240,37 @@ func GetMarshaledSliceSize[T any](items []T, marshaller marshal.Marshalizer) (in
 
 	return size, nil
 }
+
+func GetDataPoolByBlockType(
+	blockType block.Type,
+	dataPool dataRetriever.PoolsHolder,
+) (dataRetriever.ShardedDataCacherNotifier, error) {
+	switch blockType {
+	case block.TxBlock, block.InvalidBlock:
+		return dataPool.Transactions(), nil
+	case block.SmartContractResultBlock:
+		return dataPool.UnsignedTransactions(), nil
+	case block.RewardsBlock:
+		return dataPool.RewardTransactions(), nil
+	case block.PeerBlock:
+		return dataPool.ValidatorsInfo(), nil
+	default:
+		return nil, fmt.Errorf("unsupported block type for dataPool: %d", blockType)
+	}
+}
+
+func GetStorageForProposedTxsFromBlockType(blockType block.Type) (dataRetriever.UnitType, error) {
+	switch blockType {
+	case block.TxBlock, block.InvalidBlock:
+		return dataRetriever.TransactionUnit, nil
+	case block.SmartContractResultBlock:
+		return dataRetriever.UnsignedTransactionUnit, nil
+	case block.ReceiptBlock:
+		return dataRetriever.ReceiptsUnit, nil
+	case block.RewardsBlock:
+		return dataRetriever.RewardTransactionUnit, nil
+	case block.PeerBlock:
+		return dataRetriever.UnsignedTransactionUnit, nil
+	}
+	return 0, ErrInvalidBlockType
+}

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -1217,7 +1217,7 @@ func (boot *baseBootstrap) saveTxsToPool(
 			return err
 		}
 
-		tx, err := boot.unmarshallTxByBlockType(blockType, txBuff)
+		tx, err := boot.unmarshalTxByBlockType(blockType, txBuff)
 		if err != nil {
 			return err
 		}
@@ -1229,15 +1229,12 @@ func (boot *baseBootstrap) saveTxsToPool(
 			tx.Size(),
 			cacherIdentifier,
 		)
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil
 }
 
-func (boot *baseBootstrap) unmarshallTxByBlockType(
+func (boot *baseBootstrap) unmarshalTxByBlockType(
 	blockType block.Type,
 	txBuff []byte,
 ) (txSizeHandler, error) {
@@ -1247,30 +1244,19 @@ func (boot *baseBootstrap) unmarshallTxByBlockType(
 	switch blockType {
 	case block.TxBlock, block.InvalidBlock:
 		tx = &transaction.Transaction{}
-		err = boot.marshalizer.Unmarshal(tx, txBuff)
-		if err != nil {
-			return nil, err
-		}
 	case block.SmartContractResultBlock:
 		tx = &smartContractResult.SmartContractResult{}
-		err = boot.marshalizer.Unmarshal(tx, txBuff)
-		if err != nil {
-			return nil, err
-		}
 	case block.RewardsBlock:
-		tx = &state.ShardValidatorInfo{}
-		err = boot.marshalizer.Unmarshal(tx, txBuff)
-		if err != nil {
-			return nil, err
-		}
-	case block.PeerBlock:
 		tx = &rewardTx.RewardTx{}
-		err = boot.marshalizer.Unmarshal(tx, txBuff)
-		if err != nil {
-			return nil, err
-		}
+	case block.PeerBlock:
+		tx = &state.ShardValidatorInfo{}
 	default:
 		return nil, fmt.Errorf("unsupported block type: %d", blockType)
+	}
+
+	err = boot.marshalizer.Unmarshal(tx, txBuff)
+	if err != nil {
+		return nil, err
 	}
 
 	return tx, nil

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -40,6 +40,10 @@ import (
 
 var log = logger.GetOrCreate("process/sync")
 
+type txWithSize interface {
+	Size() int
+}
+
 var _ closing.Closer = (*baseBootstrap)(nil)
 
 // sleepTime defines the time in milliseconds between each iteration made in syncBlocks method
@@ -1215,140 +1219,69 @@ func (boot *baseBootstrap) saveTxsToPool(
 ) error {
 	txHashes := miniBlock.TxHashes
 
-	switch blockType {
-	case block.TxBlock, block.InvalidBlock:
-		for _, txHash := range txHashes {
-			txBuff, err := storer.Get(txHash)
-			if err != nil {
-				return err
-			}
-
-			tx := &transaction.Transaction{}
-			err = boot.marshalizer.Unmarshal(tx, txBuff)
-			if err != nil {
-				return err
-			}
-
-			cacherIdentifier := process.ShardCacherIdentifier(miniBlock.SenderShardID, miniBlock.ReceiverShardID)
-			dataPool.AddData(
-				txHash,
-				tx,
-				tx.Size(),
-				cacherIdentifier,
-			)
-			if err != nil {
-				return err
-			}
+	for _, txHash := range txHashes {
+		txBuff, err := storer.Get(txHash)
+		if err != nil {
+			return err
 		}
 
-		return nil
-	case block.SmartContractResultBlock:
-		for _, txHash := range txHashes {
-			txBuff, err := storer.Get(txHash)
-			if err != nil {
-				return err
-			}
-
-			tx := &smartContractResult.SmartContractResult{}
-			err = boot.marshalizer.Unmarshal(tx, txBuff)
-			if err != nil {
-				return err
-			}
-
-			cacherIdentifier := process.ShardCacherIdentifier(miniBlock.SenderShardID, miniBlock.ReceiverShardID)
-			dataPool.AddData(
-				txHash,
-				tx,
-				tx.Size(),
-				cacherIdentifier,
-			)
-			if err != nil {
-				return err
-			}
+		tx, err := boot.unmarshallTxByBlockType(blockType, txBuff)
+		if err != nil {
+			return err
 		}
 
-		return nil
-	case block.RewardsBlock:
-		for _, txHash := range txHashes {
-			txBuff, err := storer.Get(txHash)
-			if err != nil {
-				return err
-			}
-
-			tx := &state.ShardValidatorInfo{}
-			err = boot.marshalizer.Unmarshal(tx, txBuff)
-			if err != nil {
-				return err
-			}
-
-			cacherIdentifier := process.ShardCacherIdentifier(miniBlock.SenderShardID, miniBlock.ReceiverShardID)
-			dataPool.AddData(
-				txHash,
-				tx,
-				tx.Size(),
-				cacherIdentifier,
-			)
-			if err != nil {
-				return err
-			}
+		cacherIdentifier := process.ShardCacherIdentifier(miniBlock.SenderShardID, miniBlock.ReceiverShardID)
+		dataPool.AddData(
+			txHash,
+			tx,
+			tx.Size(),
+			cacherIdentifier,
+		)
+		if err != nil {
+			return err
 		}
-
-		return nil
-	case block.PeerBlock:
-		for _, txHash := range txHashes {
-			txBuff, err := storer.Get(txHash)
-			if err != nil {
-				return err
-			}
-
-			tx := &rewardTx.RewardTx{}
-			err = boot.marshalizer.Unmarshal(tx, txBuff)
-			if err != nil {
-				return err
-			}
-
-			cacherIdentifier := process.ShardCacherIdentifier(miniBlock.SenderShardID, miniBlock.ReceiverShardID)
-			dataPool.AddData(
-				txHash,
-				tx,
-				tx.Size(),
-				cacherIdentifier,
-			)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
-	default:
-		return fmt.Errorf("unsupported block type for dataPool: %d", blockType)
 	}
+
+	return nil
 }
 
-func (boot *baseBootstrap) getTransactionHandlerFromStorage(
-	txHash []byte,
-	storer storage.Storer,
-	marshalizer marshal.Marshalizer,
-) (data.TransactionHandler, error) {
-	if check.IfNil(storer) {
-		return nil, process.ErrNilStorage
-	}
-	if check.IfNil(marshalizer) {
-		return nil, process.ErrNilMarshalizer
+func (boot *baseBootstrap) unmarshallTxByBlockType(
+	blockType block.Type,
+	txBuff []byte,
+) (txWithSize, error) {
+	var tx txWithSize
+	var err error
+
+	switch blockType {
+	case block.TxBlock, block.InvalidBlock:
+		tx = &transaction.Transaction{}
+		err = boot.marshalizer.Unmarshal(tx, txBuff)
+		if err != nil {
+			return nil, err
+		}
+	case block.SmartContractResultBlock:
+		tx = &smartContractResult.SmartContractResult{}
+		err = boot.marshalizer.Unmarshal(tx, txBuff)
+		if err != nil {
+			return nil, err
+		}
+	case block.RewardsBlock:
+		tx = &state.ShardValidatorInfo{}
+		err = boot.marshalizer.Unmarshal(tx, txBuff)
+		if err != nil {
+			return nil, err
+		}
+	case block.PeerBlock:
+		tx = &rewardTx.RewardTx{}
+		err = boot.marshalizer.Unmarshal(tx, txBuff)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported block type for dataPool: %d", blockType)
 	}
 
-	txBuff, err := storer.Get(txHash)
-	if err != nil {
-		return nil, err
-	}
-
-	tx := transaction.Transaction{}
-	err = marshalizer.Unmarshal(&tx, txBuff)
-	if err != nil {
-		return nil, err
-	}
-
-	return &tx, nil
+	return tx, nil
 }
 
 func (boot *baseBootstrap) handleTrieSyncError(err error, ctx context.Context) {

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -40,7 +40,7 @@ import (
 
 var log = logger.GetOrCreate("process/sync")
 
-type txWithSize interface {
+type txSizeHandler interface {
 	Size() int
 }
 
@@ -1175,17 +1175,13 @@ func (boot *baseBootstrap) saveProposedTxsToPool(
 
 	separatedBodies := process.SeparateBodyByType(bodyPtr)
 
-	log.Debug("saveProposedTxsToPool",
-		"separatedBodies", len(separatedBodies),
-	)
-
 	for blockType, blockBody := range separatedBodies {
 		dataPool, err := process.GetDataPoolByBlockType(blockType, boot.dataPool)
 		if err != nil {
 			return err
 		}
 
-		unit, err := process.GetStorageForProposedTxsFromBlockType(blockType)
+		unit, err := process.GetStorageUnitByBlockType(blockType)
 		if err != nil {
 			return err
 		}
@@ -1201,10 +1197,6 @@ func (boot *baseBootstrap) saveProposedTxsToPool(
 			if err != nil {
 				return err
 			}
-
-			log.Debug("saveProposedTxsToPool",
-				"miniBlock txs", len(miniBlock.TxHashes),
-			)
 		}
 	}
 
@@ -1248,8 +1240,8 @@ func (boot *baseBootstrap) saveTxsToPool(
 func (boot *baseBootstrap) unmarshallTxByBlockType(
 	blockType block.Type,
 	txBuff []byte,
-) (txWithSize, error) {
-	var tx txWithSize
+) (txSizeHandler, error) {
+	var tx txSizeHandler
 	var err error
 
 	switch blockType {

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -1092,6 +1092,11 @@ func (boot *baseBootstrap) prepareForSyncIfNeeded(syncingNonce uint64) error {
 			return errGetBody
 		}
 
+		err = boot.saveProposedTxsToPool(currentHeader, currentBody)
+		if err != nil {
+			return err
+		}
+
 		errOnProposedBlock := boot.blockProcessor.OnProposedBlock(
 			currentBody,
 			currentHeader,
@@ -1165,6 +1170,11 @@ func (boot *baseBootstrap) saveProposedTxsToPool(
 	}
 
 	separatedBodies := process.SeparateBodyByType(bodyPtr)
+
+	log.Debug("saveProposedTxsToPool",
+		"separatedBodies", len(separatedBodies),
+	)
+
 	for blockType, blockBody := range separatedBodies {
 		dataPool, err := process.GetDataPoolByBlockType(blockType, boot.dataPool)
 		if err != nil {
@@ -1187,6 +1197,10 @@ func (boot *baseBootstrap) saveProposedTxsToPool(
 			if err != nil {
 				return err
 			}
+
+			log.Debug("saveProposedTxsToPool",
+				"miniBlock txs", len(miniBlock.TxHashes),
+			)
 		}
 	}
 

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -15,6 +15,9 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	outportcore "github.com/multiversx/mx-chain-core-go/data/outport"
+	"github.com/multiversx/mx-chain-core-go/data/rewardTx"
+	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
+	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-core-go/data/typeConverters"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
@@ -61,6 +64,7 @@ type baseBootstrap struct {
 	historyRepo dblookupext.HistoryRepository
 	headers     dataRetriever.HeadersPool
 	proofs      dataRetriever.ProofsPool
+	dataPool    dataRetriever.PoolsHolder
 
 	chainHandler     data.ChainHandler
 	blockProcessor   process.BlockProcessor
@@ -1119,6 +1123,11 @@ func (boot *baseBootstrap) prepareForSyncIfNeeded(syncingNonce uint64) error {
 			return errGetBody
 		}
 
+		err := boot.saveProposedTxsToPool(hdr, body)
+		if err != nil {
+			return err
+		}
+
 		errOnProposedBlock := boot.blockProcessor.OnProposedBlock(
 			body,
 			hdr,
@@ -1140,6 +1149,192 @@ func (boot *baseBootstrap) prepareForSyncIfNeeded(syncingNonce uint64) error {
 	boot.preparedForSync = true
 
 	return nil
+}
+
+func (boot *baseBootstrap) saveProposedTxsToPool(
+	header data.HeaderHandler,
+	body data.BodyHandler,
+) error {
+	if !header.IsHeaderV3() {
+		return nil
+	}
+
+	bodyPtr, ok := body.(*block.Body)
+	if !ok {
+		return process.ErrWrongTypeAssertion
+	}
+
+	separatedBodies := process.SeparateBodyByType(bodyPtr)
+	for blockType, blockBody := range separatedBodies {
+		dataPool, err := process.GetDataPoolByBlockType(blockType, boot.dataPool)
+		if err != nil {
+			return err
+		}
+
+		unit, err := process.GetStorageForProposedTxsFromBlockType(blockType)
+		if err != nil {
+			return err
+		}
+
+		storer, err := boot.store.GetStorer(unit)
+		if err != nil {
+			return err
+		}
+
+		for i := 0; i < len(blockBody.MiniBlocks); i++ {
+			miniBlock := blockBody.MiniBlocks[i]
+			err = boot.saveTxsToPool(dataPool, storer, miniBlock, blockType)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (boot *baseBootstrap) saveTxsToPool(
+	dataPool dataRetriever.ShardedDataCacherNotifier,
+	storer storage.Storer,
+	miniBlock *block.MiniBlock,
+	blockType block.Type,
+) error {
+	txHashes := miniBlock.TxHashes
+
+	switch blockType {
+	case block.TxBlock, block.InvalidBlock:
+		for _, txHash := range txHashes {
+			txBuff, err := storer.Get(txHash)
+			if err != nil {
+				return err
+			}
+
+			tx := &transaction.Transaction{}
+			err = boot.marshalizer.Unmarshal(tx, txBuff)
+			if err != nil {
+				return err
+			}
+
+			cacherIdentifier := process.ShardCacherIdentifier(miniBlock.SenderShardID, miniBlock.ReceiverShardID)
+			dataPool.AddData(
+				txHash,
+				tx,
+				tx.Size(),
+				cacherIdentifier,
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	case block.SmartContractResultBlock:
+		for _, txHash := range txHashes {
+			txBuff, err := storer.Get(txHash)
+			if err != nil {
+				return err
+			}
+
+			tx := &smartContractResult.SmartContractResult{}
+			err = boot.marshalizer.Unmarshal(tx, txBuff)
+			if err != nil {
+				return err
+			}
+
+			cacherIdentifier := process.ShardCacherIdentifier(miniBlock.SenderShardID, miniBlock.ReceiverShardID)
+			dataPool.AddData(
+				txHash,
+				tx,
+				tx.Size(),
+				cacherIdentifier,
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	case block.RewardsBlock:
+		for _, txHash := range txHashes {
+			txBuff, err := storer.Get(txHash)
+			if err != nil {
+				return err
+			}
+
+			tx := &state.ShardValidatorInfo{}
+			err = boot.marshalizer.Unmarshal(tx, txBuff)
+			if err != nil {
+				return err
+			}
+
+			cacherIdentifier := process.ShardCacherIdentifier(miniBlock.SenderShardID, miniBlock.ReceiverShardID)
+			dataPool.AddData(
+				txHash,
+				tx,
+				tx.Size(),
+				cacherIdentifier,
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	case block.PeerBlock:
+		for _, txHash := range txHashes {
+			txBuff, err := storer.Get(txHash)
+			if err != nil {
+				return err
+			}
+
+			tx := &rewardTx.RewardTx{}
+			err = boot.marshalizer.Unmarshal(tx, txBuff)
+			if err != nil {
+				return err
+			}
+
+			cacherIdentifier := process.ShardCacherIdentifier(miniBlock.SenderShardID, miniBlock.ReceiverShardID)
+			dataPool.AddData(
+				txHash,
+				tx,
+				tx.Size(),
+				cacherIdentifier,
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("unsupported block type for dataPool: %d", blockType)
+	}
+}
+
+func (boot *baseBootstrap) getTransactionHandlerFromStorage(
+	txHash []byte,
+	storer storage.Storer,
+	marshalizer marshal.Marshalizer,
+) (data.TransactionHandler, error) {
+	if check.IfNil(storer) {
+		return nil, process.ErrNilStorage
+	}
+	if check.IfNil(marshalizer) {
+		return nil, process.ErrNilMarshalizer
+	}
+
+	txBuff, err := storer.Get(txHash)
+	if err != nil {
+		return nil, err
+	}
+
+	tx := transaction.Transaction{}
+	err = marshalizer.Unmarshal(&tx, txBuff)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tx, nil
 }
 
 func (boot *baseBootstrap) handleTrieSyncError(err error, ctx context.Context) {

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -1270,7 +1270,7 @@ func (boot *baseBootstrap) unmarshallTxByBlockType(
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("unsupported block type for dataPool: %d", blockType)
+		return nil, fmt.Errorf("unsupported block type: %d", blockType)
 	}
 
 	return tx, nil

--- a/process/sync/baseSync_test.go
+++ b/process/sync/baseSync_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -9,11 +10,20 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/data/rewardTx"
+	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
+	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/mock"
+	"github.com/multiversx/mx-chain-go/state"
+	"github.com/multiversx/mx-chain-go/storage"
 	"github.com/multiversx/mx-chain-go/testscommon"
+	dataRetrieverMock "github.com/multiversx/mx-chain-go/testscommon/dataRetriever"
 	"github.com/multiversx/mx-chain-go/testscommon/processMocks"
+	storageStubs "github.com/multiversx/mx-chain-go/testscommon/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -439,4 +449,115 @@ func TestBaseBootstrap_PrepareForSyncAtBootstrapIfNeeded(t *testing.T) {
 
 		require.Equal(t, 1, numCalls) // still 1 call
 	})
+}
+
+func TestBaseBootstrap_SaveProposedTxsToPool(t *testing.T) {
+	t.Parallel()
+
+	marshaller := &marshal.GogoProtoMarshalizer{}
+
+	txCalls := 0
+	scCalls := 0
+	rwCalls := 0
+	peerCalls := 0
+
+	boot := &baseBootstrap{
+		marshalizer: marshaller,
+		dataPool: &dataRetrieverMock.PoolsHolderStub{
+			TransactionsCalled: func() dataRetriever.ShardedDataCacherNotifier {
+				return &testscommon.ShardedDataStub{
+					AddDataCalled: func(key []byte, data interface{}, sizeInBytes int, cacheID string) {
+						txCalls++
+					},
+				}
+			},
+			UnsignedTransactionsCalled: func() dataRetriever.ShardedDataCacherNotifier {
+				return &testscommon.ShardedDataStub{
+					AddDataCalled: func(key []byte, data interface{}, sizeInBytes int, cacheID string) {
+						scCalls++
+					},
+				}
+			},
+			RewardTransactionsCalled: func() dataRetriever.ShardedDataCacherNotifier {
+				return &testscommon.ShardedDataStub{
+					AddDataCalled: func(key []byte, data interface{}, sizeInBytes int, cacheID string) {
+						rwCalls++
+					},
+				}
+			},
+			ValidatorsInfoCalled: func() dataRetriever.ShardedDataCacherNotifier {
+				return &testscommon.ShardedDataStub{
+					AddDataCalled: func(key []byte, data interface{}, sizeInBytes int, cacheID string) {
+						peerCalls++
+					},
+				}
+			},
+		},
+		store: &storageStubs.ChainStorerStub{
+			GetStorerCalled: func(unitType dataRetriever.UnitType) (storage.Storer, error) {
+				return &storageStubs.StorerStub{
+					GetCalled: func(key []byte) ([]byte, error) {
+						switch string(key) {
+						case "txHash1":
+							tx := &transaction.Transaction{}
+							txBytes, _ := marshaller.Marshal(tx)
+							return txBytes, nil
+						case "txHash2":
+							tx := &smartContractResult.SmartContractResult{}
+							txBytes, _ := marshaller.Marshal(tx)
+							return txBytes, nil
+						case "txHash3":
+							tx := &state.ShardValidatorInfo{}
+							txBytes, _ := marshaller.Marshal(tx)
+							return txBytes, nil
+						case "txHash4":
+							tx := &rewardTx.RewardTx{}
+							txBytes, _ := marshaller.Marshal(tx)
+							return txBytes, nil
+						case "txHash5":
+							tx := &rewardTx.RewardTx{}
+							txBytes, _ := marshaller.Marshal(tx)
+							return txBytes, nil
+						default:
+							return nil, errors.New("err")
+						}
+					},
+				}, nil
+			},
+		},
+	}
+
+	header := &block.HeaderV3{}
+	body := &block.Body{
+		MiniBlocks: []*block.MiniBlock{
+			&block.MiniBlock{
+				TxHashes: [][]byte{[]byte("txHash1")},
+				Type:     block.TxBlock,
+			},
+			&block.MiniBlock{
+				TxHashes: [][]byte{[]byte("txHash2")},
+				Type:     block.InvalidBlock,
+			},
+			&block.MiniBlock{
+				TxHashes: [][]byte{[]byte("txHash3")},
+				Type:     block.SmartContractResultBlock,
+			},
+			&block.MiniBlock{
+				TxHashes: [][]byte{[]byte("txHash4")},
+				Type:     block.RewardsBlock,
+			},
+			&block.MiniBlock{
+				TxHashes: [][]byte{[]byte("txHash5")},
+				Type:     block.PeerBlock,
+			},
+		},
+	}
+
+	err := boot.SaveProposedTxsToPool(header, body)
+	require.Nil(t, err)
+
+	require.Equal(t, 2, txCalls)
+	require.Equal(t, 1, scCalls)
+	require.Equal(t, 1, rwCalls)
+	require.Equal(t, 1, peerCalls)
 }

--- a/process/sync/baseSync_test.go
+++ b/process/sync/baseSync_test.go
@@ -499,23 +499,34 @@ func TestBaseBootstrap_SaveProposedTxsToPool(t *testing.T) {
 					GetCalled: func(key []byte) ([]byte, error) {
 						switch string(key) {
 						case "txHash1":
-							tx := &transaction.Transaction{}
+							tx := &transaction.Transaction{
+								Nonce: 1,
+							}
 							txBytes, _ := marshaller.Marshal(tx)
 							return txBytes, nil
 						case "txHash2":
-							tx := &smartContractResult.SmartContractResult{}
+							tx := &transaction.Transaction{
+								Nonce: 2,
+							}
 							txBytes, _ := marshaller.Marshal(tx)
 							return txBytes, nil
 						case "txHash3":
-							tx := &state.ShardValidatorInfo{}
+							tx := &smartContractResult.SmartContractResult{
+								Nonce:        3,
+								CodeMetadata: []byte("codeMetadata"),
+							}
 							txBytes, _ := marshaller.Marshal(tx)
 							return txBytes, nil
 						case "txHash4":
-							tx := &rewardTx.RewardTx{}
+							tx := &rewardTx.RewardTx{
+								Round: 1,
+							}
 							txBytes, _ := marshaller.Marshal(tx)
 							return txBytes, nil
 						case "txHash5":
-							tx := &rewardTx.RewardTx{}
+							tx := &state.ShardValidatorInfo{
+								PublicKey: []byte("pubKey"),
+							}
 							txBytes, _ := marshaller.Marshal(tx)
 							return txBytes, nil
 						default:

--- a/process/sync/export_test.go
+++ b/process/sync/export_test.go
@@ -357,3 +357,11 @@ func (boot *baseBootstrap) ProcessWaitTime() time.Duration {
 func (boot *baseBootstrap) PrepareForSyncAtBoostrapIfNeeded() error {
 	return boot.prepareForSyncAtBoostrapIfNeeded()
 }
+
+// SaveProposedTxsToPool -
+func (boot *baseBootstrap) SaveProposedTxsToPool(
+	header data.HeaderHandler,
+	body data.BodyHandler,
+) error {
+	return boot.saveProposedTxsToPool(header, body)
+}

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -59,6 +59,7 @@ func NewMetaBootstrap(arguments ArgMetaBootstrapper) (*MetaBootstrap, error) {
 		store:                        arguments.Store,
 		headers:                      arguments.PoolsHolder.Headers(),
 		proofs:                       arguments.PoolsHolder.Proofs(),
+		dataPool:                     arguments.PoolsHolder,
 		roundHandler:                 arguments.RoundHandler,
 		hasher:                       arguments.Hasher,
 		marshalizer:                  arguments.Marshalizer,

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -46,6 +46,7 @@ func NewShardBootstrap(arguments ArgShardBootstrapper) (*ShardBootstrap, error) 
 		store:                        arguments.Store,
 		headers:                      arguments.PoolsHolder.Headers(),
 		proofs:                       arguments.PoolsHolder.Proofs(),
+		dataPool:                     arguments.PoolsHolder,
 		roundHandler:                 arguments.RoundHandler,
 		hasher:                       arguments.Hasher,
 		marshalizer:                  arguments.Marshalizer,


### PR DESCRIPTION
## Reasoning behind the pull request
- At bootstrap, we need the corresponding txs for the applied block
- Transactions should be available in storage, but tx pool expects them to be in pool
  
## Proposed changes
- When preparing tx pool context for sync, at bootstrap, updated to put transactions from storage into pools

## Testing procedure
- System tests with restarts

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
