### PR TITLE
Fix get receipts storer for supernova

### DIFF
--- a/factory/api/apiResolverFactory.go
+++ b/factory/api/apiResolverFactory.go
@@ -247,6 +247,7 @@ func CreateApiResolver(args *ApiResolverArgs) (facade.ApiResolver, error) {
 		DataFieldParser:          dataFieldParser,
 		TxMarshaller:             args.CoreComponents.TxMarshalizer(),
 		EnableEpochsHandler:      args.CoreComponents.EnableEpochsHandler(),
+		EnableRoundsHandler:      args.CoreComponents.EnableRoundsHandler(),
 	}
 	apiTransactionProcessor, err := transactionAPI.NewAPITransactionProcessor(argsAPITransactionProc)
 	if err != nil {

--- a/integrationTests/chainSimulator/testing.go
+++ b/integrationTests/chainSimulator/testing.go
@@ -246,3 +246,29 @@ func CheckGenerateTransactions(t *testing.T, chainSimulator ChainSimulator) {
 		assert.Equal(t, expectedBalance.String(), account.Balance)
 	})
 }
+
+// GenerateMoveBalanceTxsInShardsWithMoreGasLimit -
+func GenerateMoveBalanceTxsInShardsWithMoreGasLimit(t *testing.T, chainSimulator ChainSimulator) {
+	transferValue := big.NewInt(0).Mul(OneEGLD, big.NewInt(5))
+
+	wallet0, err := chainSimulator.GenerateAndMintWalletAddress(0, InitialAmount)
+	require.Nil(t, err)
+
+	wallet1, err := chainSimulator.GenerateAndMintWalletAddress(0, InitialAmount)
+	require.Nil(t, err)
+
+	err = chainSimulator.GenerateBlocks(1)
+	require.Nil(t, err)
+
+	gasLimit := uint64(150_000)
+	tx0 := GenerateTransaction(wallet0.Bytes, 0, wallet1.Bytes, transferValue, "", gasLimit)
+
+	_, err = chainSimulator.SendTxAndGenerateBlockTilTxIsExecuted(tx0, 3)
+	require.Nil(t, err)
+
+	account, err := chainSimulator.GetAccount(wallet1)
+	require.Nil(t, err)
+	expectedBalance := big.NewInt(0).Add(InitialAmount, transferValue)
+	require.Equal(t, expectedBalance.String(), account.Balance)
+
+}

--- a/integrationTests/testProcessorNodeWithTestWebServer.go
+++ b/integrationTests/testProcessorNodeWithTestWebServer.go
@@ -240,6 +240,7 @@ func createFacadeComponents(tpn *TestProcessorNode) nodeFacade.ApiResolver {
 		DataFieldParser:          dataFieldParser,
 		TxMarshaller:             &marshallerMock.MarshalizerMock{},
 		EnableEpochsHandler:      tpn.EnableEpochsHandler,
+		EnableRoundsHandler:      tpn.EnableRoundsHandler,
 	}
 	apiTransactionHandler, err := transactionAPI.NewAPITransactionProcessor(argsApiTransactionProc)
 	log.LogIfError(err)

--- a/node/chainSimulator/chainSimulator_test.go
+++ b/node/chainSimulator/chainSimulator_test.go
@@ -548,3 +548,37 @@ func TestSimulator_SentMoveBalanceNoGasForFee(t *testing.T) {
 	_, err = chainSimulator.sendTx(ftx)
 	require.True(t, strings.Contains(err.Error(), errors.ErrInsufficientFunds.Error()))
 }
