### PR TITLE
Integrate max rounds unprocessed mb/txs in process configs

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -64,8 +64,8 @@
     ]
 
     ProcessConfigsByRound = [
-        { EnableRound = 0, MaxRoundsWithoutNewBlockReceived = 10, MaxRoundsWithoutCommittedBlock = 10, RoundModulusTriggerWhenSyncIsStuck = 20, MaxSyncWithErrorsAllowed = 10 },
-        { EnableRound = 440, MaxRoundsWithoutNewBlockReceived = 100, MaxRoundsWithoutCommittedBlock = 100, RoundModulusTriggerWhenSyncIsStuck = 200, MaxSyncWithErrorsAllowed = 100 },
+        { EnableRound = 0, MaxRoundsWithoutNewBlockReceived = 10, MaxRoundsWithoutCommittedBlock = 10, RoundModulusTriggerWhenSyncIsStuck = 20, MaxSyncWithErrorsAllowed = 10, MaxRoundsToKeepUnprocessedMiniBlocks = 300,   MaxRoundsToKeepUnprocessedTransactions = 300},
+        { EnableRound = 440, MaxRoundsWithoutNewBlockReceived = 100, MaxRoundsWithoutCommittedBlock = 100, RoundModulusTriggerWhenSyncIsStuck = 200, MaxSyncWithErrorsAllowed = 100, MaxRoundsToKeepUnprocessedMiniBlocks = 3000,   MaxRoundsToKeepUnprocessedTransactions = 3000  },
     ]
 
     EpochStartConfigsByEpoch = [

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -582,11 +582,6 @@
     TopRatedCacheCapacity = 5000
     BadRatedCacheCapacity = 5000
 
-[PoolsCleanersConfig]
-    # TODO: update these (maybe in txpool feat)
-    MaxRoundsToKeepUnprocessedMiniBlocks = 300   # max number of rounds unprocessed miniblocks are kept in pool
-    MaxRoundsToKeepUnprocessedTransactions = 300 # max number of rounds unprocessed transactions are kept in pool
-
 [TrieSyncStorage]
     Capacity = 300000
     SizeInBytes = 104857600 #100MB

--- a/common/configs/processConfigs.go
+++ b/common/configs/processConfigs.go
@@ -179,70 +179,91 @@ func (pce *processConfigsByEpoch) GetMaxShardNoncesBehindByEpoch(epoch uint32) u
 	return defaultMaxShardNoncesBehind // this should not happen
 }
 
