### PR TITLE
Supernova TxPool: Fix consumed balance check on selection

### DIFF
--- a/integrationTests/chainSimulator/mempool/mempool_test.go
+++ b/integrationTests/chainSimulator/mempool/mempool_test.go
@@ -160,16 +160,13 @@ func TestMempoolWithChainSimulator_Selection_WhenUsersHaveZeroBalance_WithRelaye
 	require.Equal(t, 2, getNumTransactionsInPool(simulator, shard))
 
 	selectedTransactions, _ := selectTransactions(t, simulator, shard)
-	require.Equal(t, 2, len(selectedTransactions))
-	require.Equal(t, alice.Bytes, selectedTransactions[0].Tx.GetSndAddr())
-	require.Equal(t, bob.Bytes, selectedTransactions[1].Tx.GetSndAddr())
+	require.Equal(t, 1, len(selectedTransactions))
+	require.Equal(t, bob.Bytes, selectedTransactions[0].Tx.GetSndAddr())
 
 	err = simulator.GenerateBlocks(1)
 	require.Nil(t, err)
-	require.Equal(t, 2, getNumTransactionsInCurrentBlock(simulator, shard))
-
-	require.Equal(t, "invalid", getTransaction(t, simulator, shard, selectedTransactions[0].TxHash).Status.String())
-	require.Equal(t, "success", getTransaction(t, simulator, shard, selectedTransactions[1].TxHash).Status.String())
+	require.Equal(t, 1, getNumTransactionsInCurrentBlock(simulator, shard))
+	require.Equal(t, "success", getTransaction(t, simulator, shard, selectedTransactions[0].TxHash).Status.String())
 }
 
 func TestMempoolWithChainSimulator_Selection_WhenInsufficientBalanceForFee_WithRelayedV3(t *testing.T) {
@@ -603,9 +600,8 @@ func Test_Selection_ShouldNotSelectSameTransactionsWithSameSender(t *testing.T) 
 	// the currentNonce should represent here the nonce of the block for which the selection is built
 	selectedTransactions, _, err = txpool.SelectTransactions(selectionSession, options, 2)
 	require.Nil(t, err)
-	require.Equal(t, 2, len(selectedTransactions))
+	require.Equal(t, 1, len(selectedTransactions))
 	require.Equal(t, "txHash2", string(selectedTransactions[0].TxHash))
-	require.Equal(t, "txHash3", string(selectedTransactions[1].TxHash))
 }
 
 func Test_Selection_ShouldNotSelectSameTransactionsWithDifferentSenders(t *testing.T) {

--- a/integrationTests/chainSimulator/vm/egldMultiTransfer/egldMultiTransfer_test.go
+++ b/integrationTests/chainSimulator/vm/egldMultiTransfer/egldMultiTransfer_test.go
@@ -285,39 +285,16 @@ func TestChainSimulator_EGLD_MultiTransfer_Insufficient_Funds(t *testing.T) {
 
 	beforeBalanceStr0 := account0.Balance
 
-	account1, err := cs.GetAccount(addrs[1])
+	_, err = cs.GetAccount(addrs[1])
 	require.Nil(t, err)
-
-	beforeBalanceStr1 := account1.Balance
 
 	egldValue, _ := big.NewInt(0).SetString(beforeBalanceStr0, 10)
 	egldValue = egldValue.Add(egldValue, big.NewInt(13))
 	tx = multiESDTNFTTransferWithEGLDTx(nonce, addrs[0].Bytes, addrs[1].Bytes, [][]byte{nftTokenID}, egldValue)
 
 	txResult, err = cs.SendTxAndGenerateBlockTilTxIsExecuted(tx, vm2.MaxNumOfBlockToGenerateWhenExecutingTx)
-	require.Nil(t, err)
-	require.NotNil(t, txResult)
-
-	require.NotEqual(t, "success", txResult.Status.String())
-
-	eventLog := string(txResult.Logs.Events[0].Topics[1])
-	require.Equal(t, "insufficient funds for token EGLD-000000", eventLog)
-
-	// check accounts balance
-	account0, err = cs.GetAccount(addrs[0])
-	require.Nil(t, err)
-
-	beforeBalance0, _ := big.NewInt(0).SetString(beforeBalanceStr0, 10)
-
-	txsFee, _ := big.NewInt(0).SetString(txResult.Fee, 10)
-	expectedBalanceWithFee0 := big.NewInt(0).Sub(beforeBalance0, txsFee)
-
-	require.Equal(t, expectedBalanceWithFee0.String(), account0.Balance)
-
-	account1, err = cs.GetAccount(addrs[1])
-	require.Nil(t, err)
-
-	require.Equal(t, beforeBalanceStr1, account1.Balance)
+	require.ErrorContains(t, err, "Transaction(s) is/are still in pending")
+	require.Nil(t, txResult)
 }
 
 func TestChainSimulator_EGLD_MultiTransfer_Invalid_Value(t *testing.T) {

--- a/integrationTests/chainSimulator/vm/egldMultiTransfer/egldMultiTransfer_test.go
+++ b/integrationTests/chainSimulator/vm/egldMultiTransfer/egldMultiTransfer_test.go
@@ -285,8 +285,11 @@ func TestChainSimulator_EGLD_MultiTransfer_Insufficient_Funds(t *testing.T) {
 
 	beforeBalanceStr0 := account0.Balance
 
+	account1, err := cs.GetAccount(addrs[1])
 	_, err = cs.GetAccount(addrs[1])
 	require.Nil(t, err)
+
+	beforeBalanceStr1 := account1.Balance
 
 	egldValue, _ := big.NewInt(0).SetString(beforeBalanceStr0, 10)
 	egldValue = egldValue.Add(egldValue, big.NewInt(13))
@@ -295,6 +298,17 @@ func TestChainSimulator_EGLD_MultiTransfer_Insufficient_Funds(t *testing.T) {
 	txResult, err = cs.SendTxAndGenerateBlockTilTxIsExecuted(tx, vm2.MaxNumOfBlockToGenerateWhenExecutingTx)
 	require.ErrorContains(t, err, "Transaction(s) is/are still in pending")
 	require.Nil(t, txResult)
+
+	// check accounts balance
+	account0, err = cs.GetAccount(addrs[0])
+	require.Nil(t, err)
+
+	require.Equal(t, beforeBalanceStr0, account0.Balance)
+
+	account1, err = cs.GetAccount(addrs[1])
+	require.Nil(t, err)
+
+	require.Equal(t, beforeBalanceStr1, account1.Balance)
 }
 
 func TestChainSimulator_EGLD_MultiTransfer_Invalid_Value(t *testing.T) {

--- a/integrationTests/multiShard/block/executingMiniblocks/executingMiniblocks_test.go
+++ b/integrationTests/multiShard/block/executingMiniblocks/executingMiniblocks_test.go
@@ -8,19 +8,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-crypto-go"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/process/factory"
 	"github.com/multiversx/mx-chain-go/sharding"
 	"github.com/multiversx/mx-chain-go/state"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestShouldProcessBlocksInMultiShardArchitecture(t *testing.T) {
@@ -230,127 +227,6 @@ func TestSimpleTransactionsWithMoreGasWhichYieldInReceiptsInMultiShardedEnvironm
 			account, _ := accWrp.(state.UserAccountHandler)
 			assert.Equal(t, expectedBalance, account.GetBalance())
 		}
-	}
-}
-
-func TestSimpleTransactionsWithMoreValueThanBalanceYieldReceiptsInMultiShardedEnvironment(t *testing.T) {
-	if testing.Short() {
-		t.Skip("this is not a short test")
-	}
-
-	numOfShards := 2
-	nodesPerShard := 2
-	numMetachainNodes := 2
-
-	nodes := integrationTests.CreateNodes(
-		numOfShards,
-		nodesPerShard,
-		numMetachainNodes,
-	)
-
-	minGasLimit := uint64(10000)
-	for _, node := range nodes {
-		node.EconomicsData.SetMinGasLimit(minGasLimit, 0)
-	}
-
-	leaders := make([]*integrationTests.TestProcessorNode, numOfShards+1)
-	for i := 0; i < numOfShards; i++ {
-		leaders[i] = nodes[i*nodesPerShard]
-	}
-	leaders[numOfShards] = nodes[numOfShards*nodesPerShard]
-
-	integrationTests.DisplayAndStartNodes(nodes)
-
-	defer func() {
-		for _, n := range nodes {
-			n.Close()
-		}
-	}()
-
-	nrTxsToSend := uint64(10)
-	initialVal := big.NewInt(0).SetUint64(nrTxsToSend * minGasLimit * integrationTests.MinTxGasPrice)
-	halfInitVal := big.NewInt(0).Div(initialVal, big.NewInt(2))
-	integrationTests.MintAllNodes(nodes, initialVal)
-	receiverAddress := []byte("12345678901234567890123456789012")
-
-	integrationTests.SetRootHashOfGenesisBlocks(nodes)
-
-	round := uint64(0)
-	nonce := uint64(0)
-	round = integrationTests.IncrementAndPrintRound(round)
-	nonce++
-
-	for _, node := range nodes {
-		for j := uint64(0); j < nrTxsToSend; j++ {
-			integrationTests.PlayerSendsTransaction(
-				nodes,
-				node.OwnAccount,
-				receiverAddress,
-				halfInitVal,
-				"",
-				minGasLimit,
-			)
-		}
-	}
-
-	time.Sleep(2 * time.Second)
-
-	integrationTests.UpdateRound(nodes, round)
-	integrationTests.ProposeBlock(nodes, leaders, round, nonce)
-	integrationTests.SyncBlock(t, nodes, leaders, round)
-	round = integrationTests.IncrementAndPrintRound(round)
-	nonce++
-
-	for _, node := range nodes {
-		if node.ShardCoordinator.SelfId() == core.MetachainShardId {
-			continue
-		}
-
-		header := node.BlockChain.GetCurrentBlockHeader()
-		shardHdr, ok := header.(*block.Header)
-		numInvalid := 0
-		require.True(t, ok)
-		for _, mb := range shardHdr.MiniBlockHeaders {
-			if mb.Type == block.InvalidBlock {
-				numInvalid++
-			}
-		}
-		assert.Equal(t, 1, numInvalid)
-	}
-
-	time.Sleep(time.Second)
-	numRoundsToTest := 6
-	for i := 0; i < numRoundsToTest; i++ {
-		integrationTests.UpdateRound(nodes, round)
-		integrationTests.ProposeBlock(nodes, leaders, round, nonce)
-		integrationTests.SyncBlock(t, nodes, leaders, round)
-		round = integrationTests.IncrementAndPrintRound(round)
-		nonce++
-
-		time.Sleep(integrationTests.StepDelay)
-	}
-
-	time.Sleep(time.Second)
-
-	expectedReceiverValue := big.NewInt(0).Mul(big.NewInt(int64(len(nodes))), halfInitVal)
-	for _, verifierNode := range nodes {
-		for _, node := range nodes {
-			accWrp, err := verifierNode.AccntState.GetExistingAccount(node.OwnAccount.Address)
-			if err != nil {
-				continue
-			}
-
-			account, _ := accWrp.(state.UserAccountHandler)
-			assert.Equal(t, big.NewInt(0), account.GetBalance())
-		}
-
-		accWrp, err := verifierNode.AccntState.GetExistingAccount(receiverAddress)
-		if err != nil {
-			continue
-		}
-
-		account, _ := accWrp.(state.UserAccountHandler)
-		assert.Equal(t, expectedReceiverValue, account.GetBalance())
 	}
 }
 

--- a/integrationTests/singleShard/block/executingMiniblocks/executingMiniblocks_test.go
+++ b/integrationTests/singleShard/block/executingMiniblocks/executingMiniblocks_test.go
@@ -196,20 +196,19 @@ func testStateOnNodes(t *testing.T, nodes []*integrationTests.TestProcessorNode,
 
 	testSameBlockHeight(t, nodes, idxProposer, expectedHeaderNonce)
 	testTxIsInMiniblock(t, proposer, hashes[txValidIdx], block.TxBlock)
-	testTxIsInMiniblock(t, proposer, hashes[txInvalidIdx], block.InvalidBlock)
+	testTxIsInNotInBody(t, proposer, hashes[txInvalidIdx])
 	testTxIsInNotInBody(t, proposer, hashes[txDeletedIdx])
 
 	// Removed from mempool.
 	_, ok := proposer.DataPool.Transactions().SearchFirstData(hashes[txValidIdx])
 	assert.False(t, ok)
 
-	// Removed from mempool.
+	// Not removed from mempool.
 	_, ok = proposer.DataPool.Transactions().SearchFirstData(hashes[txInvalidIdx])
-	assert.False(t, ok)
+	assert.True(t, ok)
 
 	// Not removed from mempool (see MX-16200).
 	_, ok = proposer.DataPool.Transactions().SearchFirstData(hashes[txDeletedIdx])
-
 	assert.True(t, ok)
 }
 

--- a/process/block/preprocess/transactions_test.go
+++ b/process/block/preprocess/transactions_test.go
@@ -1004,6 +1004,7 @@ func TestCleanupSelfShardTxCache(t *testing.T) {
 	createTx := func(sender string, nonce uint64) *transaction.Transaction {
 		return &transaction.Transaction{
 			SndAddr:  []byte(sender),
+			Value:    big.NewInt(0),
 			Nonce:    nonce,
 			GasLimit: 1000,
 			GasPrice: 500,
@@ -1012,6 +1013,7 @@ func TestCleanupSelfShardTxCache(t *testing.T) {
 	createMoreValuableTx := func(sender string, nonce uint64) *transaction.Transaction {
 		return &transaction.Transaction{
 			SndAddr:  []byte(sender),
+			Value:    big.NewInt(0),
 			Nonce:    nonce,
 			GasLimit: 1000,
 			GasPrice: 1000,
@@ -1144,7 +1146,7 @@ func TestTransactions_CreateAndProcessMiniBlockCrossShardGasLimitAddAll(t *testi
 
 	addedTxs := make([]*transaction.Transaction, 0)
 	for i := 0; i < 10; i++ {
-		newTx := &transaction.Transaction{GasLimit: uint64(i), Nonce: 42 + uint64(i)}
+		newTx := &transaction.Transaction{Value: big.NewInt(0), GasLimit: uint64(i), Nonce: 42 + uint64(i)}
 
 		txHash, _ := core.CalculateHash(args.Marshalizer, args.Hasher, newTx)
 		args.DataPool.AddData(txHash, newTx, newTx.Size(), strCache)
@@ -1220,7 +1222,7 @@ func TestTransactions_CreateAndProcessMiniBlockCrossShardGasLimitAddAllAsNoSCCal
 
 	addedTxs := make([]*transaction.Transaction, 0)
 	for i := 0; i < 10; i++ {
-		newTx := &transaction.Transaction{GasLimit: gasLimit, GasPrice: uint64(i), RcvAddr: []byte("012345678910"), Nonce: 42 + uint64(i)}
+		newTx := &transaction.Transaction{Value: big.NewInt(0), GasLimit: gasLimit, GasPrice: uint64(i), RcvAddr: []byte("012345678910"), Nonce: 42 + uint64(i)}
 
 		txHash, _ := core.CalculateHash(args.Marshalizer, args.Hasher, newTx)
 		args.DataPool.AddData(txHash, newTx, newTx.Size(), strCache)
@@ -1300,7 +1302,7 @@ func TestTransactions_CreateAndProcessMiniBlockCrossShardGasLimitAddOnly5asSCCal
 
 	scAddress, _ := hex.DecodeString("000000000000000000005fed9c659422cd8429ce92f8973bba2a9fb51e0eb3a1")
 	for i := 0; i < 10; i++ {
-		newTx := &transaction.Transaction{GasLimit: gasLimit, GasPrice: uint64(i), RcvAddr: scAddress, Nonce: 42 + uint64(i)}
+		newTx := &transaction.Transaction{Value: big.NewInt(0), GasLimit: gasLimit, GasPrice: uint64(i), RcvAddr: scAddress, Nonce: 42 + uint64(i)}
 
 		txHash, _ := core.CalculateHash(args.Marshalizer, args.Hasher, newTx)
 		args.DataPool.AddData(txHash, newTx, newTx.Size(), strCache)
@@ -2790,12 +2792,14 @@ func Test_SelectOutgoingTransactions(t *testing.T) {
 		txsToAdd := []*transaction.Transaction{
 			{
 				SndAddr:  []byte("alice"),
+				Value:    big.NewInt(0),
 				Nonce:    2,
 				GasLimit: 1000,
 				GasPrice: 500,
 			},
 			{
 				SndAddr:  []byte("bob"),
+				Value:    big.NewInt(0),
 				Nonce:    42,
 				GasLimit: 1000,
 				GasPrice: 500,

--- a/process/coordinator/processProposal_test.go
+++ b/process/coordinator/processProposal_test.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"errors"
+	"math/big"
 	"reflect"
 	"testing"
 	"time"
@@ -591,12 +592,12 @@ func TestTransactionCoordinator_SelectOutgoingTransactions_MultipleBlockTypes(t 
 
 	// add transactions to the transactions pool
 	cacheId := process.ShardCacherIdentifier(0, 0)
-	ph.Transactions().AddData(txHashesType1[0], &transaction.Transaction{SndAddr: []byte("sender1"), Nonce: 0}, 100, cacheId)
-	ph.Transactions().AddData(txHashesType1[1], &transaction.Transaction{SndAddr: []byte("sender1"), Nonce: 1}, 100, cacheId)
+	ph.Transactions().AddData(txHashesType1[0], &transaction.Transaction{SndAddr: []byte("sender1"), Value: big.NewInt(0), Nonce: 0}, 100, cacheId)
+	ph.Transactions().AddData(txHashesType1[1], &transaction.Transaction{SndAddr: []byte("sender1"), Value: big.NewInt(0), Nonce: 1}, 100, cacheId)
 
 	// add transactions to the unsigned transactions pool
-	ph.UnsignedTransactions().AddData(txHashesType2[0], &transaction.Transaction{SndAddr: []byte("sender2"), Nonce: 0}, 100, cacheId)
-	ph.UnsignedTransactions().AddData(txHashesType2[1], &transaction.Transaction{SndAddr: []byte("sender3"), Nonce: 0}, 100, cacheId)
+	ph.UnsignedTransactions().AddData(txHashesType2[0], &transaction.Transaction{SndAddr: []byte("sender2"), Value: big.NewInt(0), Nonce: 0}, 100, cacheId)
+	ph.UnsignedTransactions().AddData(txHashesType2[1], &transaction.Transaction{SndAddr: []byte("sender3"), Value: big.NewInt(0), Nonce: 0}, 100, cacheId)
 
 	// Add both block types to the keys
 	tc.preProcProposal.keysTxPreProcs = []block.Type{block.TxBlock, block.SmartContractResultBlock}

--- a/process/coordinator/process_test.go
+++ b/process/coordinator/process_test.go
@@ -1465,7 +1465,7 @@ func TestTransactionCoordinator_CreateMbsAndProcessTransactionsFromMe(t *testing
 	hasher := &hashingMocks.HasherMock{}
 	for shId := uint32(0); shId < nrShards; shId++ {
 		strCache := process.ShardCacherIdentifier(0, shId)
-		newTx := &transaction.Transaction{GasLimit: uint64(shId), Nonce: 42 + uint64(shId)}
+		newTx := &transaction.Transaction{Value: big.NewInt(0), GasLimit: uint64(shId), Nonce: 42 + uint64(shId)}
 
 		computedTxHash, _ := core.CalculateHash(marshalizer, hasher, newTx)
 		txPool.AddData(computedTxHash, newTx, newTx.Size(), strCache)
@@ -1527,7 +1527,7 @@ func TestTransactionCoordinator_CreateMbsAndProcessTransactionsFromMeMultipleMin
 
 	allTxs := 100
 	for i := 0; i < allTxs; i++ {
-		newTx := &transaction.Transaction{GasLimit: gasLimit, GasPrice: uint64(i), RcvAddr: scAddress}
+		newTx := &transaction.Transaction{Value: big.NewInt(0), GasLimit: gasLimit, GasPrice: uint64(i), RcvAddr: scAddress}
 
 		computedTxHash, _ := core.CalculateHash(marshalizer, hasher, newTx)
 		txPool.AddData(computedTxHash, newTx, newTx.Size(), strCache)
@@ -1604,7 +1604,7 @@ func TestTransactionCoordinator_CreateMbsAndProcessTransactionsFromMeMultipleMin
 	scAddress, _ := hex.DecodeString("000000000000000000005fed9c659422cd8429ce92f8973bba2a9fb51e0eb3a1")
 
 	for i := 0; i < allTxs; i++ {
-		newTx := &transaction.Transaction{GasLimit: gasLimit + gasLimit/uint64(numMiniBlocks), GasPrice: uint64(i), RcvAddr: scAddress}
+		newTx := &transaction.Transaction{Value: big.NewInt(0), GasLimit: gasLimit + gasLimit/uint64(numMiniBlocks), GasPrice: uint64(i), RcvAddr: scAddress}
 
 		computedTxHash, _ := core.CalculateHash(marshalizer, hasher, newTx)
 		txPool.AddData(computedTxHash, newTx, newTx.Size(), strCache)
@@ -1686,7 +1686,7 @@ func TestTransactionCoordinator_CompactAndExpandMiniblocksShouldWork(t *testing.
 
 	for _, shardCacher := range shardCacherIdentifiers {
 		for i := 0; i < numTxsPerBulk; i++ {
-			newTx := &transaction.Transaction{GasLimit: gasLimit, GasPrice: uint64(i), RcvAddr: scAddress}
+			newTx := &transaction.Transaction{Value: big.NewInt(0), GasLimit: gasLimit, GasPrice: uint64(i), RcvAddr: scAddress}
 
 			computedTxHash, _ := core.CalculateHash(marshalizer, hasher, newTx)
 			txPool.AddData(computedTxHash, newTx, newTx.Size(), shardCacher)
@@ -1747,7 +1747,7 @@ func TestTransactionCoordinator_GetAllCurrentUsedTxs(t *testing.T) {
 	hasher := &hashingMocks.HasherMock{}
 	for i := uint32(0); i < nrShards; i++ {
 		strCache := process.ShardCacherIdentifier(0, i)
-		newTx := &transaction.Transaction{GasLimit: uint64(i), Nonce: 42 + uint64(i)}
+		newTx := &transaction.Transaction{Value: big.NewInt(0), GasLimit: uint64(i), Nonce: 42 + uint64(i)}
 
 		computedTxHash, _ := core.CalculateHash(marshalizer, hasher, newTx)
 		txPool.AddData(computedTxHash, newTx, newTx.Size(), strCache)

--- a/txcache/selection.go
+++ b/txcache/selection.go
@@ -78,7 +78,7 @@ func selectTransactionsFromBunches(
 		if len(selectedTransactions)%loopDurationCheckInterval == 0 {
 			if time.Since(selectionLoopStartTime) > selectionLoopMaxDuration {
 				logSelect.Debug("TxCache.selectTransactionsFromBunches, selection loop timeout", "duration", time.Since(selectionLoopStartTime))
-				//break
+				break
 			}
 		}
 

--- a/txcache/selection.go
+++ b/txcache/selection.go
@@ -63,6 +63,7 @@ func selectTransactionsFromBunches(
 	accumulatedGas := uint64(0)
 	selectionLoopStartTime := time.Now()
 
+	var currentTransaction *WrappedTransaction
 	// Select transactions (sorted).
 	for transactionsHeap.Len() > 0 {
 		// Always pick the best transaction.
@@ -98,9 +99,8 @@ func selectTransactionsFromBunches(
 
 		shouldSkipTransaction := detectSkippableTransaction(virtualSession, item, senderRecord)
 		if !shouldSkipTransaction {
-			accumulatedGas += gasLimit
 			// first, we get the transaction that might be selected
-			currentTransaction := item.getCurrentTransaction()
+			currentTransaction = item.getCurrentTransaction()
 			err = virtualSession.accumulateConsumedBalance(currentTransaction, senderRecord)
 			if err != nil {
 				// This error is unlikely to occur, as it would have been raised earlier during the detectSkippableSender call.
@@ -110,6 +110,7 @@ func selectTransactionsFromBunches(
 					"txHash", currentTransaction.TxHash)
 			} else {
 				// only if there isn't any error, we select the transaction
+				accumulatedGas += gasLimit
 				item.selectCurrentTransaction()
 				selectedTransactions = append(selectedTransactions, currentTransaction)
 			}

--- a/txcache/selection.go
+++ b/txcache/selection.go
@@ -78,7 +78,7 @@ func selectTransactionsFromBunches(
 		if len(selectedTransactions)%loopDurationCheckInterval == 0 {
 			if time.Since(selectionLoopStartTime) > selectionLoopMaxDuration {
 				logSelect.Debug("TxCache.selectTransactionsFromBunches, selection loop timeout", "duration", time.Since(selectionLoopStartTime))
-				break
+				//break
 			}
 		}
 
@@ -140,7 +140,7 @@ func detectSkippableSender(virtualSession *virtualSelectionSession, item *transa
 	if item.detectMiddleGap() {
 		return true
 	}
-	if virtualSession.detectWillFeeExceedBalance(item.currentTransaction) {
+	if virtualSession.detectWillBalanceBeExceeded(item.currentTransaction) {
 		return true
 	}
 

--- a/txcache/selection.go
+++ b/txcache/selection.go
@@ -99,16 +99,17 @@ func selectTransactionsFromBunches(
 		shouldSkipTransaction := detectSkippableTransaction(virtualSession, item, senderRecord)
 		if !shouldSkipTransaction {
 			accumulatedGas += gasLimit
+			// first, we get the transaction that might be selected
 			currentTransaction := item.getCurrentTransaction()
 			err = virtualSession.accumulateConsumedBalance(currentTransaction, senderRecord)
 			if err != nil {
 				// This error is unlikely to occur, as it would have been raised earlier during the detectSkippableSender call.
-				// Even if it does occur, it doesn't imply that the transaction should not be selected.
-				// Therefore, we only log the error here.
+				// However, we should not select the transaction if anything fails here.
 				log.Warn("TxCache.selectTransactionsFromBunches error when accumulating consumed balance",
 					"err", err,
 					"txHash", currentTransaction.TxHash)
 			} else {
+				// only if there isn't any error, we select the transaction
 				item.selectCurrentTransaction()
 				selectedTransactions = append(selectedTransactions, currentTransaction)
 			}

--- a/txcache/selection.go
+++ b/txcache/selection.go
@@ -99,16 +99,18 @@ func selectTransactionsFromBunches(
 		shouldSkipTransaction := detectSkippableTransaction(virtualSession, item, senderRecord)
 		if !shouldSkipTransaction {
 			accumulatedGas += gasLimit
-			selectedTransaction := item.selectCurrentTransaction()
-			selectedTransactions = append(selectedTransactions, selectedTransaction)
-			err := virtualSession.accumulateConsumedBalance(selectedTransaction, senderRecord)
+			currentTransaction := item.getCurrentTransaction()
+			err = virtualSession.accumulateConsumedBalance(currentTransaction, senderRecord)
 			if err != nil {
 				// This error is unlikely to occur, as it would have been raised earlier during the detectSkippableSender call.
 				// Even if it does occur, it doesn't imply that the transaction should not be selected.
 				// Therefore, we only log the error here.
 				log.Warn("TxCache.selectTransactionsFromBunches error when accumulating consumed balance",
 					"err", err,
-					"txHash", selectedTransaction.TxHash)
+					"txHash", currentTransaction.TxHash)
+			} else {
+				item.selectCurrentTransaction()
+				selectedTransactions = append(selectedTransactions, currentTransaction)
 			}
 		}
 

--- a/txcache/selectionTracker_test.go
+++ b/txcache/selectionTracker_test.go
@@ -470,23 +470,23 @@ func Test_CompleteFlowShouldWork(t *testing.T) {
 
 	txs := []*WrappedTransaction{
 		// txs for first block
-		createTx([]byte("txHash1"), "alice", 11).withRelayer([]byte("bob")).withGasLimit(100_000), // the fee is 100000000000000
-		createTx([]byte("txHash2"), "alice", 12),                                                  // the fee is 50000000000000
-		createTx([]byte("txHash3"), "alice", 13),
-		createTx([]byte("txHash4"), "bob", 11),
-		createTx([]byte("txHash5"), "carol", 11),
-		createTx([]byte("txHash6"), "carol", 12).withRelayer([]byte("bob")).withGasLimit(100_000),
-		createTx([]byte("txHash7"), "carol", 13).withRelayer([]byte("alice")).withGasLimit(100_000),
-		createTx([]byte("txHash8"), "carol", 14).withRelayer([]byte("eve")).withGasLimit(100_000),
+		createTx([]byte("txHash1"), "alice", 11).withValue(big.NewInt(0)).withRelayer([]byte("bob")).withGasLimit(100_000), // the fee is 100000000000000
+		createTx([]byte("txHash2"), "alice", 12).withValue(big.NewInt(0)),                                                  // the fee is 50000000000000
+		createTx([]byte("txHash3"), "alice", 13).withValue(big.NewInt(0)),
+		createTx([]byte("txHash4"), "bob", 11).withValue(big.NewInt(0)),
+		createTx([]byte("txHash5"), "carol", 11).withValue(big.NewInt(0)),
+		createTx([]byte("txHash6"), "carol", 12).withValue(big.NewInt(0)).withRelayer([]byte("bob")).withGasLimit(100_000),
+		createTx([]byte("txHash7"), "carol", 13).withValue(big.NewInt(0)).withRelayer([]byte("alice")).withGasLimit(100_000),
+		createTx([]byte("txHash8"), "carol", 14).withValue(big.NewInt(0)).withRelayer([]byte("eve")).withGasLimit(100_000),
 
 		// txs for second block
-		createTx([]byte("txHash9"), "carol", 15),
-		createTx([]byte("txHash10"), "eve", 11).withRelayer([]byte("bob")).withGasLimit(100_000),
+		createTx([]byte("txHash9"), "carol", 15).withValue(big.NewInt(0)),
+		createTx([]byte("txHash10"), "eve", 11).withValue(big.NewInt(0)).withRelayer([]byte("bob")).withGasLimit(100_000),
 
 		// tx to be selected
-		createTx([]byte("txHash11"), "bob", 12),
-		createTx([]byte("txHash12"), "carol", 13), // this one should not be selected
-		createTx([]byte("txHash13"), "eve", 14),   // this one should not be selected
+		createTx([]byte("txHash11"), "bob", 12).withValue(big.NewInt(0)),
+		createTx([]byte("txHash12"), "carol", 13).withValue(big.NewInt(0)), // this one should not be selected
+		createTx([]byte("txHash13"), "eve", 14).withValue(big.NewInt(0)),   // this one should not be selected
 	}
 	for _, tx := range txs {
 		cache.AddTx(tx)

--- a/txcache/selection_test.go
+++ b/txcache/selection_test.go
@@ -76,14 +76,14 @@ func TestTxCache_SelectTransactions_Dummy(t *testing.T) {
 		session.SetNonce([]byte("bob"), 5)
 		session.SetNonce([]byte("carol"), 1)
 
-		cache.AddTx(createTx([]byte("hash-alice-4"), "alice", 4))
-		cache.AddTx(createTx([]byte("hash-alice-3"), "alice", 3))
-		cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2))
-		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1))
-		cache.AddTx(createTx([]byte("hash-bob-7"), "bob", 7))
-		cache.AddTx(createTx([]byte("hash-bob-6"), "bob", 6))
-		cache.AddTx(createTx([]byte("hash-bob-5"), "bob", 5))
-		cache.AddTx(createTx([]byte("hash-carol-1"), "carol", 1))
+		cache.AddTx(createRelayedTx([]byte("hash-alice-4"), "alice", "relayer", 4))
+		cache.AddTx(createRelayedTx([]byte("hash-alice-3"), "alice", "relayer", 3))
+		cache.AddTx(createRelayedTx([]byte("hash-alice-2"), "alice", "relayer", 2))
+		cache.AddTx(createRelayedTx([]byte("hash-alice-1"), "alice", "relayer", 1))
+		cache.AddTx(createRelayedTx([]byte("hash-bob-7"), "bob", "relayer", 7))
+		cache.AddTx(createRelayedTx([]byte("hash-bob-6"), "bob", "relayer", 6))
+		cache.AddTx(createRelayedTx([]byte("hash-bob-5"), "bob", "relayer", 5))
+		cache.AddTx(createRelayedTx([]byte("hash-carol-1"), "carol", "relayer", 1))
 
 		selected, accumulatedGas, err := cache.SelectTransactions(session, options, 0)
 		require.NoError(t, err)
@@ -111,9 +111,9 @@ func TestTxCache_SelectTransactions_Dummy(t *testing.T) {
 		session.SetNonce([]byte("bob"), 5)
 		session.SetNonce([]byte("carol"), 3)
 
-		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1).withGasPrice(100))
-		cache.AddTx(createTx([]byte("hash-bob-5"), "bob", 5).withGasPrice(50))
-		cache.AddTx(createTx([]byte("hash-carol-3"), "carol", 3).withGasPrice(75))
+		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1).withGasPrice(100).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-bob-5"), "bob", 5).withGasPrice(50).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-carol-3"), "carol", 3).withGasPrice(75).withValue(big.NewInt(0)))
 
 		selected, accumulatedGas, err := cache.SelectTransactions(session, options, 0)
 		require.NoError(t, err)
@@ -138,14 +138,14 @@ func TestTxCache_SelectTransactionsWithBandwidth_Dummy(t *testing.T) {
 		session.SetNonce([]byte("bob"), 5)
 		session.SetNonce([]byte("carol"), 1)
 
-		cache.AddTx(createTx([]byte("hash-alice-4"), "alice", 4).withGasLimit(100000))
-		cache.AddTx(createTx([]byte("hash-alice-3"), "alice", 3).withGasLimit(100000))
-		cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2).withGasLimit(500000))
-		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1).withGasLimit(200000))
-		cache.AddTx(createTx([]byte("hash-bob-7"), "bob", 7).withGasLimit(400000))
-		cache.AddTx(createTx([]byte("hash-bob-6"), "bob", 6).withGasLimit(50000))
-		cache.AddTx(createTx([]byte("hash-bob-5"), "bob", 5).withGasLimit(50000))
-		cache.AddTx(createTx([]byte("hash-carol-1"), "carol", 1).withGasLimit(50000))
+		cache.AddTx(createTx([]byte("hash-alice-4"), "alice", 4).withGasLimit(100000).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-3"), "alice", 3).withGasLimit(100000).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2).withGasLimit(500000).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1).withGasLimit(200000).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-bob-7"), "bob", 7).withGasLimit(400000).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-bob-6"), "bob", 6).withGasLimit(50000).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-bob-5"), "bob", 5).withGasLimit(50000).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-carol-1"), "carol", 1).withGasLimit(50000).withValue(big.NewInt(0)))
 
 		selected, accumulatedGas, err := cache.SelectTransactions(session, options, 0)
 		require.NoError(t, err)
@@ -172,17 +172,17 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 		session.SetNonce([]byte("bob"), 42)
 		session.SetNonce([]byte("carol"), 7)
 
-		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1))
-		cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2))
-		cache.AddTx(createTx([]byte("hash-alice-3"), "alice", 3))
-		cache.AddTx(createTx([]byte("hash-alice-5"), "alice", 5)) // gap
-		cache.AddTx(createTx([]byte("hash-bob-42"), "bob", 42))
-		cache.AddTx(createTx([]byte("hash-bob-44"), "bob", 44)) // gap
-		cache.AddTx(createTx([]byte("hash-bob-45"), "bob", 45))
-		cache.AddTx(createTx([]byte("hash-carol-7"), "carol", 7))
-		cache.AddTx(createTx([]byte("hash-carol-8"), "carol", 8))
-		cache.AddTx(createTx([]byte("hash-carol-10"), "carol", 10)) // gap
-		cache.AddTx(createTx([]byte("hash-carol-11"), "carol", 11))
+		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-3"), "alice", 3).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-5"), "alice", 5).withValue(big.NewInt(0))) // gap
+		cache.AddTx(createTx([]byte("hash-bob-42"), "bob", 42).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-bob-44"), "bob", 44).withValue(big.NewInt(0))) // gap
+		cache.AddTx(createTx([]byte("hash-bob-45"), "bob", 45).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-carol-7"), "carol", 7).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-carol-8"), "carol", 8).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-carol-10"), "carol", 10).withValue(big.NewInt(0))) // gap
+		cache.AddTx(createTx([]byte("hash-carol-11"), "carol", 11).withValue(big.NewInt(0)))
 
 		sorted, accumulatedGas, err := cache.SelectTransactions(session, options, 0)
 		require.NoError(t, err)
@@ -203,18 +203,18 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 		session.SetNonce([]byte("carol"), 7)
 
 		// Good
-		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1))
-		cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2))
-		cache.AddTx(createTx([]byte("hash-alice-3"), "alice", 3))
+		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-3"), "alice", 3).withValue(big.NewInt(0)))
 
 		// Initial gap
-		cache.AddTx(createTx([]byte("hash-bob-42"), "bob", 44))
-		cache.AddTx(createTx([]byte("hash-bob-43"), "bob", 45))
-		cache.AddTx(createTx([]byte("hash-bob-44"), "bob", 46))
+		cache.AddTx(createTx([]byte("hash-bob-42"), "bob", 44).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-bob-43"), "bob", 45).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-bob-44"), "bob", 46).withValue(big.NewInt(0)))
 
 		// Good
-		cache.AddTx(createTx([]byte("hash-carol-7"), "carol", 7))
-		cache.AddTx(createTx([]byte("hash-carol-8"), "carol", 8))
+		cache.AddTx(createTx([]byte("hash-carol-7"), "carol", 7).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-carol-8"), "carol", 8).withValue(big.NewInt(0)))
 
 		sorted, accumulatedGas, err := cache.SelectTransactions(session, options, 0)
 		require.NoError(t, err)
@@ -235,18 +235,18 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 		session.SetNonce([]byte("carol"), 7)
 
 		// Good
-		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1))
-		cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2))
-		cache.AddTx(createTx([]byte("hash-alice-3"), "alice", 3))
+		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-3"), "alice", 3).withValue(big.NewInt(0)))
 
 		// A few with lower nonce
-		cache.AddTx(createTx([]byte("hash-bob-42"), "bob", 40))
-		cache.AddTx(createTx([]byte("hash-bob-43"), "bob", 41))
-		cache.AddTx(createTx([]byte("hash-bob-44"), "bob", 42))
+		cache.AddTx(createTx([]byte("hash-bob-42"), "bob", 40).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-bob-43"), "bob", 41).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-bob-44"), "bob", 42).withValue(big.NewInt(0)))
 
 		// Good
-		cache.AddTx(createTx([]byte("hash-carol-7"), "carol", 7))
-		cache.AddTx(createTx([]byte("hash-carol-8"), "carol", 8))
+		cache.AddTx(createTx([]byte("hash-carol-7"), "carol", 7).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-carol-8"), "carol", 8).withValue(big.NewInt(0)))
 
 		sorted, accumulatedGas, err := cache.SelectTransactions(session, options, 0)
 		require.NoError(t, err)
@@ -264,12 +264,12 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 		session := txcachemocks.NewSelectionSessionMock()
 		session.SetNonce([]byte("alice"), 1)
 
-		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1))
-		cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2))
-		cache.AddTx(createTx([]byte("hash-alice-3a"), "alice", 3))
-		cache.AddTx(createTx([]byte("hash-alice-3b"), "alice", 3).withGasPrice(oneBillion * 2))
-		cache.AddTx(createTx([]byte("hash-alice-3c"), "alice", 3))
-		cache.AddTx(createTx([]byte("hash-alice-4"), "alice", 4))
+		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-3a"), "alice", 3).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-3b"), "alice", 3).withGasPrice(oneBillion * 2).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-3c"), "alice", 3).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-4"), "alice", 4).withValue(big.NewInt(0)))
 
 		sorted, accumulatedGas, err := cache.SelectTransactions(session, options, 0)
 		require.NoError(t, err)