+
+func TestSimulator_SendMoveBalanceTxBeforeAndAfterSupernovaWithMoreGasLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	chainSimulator, err := NewChainSimulator(ArgsChainSimulator{
+		BypassTxSignatureCheck:         true,
+		TempDir:                        t.TempDir(),
+		PathToInitialConfig:            defaultPathToInitialConfig,
+		NumOfShards:                    defaultNumOfShards,
+		RoundDurationInMillis:          defaultRoundDurationInMillis,
+		SupernovaRoundDurationInMillis: defaultSupernovaRoundDurationInMillis,
+		RoundsPerEpoch:                 defaultRoundsPerEpoch,
+		SupernovaRoundsPerEpoch:        defaultSupernovaRoundsPerEpoch,
+		ApiInterface:                   api.NewNoApiInterface(),
+		MinNodesPerShard:               defaultMinNodesPerShard,
+		MetaChainMinNodes:              defaultMetaChainMinNodes,
+		AlterConfigsFunction: func(cfg *config.Configs) {
+			cfg.EpochConfig.EnableEpochs.SupernovaEnableEpoch = 2
+		},
+	})
+	require.Nil(t, err)
+	require.NotNil(t, chainSimulator)
+
+	defer chainSimulator.Close()
+
+	chainSimulatorCommon.GenerateMoveBalanceTxsInShardsWithMoreGasLimit(t, chainSimulator)
+
+	err = chainSimulator.GenerateBlocksUntilEpochIsReached(3)
+	require.Nil(t, err)
+
+	chainSimulatorCommon.GenerateMoveBalanceTxsInShardsWithMoreGasLimit(t, chainSimulator)
+}

--- a/node/external/transactionAPI/apiTransactionArgs.go
+++ b/node/external/transactionAPI/apiTransactionArgs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data/typeConverters"
 	"github.com/multiversx/mx-chain-core-go/marshal"
+
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/dblookupext"
@@ -30,4 +31,5 @@ type ArgAPITransactionProcessor struct {
 	DataFieldParser          DataFieldParser
 	TxMarshaller             marshal.Marshalizer
 	EnableEpochsHandler      common.EnableEpochsHandler
+	EnableRoundsHandler      common.EnableRoundsHandler
 }

--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -16,6 +16,8 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-core-go/data/typeConverters"
 	"github.com/multiversx/mx-chain-core-go/marshal"
+	logger "github.com/multiversx/mx-chain-logger-go"
+
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/holders"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
@@ -28,7 +30,6 @@ import (
 	"github.com/multiversx/mx-chain-go/sharding"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/txcache"
-	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
 var log = logger.GetOrCreate("node/transactionAPI")
@@ -50,6 +51,7 @@ type apiTransactionProcessor struct {
 	refundDetector              *refundDetector
 	gasUsedAndFeeProcessor      *gasUsedAndFeeProcessor
 	enableEpochsHandler         common.EnableEpochsHandler
+	enableRoundsHandler         common.EnableRoundsHandler
 }
 
 // NewAPITransactionProcessor will create a new instance of apiTransactionProcessor
@@ -75,6 +77,7 @@ func NewAPITransactionProcessor(args *ArgAPITransactionProcessor) (*apiTransacti
 		args.LogsFacade,
 		args.ShardCoordinator,
 		args.DataFieldParser,
+		args.EnableRoundsHandler,
 	)
 
 	refundDetectorInstance := NewRefundDetector()
@@ -103,6 +106,7 @@ func NewAPITransactionProcessor(args *ArgAPITransactionProcessor) (*apiTransacti
 		refundDetector:              refundDetectorInstance,
 		gasUsedAndFeeProcessor:      gasUsedAndFeeProc,
 		enableEpochsHandler:         args.EnableEpochsHandler,
+		enableRoundsHandler:         args.EnableRoundsHandler,
 	}, nil
 }
 
@@ -777,7 +781,7 @@ func (atp *apiTransactionProcessor) lookupHistoricalTransaction(hash []byte, wit
 		block.Type(miniblockMetadata.Type), tx)
 
 	if withResults {
-		err = atp.transactionResultsProcessor.putResultsInTransaction(hash, tx, miniblockMetadata.Epoch)
+		err = atp.transactionResultsProcessor.putResultsInTransaction(hash, tx, miniblockMetadata.Epoch, miniblockMetadata.Round)
 		if err != nil {
 			return nil, err
 		}

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -21,6 +21,11 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-core-go/data/vm"
 	"github.com/multiversx/mx-chain-core-go/marshal"
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
+	datafield "github.com/multiversx/mx-chain-vm-common-go/parsers/dataField"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/holders"
 	"github.com/multiversx/mx-chain-go/config"
@@ -40,10 +45,6 @@ import (
 	storageStubs "github.com/multiversx/mx-chain-go/testscommon/storage"
 	"github.com/multiversx/mx-chain-go/testscommon/txcachemocks"
 	"github.com/multiversx/mx-chain-go/txcache"
-	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
-	datafield "github.com/multiversx/mx-chain-vm-common-go/parsers/dataField"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const maxTrackedBlocks = 100
@@ -76,6 +77,7 @@ func createMockArgAPITransactionProcessor() *ArgAPITransactionProcessor {
 		},
 		TxMarshaller:        &marshallerMock.MarshalizerMock{},
 		EnableEpochsHandler: enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
+		EnableRoundsHandler: &testscommon.EnableRoundsHandlerStub{},
 	}
 }
 