-// GetMaxRoundsWithoutNewBlockReceivedByRound returns max rounds without new block received by epoch
-func (pce *processConfigsByEpoch) GetMaxRoundsWithoutNewBlockReceivedByRound(round uint64) uint32 {
-	for i := len(pce.orderedConfigByRound) - 1; i >= 0; i-- {
-		if pce.orderedConfigByRound[i].EnableRound <= round {
-			return pce.orderedConfigByRound[i].MaxRoundsWithoutNewBlockReceived
+func getConfigValueByRound[T any](
+	configs []config.ProcessConfigByRound,
+	round uint64,
+	selector func(config.ProcessConfigByRound) T,
+	defaultValue T,
+) T {
+	for i := len(configs) - 1; i >= 0; i-- {
+		if configs[i].EnableRound <= round {
+			return selector(configs[i])
 		}
 	}
 
-	return defaultMaxRoundsWithoutNewBlockReceived // this should not happen
+	return defaultValue
+}
+
+// GetMaxRoundsWithoutNewBlockReceivedByRound returns max rounds without new block received by epoch
+func (pce *processConfigsByEpoch) GetMaxRoundsWithoutNewBlockReceivedByRound(round uint64) uint32 {
+	return getConfigValueByRound(
+		pce.orderedConfigByRound,
+		round,
+		func(cfg config.ProcessConfigByRound) uint32 {
+			return cfg.MaxRoundsWithoutNewBlockReceived
+		},
+		defaultMaxRoundsWithoutNewBlockReceived,
+	)
 }
 
 // GetMaxRoundsWithoutCommittedBlock returns max rounds without commited block
 func (pce *processConfigsByEpoch) GetMaxRoundsWithoutCommittedBlock(round uint64) uint32 {
-	for i := len(pce.orderedConfigByRound) - 1; i >= 0; i-- {
-		if pce.orderedConfigByRound[i].EnableRound <= round {
-			return pce.orderedConfigByRound[i].MaxRoundsWithoutCommittedBlock
-		}
-	}
-
-	return defaultMaxRoundsWithoutCommittedBlock // this should not happen
+	return getConfigValueByRound(
+		pce.orderedConfigByRound,
+		round,
+		func(cfg config.ProcessConfigByRound) uint32 {
+			return cfg.MaxRoundsWithoutCommittedBlock
+		},
+		defaultMaxRoundsWithoutCommittedBlock,
+	)
 }
 
 // GetRoundModulusTriggerWhenSyncIsStuck returns round modulus when sync is stuck
 func (pce *processConfigsByEpoch) GetRoundModulusTriggerWhenSyncIsStuck(round uint64) uint32 {
-	for i := len(pce.orderedConfigByRound) - 1; i >= 0; i-- {
-		if pce.orderedConfigByRound[i].EnableRound <= round {
-			return pce.orderedConfigByRound[i].RoundModulusTriggerWhenSyncIsStuck
-		}
-	}
-
-	return defaultRoundModulusTriggerWhenSyncIsStuck // this should not happen
+	return getConfigValueByRound(
+		pce.orderedConfigByRound,
+		round,
+		func(cfg config.ProcessConfigByRound) uint32 {
+			return cfg.RoundModulusTriggerWhenSyncIsStuck
+		},
+		defaultRoundModulusTriggerWhenSyncIsStuck,
+	)
 }
 
 // GetMaxSyncWithErrorsAllowed returns max allowed sync errors until an error event is triggered
 func (pce *processConfigsByEpoch) GetMaxSyncWithErrorsAllowed(round uint64) uint32 {
-	for i := len(pce.orderedConfigByRound) - 1; i >= 0; i-- {
-		if pce.orderedConfigByRound[i].EnableRound <= round {
-			return pce.orderedConfigByRound[i].MaxSyncWithErrorsAllowed
-		}
-	}
-
-	return defaultMaxSyncWithErrorsAllowed
+	return getConfigValueByRound(
+		pce.orderedConfigByRound,
+		round,
+		func(cfg config.ProcessConfigByRound) uint32 {
+			return cfg.MaxSyncWithErrorsAllowed
+		},
+		defaultMaxSyncWithErrorsAllowed,
+	)
 }
 
 // GetMaxRoundsToKeepUnprocessedMiniBlocks returns max rounds to keep unprocessed mini blocks based on round
 func (pce *processConfigsByEpoch) GetMaxRoundsToKeepUnprocessedMiniBlocks(round uint64) uint64 {
-	for i := len(pce.orderedConfigByRound) - 1; i >= 0; i-- {
-		if pce.orderedConfigByRound[i].EnableRound <= round {
-			return pce.orderedConfigByRound[i].MaxRoundsToKeepUnprocessedMiniBlocks
-		}
-	}
-
-	return defaultMaxRoundsToKeepUnprocessedMiniBlocks
+	return getConfigValueByRound(
+		pce.orderedConfigByRound,
+		round,
+		func(cfg config.ProcessConfigByRound) uint64 {
+			return cfg.MaxRoundsToKeepUnprocessedMiniBlocks
+		},
+		defaultMaxRoundsToKeepUnprocessedMiniBlocks,
+	)
 }
 
 // GetMaxRoundsToKeepUnprocessedTransactions returns max rounds to keep unprocessed transaction blocks based on round
 func (pce *processConfigsByEpoch) GetMaxRoundsToKeepUnprocessedTransactions(round uint64) uint64 {
-	for i := len(pce.orderedConfigByRound) - 1; i >= 0; i-- {
-		if pce.orderedConfigByRound[i].EnableRound <= round {
-			return pce.orderedConfigByRound[i].MaxRoundsToKeepUnprocessedTransactions
-		}
-	}
-
-	return defaultMaxRoundsToKeepUnprocessedTransactions
+	return getConfigValueByRound(
+		pce.orderedConfigByRound,
+		round,
+		func(cfg config.ProcessConfigByRound) uint64 {
+			return cfg.MaxRoundsToKeepUnprocessedTransactions
+		},
+		defaultMaxRoundsToKeepUnprocessedTransactions,
+	)
 }
 
 // IsInterfaceNil checks if the instance is nil

--- a/common/configs/processConfigs.go
+++ b/common/configs/processConfigs.go
@@ -8,19 +8,21 @@ import (
 )
 
 const (
-	defaultMaxMetaNoncesBehind                = 15
-	defaultMaxMetaNoncesBehindForGlobalStuck  = 30
-	defaultMaxShardNoncesBehind               = 15
-	defaultMaxRoundsWithoutNewBlockReceived   = 10
-	defaultMaxRoundsWithoutCommittedBlock     = 10
-	defaultRoundModulusTriggerWhenSyncIsStuck = 20
-	defaultMaxSyncWithErrorsAllowed           = 20
+	defaultMaxMetaNoncesBehind                    = 15
+	defaultMaxMetaNoncesBehindForGlobalStuck      = 30
+	defaultMaxShardNoncesBehind                   = 15
+	defaultMaxRoundsWithoutNewBlockReceived       = 10
+	defaultMaxRoundsWithoutCommittedBlock         = 10
+	defaultRoundModulusTriggerWhenSyncIsStuck     = 20
+	defaultMaxSyncWithErrorsAllowed               = 20
+	defaultMaxRoundsToKeepUnprocessedMiniBlocks   = 3000
+	defaultMaxRoundsToKeepUnprocessedTransactions = 3000
 )
 
 // ErrEmptyProcessConfigsByEpoch signals that an empty process configs by epoch has been provided
 var ErrEmptyProcessConfigsByEpoch = errors.New("empty process configs by epoch")
 
-// ErrEmptyProcessConfigsByEpoch signals that an empty process configs by round has been provided
+// ErrEmptyProcessConfigsByRound signals that an empty process configs by round has been provided
 var ErrEmptyProcessConfigsByRound = errors.New("empty process configs by round")
 
 // ErrDuplicatedEpochConfig signals that a duplicated config section has been provided
@@ -133,7 +135,7 @@ func (pce *processConfigsByEpoch) GetMaxMetaNoncesBehindByEpoch(epoch uint32) ui
 	return defaultMaxMetaNoncesBehind // this should not happen
 }
 
-// GetMaxMetaNoncesBehindForBlobalStuckByEpoch returns the max meta nonces behind for global stuck by epoch
+// GetMaxMetaNoncesBehindForGlobalStuckByEpoch returns the max meta nonces behind for global stuck by epoch
 func (pce *processConfigsByEpoch) GetMaxMetaNoncesBehindForGlobalStuckByEpoch(epoch uint32) uint32 {
 	for i := len(pce.orderedConfigByEpoch) - 1; i >= 0; i-- {
 		if pce.orderedConfigByEpoch[i].EnableEpoch <= epoch {
@@ -144,7 +146,7 @@ func (pce *processConfigsByEpoch) GetMaxMetaNoncesBehindForGlobalStuckByEpoch(ep
 	return defaultMaxMetaNoncesBehindForGlobalStuck // this should not happen
 }
 
-// GetMaxMetaNoncesBehindForBlobalStuckByEpoch returns the max meta nonces behind for global stuck by epoch
+// GetMaxShardNoncesBehindByEpoch returns the max meta nonces behind for global stuck by epoch
 func (pce *processConfigsByEpoch) GetMaxShardNoncesBehindByEpoch(epoch uint32) uint32 {
 	for i := len(pce.orderedConfigByEpoch) - 1; i >= 0; i-- {
 		if pce.orderedConfigByEpoch[i].EnableEpoch <= epoch {
@@ -197,6 +199,28 @@ func (pce *processConfigsByEpoch) GetMaxSyncWithErrorsAllowed(round uint64) uint
 	}
 
 	return defaultMaxSyncWithErrorsAllowed
+}
+
+// GetMaxRoundsToKeepUnprocessedMiniBlocks returns max rounds to keep unprocessed mini blocks based on round
+func (pce *processConfigsByEpoch) GetMaxRoundsToKeepUnprocessedMiniBlocks(round uint64) uint64 {
+	for i := len(pce.orderedConfigByRound) - 1; i >= 0; i-- {
+		if pce.orderedConfigByRound[i].EnableRound <= round {
+			return pce.orderedConfigByRound[i].MaxRoundsToKeepUnprocessedMiniBlocks
+		}
+	}
+
+	return defaultMaxRoundsToKeepUnprocessedMiniBlocks
+}
+
+// GetMaxRoundsToKeepUnprocessedTransactions returns max rounds to keep unprocessed transaction blocks based on round
+func (pce *processConfigsByEpoch) GetMaxRoundsToKeepUnprocessedTransactions(round uint64) uint64 {
+	for i := len(pce.orderedConfigByRound) - 1; i >= 0; i-- {
+		if pce.orderedConfigByRound[i].EnableRound <= round {
+			return pce.orderedConfigByRound[i].MaxRoundsToKeepUnprocessedTransactions
+		}
+	}
+
+	return defaultMaxRoundsToKeepUnprocessedTransactions
 }
 
 // IsInterfaceNil checks if the instance is nil

--- a/common/configs/processConfigs.go
+++ b/common/configs/processConfigs.go
@@ -2,10 +2,14 @@ package configs
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 
 	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/process"
 )
+
+const minRoundsToKeepUnprocessedData = uint64(1)
 
 const (
 	defaultMaxMetaNoncesBehind                    = 15
@@ -113,12 +117,30 @@ func checkConfigsByRound(configsByRound []config.ProcessConfigByRound) error {
 		if exists {
 			return ErrDuplicatedRoundConfig
 		}
+		err := checkRoundConfigValues(cfg)
+		if err != nil {
+			return err
+		}
+
 		seen[cfg.EnableRound] = struct{}{}
 	}
 
 	_, exists := seen[0]
 	if !exists {
 		return ErrMissingRoundZeroConfig
+	}
+
+	return nil
+}
+
+func checkRoundConfigValues(cfg config.ProcessConfigByRound) error {
+	if cfg.MaxRoundsToKeepUnprocessedTransactions < minRoundsToKeepUnprocessedData {
+		return fmt.Errorf("%w for MaxRoundsToKeepUnprocessedTransactions, received %d, min expected %d",
+			process.ErrInvalidValue, cfg.MaxRoundsToKeepUnprocessedTransactions, minRoundsToKeepUnprocessedData)
+	}
+	if cfg.MaxRoundsToKeepUnprocessedMiniBlocks < minRoundsToKeepUnprocessedData {
+		return fmt.Errorf("%w for MaxRoundsToKeepUnprocessedMiniBlocks, received %d, min expected %d",
+			process.ErrInvalidValue, cfg.MaxRoundsToKeepUnprocessedMiniBlocks, minRoundsToKeepUnprocessedData)
 	}
 
 	return nil

--- a/common/configs/processConfigs_test.go
+++ b/common/configs/processConfigs_test.go
@@ -1,10 +1,12 @@
 package configs_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/common/configs"
 	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/process"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,6 +53,36 @@ func TestNewProcessConfigsByEpoch(t *testing.T) {
 		require.Equal(t, configs.ErrMissingEpochZeroConfig, err)
 	})
 
+	t.Run("should return error for zero MaxRoundsToKeepUnprocessedTransactions value", func(t *testing.T) {
+		t.Parallel()
+
+		confByEpoch := []config.ProcessConfigByEpoch{
+			{EnableEpoch: 0, MaxMetaNoncesBehind: 15},
+		}
+		confByRound := []config.ProcessConfigByRound{
+			{EnableRound: 1, MaxRoundsToKeepUnprocessedMiniBlocks: 15, MaxRoundsToKeepUnprocessedTransactions: 0},
+		}
+		pce, err := configs.NewProcessConfigsHandler(confByEpoch, confByRound)
+		require.Nil(t, pce)
+		require.ErrorIs(t, err, process.ErrInvalidValue)
+		require.True(t, strings.Contains(err.Error(), "MaxRoundsToKeepUnprocessedTransactions"))
+	})
+
+	t.Run("should return error for zero MaxRoundsToKeepUnprocessedMiniBlocks value", func(t *testing.T) {
+		t.Parallel()
+
+		confByEpoch := []config.ProcessConfigByEpoch{
+			{EnableEpoch: 0, MaxMetaNoncesBehind: 15},
+		}
+		confByRound := []config.ProcessConfigByRound{
+			{EnableRound: 1, MaxRoundsToKeepUnprocessedMiniBlocks: 0, MaxRoundsToKeepUnprocessedTransactions: 15},
+		}
+		pce, err := configs.NewProcessConfigsHandler(confByEpoch, confByRound)
+		require.Nil(t, pce)
+		require.ErrorIs(t, err, process.ErrInvalidValue)
+		require.True(t, strings.Contains(err.Error(), "MaxRoundsToKeepUnprocessedMiniBlocks"))
+	})
+
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
@@ -60,8 +92,8 @@ func TestNewProcessConfigsByEpoch(t *testing.T) {
 			{EnableEpoch: 1, MaxMetaNoncesBehind: 45},
 		}
 		confByRound := []config.ProcessConfigByRound{
-			{EnableRound: 0, MaxRoundsWithoutNewBlockReceived: 10},
-			{EnableRound: 1, MaxRoundsWithoutNewBlockReceived: 11},
+			{EnableRound: 0, MaxRoundsWithoutNewBlockReceived: 10, MaxRoundsToKeepUnprocessedMiniBlocks: 1, MaxRoundsToKeepUnprocessedTransactions: 1},
+			{EnableRound: 1, MaxRoundsWithoutNewBlockReceived: 11, MaxRoundsToKeepUnprocessedMiniBlocks: 1, MaxRoundsToKeepUnprocessedTransactions: 1},
 		}
 
 		pce, err := configs.NewProcessConfigsHandler(conf, confByRound)
@@ -93,14 +125,18 @@ func TestProcessConfigsByEpoch_Getters(t *testing.T) {
 
 	confByRound := []config.ProcessConfigByRound{
 		{EnableRound: 0,
-			MaxRoundsWithoutNewBlockReceived: 10,
-			MaxRoundsWithoutCommittedBlock:   20,
-			MaxSyncWithErrorsAllowed:         30,
+			MaxRoundsWithoutNewBlockReceived:       10,
+			MaxRoundsWithoutCommittedBlock:         20,
+			MaxSyncWithErrorsAllowed:               30,
+			MaxRoundsToKeepUnprocessedTransactions: 50,
+			MaxRoundsToKeepUnprocessedMiniBlocks:   50,
 		},
 		{EnableRound: 1,
-			MaxRoundsWithoutNewBlockReceived: 11,
-			MaxRoundsWithoutCommittedBlock:   21,
-			MaxSyncWithErrorsAllowed:         31,
+			MaxRoundsWithoutNewBlockReceived:       11,
+			MaxRoundsWithoutCommittedBlock:         21,
+			MaxSyncWithErrorsAllowed:               31,
+			MaxRoundsToKeepUnprocessedTransactions: 500,
+			MaxRoundsToKeepUnprocessedMiniBlocks:   500,
 		},
 	}
 

--- a/common/configs/processConfigs_test.go
+++ b/common/configs/processConfigs_test.go
@@ -129,14 +129,14 @@ func TestProcessConfigsByEpoch_Getters(t *testing.T) {
 			MaxRoundsWithoutCommittedBlock:         20,
 			MaxSyncWithErrorsAllowed:               30,
 			MaxRoundsToKeepUnprocessedTransactions: 50,
-			MaxRoundsToKeepUnprocessedMiniBlocks:   50,
+			MaxRoundsToKeepUnprocessedMiniBlocks:   60,
 		},
 		{EnableRound: 1,
 			MaxRoundsWithoutNewBlockReceived:       11,
 			MaxRoundsWithoutCommittedBlock:         21,
 			MaxSyncWithErrorsAllowed:               31,
 			MaxRoundsToKeepUnprocessedTransactions: 500,
-			MaxRoundsToKeepUnprocessedMiniBlocks:   500,
+			MaxRoundsToKeepUnprocessedMiniBlocks:   600,
 		},
 	}
 
@@ -210,5 +210,29 @@ func TestProcessConfigsByEpoch_Getters(t *testing.T) {
 
 		maxSyncWithErrorsAllowed = pce.GetMaxSyncWithErrorsAllowed(1)
 		require.Equal(t, uint32(31), maxSyncWithErrorsAllowed)
+	})
+
+	t.Run("get max rounds to keep unprocessed transactions", func(t *testing.T) {
+		t.Parallel()
+
+		pce, _ := configs.NewProcessConfigsHandler(conf, confByRound)
+
+		res := pce.GetMaxRoundsToKeepUnprocessedTransactions(0)
+		require.Equal(t, uint64(50), res)
+
+		res = pce.GetMaxRoundsToKeepUnprocessedTransactions(1)
+		require.Equal(t, uint64(500), res)
+	})
+
+	t.Run("get max rounds to keep unprocessed mini blocks", func(t *testing.T) {
+		t.Parallel()
+
+		pce, _ := configs.NewProcessConfigsHandler(conf, confByRound)
+
+		res := pce.GetMaxRoundsToKeepUnprocessedMiniBlocks(0)
+		require.Equal(t, uint64(60), res)
+
+		res = pce.GetMaxRoundsToKeepUnprocessedMiniBlocks(1)
+		require.Equal(t, uint64(600), res)
 	})
 }

--- a/common/interface.go
+++ b/common/interface.go
@@ -487,6 +487,8 @@ type ProcessConfigsHandler interface {
 	GetMaxRoundsWithoutCommittedBlock(round uint64) uint32
 	GetRoundModulusTriggerWhenSyncIsStuck(round uint64) uint32
 	GetMaxSyncWithErrorsAllowed(round uint64) uint32
+	GetMaxRoundsToKeepUnprocessedTransactions(round uint64) uint64
+	GetMaxRoundsToKeepUnprocessedMiniBlocks(round uint64) uint64
 
 	IsInterfaceNil() bool
 }

--- a/config/config.go
+++ b/config/config.go
@@ -386,6 +386,12 @@ type ProcessConfigByRound struct {
 	// MaxSyncWithErrorsAllowed defines the maximum allowed number of sync with errors,
 	// before a special action to be applied
 	MaxSyncWithErrorsAllowed uint32
+
+	// Max number of rounds unprocessed miniblocks are kept in pool
+	MaxRoundsToKeepUnprocessedMiniBlocks uint64
+
+	// Max number of rounds unprocessed transactions are kept in pool
+	MaxRoundsToKeepUnprocessedTransactions uint64
 }
 
 // GeneralSettingsConfig will hold the general settings for a node

--- a/config/config.go
+++ b/config/config.go
@@ -265,9 +265,8 @@ type Config struct {
 	Requesters            RequesterConfig
 	VMOutputCacher        CacheConfig
 
-	PeersRatingConfig   PeersRatingConfig
-	PoolsCleanersConfig PoolsCleanersConfig
-	Redundancy          RedundancyConfig
+	PeersRatingConfig PeersRatingConfig
+	Redundancy        RedundancyConfig
 
 	InterceptedDataVerifier InterceptedDataVerifierConfig
 }
@@ -783,12 +782,6 @@ type RequesterConfig struct {
 	NumCrossShardPeers  uint32
 	NumTotalPeers       uint32
 	NumFullHistoryPeers uint32
-}
-
-// PoolsCleanersConfig represents the config options to be used by the pools cleaners
-type PoolsCleanersConfig struct {
-	MaxRoundsToKeepUnprocessedMiniBlocks   int64
-	MaxRoundsToKeepUnprocessedTransactions int64
 }
 
 // RedundancyConfig represents the config options to be used when setting the redundancy configuration

--- a/factory/mock/coreComponentsMock.go
+++ b/factory/mock/coreComponentsMock.go
@@ -62,6 +62,7 @@ type CoreComponentsMock struct {
 	FieldsSizeCheckerField             common.FieldsSizeChecker
 	EpochChangeGracePeriodHandlerField common.EpochChangeGracePeriodHandler
 	ProcessConfigsHandlerField         common.ProcessConfigsHandler
+	ProcessConfigsHandlerCalled        func() common.ProcessConfigsHandler
 	CommonConfigsHandlerField          common.CommonConfigsHandler
 }
 
@@ -280,6 +281,9 @@ func (ccm *CoreComponentsMock) EpochChangeGracePeriodHandler() common.EpochChang
 
 // ProcessConfigsHandler -
 func (ccm *CoreComponentsMock) ProcessConfigsHandler() common.ProcessConfigsHandler {
+	if ccm.ProcessConfigsHandlerCalled != nil {
+		return ccm.ProcessConfigsHandlerCalled()
+	}
 	return ccm.ProcessConfigsHandlerField
 }
 

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -503,7 +503,7 @@ func (pcf *processComponentsFactory) Create() (*processComponents, error) {
 	}
 	mbsPoolsCleaner, err := poolsCleaner.NewMiniBlocksPoolsCleaner(argsMiniBlocksPoolsCleaner)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w in processComponentsFactory.Create for NewMiniBlocksPoolsCleaner", err)
 	}
 
 	mbsPoolsCleaner.StartCleaning()
@@ -519,7 +519,7 @@ func (pcf *processComponentsFactory) Create() (*processComponents, error) {
 	}
 	txsPoolsCleaner, err := poolsCleaner.NewTxsPoolsCleaner(argsBasePoolsCleaner)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w in processComponentsFactory.Create for NewTxsPoolsCleaner", err)
 	}
 
 	txsPoolsCleaner.StartCleaning()

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -495,9 +495,9 @@ func (pcf *processComponentsFactory) Create() (*processComponents, error) {
 
 	argsMiniBlocksPoolsCleaner := poolsCleaner.ArgMiniBlocksPoolsCleaner{
 		ArgBasePoolsCleaner: poolsCleaner.ArgBasePoolsCleaner{
-			RoundHandler:                   pcf.coreData.RoundHandler(),
-			ShardCoordinator:               pcf.bootstrapComponents.ShardCoordinator(),
-			MaxRoundsToKeepUnprocessedData: pcf.config.PoolsCleanersConfig.MaxRoundsToKeepUnprocessedMiniBlocks,
+			RoundHandler:          pcf.coreData.RoundHandler(),
+			ShardCoordinator:      pcf.bootstrapComponents.ShardCoordinator(),
+			ProcessConfigsHandler: pcf.coreData.ProcessConfigsHandler(),
 		},
 		MiniblocksPool: pcf.data.Datapool().MiniBlocks(),
 	}
@@ -510,9 +510,9 @@ func (pcf *processComponentsFactory) Create() (*processComponents, error) {
 
 	argsBasePoolsCleaner := poolsCleaner.ArgTxsPoolsCleaner{
 		ArgBasePoolsCleaner: poolsCleaner.ArgBasePoolsCleaner{
-			RoundHandler:                   pcf.coreData.RoundHandler(),
-			ShardCoordinator:               pcf.bootstrapComponents.ShardCoordinator(),
-			MaxRoundsToKeepUnprocessedData: pcf.config.PoolsCleanersConfig.MaxRoundsToKeepUnprocessedTransactions,
+			RoundHandler:          pcf.coreData.RoundHandler(),
+			ShardCoordinator:      pcf.bootstrapComponents.ShardCoordinator(),
+			ProcessConfigsHandler: pcf.coreData.ProcessConfigsHandler(),
 		},
 		AddressPubkeyConverter: pcf.coreData.AddressPubKeyConverter(),
 		DataPool:               pcf.data.Datapool(),

--- a/factory/processing/processComponents_test.go
+++ b/factory/processing/processComponents_test.go
@@ -719,20 +719,24 @@ func TestProcessComponentsFactory_Create(t *testing.T) {
 		}
 		testCreateWithArgs(t, args, expectedErr.Error())
 	})
-	t.Run("NewMiniBlocksPoolsCleaner fails should error", func(t *testing.T) {
-		t.Parallel()
+	/*
+		t.Run("NewMiniBlocksPoolsCleaner fails should error", func(t *testing.T) {
+			t.Parallel()
 
-		args := createMockProcessComponentsFactoryArgs()
-		args.Config.PoolsCleanersConfig.MaxRoundsToKeepUnprocessedMiniBlocks = 0
-		testCreateWithArgs(t, args, "MaxRoundsToKeepUnprocessedData")
-	})
-	t.Run("NewTxsPoolsCleaner fails should error", func(t *testing.T) {
-		t.Parallel()
+			args := createMockProcessComponentsFactoryArgs()
+			args.Config.PoolsCleanersConfig.MaxRoundsToKeepUnprocessedMiniBlocks = 0
+			testCreateWithArgs(t, args, "MaxRoundsToKeepUnprocessedData")
+		})
 
-		args := createMockProcessComponentsFactoryArgs()
-		args.Config.PoolsCleanersConfig.MaxRoundsToKeepUnprocessedTransactions = 0
-		testCreateWithArgs(t, args, "MaxRoundsToKeepUnprocessedData")
-	})
+		t.Run("NewTxsPoolsCleaner fails should error", func(t *testing.T) {
+			t.Parallel()
+
+			args := createMockProcessComponentsFactoryArgs()
+			args.Config.PoolsCleanersConfig.MaxRoundsToKeepUnprocessedTransactions = 0
+			testCreateWithArgs(t, args, "MaxRoundsToKeepUnprocessedData")
+		})
+
+	*/
 	t.Run("createHardforkTrigger fails due to Decode failure should error", func(t *testing.T) {
 		t.Parallel()
 

--- a/factory/processing/processComponents_test.go
+++ b/factory/processing/processComponents_test.go
@@ -719,24 +719,34 @@ func TestProcessComponentsFactory_Create(t *testing.T) {
 		}
 		testCreateWithArgs(t, args, expectedErr.Error())
 	})
-	/*
-		t.Run("NewMiniBlocksPoolsCleaner fails should error", func(t *testing.T) {
-			t.Parallel()
+	t.Run("NewMiniBlocksPoolsCleaner fails should error", func(t *testing.T) {
+		t.Parallel()
 
-			args := createMockProcessComponentsFactoryArgs()
-			args.Config.PoolsCleanersConfig.MaxRoundsToKeepUnprocessedMiniBlocks = 0
-			testCreateWithArgs(t, args, "MaxRoundsToKeepUnprocessedData")
-		})
+		args := createMockProcessComponentsFactoryArgs()
+		ct := 0
+		args.CoreData.(*mock.CoreComponentsMock).ProcessConfigsHandlerCalled = func() common.ProcessConfigsHandler {
+			if ct == 1 {
+				return nil
+			}
+			ct++
+			return args.CoreData.(*mock.CoreComponentsMock).ProcessConfigsHandlerField
+		}
+		testCreateWithArgs(t, args, "NewMiniBlocksPoolsCleaner")
+	})
+	t.Run("NewTxsPoolsCleaner fails should error", func(t *testing.T) {
+		t.Parallel()
 
-		t.Run("NewTxsPoolsCleaner fails should error", func(t *testing.T) {
-			t.Parallel()
-
-			args := createMockProcessComponentsFactoryArgs()
-			args.Config.PoolsCleanersConfig.MaxRoundsToKeepUnprocessedTransactions = 0
-			testCreateWithArgs(t, args, "MaxRoundsToKeepUnprocessedData")
-		})
-
-	*/
+		args := createMockProcessComponentsFactoryArgs()
+		ct := 0
+		args.CoreData.(*mock.CoreComponentsMock).ProcessConfigsHandlerCalled = func() common.ProcessConfigsHandler {
+			if ct == 2 {
+				return nil
+			}
+			ct++
+			return args.CoreData.(*mock.CoreComponentsMock).ProcessConfigsHandlerField
+		}
+		testCreateWithArgs(t, args, "NewTxsPoolsCleaner")
+	})
 	t.Run("createHardforkTrigger fails due to Decode failure should error", func(t *testing.T) {
 		t.Parallel()
 

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -171,10 +171,12 @@ var TestProcessConfigsHandler, _ = configs.NewProcessConfigsHandler([]config.Pro
 }},
 	[]config.ProcessConfigByRound{
 		{
-			EnableRound:                        0,
-			MaxRoundsWithoutNewBlockReceived:   10,
-			MaxRoundsWithoutCommittedBlock:     10,
-			RoundModulusTriggerWhenSyncIsStuck: 20,
+			EnableRound:                            0,
+			MaxRoundsWithoutNewBlockReceived:       10,
+			MaxRoundsWithoutCommittedBlock:         10,
+			RoundModulusTriggerWhenSyncIsStuck:     20,
+			MaxRoundsToKeepUnprocessedTransactions: 50,
+			MaxRoundsToKeepUnprocessedMiniBlocks:   50,
 		},
 	},
 )

--- a/node/chainSimulator/components/coreComponents_test.go
+++ b/node/chainSimulator/components/coreComponents_test.go
@@ -64,7 +64,7 @@ func createArgsCoreComponentsHolder() ArgsCoreComponentsHolder {
 					MaxShardNoncesBehind:              15,
 				}},
 				ProcessConfigsByRound: []config.ProcessConfigByRound{
-					{EnableRound: 0, MaxRoundsWithoutNewBlockReceived: 10, MaxRoundsWithoutCommittedBlock: 10},
+					{EnableRound: 0, MaxRoundsWithoutNewBlockReceived: 10, MaxRoundsWithoutCommittedBlock: 10, MaxRoundsToKeepUnprocessedTransactions: 50, MaxRoundsToKeepUnprocessedMiniBlocks: 50},
 				},
 				EpochStartConfigsByEpoch: []config.EpochStartConfigByEpoch{
 					{EnableEpoch: 0, GracePeriodRounds: 25, ExtraDelayForRequestBlockInfoInMilliseconds: 3000},

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -155,7 +155,12 @@ func NewShardProcessorEmptyWith3shards(
 		MaxShardNoncesBehind:              15,
 	}},
 		[]config.ProcessConfigByRound{
-			{EnableRound: 0, MaxRoundsWithoutNewBlockReceived: 10},
+			{
+				EnableRound:                            0,
+				MaxRoundsWithoutNewBlockReceived:       10,
+				MaxRoundsToKeepUnprocessedMiniBlocks:   50,
+				MaxRoundsToKeepUnprocessedTransactions: 50,
+			},
 		},
 	)
 

