### PR TITLE
MaxConsecutiveRoundsOfRatingDecrease in configs by round

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -27,11 +27,6 @@
     # GenesisMaxNumberOfShards represents the maximum number of shards to be created at genesis (excluding metaChain shard)
     GenesisMaxNumberOfShards  = 3
 
-    # MaxConsecutiveRoundsOfRatingDecrease represents the max number of consecutive rounds in which a block is not proposed
-    # on a shard and the validators' rating could be decreased. If, for instance, a shard gets stuck for more rounds
-    # than this value, then the validators rating decrease should stop so they won't get jailed
-    MaxConsecutiveRoundsOfRatingDecrease = 600
-
     # SyncProcessTimeInMillis is the value in milliseconds used when processing blocks while synchronizing blocks
     SyncProcessTimeInMillis = 12000
 
@@ -74,7 +69,11 @@
         MaxRoundsToKeepUnprocessedTransactions = 300,
         NumFloodingRoundsFastReacting = 10,
         NumFloodingRoundsSlowReacting = 2,
-        NumFloodingRoundsOutOfSpecs = 2
+        NumFloodingRoundsOutOfSpecs = 2,
+        # MaxConsecutiveRoundsOfRatingDecrease represents the max number of consecutive rounds in which a block is not proposed
+        # on a shard and the validators' rating could be decreased. If, for instance, a shard gets stuck for more rounds
+        # than this value, then the validators rating decrease should stop so they won't get jailed
+        MaxConsecutiveRoundsOfRatingDecrease = 600
         },
         {
         EnableRound = 440,
@@ -86,7 +85,8 @@
         MaxRoundsToKeepUnprocessedTransactions = 3000,
         NumFloodingRoundsFastReacting = 100,
         NumFloodingRoundsSlowReacting = 20,
-        NumFloodingRoundsOutOfSpecs = 20
+        NumFloodingRoundsOutOfSpecs = 20,
+        MaxConsecutiveRoundsOfRatingDecrease = 6000
         }
     ]
 

--- a/common/configs/consts.go
+++ b/common/configs/consts.go
@@ -18,4 +18,5 @@ const (
 	defaultNumFloodingRoundsFastReacting          = 20
 	defaultNumFloodingRoundsSlowReacting          = 20
 	defaultNumFloodingRoundsOutOfSpecs            = 20
+	defaultMaxConsecutiveRoundsOfRatingDecrease   = 600
 )

--- a/common/configs/dto/dto.go
+++ b/common/configs/dto/dto.go
@@ -10,4 +10,6 @@ const (
 	NumFloodingRoundsSlowReacting ConfigVariable = "NumFloodingRoundsSlowReacting"
 	// NumFloodingRoundsOutOfSpecs defines variable name for NumFloodingRoundsOutOfSpecs
 	NumFloodingRoundsOutOfSpecs ConfigVariable = "NumFloodingRoundsOutOfSpecs"
+	// MaxConsecutiveRoundsOfRatingDecrease defines variable name for MaxConsecutiveRoundsOfRatingDecrease
+	MaxConsecutiveRoundsOfRatingDecrease ConfigVariable = "MaxConsecutiveRoundsOfRatingDecrease"
 )

--- a/common/configs/processConfigs.go
+++ b/common/configs/processConfigs.go
@@ -106,7 +106,7 @@ func checkConfigsByRound(configsByRound []config.ProcessConfigByRound) error {
 		}
 		err := checkRoundConfigValues(cfg)
 		if err != nil {
-			return err
+			return fmt.Errorf("%w in checkConfigsByRound for enable round: %d", err, cfg.EnableRound)
 		}
 
 		seen[cfg.EnableRound] = struct{}{}
@@ -140,6 +140,9 @@ func checkRoundConfigValues(cfg config.ProcessConfigByRound) error {
 	if cfg.NumFloodingRoundsOutOfSpecs < minFloodingRounds {
 		return fmt.Errorf("%w for NumFloodingRoundsOutOfSpecs, received %d, min expected %d",
 			process.ErrInvalidValue, cfg.NumFloodingRoundsOutOfSpecs, minFloodingRounds)
+	}
+	if cfg.MaxConsecutiveRoundsOfRatingDecrease == 0 {
+		return process.ErrZeroMaxConsecutiveRoundsOfRatingDecrease
 	}
 
 	return nil

--- a/common/configs/processConfigs_test.go
+++ b/common/configs/processConfigs_test.go
@@ -21,6 +21,7 @@ func getConfigsByRound() []config.ProcessConfigByRound {
 			NumFloodingRoundsSlowReacting:          2,
 			NumFloodingRoundsFastReacting:          3,
 			NumFloodingRoundsOutOfSpecs:            4,
+			MaxConsecutiveRoundsOfRatingDecrease:   600,
 		},
 		{
 			EnableRound:                            1,
@@ -30,6 +31,7 @@ func getConfigsByRound() []config.ProcessConfigByRound {
 			NumFloodingRoundsSlowReacting:          20,
 			NumFloodingRoundsFastReacting:          30,
 			NumFloodingRoundsOutOfSpecs:            40,
+			MaxConsecutiveRoundsOfRatingDecrease:   6000,
 		},
 	}
 }