@@ -294,14 +294,14 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 		session.SetBalance([]byte("bob"), big.NewInt(70000000000000))
 
 		// Enough balance
-		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1))
-		cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2))
-		cache.AddTx(createTx([]byte("hash-alice-3"), "alice", 3))
+		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-alice-3"), "alice", 3).withValue(big.NewInt(0)))
 
 		// Not enough balance
-		cache.AddTx(createTx([]byte("hash-bob-42"), "bob", 40))
-		cache.AddTx(createTx([]byte("hash-bob-43"), "bob", 41))
-		cache.AddTx(createTx([]byte("hash-bob-44"), "bob", 42))
+		cache.AddTx(createTx([]byte("hash-bob-42"), "bob", 40).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-bob-43"), "bob", 41).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-bob-44"), "bob", 42).withValue(big.NewInt(0)))
 
 		sorted, accumulatedGas, err := cache.SelectTransactions(session, options, 0)
 		require.NoError(t, err)
@@ -324,10 +324,10 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 			return bytes.Equal(tx.GetData(), []byte("t"))
 		}
 
-		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1).withData([]byte("x")).withGasLimit(100000))
-		cache.AddTx(createTx([]byte("hash-bob-42a"), "bob", 42).withData([]byte("y")).withGasLimit(100000))
-		cache.AddTx(createTx([]byte("hash-bob-43a"), "bob", 43).withData([]byte("z")).withGasLimit(100000))
-		cache.AddTx(createTx([]byte("hash-bob-43b"), "bob", 43).withData([]byte("t")).withGasLimit(100000))
+		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1).withData([]byte("x")).withGasLimit(100000).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-bob-42a"), "bob", 42).withData([]byte("y")).withGasLimit(100000).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-bob-43a"), "bob", 43).withData([]byte("z")).withGasLimit(100000).withValue(big.NewInt(0)))
+		cache.AddTx(createTx([]byte("hash-bob-43b"), "bob", 43).withData([]byte("t")).withGasLimit(100000).withValue(big.NewInt(0)))
 
 		sorted, accumulatedGas, err := cache.SelectTransactions(session, options, 0)
 		require.NoError(t, err)