@@ -215,6 +217,15 @@ func TestNewAPITransactionProcessor(t *testing.T) {
 
 		_, err := NewAPITransactionProcessor(arguments)
 		require.Equal(t, process.ErrNilEnableEpochsHandler, err)
+	})
+	t.Run("NilEnableRoundsHandler", func(t *testing.T) {
+		t.Parallel()
+
+		arguments := createMockArgAPITransactionProcessor()
+		arguments.EnableRoundsHandler = nil
+
+		_, err := NewAPITransactionProcessor(arguments)
+		require.Equal(t, process.ErrNilEnableRoundsHandler, err)
 	})
 }
 
@@ -375,6 +386,7 @@ func TestNode_GetSCRs(t *testing.T) {
 		},
 		EnableEpochsHandler: enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 		TxMarshaller:        &mock.MarshalizerFake{},
+		EnableRoundsHandler: &testscommon.EnableRoundsHandlerStub{},
 	}
 	apiTransactionProc, _ := NewAPITransactionProcessor(args)
 
@@ -593,6 +605,7 @@ func TestNode_GetTransactionWithResultsFromStorage(t *testing.T) {
 		},
 		TxMarshaller:        &marshallerMock.MarshalizerMock{},
 		EnableEpochsHandler: enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
+		EnableRoundsHandler: &testscommon.EnableRoundsHandlerStub{},
 	}
 	apiTransactionProc, _ := NewAPITransactionProcessor(args)
 
@@ -1628,6 +1641,7 @@ func createAPITransactionProc(t *testing.T, epoch uint32, withDbLookupExt bool) 
 				return flag == common.RelayedTransactionsV1V2DisableFlag
 			},
 		},
+		EnableRoundsHandler: &testscommon.EnableRoundsHandlerStub{},
 	}
 	apiTransactionProc, err := NewAPITransactionProcessor(args)
 	require.Nil(t, err)

--- a/node/external/transactionAPI/apiTransactionResults.go
+++ b/node/external/transactionAPI/apiTransactionResults.go
@@ -9,6 +9,8 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-core-go/marshal"
+
+	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/dblookupext"
 	"github.com/multiversx/mx-chain-go/node/filters"
