### PR TITLE
HIGH-018: Round-only V3 header creation can deadlock consensus if round activates before epoch

### DIFF
--- a/consensus/spos/bls/v2/subroundBlock.go
+++ b/consensus/spos/bls/v2/subroundBlock.go
@@ -435,7 +435,13 @@ func (sr *subroundBlock) createHeader() (data.HeaderHandler, error) {
 }
 
 func (sr *subroundBlock) createHeaderBasedOnRound(round uint64, nonce uint64) (data.HeaderHandler, error) {
-	if sr.EnableRoundsHandler().IsFlagEnabledInRound(common.SupernovaRoundFlag, round) {
+	isSupernovaActiveInRound := sr.EnableRoundsHandler().IsFlagEnabledInRound(common.SupernovaRoundFlag, round)
+	isSupernovaActiveInEpoch := sr.EnableEpochsHandler().IsFlagEnabled(common.SupernovaFlag)
+	if isSupernovaActiveInRound && !isSupernovaActiveInEpoch {
+		log.Warn("Supernova is active in round but not in epoch, creating header v2...")
+	}
+
+	if isSupernovaActiveInRound && isSupernovaActiveInEpoch {
 		return sr.BlockProcessor().CreateNewHeaderProposal(round, nonce)
 	}
 

--- a/consensus/spos/bls/v2/subroundBlock_test.go
+++ b/consensus/spos/bls/v2/subroundBlock_test.go
@@ -736,6 +736,12 @@ func TestSubroundBlock_DoBlockJob(t *testing.T) {
 			},
 		}
 		container.SetEnableRoundsHandler(enableRoundsHandler)
+		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledCalled: func(flag core.EnableEpochFlag) bool {
+				return flag == common.SupernovaFlag
+			},
+		}
+		container.SetEnableEpochsHandler(enableEpochsHandler)
 
 		leader, err := sr.GetLeader()
 		require.Nil(t, err)


### PR DESCRIPTION
## Reasoning behind the pull request
- header is created on round only
  
## Proposed changes
- check epoch as well when deciding what header to be created

## Testing procedure
- with feat branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