--- a/process/block/poolsCleaner/basePoolsCleaner.go
+++ b/process/block/poolsCleaner/basePoolsCleaner.go
@@ -1,10 +1,10 @@
 package poolsCleaner
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/sharding"
 )
@@ -13,25 +13,25 @@ const minRoundsToKeepUnprocessedData = int64(1)
 
 // ArgBasePoolsCleaner is the base argument structure used to create pools cleaners
 type ArgBasePoolsCleaner struct {
-	RoundHandler                   process.RoundHandler
-	ShardCoordinator               sharding.Coordinator
-	MaxRoundsToKeepUnprocessedData int64
+	RoundHandler          process.RoundHandler
+	ShardCoordinator      sharding.Coordinator
+	ProcessConfigsHandler common.ProcessConfigsHandler
 }
 
 type basePoolsCleaner struct {
-	roundHandler                   process.RoundHandler
-	shardCoordinator               sharding.Coordinator
-	maxRoundsToKeepUnprocessedData int64
-	cancelFunc                     func()
-	isCleaningRoutineRunning       bool
-	mut                            sync.Mutex
+	roundHandler             process.RoundHandler
+	shardCoordinator         sharding.Coordinator
+	processConfigsHandler    common.ProcessConfigsHandler
+	cancelFunc               func()
+	isCleaningRoutineRunning bool
+	mut                      sync.Mutex
 }
 
 func newBasePoolsCleaner(args ArgBasePoolsCleaner) basePoolsCleaner {
 	return basePoolsCleaner{
-		roundHandler:                   args.RoundHandler,
-		shardCoordinator:               args.ShardCoordinator,
-		maxRoundsToKeepUnprocessedData: args.MaxRoundsToKeepUnprocessedData,
+		roundHandler:          args.RoundHandler,
+		shardCoordinator:      args.ShardCoordinator,
+		processConfigsHandler: args.ProcessConfigsHandler,
 	}
 }
 