@@ -152,6 +154,20 @@ func TestNewProcessConfigsByEpoch(t *testing.T) {
 		require.True(t, strings.Contains(err.Error(), "NumFloodingRoundsOutOfSpecs"))
 	})
 
+	t.Run("should return error for invalid max consecutive rounds of rating decrease value", func(t *testing.T) {
+		t.Parallel()
+
+		confByEpoch := []config.ProcessConfigByEpoch{
+			{EnableEpoch: 0, MaxMetaNoncesBehind: 15},
+		}
+		confByRound := getConfigsByRound()
+		confByRound[0].MaxConsecutiveRoundsOfRatingDecrease = 0
+
+		pce, err := configs.NewProcessConfigsHandler(confByEpoch, confByRound, &epochNotifier.RoundNotifierStub{})
+		require.Nil(t, pce)
+		require.ErrorIs(t, err, process.ErrZeroMaxConsecutiveRoundsOfRatingDecrease)
+	})
+
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
@@ -199,6 +215,7 @@ func TestProcessConfigsByEpoch_Getters(t *testing.T) {
 			NumFloodingRoundsSlowReacting:          2,
 			NumFloodingRoundsFastReacting:          3,
 			NumFloodingRoundsOutOfSpecs:            4,
+			MaxConsecutiveRoundsOfRatingDecrease:   600,
 		},
 		{EnableRound: 1,
 			MaxRoundsWithoutNewBlockReceived:       11,
@@ -209,6 +226,7 @@ func TestProcessConfigsByEpoch_Getters(t *testing.T) {
 			NumFloodingRoundsSlowReacting:          20,
 			NumFloodingRoundsFastReacting:          30,
 			NumFloodingRoundsOutOfSpecs:            40,
+			MaxConsecutiveRoundsOfRatingDecrease:   6000,
 		},
 	}
 

--- a/common/configs/vars.go
+++ b/common/configs/vars.go
@@ -25,5 +25,11 @@ func initCfgVarMap() map[dto.ConfigVariable]configVariableHandler {
 			},
 			defaultValue: defaultNumFloodingRoundsOutOfSpecs,
 		},
+		dto.MaxConsecutiveRoundsOfRatingDecrease: {
+			valueSelector: func(cfg config.ProcessConfigByRound) uint64 {
+				return cfg.MaxConsecutiveRoundsOfRatingDecrease
+			},
+			defaultValue: defaultMaxConsecutiveRoundsOfRatingDecrease,
+		},
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -395,29 +395,30 @@ type ProcessConfigByRound struct {
 	NumFloodingRoundsFastReacting uint32
 	NumFloodingRoundsSlowReacting uint32
 	NumFloodingRoundsOutOfSpecs   uint32
+
+	MaxConsecutiveRoundsOfRatingDecrease uint32
 }
 
 // GeneralSettingsConfig will hold the general settings for a node
 type GeneralSettingsConfig struct {
 	StatusPollingIntervalSec int
 	// TODO: add config per epoch for supernova
-	MaxComputableRounds                  uint64
-	MaxConsecutiveRoundsOfRatingDecrease uint64
-	StartInEpochEnabled                  bool
-	ChainID                              string
-	MinTransactionVersion                uint32
-	GenesisString                        string
-	GenesisMaxNumberOfShards             uint32
-	SyncProcessTimeInMillis              uint32
-	SyncProcessTimeSupernovaInMillis     uint32
-	SetGuardianEpochsDelay               uint32
-	ChainParametersByEpoch               []ChainParametersByEpochConfig
-	EpochChangeGracePeriodByEpoch        []EpochChangeGracePeriodByEpoch
-	ProcessConfigsByEpoch                []ProcessConfigByEpoch
-	ProcessConfigsByRound                []ProcessConfigByRound `toml:"ProcessConfigsByRound"`
-	EpochStartConfigsByEpoch             []EpochStartConfigByEpoch
-	EpochStartConfigsByRound             []EpochStartConfigByRound
-	ConsensusConfigsByEpoch              []ConsensusConfigByEpoch
+	MaxComputableRounds              uint64
+	StartInEpochEnabled              bool
+	ChainID                          string
+	MinTransactionVersion            uint32
+	GenesisString                    string
+	GenesisMaxNumberOfShards         uint32
+	SyncProcessTimeInMillis          uint32
+	SyncProcessTimeSupernovaInMillis uint32
+	SetGuardianEpochsDelay           uint32
+	ChainParametersByEpoch           []ChainParametersByEpochConfig
+	EpochChangeGracePeriodByEpoch    []EpochChangeGracePeriodByEpoch
+	ProcessConfigsByEpoch            []ProcessConfigByEpoch
+	ProcessConfigsByRound            []ProcessConfigByRound `toml:"ProcessConfigsByRound"`
+	EpochStartConfigsByEpoch         []EpochStartConfigByEpoch
+	EpochStartConfigsByRound         []EpochStartConfigByRound
+	ConsensusConfigsByEpoch          []ConsensusConfigByEpoch
 }
 
 // HardwareRequirementsConfig will hold the hardware requirements config

