### PR TITLE
Fix reward for protocol sustainability tx

### DIFF
--- a/epochStart/metachain/rewardsV2.go
+++ b/epochStart/metachain/rewardsV2.go
@@ -161,7 +161,7 @@ func (rc *rewardsCreatorV2) createRewardsMiniBlocks(
 	rc.clean()
 	rc.flagDelegationSystemSCEnabled.SetValue(args.newEpoch >= rc.enableEpochsHandler.GetActivationEpoch(common.StakingV2Flag))
 
-	protRwdTx, protRwdShardId, err := rc.createProtocolSustainabilityRewardTransaction(args.newEpoch, args.round, args.computedEconomics.GetRewardsForProtocolSustainability())
+	protRwdTx, protRwdShardId, err := rc.createProtocolSustainabilityRewardTransaction(args.newEpoch, args.round, rc.economicsDataProvider.RewardsForProtocolSustainability())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- Wrong protocol sustainability reward value in reward tx, was just a merge issue
- It was merged correctly `stakingv5 -> rc` [here](https://github.com/multiversx/mx-chain-go/pull/7477/changes#diff-913985def3d3b1c33ad55dd1d6371ba335e89509fa500459d1ce558682cfb8eeR110)
- It was changed when merged `rc -> feat` [here](https://github.com/multiversx/mx-chain-go/pull/7547/changes#diff-913985def3d3b1c33ad55dd1d6371ba335e89509fa500459d1ce558682cfb8eeR164)
  
## Proposed changes
- The corrrect 10% value for protocol sustainability reward is in `rc.economicsDataProvider.RewardsForProtocolSustainability()`
- 
- 

## Testing
- Also epoch start data shows correct value now
<img width="1198" height="154" alt="image" src="https://github.com/user-attachments/assets/8f6514c5-8ef5-4b2d-b58a-20b6cd558fc1" />

- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
