### PR TITLE
Import db check in round handler

### DIFF
--- a/consensus/round/round.go
+++ b/consensus/round/round.go
@@ -29,6 +29,7 @@ type ArgsRound struct {
 	StartRound                int64
 	SupernovaStartRound       int64
 	EnableRoundsHandler       common.EnableRoundsHandler
+	ImportDBMode              bool
 }
 
 // round defines the data needed by the roundHandler
@@ -42,6 +43,7 @@ type round struct {
 	syncTimer                 ntp.SyncTimer
 	startRound                int64
 	supernovaStartRound       int64
+	importDBMode              bool
 
 	*sync.RWMutex
 
@@ -70,6 +72,7 @@ func NewRound(args ArgsRound) (*round, error) {
 		genesisTimeStamp:          args.GenesisTimeStamp,
 		RWMutex:                   &sync.RWMutex{},
 		enableRoundsHandler:       args.EnableRoundsHandler,
+		importDBMode:              args.ImportDBMode,
 	}
 	rnd.UpdateRound(args.GenesisTimeStamp, args.CurrentTimeStamp)
 
@@ -115,7 +118,7 @@ func (rnd *round) isSupernovaActivated(currentTimeStamp time.Time) bool {
 
 	currentTimeAfterSupernova := currentTimeStamp.UnixMilli() >= rnd.supernovaGenesisTimeStamp.UnixMilli()
 
-	if currentTimeAfterSupernova {
+	if currentTimeAfterSupernova && !rnd.importDBMode {
 		log.Debug("isSupernovaActivated: force set supernovaActivated",
 			"currentTimeAfterSupernova", currentTimeAfterSupernova,
 		)

--- a/consensus/round/round_test.go
+++ b/consensus/round/round_test.go
@@ -253,6 +253,50 @@ func TestRound_UpdateRoundShouldAdvanceOneRound(t *testing.T) {
 		assert.Equal(t, int64(7), rnd.Index())
 		assert.Equal(t, currentTime.Add(supernovaRoundDuration).UnixMilli(), rnd.TimeStamp().UnixMilli())
 	})
+
+	t.Run("after supernova genesis time, in import db mode", func(t *testing.T) {
+		t.Parallel()
+
+		genesisTime := time.Now()
+
+		roundDuration := 10 * time.Millisecond
+
+		supernovaRoundDuration := 5 * time.Millisecond
+		supernovaStartRond := int64(5)
+		supernovaGenesisTime := genesisTime.Add(time.Duration(supernovaStartRond) * roundDuration)
+
+		args := createDefaultRoundArgs()
+		args.RoundTimeDuration = roundDuration
+		args.SupernovaTimeDuration = supernovaRoundDuration
+		args.EnableRoundsHandler = &testscommon.EnableRoundsHandlerStub{
+			IsFlagEnabledInRoundCalled: func(flag common.EnableRoundFlag, round uint64) bool {
+				return flag != common.SupernovaRoundFlag && round >= uint64(supernovaStartRond)
+			},
+		}
+		args.ImportDBMode = true
+
+		args.SupernovaStartRound = supernovaStartRond
+		args.GenesisTimeStamp = genesisTime
+		args.SupernovaGenesisTimeStamp = supernovaGenesisTime
+
+		// set current time 2 rounds ahead
+		currentTime := genesisTime.Add(roundDuration * 2)
+
+		args.CurrentTimeStamp = currentTime
+
+		rnd, _ := round.NewRound(args)
+
+		assert.Equal(t, roundDuration, rnd.TimeDuration())
+		assert.Equal(t, int64(2), rnd.Index())
+
+		rnd.UpdateRound(genesisTime, genesisTime.Add(roundDuration*6))
+
+		// if in import db and supernova enable flag not enabled, do not activate
+		// supernova even if supernova genesis time was reached
+
+		assert.Equal(t, roundDuration, rnd.TimeDuration())
+		assert.Equal(t, int64(6), rnd.Index())
+	})
 }
 
 func TestRound_IndexShouldReturnFirstIndex(t *testing.T) {

--- a/epochStart/metachain/economics.go
+++ b/epochStart/metachain/economics.go
@@ -492,7 +492,15 @@ func (e *economics) adjustRewardsPerBlockWithLeaderPercentage(
 
 // compute inflation rate from genesisTotalSupply and economics settings for that year
 func (e *economics) computeInflationBeforeSupernova(currentRound uint64, epoch uint32) float64 {
-	roundsPerDay := numberOfSecondsInDay / uint64(e.roundTime.TimeDuration().Seconds())
+	roundDurationInSec := e.roundTime.TimeDuration().Seconds()
+	if roundDurationInSec <= 0 {
+		// this means that round duration is sub-seconds
+		// set it to 1 second
+		log.Error("computeInflationBeforeSupernova: sub second round time before supernova activation")
+		roundDurationInSec = 1
+	}
+
+	roundsPerDay := numberOfSecondsInDay / uint64(roundDurationInSec)
 	roundsPerYear := numberOfDaysInYear * roundsPerDay
 	yearsIndex := uint32(currentRound/roundsPerYear) + 1
 

--- a/factory/core/coreComponents.go
+++ b/factory/core/coreComponents.go
@@ -312,6 +312,7 @@ func (ccf *coreComponentsFactory) Create() (*coreComponents, error) {
 		StartRound:                startRound,
 		SupernovaStartRound:       supernovaStartRound,
 		EnableRoundsHandler:       enableRoundsHandler,
+		ImportDBMode:              ccf.importDbConfig.IsImportDBMode,
 	}
 	roundHandler, err := round.NewRound(roundArgs)
 	if err != nil {


### PR DESCRIPTION
## Reasoning behind the pull request
- When starting the node we have to determine if we start with supernova parameters in round handler or with initial params
- This is done based on supernova activation time
  
## Proposed changes
- Added additional check to not consider supernova force activation at start if in import db mode

## Testing procedure
- ImportDB test

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