@@ -25,6 +27,7 @@ type apiTransactionResultsProcessor struct {
 	shardCoordinator       sharding.Coordinator
 	refundDetector         *refundDetector
 	logsFacade             LogsFacade
+	enableRoundsHandler    common.EnableRoundsHandler
 }
 
 func newAPITransactionResultProcessor(
@@ -36,6 +39,7 @@ func newAPITransactionResultProcessor(
 	logsFacade LogsFacade,
 	shardCoordinator sharding.Coordinator,
 	dataFieldParser DataFieldParser,
+	enableRoundsHandler common.EnableRoundsHandler,
 ) *apiTransactionResultsProcessor {
 	refundDetector := NewRefundDetector()
 
@@ -49,10 +53,11 @@ func newAPITransactionResultProcessor(
 		refundDetector:         refundDetector,
 		logsFacade:             logsFacade,
 		dataFieldParser:        dataFieldParser,
+		enableRoundsHandler:    enableRoundsHandler,
 	}
 }
 
-func (arp *apiTransactionResultsProcessor) putResultsInTransaction(hash []byte, tx *transaction.ApiTransactionResult, epoch uint32) error {
+func (arp *apiTransactionResultsProcessor) putResultsInTransaction(hash []byte, tx *transaction.ApiTransactionResult, epoch uint32, round uint64) error {
 	// TODO: Note that the following call produces an effect even if the function "putResultsInTransaction" results in an error.
 	// TODO: Refactor this package to use less functions with side-effects.
 	arp.loadLogsIntoTransaction(hash, tx, epoch)
@@ -67,14 +72,14 @@ func (arp *apiTransactionResultsProcessor) putResultsInTransaction(hash []byte, 
 	}
 
 	if len(resultsHashes.ReceiptsHash) > 0 {
-		return arp.putReceiptInTransaction(tx, resultsHashes.ReceiptsHash, epoch)
+		return arp.putReceiptInTransaction(tx, resultsHashes.ReceiptsHash, epoch, round)
 	}
 
 	return arp.putSmartContractResultsInTransaction(tx, resultsHashes.ScResultsHashesAndEpoch)
 }
 
-func (arp *apiTransactionResultsProcessor) putReceiptInTransaction(tx *transaction.ApiTransactionResult, receiptHash []byte, epoch uint32) error {
-	rec, err := arp.getReceiptFromStorage(receiptHash, epoch)
+func (arp *apiTransactionResultsProcessor) putReceiptInTransaction(tx *transaction.ApiTransactionResult, receiptHash []byte, epoch uint32, round uint64) error {
+	rec, err := arp.getReceiptFromStorage(receiptHash, epoch, round)
 	if err != nil {
 		return fmt.Errorf("%w: %v, hash = %s", errCannotLoadReceipts, err, hex.EncodeToString(receiptHash))
 	}
@@ -83,8 +88,9 @@ func (arp *apiTransactionResultsProcessor) putReceiptInTransaction(tx *transacti
 	return nil
 }
 
-func (arp *apiTransactionResultsProcessor) getReceiptFromStorage(hash []byte, epoch uint32) (*transaction.ApiReceipt, error) {
-	receiptsStorer, err := arp.storageService.GetStorer(dataRetriever.UnsignedTransactionUnit)
+func (arp *apiTransactionResultsProcessor) getReceiptFromStorage(hash []byte, epoch uint32, round uint64) (*transaction.ApiReceipt, error) {
+	unitType := arp.getReceiptsStorerUnitType(round)
+	receiptsStorer, err := arp.storageService.GetStorer(unitType)
 	if err != nil {
 		return nil, err
 	}
@@ -95,6 +101,13 @@ func (arp *apiTransactionResultsProcessor) getReceiptFromStorage(hash []byte, ep
 	}
 
 	return arp.txUnmarshaller.unmarshalReceipt(receiptBytes)
+}
+
+func (arp *apiTransactionResultsProcessor) getReceiptsStorerUnitType(round uint64) dataRetriever.UnitType {
+	if arp.enableRoundsHandler.IsFlagEnabledInRound(common.SupernovaRoundFlag, round) {
+		return dataRetriever.ReceiptsUnit
+	}
+	return dataRetriever.UnsignedTransactionUnit
 }
 
 func (arp *apiTransactionResultsProcessor) putSmartContractResultsInTransaction(

--- a/node/external/transactionAPI/apiTransactionResults_test.go
+++ b/node/external/transactionAPI/apiTransactionResults_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/receipt"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	datafield "github.com/multiversx/mx-chain-vm-common-go/parsers/dataField"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/dblookupext"
 	"github.com/multiversx/mx-chain-go/node/mock"
@@ -21,8 +25,6 @@ import (
 	"github.com/multiversx/mx-chain-go/testscommon/genericMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
 	storageStubs "github.com/multiversx/mx-chain-go/testscommon/storage"
-	datafield "github.com/multiversx/mx-chain-vm-common-go/parsers/dataField"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPutEventsInTransactionReceipt(t *testing.T) {
@@ -71,9 +73,11 @@ func TestPutEventsInTransactionReceipt(t *testing.T) {
 		shardCoordinator,
 		&enableEpochsHandlerMock.EnableEpochsHandlerStub{},
 	)
-	n := newAPITransactionResultProcessor(pubKeyConverter, historyRepo, dataStore, marshalizerdMock, txUnmarshalerAndPreparer, logsFacade, shardCoordinator, dataFieldParser)
+	enableRoundsHandler := &testscommon.EnableRoundsHandlerStub{}
+	n := newAPITransactionResultProcessor(pubKeyConverter, historyRepo, dataStore, marshalizerdMock, txUnmarshalerAndPreparer, logsFacade, shardCoordinator, dataFieldParser, enableRoundsHandler)
 
 	epoch := uint32(0)
+	round := uint64(1)
 
 	tx := &transaction.ApiTransactionResult{}
 
@@ -87,7 +91,7 @@ func TestPutEventsInTransactionReceipt(t *testing.T) {
 		SndAddr: encodedSndAddr,
 	}
 
-	err = n.putResultsInTransaction(txHash, tx, epoch)
+	err = n.putResultsInTransaction(txHash, tx, epoch, round)
 	require.Nil(t, err)
 	require.Equal(t, expectedRecAPI, tx.Receipt)
 }
@@ -96,6 +100,7 @@ func TestApiTransactionProcessor_PutResultsInTransactionWhenNoResultsShouldWork(
 	t.Parallel()
 
 	epoch := uint32(0)
+	round := uint64(1)
 	historyRepo := &dbLookupExtMock.HistoryRepositoryStub{
 		GetEventsHashesByTxHashCalled: func(hash []byte, epoch uint32) (*dblookupext.ResultsHashesByTxHash, error) {
 			return nil, dblookupext.ErrNotFoundInStorage
@@ -109,6 +114,8 @@ func TestApiTransactionProcessor_PutResultsInTransactionWhenNoResultsShouldWork(
 	}
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
+
+	enableRoundsHandler := &testscommon.EnableRoundsHandlerStub{}
 	n := newAPITransactionResultProcessor(
 		testscommon.RealWorldBech32PubkeyConverter,
 		historyRepo,
@@ -124,10 +131,11 @@ func TestApiTransactionProcessor_PutResultsInTransactionWhenNoResultsShouldWork(
 		&testscommon.LogsFacadeStub{},
 		shardCoordinator,
 		dataFieldParser,
+		enableRoundsHandler,
 	)
 
 	tx := &transaction.ApiTransactionResult{}
-	err := n.putResultsInTransaction([]byte("txHash"), tx, epoch)
+	err := n.putResultsInTransaction([]byte("txHash"), tx, epoch, round)
 	require.Nil(t, err)
 	require.Empty(t, tx.SmartContractResults)
 }
@@ -136,6 +144,7 @@ func TestPutEventsInTransactionSmartContractResults(t *testing.T) {
 	t.Parallel()
 
 	testEpoch := uint32(0)
+	testRound := uint64(1)
 	testTxHash := []byte("txHash")
 	scrHash1 := []byte("scrHash1")
 	scrHash2 := []byte("scrHash2")
@@ -237,7 +246,8 @@ func TestPutEventsInTransactionSmartContractResults(t *testing.T) {
 		shardCoordinator,
 		&enableEpochsHandlerMock.EnableEpochsHandlerStub{},
 	)
-	n := newAPITransactionResultProcessor(pubKeyConverter, historyRepo, dataStore, marshalizerdMock, txUnmarshalerAndPreparer, logsFacade, shardCoordinator, dataFieldParser)
+	enableRoundsHandler := &testscommon.EnableRoundsHandlerStub{}
+	n := newAPITransactionResultProcessor(pubKeyConverter, historyRepo, dataStore, marshalizerdMock, txUnmarshalerAndPreparer, logsFacade, shardCoordinator, dataFieldParser, enableRoundsHandler)
 
 	encodedSndAddr, err := pubKeyConverter.Encode(scr1.SndAddr)
 	require.Nil(t, err)
@@ -279,7 +289,7 @@ func TestPutEventsInTransactionSmartContractResults(t *testing.T) {
 	}
 
 	tx := &transaction.ApiTransactionResult{}
-	err = n.putResultsInTransaction(testTxHash, tx, testEpoch)
+	err = n.putResultsInTransaction(testTxHash, tx, testEpoch, testRound)
 	require.Nil(t, err)
 	require.Equal(t, expectedSCRS, tx.SmartContractResults)
 }
@@ -288,6 +298,7 @@ func TestPutLogsInTransaction(t *testing.T) {
 	t.Parallel()
 
 	testEpoch := uint32(7)
+	testRound := uint64(70)
 	testTxHash := []byte("txHash")
 
 	logs := &transaction.ApiLogs{
@@ -341,12 +352,50 @@ func TestPutLogsInTransaction(t *testing.T) {
 		shardCoordinator,
 		&enableEpochsHandlerMock.EnableEpochsHandlerStub{},
 	)
-	n := newAPITransactionResultProcessor(pubKeyConverter, historyRepo, dataStore, marshalizerMock, txUnmarshalerAndPreparer, logsFacade, shardCoordinator, dataFieldParser)
+	enableRoundsHandler := &testscommon.EnableRoundsHandlerStub{}
+	n := newAPITransactionResultProcessor(pubKeyConverter, historyRepo, dataStore, marshalizerMock, txUnmarshalerAndPreparer, logsFacade, shardCoordinator, dataFieldParser, enableRoundsHandler)
 
 	tx := &transaction.ApiTransactionResult{}
-	err := n.putResultsInTransaction(testTxHash, tx, testEpoch)
+	err := n.putResultsInTransaction(testTxHash, tx, testEpoch, testRound)
 	// TODO: Note that "putResultsInTransaction" produces an effect on "tx" even if it returns an error.
 	// TODO: Refactor this package to use less functions with side-effects.
 	require.Errorf(t, err, "local err")
 	require.Equal(t, logs, tx.Logs)
+}
+
+func TestPutReceiptInTransactionAfterSupernovaWillReturnError(t *testing.T) {
+	t.Parallel()
+
+	dataStore := &storageStubs.ChainStorerStub{
+		GetStorerCalled: func(unitType dataRetriever.UnitType) (storage.Storer, error) {
+			switch unitType {
+			case dataRetriever.ReceiptsUnit:
+				return nil, expectedErr
+			default:
+				require.Fail(t, "should have not been called")
+				return nil, nil
+			}
+		},
+	}
+	enableRoundsHandler := &testscommon.EnableRoundsHandlerStub{
+		IsFlagEnabledInRoundCalled: func(flag common.EnableRoundFlag, round uint64) bool {
+			return true
+		},
+	}
+
+	n := newAPITransactionResultProcessor(
+		&testscommon.PubkeyConverterMock{},
+		&dbLookupExtMock.HistoryRepositoryStub{},
+		dataStore,
+		&mock.MarshalizerFake{},
+		&txUnmarshaller{},
+		&testscommon.LogsFacadeStub{},
+		mock.NewOneShardCoordinatorMock(),
+		&testscommon.DataFieldParserStub{},
+		enableRoundsHandler,
+	)
+
+	tx := &transaction.ApiTransactionResult{}
+	err := n.putReceiptInTransaction(tx, []byte("hash"), 2, 20)
+	require.Error(t, err, expectedErr)
 }

--- a/node/external/transactionAPI/check.go
+++ b/node/external/transactionAPI/check.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
+
 	"github.com/multiversx/mx-chain-go/process"
 )
 
@@ -49,6 +50,9 @@ func checkNilArgs(arg *ArgAPITransactionProcessor) error {
 	}
 	if check.IfNil(arg.EnableEpochsHandler) {
 		return process.ErrNilEnableEpochsHandler
+	}
+	if check.IfNil(arg.EnableRoundsHandler) {
+		return process.ErrNilEnableRoundsHandler
 	}
 
 	return nil


### PR DESCRIPTION
## Reasoning behind the pull request
- Transactions with receipts could not be found after supernova is enabled
- 
- 
  
## Proposed changes
- Before Supernova look for receipts in `UnsignedTransaction` storer, after supernova activation look for receipts in `Receipts` storer
- 
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