@@ -42,10 +42,15 @@ func checkBaseArgs(args ArgBasePoolsCleaner) error {
 	if check.IfNil(args.ShardCoordinator) {
 		return process.ErrNilShardCoordinator
 	}
-	if args.MaxRoundsToKeepUnprocessedData < minRoundsToKeepUnprocessedData {
-		return fmt.Errorf("%w for MaxRoundsToKeepUnprocessedData, received %d, min expected %d",
-			process.ErrInvalidValue, args.MaxRoundsToKeepUnprocessedData, minRoundsToKeepUnprocessedData)
+	if check.IfNil(args.ProcessConfigsHandler) {
+		return process.ErrNilProcessConfigsHandler
 	}
+
+	// TODO: Move these checks
+	//if args.MaxRoundsToKeepUnprocessedData < minRoundsToKeepUnprocessedData {
+	//	return fmt.Errorf("%w for MaxRoundsToKeepUnprocessedData, received %d, min expected %d",
+	//		process.ErrInvalidValue, args.MaxRoundsToKeepUnprocessedData, minRoundsToKeepUnprocessedData)
+	//}
 
 	return nil
 }

--- a/process/block/poolsCleaner/basePoolsCleaner.go
+++ b/process/block/poolsCleaner/basePoolsCleaner.go
@@ -9,8 +9,6 @@ import (
 	"github.com/multiversx/mx-chain-go/sharding"
 )
 
-const minRoundsToKeepUnprocessedData = int64(1)
-
 // ArgBasePoolsCleaner is the base argument structure used to create pools cleaners
 type ArgBasePoolsCleaner struct {
 	RoundHandler          process.RoundHandler
@@ -45,12 +43,6 @@ func checkBaseArgs(args ArgBasePoolsCleaner) error {
 	if check.IfNil(args.ProcessConfigsHandler) {
 		return process.ErrNilProcessConfigsHandler
 	}
-
-	// TODO: Move these checks
-	//if args.MaxRoundsToKeepUnprocessedData < minRoundsToKeepUnprocessedData {
-	//	return fmt.Errorf("%w for MaxRoundsToKeepUnprocessedData, received %d, min expected %d",
-	//		process.ErrInvalidValue, args.MaxRoundsToKeepUnprocessedData, minRoundsToKeepUnprocessedData)
-	//}
 
 	return nil
 }

--- a/process/block/poolsCleaner/miniBlocksPoolsCleaner.go
+++ b/process/block/poolsCleaner/miniBlocksPoolsCleaner.go
@@ -161,8 +161,9 @@ func (mbpc *miniBlocksPoolsCleaner) cleanMiniblocksPoolsIfNeeded() int {
 			continue
 		}
 
-		roundDif := mbpc.roundHandler.Index() - mbi.round
-		if roundDif <= mbpc.maxRoundsToKeepUnprocessedData {
+		round := mbpc.roundHandler.Index()
+		roundDif := round - mbi.round
+		if roundDif <= int64(mbpc.processConfigsHandler.GetMaxRoundsToKeepUnprocessedMiniBlocks(uint64(round))) {
 			log.Trace("cleaning miniblock not yet allowed",
 				"hash", []byte(hash),
 				"round", mbi.round,

--- a/process/block/poolsCleaner/miniBlocksPoolsCleaner_test.go
+++ b/process/block/poolsCleaner/miniBlocksPoolsCleaner_test.go
@@ -1,11 +1,10 @@
 package poolsCleaner
 
 import (
-	"errors"
-	"strings"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-go/testscommon"
 
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/mock"
@@ -17,9 +16,13 @@ import (
 func createMockArgMiniBlocksPoolsCleaner() ArgMiniBlocksPoolsCleaner {
 	return ArgMiniBlocksPoolsCleaner{
 		ArgBasePoolsCleaner: ArgBasePoolsCleaner{
-			RoundHandler:                   &mock.RoundHandlerMock{},
-			ShardCoordinator:               &mock.CoordinatorStub{},
-			MaxRoundsToKeepUnprocessedData: 1,
+			RoundHandler:     &mock.RoundHandlerMock{},
+			ShardCoordinator: &mock.CoordinatorStub{},
+			ProcessConfigsHandler: &testscommon.ProcessConfigsHandlerStub{
+				GetMaxRoundsToKeepUnprocessedMiniBlocksCalled: func(round uint64) uint64 {
+					return 1
+				},
+			},
 		},
 		MiniblocksPool: cache.NewCacherStub(),
 	}
@@ -58,6 +61,8 @@ func TestNewMiniBlocksPoolsCleaner_NilShardCoordinatorShouldErr(t *testing.T) {
 	assert.Nil(t, miniblockCleaner)
 }
 
+// TODO: FIx this test somewhere else
+/*
 func TestNewMiniBlocksPoolsCleaner_InvalidMaxRoundsToKeepUnprocessedDataShouldErr(t *testing.T) {
 	t.Parallel()
 
@@ -69,6 +74,7 @@ func TestNewMiniBlocksPoolsCleaner_InvalidMaxRoundsToKeepUnprocessedDataShouldEr
 	assert.True(t, strings.Contains(err.Error(), "MaxRoundsToKeepUnprocessedData"))
 	assert.Nil(t, miniblockCleaner)
 }
+*/
 
 func TestNewMiniBlocksPoolsCleaner_ShouldWork(t *testing.T) {
 	t.Parallel()
@@ -165,7 +171,7 @@ func TestCleanMiniblocksPoolsIfNeeded_MbShouldBeRemovedFromPoolAndMap(t *testing
 	miniblockCleaner.receivedMiniBlock(key, miniblock)
 
 	roundHandler.IndexCalled = func() int64 {
-		return args.MaxRoundsToKeepUnprocessedData + 1
+		return int64(args.ProcessConfigsHandler.GetMaxRoundsToKeepUnprocessedMiniBlocks(0) + 1)
 	}
 	result := miniblockCleaner.cleanMiniblocksPoolsIfNeeded()
 	assert.Equal(t, 0, result)

--- a/process/block/poolsCleaner/miniBlocksPoolsCleaner_test.go
+++ b/process/block/poolsCleaner/miniBlocksPoolsCleaner_test.go
@@ -61,21 +61,6 @@ func TestNewMiniBlocksPoolsCleaner_NilShardCoordinatorShouldErr(t *testing.T) {
 	assert.Nil(t, miniblockCleaner)
 }
 
-// TODO: FIx this test somewhere else
-/*
-func TestNewMiniBlocksPoolsCleaner_InvalidMaxRoundsToKeepUnprocessedDataShouldErr(t *testing.T) {
-	t.Parallel()
-
-	args := createMockArgMiniBlocksPoolsCleaner()
-	args.MaxRoundsToKeepUnprocessedData = 0
-	miniblockCleaner, err := NewMiniBlocksPoolsCleaner(args)
-
-	assert.True(t, errors.Is(err, process.ErrInvalidValue))
-	assert.True(t, strings.Contains(err.Error(), "MaxRoundsToKeepUnprocessedData"))
-	assert.Nil(t, miniblockCleaner)
-}
-*/
-
 func TestNewMiniBlocksPoolsCleaner_ShouldWork(t *testing.T) {
 	t.Parallel()
 

--- a/process/block/poolsCleaner/txsPoolsCleaner.go
+++ b/process/block/poolsCleaner/txsPoolsCleaner.go
@@ -270,8 +270,9 @@ func (tpc *txsPoolsCleaner) cleanTxsPoolsIfNeeded() int {
 			continue
 		}
 
+		round := tpc.roundHandler.Index()
 		roundDif := tpc.roundHandler.Index() - currTxInfo.round
-		if roundDif <= tpc.maxRoundsToKeepUnprocessedData {
+		if roundDif <= int64(tpc.processConfigsHandler.GetMaxRoundsToKeepUnprocessedTransactions(uint64(round))) {
 			log.Trace("cleaning transaction not yet allowed",
 				"hash", []byte(hash),
 				"round", currTxInfo.round,

--- a/process/block/poolsCleaner/txsPoolsCleaner_test.go
+++ b/process/block/poolsCleaner/txsPoolsCleaner_test.go
@@ -123,21 +123,6 @@ func TestNewTxsPoolsCleaner_NilShardCoordinatorErr(t *testing.T) {
 	assert.Equal(t, process.ErrNilShardCoordinator, err)
 }
 
-// TODO: Fix this
-/*
-func TestNewTxsPoolsCleaner_InvalidMaxRoundsToKeepUnprocessedDataShouldErr(t *testing.T) {
-	t.Parallel()
-
-	args := createMockArgTxsPoolsCleaner()
-	args.MaxRoundsToKeepUnprocessedData = 0
-	txsPoolsCleaner, err := NewTxsPoolsCleaner(args)
-	assert.True(t, errors.Is(err, process.ErrInvalidValue))
-	assert.True(t, strings.Contains(err.Error(), "MaxRoundsToKeepUnprocessedData"))
-	assert.Nil(t, txsPoolsCleaner)
-}
-
-*/
-
 func TestNewTxsPoolsCleaner_ShouldWork(t *testing.T) {
 	t.Parallel()
 

--- a/process/block/poolsCleaner/txsPoolsCleaner_test.go
+++ b/process/block/poolsCleaner/txsPoolsCleaner_test.go
@@ -1,8 +1,6 @@
 package poolsCleaner
 
 import (
-	"errors"
-	"strings"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
@@ -21,9 +19,13 @@ import (
 func createMockArgTxsPoolsCleaner() ArgTxsPoolsCleaner {
 	return ArgTxsPoolsCleaner{
 		ArgBasePoolsCleaner: ArgBasePoolsCleaner{
-			RoundHandler:                   &mock.RoundHandlerMock{},
-			ShardCoordinator:               mock.NewMultipleShardsCoordinatorMock(),
-			MaxRoundsToKeepUnprocessedData: 1,
+			RoundHandler:     &mock.RoundHandlerMock{},
+			ShardCoordinator: mock.NewMultipleShardsCoordinatorMock(),
+			ProcessConfigsHandler: &testscommon.ProcessConfigsHandlerStub{
+				GetMaxRoundsToKeepUnprocessedTransactionsCalled: func(round uint64) uint64 {
+					return 1
+				},
+			},
 		},
 		AddressPubkeyConverter: &testscommon.PubkeyConverterStub{},
 		DataPool:               dataRetrieverMock.NewPoolsHolderMock(),
@@ -121,6 +123,8 @@ func TestNewTxsPoolsCleaner_NilShardCoordinatorErr(t *testing.T) {
 	assert.Equal(t, process.ErrNilShardCoordinator, err)
 }
 
+// TODO: Fix this
+/*
 func TestNewTxsPoolsCleaner_InvalidMaxRoundsToKeepUnprocessedDataShouldErr(t *testing.T) {
 	t.Parallel()
 
@@ -131,6 +135,8 @@ func TestNewTxsPoolsCleaner_InvalidMaxRoundsToKeepUnprocessedDataShouldErr(t *te
 	assert.True(t, strings.Contains(err.Error(), "MaxRoundsToKeepUnprocessedData"))
 	assert.Nil(t, txsPoolsCleaner)
 }
+
+*/
 
 func TestNewTxsPoolsCleaner_ShouldWork(t *testing.T) {
 	t.Parallel()
@@ -351,7 +357,7 @@ func TestCleanTxsPoolsIfNeeded_RoundDiffTooBigShouldBeRemoved(t *testing.T) {
 	txsPoolsCleaner.receivedUnsignedTx(txKey, tx)
 
 	roundHandler.IndexCalled = func() int64 {
-		return args.MaxRoundsToKeepUnprocessedData + 1
+		return int64(args.ProcessConfigsHandler.GetMaxRoundsToKeepUnprocessedTransactions(0) + 1)
 	}
 	numTxsInMap := txsPoolsCleaner.cleanTxsPoolsIfNeeded()
 	assert.Equal(t, 0, numTxsInMap)

--- a/process/track/baseBlockTrack_test.go
+++ b/process/track/baseBlockTrack_test.go
@@ -142,7 +142,7 @@ func CreateShardTrackerMockArguments() track.ArgShardTracker {
 		MaxShardNoncesBehind:              15,
 	}},
 		[]config.ProcessConfigByRound{
-			{EnableRound: 0, MaxRoundsWithoutNewBlockReceived: 10},
+			{EnableRound: 0, MaxRoundsWithoutNewBlockReceived: 10, MaxRoundsToKeepUnprocessedTransactions: 50, MaxRoundsToKeepUnprocessedMiniBlocks: 50},
 		},
 	)
 

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -319,9 +319,13 @@ func GetNetworkFactoryArgs() networkComp.NetworkComponentsFactoryArgs {
 			TopRatedCacheCapacity: 1000,
 			BadRatedCacheCapacity: 1000,
 		},
-		PoolsCleanersConfig: config.PoolsCleanersConfig{
-			MaxRoundsToKeepUnprocessedMiniBlocks:   50,
-			MaxRoundsToKeepUnprocessedTransactions: 50,
+		GeneralSettings: config.GeneralSettingsConfig{
+			ProcessConfigsByRound: []config.ProcessConfigByRound{
+				{
+					MaxRoundsToKeepUnprocessedMiniBlocks:   50,
+					MaxRoundsToKeepUnprocessedTransactions: 50,
+				},
+			},
 		},
 	}
 

--- a/testscommon/components/configs.go
+++ b/testscommon/components/configs.go
@@ -113,10 +113,6 @@ func GetGeneralConfig() config.Config {
 			TopRatedCacheCapacity: 1000,
 			BadRatedCacheCapacity: 1000,
 		},
-		PoolsCleanersConfig: config.PoolsCleanersConfig{
-			MaxRoundsToKeepUnprocessedMiniBlocks:   50,
-			MaxRoundsToKeepUnprocessedTransactions: 50,
-		},
 		BuiltInFunctions: config.BuiltInFunctionsConfig{
 			AutomaticCrawlerAddresses: []string{
 				"erd1he8wwxn4az3j82p7wwqsdk794dm7hcrwny6f8dfegkfla34udx7qrf7xje", // shard 0
@@ -178,7 +174,13 @@ func GetGeneralConfig() config.Config {
 				MaxShardNoncesBehind:              15,
 			}},
 			ProcessConfigsByRound: []config.ProcessConfigByRound{
-				{EnableRound: 0, MaxRoundsWithoutNewBlockReceived: 10, MaxRoundsWithoutCommittedBlock: 10},
+				{
+					EnableRound:                            0,
+					MaxRoundsWithoutNewBlockReceived:       10,
+					MaxRoundsWithoutCommittedBlock:         10,
+					MaxRoundsToKeepUnprocessedMiniBlocks:   50,
+					MaxRoundsToKeepUnprocessedTransactions: 50,
+				},
 			},
 			EpochStartConfigsByEpoch: []config.EpochStartConfigByEpoch{
 				{EnableEpoch: 0, GracePeriodRounds: 25, ExtraDelayForRequestBlockInfoInMilliseconds: 3000},

--- a/testscommon/generalConfig.go
+++ b/testscommon/generalConfig.go
@@ -80,7 +80,13 @@ func GetGeneralConfig() config.Config {
 				MaxShardNoncesBehind:              15,
 			}},
 			ProcessConfigsByRound: []config.ProcessConfigByRound{
-				{EnableRound: 0, MaxRoundsWithoutNewBlockReceived: 10, MaxRoundsWithoutCommittedBlock: 10},
+				{
+					EnableRound:                            0,
+					MaxRoundsWithoutNewBlockReceived:       10,
+					MaxRoundsWithoutCommittedBlock:         10,
+					MaxRoundsToKeepUnprocessedMiniBlocks:   50,
+					MaxRoundsToKeepUnprocessedTransactions: 50,
+				},
 			},
 			EpochStartConfigsByEpoch: []config.EpochStartConfigByEpoch{
 				{EnableEpoch: 0, GracePeriodRounds: 25, ExtraDelayForRequestBlockInfoInMilliseconds: 3000},
@@ -467,10 +473,6 @@ func GetGeneralConfig() config.Config {
 		PeersRatingConfig: config.PeersRatingConfig{
 			TopRatedCacheCapacity: 1000,
 			BadRatedCacheCapacity: 1000,
-		},
-		PoolsCleanersConfig: config.PoolsCleanersConfig{
-			MaxRoundsToKeepUnprocessedMiniBlocks:   50,
-			MaxRoundsToKeepUnprocessedTransactions: 50,
 		},
 		BuiltInFunctions: config.BuiltInFunctionsConfig{
 			AutomaticCrawlerAddresses: []string{

--- a/testscommon/processConfigsHandlerStub.go
+++ b/testscommon/processConfigsHandlerStub.go
@@ -16,11 +16,13 @@ func GetDefaultProcessConfigsHandler() common.ProcessConfigsHandler {
 	}},
 		[]config.ProcessConfigByRound{
 			{
-				EnableRound:                        0,
-				MaxRoundsWithoutNewBlockReceived:   10,
-				MaxRoundsWithoutCommittedBlock:     10,
-				RoundModulusTriggerWhenSyncIsStuck: 20,
-				MaxSyncWithErrorsAllowed:           10,
+				EnableRound:                            0,
+				MaxRoundsWithoutNewBlockReceived:       10,
+				MaxRoundsWithoutCommittedBlock:         10,
+				RoundModulusTriggerWhenSyncIsStuck:     20,
+				MaxSyncWithErrorsAllowed:               10,
+				MaxRoundsToKeepUnprocessedMiniBlocks:   50,
+				MaxRoundsToKeepUnprocessedTransactions: 50,
 			},
 		},
 	)

--- a/testscommon/processConfigsHandlerStub.go
+++ b/testscommon/processConfigsHandlerStub.go
@@ -37,6 +37,8 @@ type ProcessConfigsHandlerStub struct {
 	GetMaxRoundsWithoutCommittedBlockCalled           func(round uint64) uint32
 	GetRoundModulusTriggerWhenSyncIsStuckCalled       func(round uint64) uint32
 	GetMaxSyncWithErrorsAllowedCalled                 func(round uint64) uint32
+	GetMaxRoundsToKeepUnprocessedTransactionsCalled   func(round uint64) uint64
+	GetMaxRoundsToKeepUnprocessedMiniBlocksCalled     func(round uint64) uint64
 }
 
 // GetMaxMetaNoncesBehindByEpoch -
@@ -97,6 +99,23 @@ func (p *ProcessConfigsHandlerStub) GetRoundModulusTriggerWhenSyncIsStuck(round 
 func (p *ProcessConfigsHandlerStub) GetMaxSyncWithErrorsAllowed(round uint64) uint32 {
 	if p.GetMaxSyncWithErrorsAllowedCalled != nil {
 		return p.GetMaxSyncWithErrorsAllowedCalled(round)
+	}
+
+	return 0
+}
+
+// GetMaxRoundsToKeepUnprocessedTransactions -
+func (p *ProcessConfigsHandlerStub) GetMaxRoundsToKeepUnprocessedTransactions(round uint64) uint64 {
+	if p.GetMaxRoundsToKeepUnprocessedTransactionsCalled != nil {
+		return p.GetMaxRoundsToKeepUnprocessedTransactionsCalled(round)
+	}
+	return 0
+}
+
+// GetMaxRoundsToKeepUnprocessedMiniBlocks -
+func (p *ProcessConfigsHandlerStub) GetMaxRoundsToKeepUnprocessedMiniBlocks(round uint64) uint64 {
+	if p.GetMaxRoundsToKeepUnprocessedMiniBlocksCalled != nil {
+		return p.GetMaxRoundsToKeepUnprocessedMiniBlocksCalled(round)
 	}
 
 	return 0


### PR DESCRIPTION
## Reasoning behind the pull request
- Move `MaxRoundsToKeepUnprocessedMiniBlocks` && `MaxRoundsToKeepUnprocessedTransactions` to `ProcessConfigsByRound` config and component
  
## Proposed changes
- 
- 
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
