### PR TITLE
change check for meta notarizing shard headers

### DIFF
--- a/epochStart/bootstrap/disabled/disabledEpochStartTrigger.go
+++ b/epochStart/bootstrap/disabled/disabledEpochStartTrigger.go
@@ -26,6 +26,11 @@ func (e *epochStartTrigger) ShouldProposeEpochChange(_ uint64, _ uint64) bool {
 func (e *epochStartTrigger) SetEpochChangeProposed(_ bool) {
 }
 
+// GetEpochChangeProposed -
+func (e *epochStartTrigger) GetEpochChangeProposed() bool {
+	return false
+}
+
 // SetEpochChange -
 func (e *epochStartTrigger) SetEpochChange(_ uint64) {}
 

--- a/epochStart/interface.go
+++ b/epochStart/interface.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
+
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/state"
-	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
 // TriggerHandler defines the functionalities for an start of epoch trigger
@@ -23,6 +24,7 @@ type TriggerHandler interface {
 	SetEpochChange(round uint64)
 	ShouldProposeEpochChange(round uint64, nonce uint64) bool
 	SetEpochChangeProposed(value bool)
+	GetEpochChangeProposed() bool
 	EpochStartRound() uint64
 	EpochStartMetaHdrHash() []byte
 	LastCommitedEpochStartHdr() (data.HeaderHandler, error)

--- a/epochStart/metachain/trigger.go
+++ b/epochStart/metachain/trigger.go
@@ -243,6 +243,13 @@ func (t *trigger) SetEpochChangeProposed(value bool) {
 	t.epochChangeProposed = value
 }
 
+// GetEpochChangeProposed returns the epoch change proposed flag
+func (t *trigger) GetEpochChangeProposed() bool {
+	t.mutTrigger.RLock()
+	defer t.mutTrigger.RUnlock()
+	return t.epochChangeProposed
+}
+
 func (t *trigger) shouldTriggerEpochStart(currentRound uint64, currentNonce uint64) bool {
 	isZeroEpochEdgeCase := currentNonce < minimumNonceToStartEpoch
 	isNormalEpochStart := currentRound > t.currEpochStartRound+t.getRoundsPerEpoch(t.epoch)-t.getOffsetPerEpoch(t.epoch)

--- a/epochStart/shardchain/trigger.go
+++ b/epochStart/shardchain/trigger.go
@@ -1246,6 +1246,11 @@ func (t *trigger) SetEpochChangeProposed(_ bool) {
 	// no implementation needed
 }
 
+// GetEpochChangeProposed will always return false
+func (t *trigger) GetEpochChangeProposed() bool {
+	return false
+}
+
 // SetFinalityAttestingRound sets the round which finalized the start of epoch block
 func (t *trigger) SetFinalityAttestingRound(_ uint64) {
 }

--- a/factory/mock/epochStartTriggerStub.go
+++ b/factory/mock/epochStartTriggerStub.go
@@ -23,6 +23,7 @@ type EpochStartTriggerStub struct {
 	ShouldProposeEpochChangeCalled    func(round uint64, nonce uint64) bool
 	SetEpochChangeCalled              func(round uint64)
 	SetEpochChangeProposedCalled      func(value bool)
+	GetEpochChangeProposedCalled      func() bool
 }
 
 // SetEpochChange -
@@ -46,6 +47,15 @@ func (e *EpochStartTriggerStub) SetEpochChangeProposed(value bool) {
 	if e.SetEpochChangeProposedCalled != nil {
 		e.SetEpochChangeProposedCalled(value)
 	}
+}
+
+// GetEpochChangeProposed -
+func (e *EpochStartTriggerStub) GetEpochChangeProposed() bool {
+	if e.GetEpochChangeProposedCalled != nil {
+		return e.GetEpochChangeProposedCalled()
+	}
+
+	return false
 }
 
 // RevertStateToBlock -

--- a/integrationTests/mock/endOfEpochTriggerStub.go
+++ b/integrationTests/mock/endOfEpochTriggerStub.go
@@ -23,6 +23,7 @@ type EpochStartTriggerStub struct {
 	ShouldProposeEpochChangeCalled    func(round uint64, nonce uint64) bool
 	SetEpochChangeCalled              func(round uint64)
 	SetEpochChangeProposedCalled      func(value bool)
+	GetEpochChangeProposedCalled      func() bool
 }
 
 // SetEpochChange -
@@ -46,6 +47,15 @@ func (e *EpochStartTriggerStub) SetEpochChangeProposed(value bool) {
 	if e.SetEpochChangeProposedCalled != nil {
 		e.SetEpochChangeProposedCalled(value)
 	}
+}
+
+// GetEpochChangeProposed -
+func (e *EpochStartTriggerStub) GetEpochChangeProposed() bool {
+	if e.GetEpochChangeProposedCalled != nil {
+		return e.GetEpochChangeProposedCalled()
+	}
+
+	return false
 }
 
 // RevertStateToBlock -

--- a/node/mock/endOfEpochTriggerStub.go
+++ b/node/mock/endOfEpochTriggerStub.go
@@ -21,6 +21,7 @@ type EpochStartTriggerStub struct {
 	ShouldProposeEpochChangeCalled    func(round uint64, nonce uint64) bool
 	SetEpochChangeCalled              func(round uint64)
 	SetEpochChangeProposedCalled      func(value bool)
+	GetEpochChangeProposedCalled      func() bool
 }
 
 // SetEpochChange -
@@ -44,6 +45,15 @@ func (e *EpochStartTriggerStub) SetEpochChangeProposed(value bool) {
 	if e.SetEpochChangeProposedCalled != nil {
 		e.SetEpochChangeProposedCalled(value)
 	}
+}
+
+// GetEpochChangeProposed -
+func (e *EpochStartTriggerStub) GetEpochChangeProposed() bool {
+	if e.GetEpochChangeProposedCalled != nil {
+		return e.GetEpochChangeProposedCalled()
+	}
+
+	return false
 }
 
 // RevertStateToBlock -

--- a/process/block/metablockProposal.go
+++ b/process/block/metablockProposal.go
@@ -111,7 +111,7 @@ func (mp *metaProcessor) CreateBlockProposal(
 
 	metaHdr.SoftwareVersion = []byte(mp.headerIntegrityVerifier.GetVersion(metaHdr.Epoch, metaHdr.Round))
 
-	if metaHdr.IsStartOfEpochBlock() || metaHdr.GetEpochChangeProposed() || mp.epochStartTrigger.IsEpochStart() {
+	if metaHdr.IsStartOfEpochBlock() || metaHdr.GetEpochChangeProposed() || mp.epochStartTrigger.GetEpochChangeProposed() {
 		// no new transactions in start of epoch block
 		// to simplify bootstrapping
 		return metaHdr, &block.Body{}, nil
@@ -976,6 +976,11 @@ func (mp *metaProcessor) checkShardHeadersValidityAndFinalityProposal(
 	usedShardHeaders, err := mp.getShardHeadersFromMetaHeader(metaHeaderHandler)
 	if err != nil {
 		return fmt.Errorf("%w : checkShardHeadersValidityAndFinalityProposal -> getShardHeadersFromMetaHeader", err)
+	}
+
+	shouldNotHaveShardHeaders := metaHeaderHandler.IsStartOfEpochBlock() || metaHeaderHandler.IsEpochChangeProposed() || mp.epochStartTrigger.GetEpochChangeProposed()
+	if len(usedShardHeaders.orderedShardHeaders) > 0 && shouldNotHaveShardHeaders {
+		return fmt.Errorf("%w : between epoch change proposed and epoch start block", process.ErrShardHeadersShouldNotBeNotarized)
 	}
 
 	ok := mp.hasProofsForHeaders(usedShardHeaders.headersPerShard)

--- a/process/block/metablockProposal_test.go
+++ b/process/block/metablockProposal_test.go
@@ -649,7 +649,7 @@ func TestMetaProcessor_CreateBlockProposal(t *testing.T) {
 		require.NotNil(t, header)
 		require.NotNil(t, body)
 	})
-	t.Run("no mini blocks added if isEpochStart", func(t *testing.T) {
+	t.Run("no mini blocks added if epoch change propose set", func(t *testing.T) {
 		t.Parallel()
 
 		coreComponents, dataComponents, bootstrapComponents, statusComponents := createMockComponentHolders()
@@ -661,7 +661,7 @@ func TestMetaProcessor_CreateBlockProposal(t *testing.T) {
 			},
 		}
 		arguments.EpochStartTrigger = &testscommon.EpochStartTriggerStub{
-			IsEpochStartCalled: func() bool {
+			GetEpochChangeProposedCalled: func() bool {
 				return true
 			},
 		}
@@ -1157,6 +1157,11 @@ func Test_checkShardHeadersValidityAndFinalityProposal(t *testing.T) {
 					return nil, nil, expectedErr
 				},
 			},
+			"epochStartTrigger": &testscommon.EpochStartTriggerStub{
+				GetEpochChangeProposedCalled: func() bool {
+					return false
+				},
+			},
 		})
 		require.Nil(t, err)
 
@@ -1187,6 +1192,11 @@ func Test_checkShardHeadersValidityAndFinalityProposal(t *testing.T) {
 			"blockTracker": &mock.BlockTrackerMock{
 				GetLastCrossNotarizedHeaderCalled: func(_ uint32) (data.HeaderHandler, []byte, error) {
 					return &testscommon.HeaderHandlerStub{}, nil, nil
+				},
+			},
+			"epochStartTrigger": &testscommon.EpochStartTriggerStub{
+				GetEpochChangeProposedCalled: func() bool {
+					return false
 				},
 			},
 			"dataPool": dataPoolMock,
@@ -1240,6 +1250,11 @@ func Test_checkShardHeadersValidityAndFinalityProposal(t *testing.T) {
 			"blockTracker": &mock.BlockTrackerMock{
 				GetLastCrossNotarizedHeaderCalled: func(_ uint32) (data.HeaderHandler, []byte, error) {
 					return &testscommon.HeaderHandlerStub{}, nil, nil
+				},
+			},
+			"epochStartTrigger": &testscommon.EpochStartTriggerStub{
+				GetEpochChangeProposedCalled: func() bool {
+					return false
 				},
 			},
 			"dataPool":   dataPoolMock,
@@ -1296,6 +1311,11 @@ func Test_checkShardHeadersValidityAndFinalityProposal(t *testing.T) {
 					return &testscommon.HeaderHandlerStub{}, nil, nil
 				},
 			},
+			"epochStartTrigger": &testscommon.EpochStartTriggerStub{
+				GetEpochChangeProposedCalled: func() bool {
+					return false
+				},
+			},
 			"dataPool":    dataPoolMock,
 			"marshalizer": marshaller,
 			"blockChain": &testscommon.ChainHandlerStub{
@@ -1334,6 +1354,11 @@ func Test_checkShardHeadersValidityAndFinalityProposal(t *testing.T) {
 			"blockTracker": &mock.BlockTrackerMock{
 				GetLastCrossNotarizedHeaderCalled: func(_ uint32) (data.HeaderHandler, []byte, error) {
 					return &testscommon.HeaderHandlerStub{}, nil, nil
+				},
+			},
+			"epochStartTrigger": &testscommon.EpochStartTriggerStub{
+				GetEpochChangeProposedCalled: func() bool {
+					return false
 				},
 			},
 			"dataPool":    dataPoolMock,

--- a/process/errors.go
+++ b/process/errors.go
@@ -1448,3 +1448,6 @@ var ErrNoReferencedHeader = errors.New("no referenced header")
 
 // ErrExecutionResultNotFound signals that the execution result was not found
 var ErrExecutionResultNotFound = errors.New("execution result not found")
+
+// ErrShardHeadersShouldNotBeNotarized signals that shard headers should not be notarized
+var ErrShardHeadersShouldNotBeNotarized = errors.New("shard headers should not be notarized")

--- a/process/interface.go
+++ b/process/interface.go
@@ -554,6 +554,7 @@ type EpochStartTriggerHandler interface {
 	SetEpochChange(round uint64)
 	ShouldProposeEpochChange(round uint64, nonce uint64) bool
 	SetEpochChangeProposed(value bool)
+	GetEpochChangeProposed() bool
 	IsEpochStart() bool
 	Epoch() uint32
 	MetaEpoch() uint32

--- a/process/mock/endOfEpochTriggerStub.go
+++ b/process/mock/endOfEpochTriggerStub.go
@@ -24,12 +24,21 @@ type EpochStartTriggerStub struct {
 	ShouldProposeEpochChangeCalled    func(round uint64, nonce uint64) bool
 	SetEpochChangeCalled              func(round uint64)
 	SetEpochChangeProposedCalled      func(value bool)
+	GetEpochChangeProposedCalled      func() bool
 }
 
 func (e *EpochStartTriggerStub) SetEpochChangeProposed(value bool) {
 	if e.SetEpochChangeProposedCalled != nil {
 		e.SetEpochChangeProposedCalled(value)
 	}
+}
+
+// GetEpochChangeProposed -
+func (e *EpochStartTriggerStub) GetEpochChangeProposed() bool {
+	if e.GetEpochChangeProposedCalled != nil {
+		return e.GetEpochChangeProposedCalled()
+	}
+	return false
 }
 
 // SetEpochChange -

--- a/testscommon/epochStartTriggerStub.go
+++ b/testscommon/epochStartTriggerStub.go
@@ -23,6 +23,7 @@ type EpochStartTriggerStub struct {
 	ShouldProposeEpochChangeCalled    func(round uint64, nonce uint64) bool
 	SetEpochChangeCalled              func(round uint64)
 	SetEpochChangeProposedCalled      func(value bool)
+	GetEpochChangeProposedCalled      func() bool
 }
 
 // SetEpochChange -
@@ -117,6 +118,14 @@ func (e *EpochStartTriggerStub) SetEpochChangeProposed(value bool) {
 	if e.SetEpochChangeProposedCalled != nil {
 		e.SetEpochChangeProposedCalled(value)
 	}
+}
+
+// GetEpochChangeProposed -
+func (e *EpochStartTriggerStub) GetEpochChangeProposed() bool {
+	if e.GetEpochChangeProposedCalled != nil {
+		return e.GetEpochChangeProposedCalled()
+	}
+	return false
 }
 
 // Update -


### PR DESCRIPTION
## Reasoning behind the pull request
This PR modifies the check for meta nodes notarizing shard headers during epoch change transitions. The main change adds a validation to prevent shard headers from being notarized between the time an epoch change is proposed and when the epoch start block is created.
  
## Proposed changes
- Added GetEpochChangeProposed() method to the EpochStartTriggerHandler interface and all implementing types
- Introduced new error ErrShardHeadersShouldNotBeNotarized to signal invalid shard header notarization during epoch transitions
- Modified meta block proposal creation logic to check the epoch change proposed state from the trigger handler instead of checking if it's epoch start
- Added validation in checkShardHeadersValidityAndFinalityProposal to reject blocks with shard headers when epoch change is proposed

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