--- a/config/config.go
+++ b/config/config.go
@@ -396,7 +396,7 @@ type ProcessConfigByRound struct {
 	NumFloodingRoundsSlowReacting uint32
 	NumFloodingRoundsOutOfSpecs   uint32
 
-	MaxConsecutiveRoundsOfRatingDecrease uint32
+	MaxConsecutiveRoundsOfRatingDecrease uint64
 }
 
 // GeneralSettingsConfig will hold the general settings for a node

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/hashing/sha256"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/common/configs/dto"
 	"github.com/multiversx/mx-chain-go/common/enablers"
 	"github.com/multiversx/mx-chain-go/common/forking"
 	"github.com/multiversx/mx-chain-go/config"
@@ -798,19 +799,26 @@ func createFullArgumentsForSystemSCProcessing(enableEpochsConfig config.EnableEp
 	peerAccountsDB := createAccountsDB(hasher, marshalizer, peerAccCreator, trieFactoryManager, enableEpochsHandler)
 
 	argsValidatorsProcessor := peer.ArgValidatorStatisticsProcessor{
-		Marshalizer:                          marshalizer,
-		NodesCoordinator:                     &shardingMocks.NodesCoordinatorStub{},
-		ShardCoordinator:                     &mock.ShardCoordinatorStub{},
-		DataPool:                             &dataRetrieverMock.PoolsHolderStub{},
-		StorageService:                       &storageMock.ChainStorerStub{},
-		PubkeyConv:                           &testscommon.PubkeyConverterMock{},
-		PeerAdapter:                          peerAccountsDB,
-		Rater:                                &mock.RaterStub{},
-		RewardsHandler:                       &mock.RewardsHandlerStub{},
-		NodesSetup:                           &genesisMocks.NodesSetupStub{},
-		MaxComputableRounds:                  1,
-		MaxConsecutiveRoundsOfRatingDecrease: 2000,
-		EnableEpochsHandler:                  enableEpochsHandler,
+		Marshalizer:         marshalizer,
+		NodesCoordinator:    &shardingMocks.NodesCoordinatorStub{},
+		ShardCoordinator:    &mock.ShardCoordinatorStub{},
+		DataPool:            &dataRetrieverMock.PoolsHolderStub{},
+		StorageService:      &storageMock.ChainStorerStub{},
+		PubkeyConv:          &testscommon.PubkeyConverterMock{},
+		PeerAdapter:         peerAccountsDB,
+		Rater:               &mock.RaterStub{},
+		RewardsHandler:      &mock.RewardsHandlerStub{},
+		NodesSetup:          &genesisMocks.NodesSetupStub{},
+		MaxComputableRounds: 1,
+		EnableEpochsHandler: enableEpochsHandler,
+		ProcessConfigsHandler: &testscommon.ProcessConfigsHandlerStub{
+			GetValueCalled: func(variable dto.ConfigVariable) uint64 {
+				if variable == dto.MaxConsecutiveRoundsOfRatingDecrease {
+					return 2000
+				}
+				return 10
+			},
+		},
 	}
 	vCreator, _ := peer.NewValidatorStatisticsProcessor(argsValidatorsProcessor)
 

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -847,21 +847,21 @@ func (pcf *processComponentsFactory) newValidatorStatisticsProcessor() (process.
 	}
 
 	arguments := peer.ArgValidatorStatisticsProcessor{
-		PeerAdapter:                          pcf.state.PeerAccounts(),
-		PubkeyConv:                           pcf.coreData.ValidatorPubKeyConverter(),
-		NodesCoordinator:                     pcf.nodesCoordinator,
-		ShardCoordinator:                     pcf.bootstrapComponents.ShardCoordinator(),
-		DataPool:                             peerDataPool,
-		StorageService:                       storageService,
-		Marshalizer:                          pcf.coreData.InternalMarshalizer(),
-		Rater:                                pcf.coreData.Rater(),
-		MaxComputableRounds:                  pcf.config.GeneralSettings.MaxComputableRounds,
-		MaxConsecutiveRoundsOfRatingDecrease: pcf.config.GeneralSettings.MaxConsecutiveRoundsOfRatingDecrease,
-		RewardsHandler:                       pcf.coreData.EconomicsData(),
-		NodesSetup:                           pcf.coreData.GenesisNodesSetup(),
-		RatingEnableEpoch:                    ratingEnabledEpoch,
-		GenesisNonce:                         genesisHeader.GetNonce(),
-		EnableEpochsHandler:                  pcf.coreData.EnableEpochsHandler(),
+		PeerAdapter:           pcf.state.PeerAccounts(),
+		PubkeyConv:            pcf.coreData.ValidatorPubKeyConverter(),
+		NodesCoordinator:      pcf.nodesCoordinator,
+		ShardCoordinator:      pcf.bootstrapComponents.ShardCoordinator(),
+		DataPool:              peerDataPool,
+		StorageService:        storageService,
+		Marshalizer:           pcf.coreData.InternalMarshalizer(),
+		Rater:                 pcf.coreData.Rater(),
+		MaxComputableRounds:   pcf.config.GeneralSettings.MaxComputableRounds,
+		RewardsHandler:        pcf.coreData.EconomicsData(),
+		NodesSetup:            pcf.coreData.GenesisNodesSetup(),
+		RatingEnableEpoch:     ratingEnabledEpoch,
+		GenesisNonce:          genesisHeader.GetNonce(),
+		EnableEpochsHandler:   pcf.coreData.EnableEpochsHandler(),
+		ProcessConfigsHandler: pcf.coreData.ProcessConfigsHandler(),
 	}
 
 	return peer.NewValidatorStatisticsProcessor(arguments)

--- a/factory/processing/processComponents_test.go
+++ b/factory/processing/processComponents_test.go
@@ -725,7 +725,7 @@ func TestProcessComponentsFactory_Create(t *testing.T) {
 		args := createMockProcessComponentsFactoryArgs()
 		ct := 0
 		args.CoreData.(*mock.CoreComponentsMock).ProcessConfigsHandlerCalled = func() common.ProcessConfigsHandler {
-			if ct == 1 {
+			if ct == 2 {
 				return nil
 			}
 			ct++
@@ -739,7 +739,7 @@ func TestProcessComponentsFactory_Create(t *testing.T) {
 		args := createMockProcessComponentsFactoryArgs()
 		ct := 0
 		args.CoreData.(*mock.CoreComponentsMock).ProcessConfigsHandlerCalled = func() common.ProcessConfigsHandler {
-			if ct == 2 {
+			if ct == 3 {
 				return nil
 			}
 			ct++

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -742,20 +742,20 @@ func (tpn *TestProcessorNode) initValidatorStatistics() {
 	}
 
 	arguments := peer.ArgValidatorStatisticsProcessor{
-		PeerAdapter:                          tpn.PeerState,
-		PubkeyConv:                           TestValidatorPubkeyConverter,
-		NodesCoordinator:                     tpn.NodesCoordinator,
-		ShardCoordinator:                     tpn.ShardCoordinator,
-		DataPool:                             tpn.DataPool,
-		StorageService:                       tpn.Storage,
-		Marshalizer:                          TestMarshalizer,
-		Rater:                                rater,
-		MaxComputableRounds:                  1000,
-		MaxConsecutiveRoundsOfRatingDecrease: 2000,
-		RewardsHandler:                       tpn.EconomicsData,
-		NodesSetup:                           tpn.NodesSetup,
-		GenesisNonce:                         tpn.BlockChain.GetGenesisHeader().GetNonce(),
-		EnableEpochsHandler:                  tpn.EnableEpochsHandler,
+		PeerAdapter:           tpn.PeerState,
+		PubkeyConv:            TestValidatorPubkeyConverter,
+		NodesCoordinator:      tpn.NodesCoordinator,
+		ShardCoordinator:      tpn.ShardCoordinator,
+		DataPool:              tpn.DataPool,
+		StorageService:        tpn.Storage,
+		Marshalizer:           TestMarshalizer,
+		Rater:                 rater,
+		MaxComputableRounds:   1000,
+		RewardsHandler:        tpn.EconomicsData,
+		NodesSetup:            tpn.NodesSetup,
+		GenesisNonce:          tpn.BlockChain.GetGenesisHeader().GetNonce(),
+		EnableEpochsHandler:   tpn.EnableEpochsHandler,
+		ProcessConfigsHandler: tpn.ProcessConfigsHandler,
 	}
 
 	tpn.ValidatorStatisticsProcessor, _ = peer.NewValidatorStatisticsProcessor(arguments)

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -180,6 +180,7 @@ var TestProcessConfigsHandler, _ = configs.NewProcessConfigsHandler([]config.Pro
 			NumFloodingRoundsSlowReacting:          20,
 			NumFloodingRoundsFastReacting:          30,
 			NumFloodingRoundsOutOfSpecs:            40,
+			MaxConsecutiveRoundsOfRatingDecrease:   600,
 		},
 	},
 	forking.NewGenericRoundNotifier(),

--- a/integrationTests/vm/staking/systemSCCreator.go
+++ b/integrationTests/vm/staking/systemSCCreator.go
@@ -115,19 +115,19 @@ func createValidatorStatisticsProcessor(
 	peerAccounts state.AccountsAdapter,
 ) process.ValidatorStatisticsProcessor {
 	argsValidatorsProcessor := peer.ArgValidatorStatisticsProcessor{
-		Marshalizer:                          coreComponents.InternalMarshalizer(),
-		NodesCoordinator:                     nc,
-		ShardCoordinator:                     shardCoordinator,
-		DataPool:                             dataComponents.Datapool(),
-		StorageService:                       dataComponents.StorageService(),
-		PubkeyConv:                           coreComponents.AddressPubKeyConverter(),
-		PeerAdapter:                          peerAccounts,
-		Rater:                                coreComponents.Rater(),
-		RewardsHandler:                       &epochStartMock.RewardsHandlerStub{},
-		NodesSetup:                           &genesisMocks.NodesSetupStub{},
-		MaxComputableRounds:                  1,
-		MaxConsecutiveRoundsOfRatingDecrease: 2000,
-		EnableEpochsHandler:                  coreComponents.EnableEpochsHandler(),
+		Marshalizer:           coreComponents.InternalMarshalizer(),
+		NodesCoordinator:      nc,
+		ShardCoordinator:      shardCoordinator,
+		DataPool:              dataComponents.Datapool(),
+		StorageService:        dataComponents.StorageService(),
+		PubkeyConv:            coreComponents.AddressPubKeyConverter(),
+		PeerAdapter:           peerAccounts,
+		Rater:                 coreComponents.Rater(),
+		RewardsHandler:        &epochStartMock.RewardsHandlerStub{},
+		NodesSetup:            &genesisMocks.NodesSetupStub{},
+		MaxComputableRounds:   1,
+		EnableEpochsHandler:   coreComponents.EnableEpochsHandler(),
+		ProcessConfigsHandler: coreComponents.ProcessConfigsHandler(),
 	}
 	validatorStatisticsProcessor, _ := peer.NewValidatorStatisticsProcessor(argsValidatorsProcessor)
 	return validatorStatisticsProcessor

--- a/node/chainSimulator/components/coreComponents_test.go
+++ b/node/chainSimulator/components/coreComponents_test.go
@@ -73,6 +73,7 @@ func createArgsCoreComponentsHolder() ArgsCoreComponentsHolder {
 						NumFloodingRoundsSlowReacting:          20,
 						NumFloodingRoundsFastReacting:          30,
 						NumFloodingRoundsOutOfSpecs:            40,
+						MaxConsecutiveRoundsOfRatingDecrease:   600,
 					},
 				},
 				EpochStartConfigsByEpoch: []config.EpochStartConfigByEpoch{

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -163,6 +163,7 @@ func NewShardProcessorEmptyWith3shards(
 				NumFloodingRoundsSlowReacting:          20,
 				NumFloodingRoundsFastReacting:          30,
 				NumFloodingRoundsOutOfSpecs:            40,
+				MaxConsecutiveRoundsOfRatingDecrease:   600,
 			},
 		},
 		&epochNotifier.RoundNotifierStub{},

--- a/process/peer/process.go
+++ b/process/peer/process.go
@@ -111,10 +111,6 @@ func NewValidatorStatisticsProcessor(arguments ArgValidatorStatisticsProcessor) 
 	if arguments.MaxComputableRounds == 0 {
 		return nil, process.ErrZeroMaxComputableRounds
 	}
-	// TODO: Here
-	//if arguments.MaxConsecutiveRoundsOfRatingDecrease == 0 {
-	//	return nil, process.ErrZeroMaxConsecutiveRoundsOfRatingDecrease
-	//}
 	if check.IfNil(arguments.Rater) {
 		return nil, process.ErrNilRater
 	}

--- a/process/peer/process.go
+++ b/process/peer/process.go
@@ -14,6 +14,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/marshal"
+	"github.com/multiversx/mx-chain-go/common/configs/dto"
 	logger "github.com/multiversx/mx-chain-logger-go"
 
 	"github.com/multiversx/mx-chain-go/common"
@@ -45,41 +46,41 @@ const (
 
 // ArgValidatorStatisticsProcessor holds all dependencies for the validatorStatistics
 type ArgValidatorStatisticsProcessor struct {
-	Marshalizer                          marshal.Marshalizer
-	NodesCoordinator                     nodesCoordinator.NodesCoordinator
-	ShardCoordinator                     sharding.Coordinator
-	DataPool                             DataPool
-	StorageService                       dataRetriever.StorageService
-	PubkeyConv                           core.PubkeyConverter
-	PeerAdapter                          state.AccountsAdapter
-	Rater                                sharding.PeerAccountListAndRatingHandler
-	RewardsHandler                       process.RewardsHandler
-	MaxComputableRounds                  uint64
-	MaxConsecutiveRoundsOfRatingDecrease uint64
-	NodesSetup                           sharding.GenesisNodesSetupHandler
-	GenesisNonce                         uint64
-	RatingEnableEpoch                    uint32
-	EnableEpochsHandler                  common.EnableEpochsHandler
+	Marshalizer           marshal.Marshalizer
+	NodesCoordinator      nodesCoordinator.NodesCoordinator
+	ShardCoordinator      sharding.Coordinator
+	DataPool              DataPool
+	StorageService        dataRetriever.StorageService
+	PubkeyConv            core.PubkeyConverter
+	PeerAdapter           state.AccountsAdapter
+	Rater                 sharding.PeerAccountListAndRatingHandler
+	RewardsHandler        process.RewardsHandler
+	MaxComputableRounds   uint64
+	NodesSetup            sharding.GenesisNodesSetupHandler
+	GenesisNonce          uint64
+	RatingEnableEpoch     uint32
+	EnableEpochsHandler   common.EnableEpochsHandler
+	ProcessConfigsHandler common.ProcessConfigsHandler
 }
 
 type validatorStatistics struct {
-	marshalizer                          marshal.Marshalizer
-	dataPool                             DataPool
-	storageService                       dataRetriever.StorageService
-	nodesCoordinator                     nodesCoordinator.NodesCoordinator
-	shardCoordinator                     sharding.Coordinator
-	pubkeyConv                           core.PubkeyConverter
-	peerAdapter                          state.AccountsAdapter
-	rater                                sharding.PeerAccountListAndRatingHandler
-	rewardsHandler                       process.RewardsHandler
-	maxComputableRounds                  uint64
-	maxConsecutiveRoundsOfRatingDecrease uint64
-	missedBlocksCounters                 validatorRoundCounters
-	mutValidatorStatistics               sync.RWMutex
-	genesisNonce                         uint64
-	ratingEnableEpoch                    uint32
-	lastFinalizedRootHash                []byte
-	enableEpochsHandler                  common.EnableEpochsHandler
+	marshalizer            marshal.Marshalizer
+	dataPool               DataPool
+	storageService         dataRetriever.StorageService
+	nodesCoordinator       nodesCoordinator.NodesCoordinator
+	shardCoordinator       sharding.Coordinator
+	pubkeyConv             core.PubkeyConverter
+	peerAdapter            state.AccountsAdapter
+	rater                  sharding.PeerAccountListAndRatingHandler
+	rewardsHandler         process.RewardsHandler
+	maxComputableRounds    uint64
+	missedBlocksCounters   validatorRoundCounters
+	mutValidatorStatistics sync.RWMutex
+	genesisNonce           uint64
+	ratingEnableEpoch      uint32
+	lastFinalizedRootHash  []byte
+	enableEpochsHandler    common.EnableEpochsHandler
+	processConfigsHandler  common.ProcessConfigsHandler
 }
 
 // NewValidatorStatisticsProcessor instantiates a new validatorStatistics structure responsible for keeping account of
@@ -110,9 +111,10 @@ func NewValidatorStatisticsProcessor(arguments ArgValidatorStatisticsProcessor) 
 	if arguments.MaxComputableRounds == 0 {
 		return nil, process.ErrZeroMaxComputableRounds
 	}
-	if arguments.MaxConsecutiveRoundsOfRatingDecrease == 0 {
-		return nil, process.ErrZeroMaxConsecutiveRoundsOfRatingDecrease
-	}
+	// TODO: Here
+	//if arguments.MaxConsecutiveRoundsOfRatingDecrease == 0 {
+	//	return nil, process.ErrZeroMaxConsecutiveRoundsOfRatingDecrease
+	//}
 	if check.IfNil(arguments.Rater) {
 		return nil, process.ErrNilRater
 	}
@@ -125,6 +127,9 @@ func NewValidatorStatisticsProcessor(arguments ArgValidatorStatisticsProcessor) 
 	if check.IfNil(arguments.EnableEpochsHandler) {
 		return nil, process.ErrNilEnableEpochsHandler
 	}
+	if check.IfNil(arguments.ProcessConfigsHandler) {
+		return nil, process.ErrNilProcessConfigsHandler
+	}
 	err := core.CheckHandlerCompatibility(arguments.EnableEpochsHandler, []core.EnableEpochFlag{
 		common.StopDecreasingValidatorRatingWhenStuckFlag,
 		common.SwitchJailWaitingFlag,
@@ -136,20 +141,20 @@ func NewValidatorStatisticsProcessor(arguments ArgValidatorStatisticsProcessor) 
 	}
 
 	vs := &validatorStatistics{
-		peerAdapter:                          arguments.PeerAdapter,
-		pubkeyConv:                           arguments.PubkeyConv,
-		nodesCoordinator:                     arguments.NodesCoordinator,
-		shardCoordinator:                     arguments.ShardCoordinator,
-		dataPool:                             arguments.DataPool,
-		storageService:                       arguments.StorageService,
-		marshalizer:                          arguments.Marshalizer,
-		missedBlocksCounters:                 make(validatorRoundCounters),
-		rater:                                arguments.Rater,
-		rewardsHandler:                       arguments.RewardsHandler,
-		maxComputableRounds:                  arguments.MaxComputableRounds,
-		maxConsecutiveRoundsOfRatingDecrease: arguments.MaxConsecutiveRoundsOfRatingDecrease,
-		genesisNonce:                         arguments.GenesisNonce,
-		enableEpochsHandler:                  arguments.EnableEpochsHandler,
+		peerAdapter:           arguments.PeerAdapter,
+		pubkeyConv:            arguments.PubkeyConv,
+		nodesCoordinator:      arguments.NodesCoordinator,
+		shardCoordinator:      arguments.ShardCoordinator,
+		dataPool:              arguments.DataPool,
+		storageService:        arguments.StorageService,
+		marshalizer:           arguments.Marshalizer,
+		missedBlocksCounters:  make(validatorRoundCounters),
+		rater:                 arguments.Rater,
+		rewardsHandler:        arguments.RewardsHandler,
+		maxComputableRounds:   arguments.MaxComputableRounds,
+		genesisNonce:          arguments.GenesisNonce,
+		enableEpochsHandler:   arguments.EnableEpochsHandler,
+		processConfigsHandler: arguments.ProcessConfigsHandler,
 	}
 
 	err = vs.saveInitialState(arguments.NodesSetup)
@@ -803,7 +808,7 @@ func (vs *validatorStatistics) checkForMissedBlocks(
 		return nil
 	}
 	if vs.enableEpochsHandler.IsFlagEnabled(common.StopDecreasingValidatorRatingWhenStuckFlag) {
-		if missedRounds > vs.maxConsecutiveRoundsOfRatingDecrease {
+		if missedRounds > vs.processConfigsHandler.GetValue(dto.MaxConsecutiveRoundsOfRatingDecrease) {
 			return nil
 		}
 	}

--- a/process/peer/process_test.go
+++ b/process/peer/process_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/common/configs/dto"
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
@@ -125,17 +126,24 @@ func createMockArguments() peer.ArgValidatorStatisticsProcessor {
 				return nil
 			},
 		},
-		StorageService:                       &storageStubs.ChainStorerStub{},
-		NodesCoordinator:                     &shardingMocks.NodesCoordinatorMock{},
-		ShardCoordinator:                     mock.NewOneShardCoordinatorMock(),
-		PubkeyConv:                           createMockPubkeyConverter(),
-		PeerAdapter:                          getAccountsMock(),
-		Rater:                                createMockRater(),
-		RewardsHandler:                       economicsData,
-		MaxComputableRounds:                  1000,
-		MaxConsecutiveRoundsOfRatingDecrease: 2000,
-		NodesSetup:                           &genesisMocks.NodesSetupStub{},
-		EnableEpochsHandler:                  enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.SwitchJailWaitingFlag, common.BelowSignedThresholdFlag),
+		StorageService:      &storageStubs.ChainStorerStub{},
+		NodesCoordinator:    &shardingMocks.NodesCoordinatorMock{},
+		ShardCoordinator:    mock.NewOneShardCoordinatorMock(),
+		PubkeyConv:          createMockPubkeyConverter(),
+		PeerAdapter:         getAccountsMock(),
+		Rater:               createMockRater(),
+		RewardsHandler:      economicsData,
+		MaxComputableRounds: 1000,
+		NodesSetup:          &genesisMocks.NodesSetupStub{},
+		EnableEpochsHandler: enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.SwitchJailWaitingFlag, common.BelowSignedThresholdFlag),
+		ProcessConfigsHandler: &testscommon.ProcessConfigsHandlerStub{
+			GetValueCalled: func(variable dto.ConfigVariable) uint64 {
+				if variable == dto.MaxConsecutiveRoundsOfRatingDecrease {
+					return 2000
+				}
+				return 10
+			},
+		},
 	}
 	return arguments
 }
@@ -224,17 +232,6 @@ func TestNewValidatorStatisticsProcessor_ZeroMaxComputableRoundsShouldErr(t *tes
 
 	assert.Nil(t, validatorStatistics)
 	assert.Equal(t, process.ErrZeroMaxComputableRounds, err)
-}
-
-func TestNewValidatorStatisticsProcessor_ZeroMaxConsecutiveRoundsOfRatingDecreaseShouldErr(t *testing.T) {
-	t.Parallel()
-
-	arguments := createMockArguments()
-	arguments.MaxConsecutiveRoundsOfRatingDecrease = 0
-	validatorStatistics, err := peer.NewValidatorStatisticsProcessor(arguments)
-
-	assert.Nil(t, validatorStatistics)
-	assert.Equal(t, process.ErrZeroMaxConsecutiveRoundsOfRatingDecrease, err)
 }
 
 func TestNewValidatorStatisticsProcessor_NilRaterShouldErr(t *testing.T) {
@@ -1476,7 +1473,14 @@ func TestValidatorStatisticsProcessor_CheckForMissedBlocksMissedRoundsGreaterTha
 	arguments.MaxComputableRounds = 1
 	enableEpochsHandler, _ := arguments.EnableEpochsHandler.(*enableEpochsHandlerMock.EnableEpochsHandlerStub)
 	enableEpochsHandler.RemoveActiveFlags(common.StopDecreasingValidatorRatingWhenStuckFlag)
-	arguments.MaxConsecutiveRoundsOfRatingDecrease = 4
+	arguments.ProcessConfigsHandler = &testscommon.ProcessConfigsHandlerStub{
+		GetValueCalled: func(variable dto.ConfigVariable) uint64 {
+			if variable == dto.MaxConsecutiveRoundsOfRatingDecrease {
+				return 4
+			}
+			return 0
+		},
+	}
 
 	validatorStatistics, _ := peer.NewValidatorStatisticsProcessor(arguments)
 

--- a/process/track/baseBlockTrack_test.go
+++ b/process/track/baseBlockTrack_test.go
@@ -151,6 +151,7 @@ func CreateShardTrackerMockArguments() track.ArgShardTracker {
 				NumFloodingRoundsSlowReacting:          20,
 				NumFloodingRoundsFastReacting:          30,
 				NumFloodingRoundsOutOfSpecs:            40,
+				MaxConsecutiveRoundsOfRatingDecrease:   600,
 			},
 		},
 		&epochNotifier.RoundNotifierStub{},

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -326,6 +326,7 @@ func GetNetworkFactoryArgs() networkComp.NetworkComponentsFactoryArgs {
 					NumFloodingRoundsSlowReacting:          20,
 					NumFloodingRoundsFastReacting:          30,
 					NumFloodingRoundsOutOfSpecs:            40,
+					MaxConsecutiveRoundsOfRatingDecrease:   600,
 				},
 			},
 		},

--- a/testscommon/components/configs.go
+++ b/testscommon/components/configs.go
@@ -183,6 +183,7 @@ func GetGeneralConfig() config.Config {
 					NumFloodingRoundsFastReacting:          20,
 					NumFloodingRoundsOutOfSpecs:            20,
 					NumFloodingRoundsSlowReacting:          20,
+					MaxConsecutiveRoundsOfRatingDecrease:   600,
 				},
 			},
 			EpochStartConfigsByEpoch: []config.EpochStartConfigByEpoch{

--- a/testscommon/generalConfig.go
+++ b/testscommon/generalConfig.go
@@ -50,14 +50,13 @@ func GetGeneralConfig() config.Config {
 			CacheRefreshIntervalInSec: uint32(100),
 		},
 		GeneralSettings: config.GeneralSettingsConfig{
-			StartInEpochEnabled:                  true,
-			GenesisMaxNumberOfShards:             100,
-			MaxComputableRounds:                  1000,
-			MaxConsecutiveRoundsOfRatingDecrease: 2000,
-			SyncProcessTimeInMillis:              6000,
-			SyncProcessTimeSupernovaInMillis:     3000,
-			SetGuardianEpochsDelay:               20,
-			StatusPollingIntervalSec:             10,
+			StartInEpochEnabled:              true,
+			GenesisMaxNumberOfShards:         100,
+			MaxComputableRounds:              1000,
+			SyncProcessTimeInMillis:          6000,
+			SyncProcessTimeSupernovaInMillis: 3000,
+			SetGuardianEpochsDelay:           20,
+			StatusPollingIntervalSec:         10,
 			ChainParametersByEpoch: []config.ChainParametersByEpochConfig{
 				{
 					EnableEpoch:                 0,
@@ -89,6 +88,7 @@ func GetGeneralConfig() config.Config {
 					NumFloodingRoundsSlowReacting:          20,
 					NumFloodingRoundsFastReacting:          30,
 					NumFloodingRoundsOutOfSpecs:            40,
+					MaxConsecutiveRoundsOfRatingDecrease:   2000,
 				},
 			},
 			EpochStartConfigsByEpoch: []config.EpochStartConfigByEpoch{

--- a/testscommon/processConfigsHandlerStub.go
+++ b/testscommon/processConfigsHandlerStub.go
@@ -28,6 +28,7 @@ func GetDefaultProcessConfigsHandler() common.ProcessConfigsHandler {
 				NumFloodingRoundsSlowReacting:          20,
 				NumFloodingRoundsFastReacting:          30,
 				NumFloodingRoundsOutOfSpecs:            40,
+				MaxConsecutiveRoundsOfRatingDecrease:   600,
 			},
 		},
 		&epochNotifier.RoundNotifierStub{},


### PR DESCRIPTION
## Reasoning behind the pull request
- Integrate `MaxConsecutiveRoundsOfRatingDecrease` in `ProcessConfigsByRound`
## Proposed changes
- 
- 
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
