### PR TITLE
HIGH 019 - Add StartRound check

### DIFF
--- a/factory/core/coreComponents.go
+++ b/factory/core/coreComponents.go
@@ -287,6 +287,13 @@ func (ccf *coreComponentsFactory) Create() (*coreComponents, error) {
 	genesisTime := common.GetGenesisStartTimeFromUnixTimestamp(genesisNodesConfig.GetStartTime(), enableEpochsHandler)
 	supernovaGenesisTime := genesisTime.Add(time.Duration(supernovaStartRound * genesisRoundDuration.Nanoseconds()))
 
+	if supernovaStartRound < startRound {
+		return nil, fmt.Errorf("supernovaStartRound %d lower then startRound %d",
+			supernovaStartRound,
+			startRound,
+		)
+	}
+
 	if supernovaGenesisTime.Compare(genesisTime) < 0 {
 		return nil, fmt.Errorf("supernovaGenesisTime %d lower then genesisTime %d",
 			supernovaGenesisTime.UnixMilli(),


### PR DESCRIPTION
## Reasoning behind the pull request
- When node starts, start round and genesis time have to be aligned, for both initial genesis time and for supernova start time
- Supernova start round and start time have to be set at initial genesis of after, not before
  
## Proposed changes
- Add additional check for start round for supernova

## Testing procedure
- Standard system test

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
