### PR TITLE
use hash from proof when sync is stuck due to invalid header

### DIFF
--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -1646,6 +1646,12 @@ func (boot *baseBootstrap) getNextHeaderRequestingIfMissing() (data.HeaderHandle
 		hash = boot.forkInfo.Hash
 	}
 
+	// if there is a proof for the current nonce, use the header hash from proof
+	proof, err := boot.dataPool.Proofs().GetProofByNonce(nonce, boot.shardCoordinator.SelfId())
+	if err == nil {
+		hash = proof.GetHeaderHash()
+	}
+
 	if hash != nil {
 		header, err := boot.getHeaderWithHashRequestingIfMissing(hash)
 		return header, err

--- a/process/sync/metablock_test.go
+++ b/process/sync/metablock_test.go
@@ -1966,6 +1966,9 @@ func TestMetaBootstrap_SyncBlock_WithEquivalentProofs(t *testing.T) {
 				GetProofCalled: func(shardID uint32, headerHash []byte) (data.HeaderProofHandler, error) {
 					return nil, errors.New("missing proof")
 				},
+				GetProofByNonceCalled: func(headerNonce uint64, shardID uint32) (data.HeaderProofHandler, error) {
+					return nil, errors.New("missing proof")
+				},
 				HasProofCalled: func(shardID uint32, headerHash []byte) bool {
 					if numProofCalls == 0 {
 						numProofCalls++

--- a/process/sync/shardblock_test.go
+++ b/process/sync/shardblock_test.go
@@ -2518,6 +2518,9 @@ func TestShardBootstrap_SyncBlock_WithEquivalentProofs(t *testing.T) {
 				GetProofCalled: func(shardID uint32, headerHash []byte) (data.HeaderProofHandler, error) {
 					return nil, errors.New("missing proof")
 				},
+				GetProofByNonceCalled: func(headerNonce uint64, shardID uint32) (data.HeaderProofHandler, error) {
+					return nil, errors.New("missing proof")
+				},
 				HasProofCalled: func(shardID uint32, headerHash []byte) bool {
 					if numProofCalls == 0 {
 						numProofCalls++


### PR DESCRIPTION
## Reasoning behind the pull request
- sync may get stuck when multiple headers are proposed, one has consensus but the while syncing requests the invalid nonce
  
## Proposed changes
- get the header hash from the proof for the nonce that is being synced

## Testing procedure
- with feat branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