@@ -357,7 +357,7 @@ func TestTxCache_SelectTransactions_WhenTransactionsAddedInReversedNonceOrder(t 
 
 		for txNonce := nTransactionsPerSender - 1; txNonce >= 0; txNonce-- {
 			txHash := fmt.Sprintf("hash:%d:%d", senderTag, txNonce)
-			tx := createTx([]byte(txHash), sender, uint64(txNonce))
+			tx := createTx([]byte(txHash), sender, uint64(txNonce)).withValue(big.NewInt(0))
 			cache.AddTx(tx)
 		}
 	}

--- a/txcache/testutils_test.go
+++ b/txcache/testutils_test.go
@@ -143,7 +143,7 @@ func addManyTransactionsWithUniformDistribution(cache *TxCache, nSenders int, nT
 		for nonce := nTransactionsPerSender - 1; nonce >= 0; nonce-- {
 			transactionHash := createFakeTxHash(sender, nonce)
 			gasPrice := oneBillion + rand.Intn(3*oneBillion)
-			transaction := createTx(transactionHash, string(sender), uint64(nonce)).withGasPrice(uint64(gasPrice))
+			transaction := createTx(transactionHash, string(sender), uint64(nonce)).withGasPrice(uint64(gasPrice)).withValue(big.NewInt(0))
 
 			cache.AddTx(transaction)
 		}
@@ -161,7 +161,7 @@ func createBunchesOfTransactionsWithUniformDistribution(nSenders int, nTransacti
 		for nonce := 0; nonce < nTransactionsPerSender; nonce++ {
 			transactionHash := createFakeTxHash(sender, nonce)
 			gasPrice := oneBillion + rand.Intn(3*oneBillion)
-			transaction := createTx(transactionHash, string(sender), uint64(nonce)).withGasPrice(uint64(gasPrice))
+			transaction := createTx(transactionHash, string(sender), uint64(nonce)).withGasPrice(uint64(gasPrice)).withValue(big.NewInt(0))
 			transaction.precomputeFields(host)
 
 			bunch = append(bunch, transaction)
@@ -185,6 +185,24 @@ func createTx(hash []byte, sender string, nonce uint64) *WrappedTransaction {
 		Tx:     tx,
 		TxHash: hash,
 		Size:   int64(estimatedSizeOfBoundedTxFields),
+	}
+}
+
+func createRelayedTx(hash []byte, sender string, relayer string, nonce uint64) *WrappedTransaction {
+	tx := &transaction.Transaction{
+		SndAddr:  []byte(sender),
+		Nonce:    nonce,
+		GasLimit: 50000,
+		GasPrice: oneBillion,
+		Value:    big.NewInt(0),
+	}
+
+	return &WrappedTransaction{
+		Tx:       tx,
+		TxHash:   hash,
+		Size:     int64(estimatedSizeOfBoundedTxFields),
+		FeePayer: []byte(relayer),
+		Fee:      big.NewInt(0),
 	}
 }
 

--- a/txcache/transactionsHeapItem.go
+++ b/txcache/transactionsHeapItem.go
@@ -29,11 +29,13 @@ func newTransactionsHeapItem(bunch bunchOfTransactions) (*transactionsHeapItem, 
 	}, nil
 }
 
-func (item *transactionsHeapItem) selectCurrentTransaction() *WrappedTransaction {
+func (item *transactionsHeapItem) getCurrentTransaction() *WrappedTransaction {
+	return item.currentTransaction
+}
+
+func (item *transactionsHeapItem) selectCurrentTransaction() {
 	item.latestSelectedTransaction = item.currentTransaction
 	item.latestSelectedTransactionNonce = item.currentTransactionNonce
-
-	return item.currentTransaction
 }
 
 func (item *transactionsHeapItem) gotoNextTransaction() bool {

--- a/txcache/transactionsHeapItem_test.go
+++ b/txcache/transactionsHeapItem_test.go
@@ -44,7 +44,8 @@ func TestTransactionsHeapItem_selectTransaction(t *testing.T) {
 	item, err := newTransactionsHeapItem(bunchOfTransactions{a, b})
 	require.NoError(t, err)
 
-	selected := item.selectCurrentTransaction()
+	selected := item.getCurrentTransaction()
+	item.selectCurrentTransaction()
 	require.Equal(t, a, selected)
 	require.Equal(t, a, item.latestSelectedTransaction)
 	require.Equal(t, 42, int(item.latestSelectedTransactionNonce))
@@ -52,7 +53,8 @@ func TestTransactionsHeapItem_selectTransaction(t *testing.T) {
 	ok := item.gotoNextTransaction()
 	require.True(t, ok)
 
-	selected = item.selectCurrentTransaction()
+	selected = item.getCurrentTransaction()
+	item.selectCurrentTransaction()
 	require.Equal(t, b, selected)
 	require.Equal(t, b, item.latestSelectedTransaction)
 	require.Equal(t, 43, int(item.latestSelectedTransactionNonce))

--- a/txcache/virtualSelectionSession.go
+++ b/txcache/virtualSelectionSession.go
@@ -101,9 +101,15 @@ func (virtualSession *virtualSelectionSession) consumedBalanceExceedsInitialBala
 
 	consumedBalance := record.getConsumedBalance()
 	futureConsumedBalance := new(big.Int).Add(consumedBalance, value)
-	feePayerBalance := record.getInitialBalance()
+	initialBalance := record.getInitialBalance()
 
-	willFeeExceedBalance := futureConsumedBalance.Cmp(feePayerBalance) > 0
+	willFeeExceedBalance := futureConsumedBalance.Cmp(initialBalance) > 0
+	if willFeeExceedBalance {
+		logSelect.Trace("virtualSelectionSession.consumedBalanceExceedsInitialBalance",
+			"initialBalance", initialBalance,
+			"consumedBalance", consumedBalance,
+		)
+	}
 	return willFeeExceedBalance
 }
 
@@ -128,6 +134,11 @@ func (virtualSession *virtualSelectionSession) detectWillBalanceBeExceeded(tx *W
 	}
 
 	if virtualSession.consumedBalanceExceedsInitialBalance(sender, transferredValue) {
+		logSelect.Debug("virtualSelectionSession.detectWillBalanceBeExceeded balance exceeded  by transferred value",
+			"txHash", tx.TxHash,
+			"sender", sender,
+			"transferredValue", transferredValue,
+		)
 		return true
 	}
 
@@ -139,11 +150,22 @@ func (virtualSession *virtualSelectionSession) detectWillBalanceBeExceeded(tx *W
 	}
 
 	if virtualSession.consumedBalanceExceedsInitialBalance(feePayer, fee) {
+		logSelect.Debug("virtualSelectionSession.detectWillBalanceBeExceeded balance exceeded by fee",
+			"txHash", tx.TxHash,
+			"feePayer", feePayer,
+			"fee", fee,
+		)
 		return true
 	}
 
 	accumulatedBalance := big.NewInt(0).Add(transferredValue, fee)
 	if bytes.Equal(sender, feePayer) && virtualSession.consumedBalanceExceedsInitialBalance(sender, accumulatedBalance) {
+		logSelect.Debug("virtualSelectionSession.detectWillBalanceBeExceeded balance exceeded by sum of transferred value and fee",
+			"txHash", tx.TxHash,
+			"sender", sender,
+			"transferredValue", transferredValue,
+			"fee", fee,
+		)
 		return true
 	}
 

--- a/txcache/virtualSelectionSession.go
+++ b/txcache/virtualSelectionSession.go
@@ -59,11 +59,6 @@ func (virtualSession *virtualSelectionSession) getNonceForAccountRecord(accountR
 }
 
 func (virtualSession *virtualSelectionSession) accumulateConsumedBalance(tx *WrappedTransaction, senderRecord *virtualAccountRecord) error {
-	transferredValue := tx.TransferredValue
-	if transferredValue != nil {
-		senderRecord.accumulateConsumedBalance(transferredValue)
-	}
-
 	var feePayerRecord *virtualAccountRecord
 
 	// check if there's a need to search for another record
@@ -86,6 +81,14 @@ func (virtualSession *virtualSelectionSession) accumulateConsumedBalance(tx *Wra
 	fee := tx.Fee
 	if fee != nil {
 		feePayerRecord.accumulateConsumedBalance(fee)
+	}
+
+	// getting the record of the gee payer might generate an unexpected failure.
+	// this means that the transaction will not be selected.
+	// accumulate the transferred value only if there isn't any error until here.
+	transferredValue := tx.TransferredValue
+	if transferredValue != nil {
+		senderRecord.accumulateConsumedBalance(transferredValue)
 	}
 
 	return nil

--- a/txcache/virtualSelectionSession.go
+++ b/txcache/virtualSelectionSession.go
@@ -1,6 +1,7 @@
 package txcache
 
 import (
+	"bytes"
 	"math/big"
 
 	"github.com/multiversx/mx-chain-core-go/core"
@@ -90,38 +91,63 @@ func (virtualSession *virtualSelectionSession) accumulateConsumedBalance(tx *Wra
 	return nil
 }
 
-func (virtualSession *virtualSelectionSession) detectWillFeeExceedBalance(tx *WrappedTransaction) bool {
-	fee := tx.Fee
-	if fee == nil {
-		// unexpected failure
-		log.Debug("virtualSelectionSession.detectWillFeeExceedBalance nil fee")
-		return false
-	}
-
-	// Here, we are not interested into an eventual transfer of value (we only check if there's enough balance to pay the transaction fee).
-	feePayer := tx.FeePayer
-	feePayerRecord, err := virtualSession.getRecord(feePayer)
+func (virtualSession *virtualSelectionSession) consumedBalanceExceedsInitialBalance(address []byte, value *big.Int) bool {
+	record, err := virtualSession.getRecord(address)
 	if err != nil {
-		log.Debug("virtualSelectionSession.detectWillFeeExceedBalance",
+		log.Debug("virtualSelectionSession.consumedBalanceExceedsInitialBalance",
 			"err", err)
 		return false
 	}
 
-	consumedBalance := feePayerRecord.getConsumedBalance()
-	futureConsumedBalance := new(big.Int).Add(consumedBalance, fee)
-	feePayerBalance := feePayerRecord.getInitialBalance()
+	consumedBalance := record.getConsumedBalance()
+	futureConsumedBalance := new(big.Int).Add(consumedBalance, value)
+	feePayerBalance := record.getInitialBalance()
 
 	willFeeExceedBalance := futureConsumedBalance.Cmp(feePayerBalance) > 0
-	if willFeeExceedBalance {
-		logSelect.Trace("virtualSelectionSession.detectWillFeeExceedBalance",
-			"tx", tx.TxHash,
-			"feePayer", feePayer,
-			"initialBalance", feePayerBalance,
-			"consumedBalance", consumedBalance,
-		)
+	return willFeeExceedBalance
+}
+
+// the selection of transactions has to be as restrictive as proposing the block.
+// this means that we should check not only if fee exceeds the balance of relayer, but also if the transferred value exceeds it
+func (virtualSession *virtualSelectionSession) detectWillBalanceBeExceeded(tx *WrappedTransaction) bool {
+	if tx == nil {
+		log.Debug("virtualSelectionSession.detectWillFeeExceedBalance nil wrapped transaction")
+		return false
 	}
 
-	return willFeeExceedBalance
+	if tx.Tx == nil {
+		log.Debug("virtualSelectionSession.detectWillFeeExceedBalance nil tx")
+		return false
+	}
+
+	sender := tx.Tx.GetSndAddr()
+	transferredValue := tx.TransferredValue
+	if transferredValue == nil {
+		log.Debug("virtualSelectionSession.detectWillFeeExceedBalance nil transferredValue")
+		return false
+	}
+
+	if virtualSession.consumedBalanceExceedsInitialBalance(sender, transferredValue) {
+		return true
+	}
+
+	feePayer := tx.FeePayer
+	fee := tx.Fee
+	if fee == nil {
+		log.Debug("virtualSelectionSession.detectWillFeeExceedBalance nil fee")
+		return false
+	}
+
+	if virtualSession.consumedBalanceExceedsInitialBalance(feePayer, fee) {
+		return true
+	}
+
+	accumulatedBalance := big.NewInt(0).Add(transferredValue, fee)
+	if bytes.Equal(sender, feePayer) && virtualSession.consumedBalanceExceedsInitialBalance(sender, accumulatedBalance) {
+		return true
+	}
+
+	return false
 }
 
 func (virtualSession *virtualSelectionSession) isIncorrectlyGuarded(tx data.TransactionHandler) bool {

--- a/txcache/virtualSelectionSession.go
+++ b/txcache/virtualSelectionSession.go
@@ -103,33 +103,33 @@ func (virtualSession *virtualSelectionSession) consumedBalanceExceedsInitialBala
 	futureConsumedBalance := new(big.Int).Add(consumedBalance, value)
 	initialBalance := record.getInitialBalance()
 
-	willFeeExceedBalance := futureConsumedBalance.Cmp(initialBalance) > 0
-	if willFeeExceedBalance {
+	willBalanceBeExceeded := futureConsumedBalance.Cmp(initialBalance) > 0
+	if willBalanceBeExceeded {
 		logSelect.Trace("virtualSelectionSession.consumedBalanceExceedsInitialBalance",
 			"initialBalance", initialBalance,
 			"consumedBalance", consumedBalance,
 		)
 	}
-	return willFeeExceedBalance
+	return willBalanceBeExceeded
 }
 
 // the selection of transactions has to be as restrictive as proposing the block.
 // this means that we should check not only if fee exceeds the balance of relayer, but also if the transferred value exceeds it
 func (virtualSession *virtualSelectionSession) detectWillBalanceBeExceeded(tx *WrappedTransaction) bool {
 	if tx == nil {
-		log.Debug("virtualSelectionSession.detectWillFeeExceedBalance nil wrapped transaction")
+		log.Debug("virtualSelectionSession.detectWillBalanceBeExceeded nil wrapped transaction")
 		return false
 	}
 
 	if tx.Tx == nil {
-		log.Debug("virtualSelectionSession.detectWillFeeExceedBalance nil tx")
+		log.Debug("virtualSelectionSession.detectWillBalanceBeExceeded nil tx")
 		return false
 	}
 
 	sender := tx.Tx.GetSndAddr()
 	transferredValue := tx.TransferredValue
 	if transferredValue == nil {
-		log.Debug("virtualSelectionSession.detectWillFeeExceedBalance nil transferredValue")
+		log.Trace("virtualSelectionSession.detectWillBalanceBeExceeded nil transferredValue")
 		return false
 	}
 
@@ -145,12 +145,12 @@ func (virtualSession *virtualSelectionSession) detectWillBalanceBeExceeded(tx *W
 	feePayer := tx.FeePayer
 	fee := tx.Fee
 	if fee == nil {
-		log.Debug("virtualSelectionSession.detectWillFeeExceedBalance nil fee")
+		log.Debug("virtualSelectionSession.detectWillBalanceBeExceeded nil fee")
 		return false
 	}
 
 	if virtualSession.consumedBalanceExceedsInitialBalance(feePayer, fee) {
-		logSelect.Debug("virtualSelectionSession.detectWillBalanceBeExceeded balance exceeded by fee",
+		logSelect.Trace("virtualSelectionSession.detectWillBalanceBeExceeded balance exceeded by fee",
 			"txHash", tx.TxHash,
 			"feePayer", feePayer,
 			"fee", fee,
@@ -160,7 +160,7 @@ func (virtualSession *virtualSelectionSession) detectWillBalanceBeExceeded(tx *W
 
 	accumulatedBalance := big.NewInt(0).Add(transferredValue, fee)
 	if bytes.Equal(sender, feePayer) && virtualSession.consumedBalanceExceedsInitialBalance(sender, accumulatedBalance) {
-		logSelect.Debug("virtualSelectionSession.detectWillBalanceBeExceeded balance exceeded by sum of transferred value and fee",
+		logSelect.Trace("virtualSelectionSession.detectWillBalanceBeExceeded balance exceeded by sum of transferred value and fee",
 			"txHash", tx.TxHash,
 			"sender", sender,
 			"transferredValue", transferredValue,

--- a/txcache/virtualSelectionSession.go
+++ b/txcache/virtualSelectionSession.go
@@ -83,7 +83,7 @@ func (virtualSession *virtualSelectionSession) accumulateConsumedBalance(tx *Wra
 		feePayerRecord.accumulateConsumedBalance(fee)
 	}
 
-	// getting the record of the gee payer might generate an unexpected failure.
+	// getting the record of the fee payer might generate an unexpected failure.
 	// this means that the transaction will not be selected.
 	// accumulate the transferred value only if there isn't any error until here.
 	transferredValue := tx.TransferredValue

--- a/txcache/virtualSelectionSession.go
+++ b/txcache/virtualSelectionSession.go
@@ -96,7 +96,7 @@ func (virtualSession *virtualSelectionSession) consumedBalanceExceedsInitialBala
 	if err != nil {
 		log.Debug("virtualSelectionSession.consumedBalanceExceedsInitialBalance",
 			"err", err)
-		return false
+		return true
 	}
 
 	consumedBalance := record.getConsumedBalance()
@@ -118,19 +118,19 @@ func (virtualSession *virtualSelectionSession) consumedBalanceExceedsInitialBala
 func (virtualSession *virtualSelectionSession) detectWillBalanceBeExceeded(tx *WrappedTransaction) bool {
 	if tx == nil {
 		log.Debug("virtualSelectionSession.detectWillBalanceBeExceeded nil wrapped transaction")
-		return false
+		return true
 	}
 
 	if tx.Tx == nil {
 		log.Debug("virtualSelectionSession.detectWillBalanceBeExceeded nil tx")
-		return false
+		return true
 	}
 
 	sender := tx.Tx.GetSndAddr()
 	transferredValue := tx.TransferredValue
 	if transferredValue == nil {
 		log.Trace("virtualSelectionSession.detectWillBalanceBeExceeded nil transferredValue")
-		return false
+		return true
 	}
 
 	if virtualSession.consumedBalanceExceedsInitialBalance(sender, transferredValue) {
@@ -146,7 +146,7 @@ func (virtualSession *virtualSelectionSession) detectWillBalanceBeExceeded(tx *W
 	fee := tx.Fee
 	if fee == nil {
 		log.Debug("virtualSelectionSession.detectWillBalanceBeExceeded nil fee")
-		return false
+		return true
 	}
 
 	if virtualSession.consumedBalanceExceedsInitialBalance(feePayer, fee) {

--- a/txcache/virtualSelectionSession_test.go
+++ b/txcache/virtualSelectionSession_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-go/testscommon/txcachemocks"
 	"github.com/stretchr/testify/require"
 )
@@ -305,11 +306,15 @@ func Test_detectWillFeeExceedBalance(t *testing.T) {
 		}
 
 		tx := WrappedTransaction{
+			TransferredValue: big.NewInt(0),
+			Tx: &transaction.Transaction{
+				SndAddr: []byte("alice"),
+			},
 			Fee:      big.NewInt(2),
 			FeePayer: []byte("alice"),
 		}
 
-		actualRes := virtualSession.detectWillFeeExceedBalance(&tx)
+		actualRes := virtualSession.detectWillBalanceBeExceeded(&tx)
 		require.True(t, actualRes)
 	})
 
@@ -338,7 +343,7 @@ func Test_detectWillFeeExceedBalance(t *testing.T) {
 			FeePayer: []byte("alice"),
 		}
 
-		actualRes := virtualSession.detectWillFeeExceedBalance(&tx)
+		actualRes := virtualSession.detectWillBalanceBeExceeded(&tx)
 		require.False(t, actualRes)
 	})
 }

--- a/txcache/virtualSelectionSession_test.go
+++ b/txcache/virtualSelectionSession_test.go
@@ -282,7 +282,7 @@ func Test_accumulateConsumedBalance(t *testing.T) {
 	})
 }
 
-func Test_detectWillFeeExceedBalance(t *testing.T) {
+func Test_detectWillBalanceBeExceeded(t *testing.T) {
 	t.Parallel()
 
 	t.Run("should exceed balance", func(t *testing.T) {

--- a/txcache/virtualSelectionSession_test.go
+++ b/txcache/virtualSelectionSession_test.go
@@ -339,8 +339,12 @@ func Test_detectWillBalanceBeExceeded(t *testing.T) {
 		}
 
 		tx := WrappedTransaction{
-			Fee:      big.NewInt(2),
-			FeePayer: []byte("alice"),
+			Tx: &transaction.Transaction{
+				SndAddr: []byte("bob"),
+			},
+			TransferredValue: big.NewInt(0),
+			Fee:              big.NewInt(2),
+			FeePayer:         []byte("alice"),
 		}
 
 		actualRes := virtualSession.detectWillBalanceBeExceeded(&tx)


### PR DESCRIPTION
## Reasoning behind the pull request
**- Currently, the constraints on selection are not the same with the ones of validating a proposed block. This PR solves this issue by: not selecting txs which have a value + fee greater than the initial value, not selecting any txs that might generate unexpected failure. A transaction is selected only after all the conditions are fine but also only after there is not any unexpected issue.**
  
## Proposed changes

## Testing procedure


## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
