### PR TITLE
MEDIUM-001: Retry path for failed async execution returns early and skips backoff

### DIFF
--- a/process/asyncExecution/headersExecutor.go
+++ b/process/asyncExecution/headersExecutor.go
@@ -167,7 +167,7 @@ func (he *headersExecutor) handleProcessError(ctx context.Context, pair cache.He
 
 	for retryCount < maxRetryAttempts {
 		pairFromQueue, ok := he.blocksCache.GetByNonce(pair.Header.GetNonce())
-		if ok && bytes.Equal(pair.HeaderHash, pairFromQueue.HeaderHash) {
+		if ok && !bytes.Equal(pair.HeaderHash, pairFromQueue.HeaderHash) {
 			// continue the processing (pop the next header from queue)
 			return
 		}

--- a/process/asyncExecution/headersExecutor.go
+++ b/process/asyncExecution/headersExecutor.go
@@ -176,6 +176,13 @@ func (he *headersExecutor) handleProcessError(ctx context.Context, pair cache.He
 		case <-ctx.Done():
 			return
 		default:
+			// Exponential backoff with maximum limit
+			time.Sleep(backoffTime)
+			backoffTime = backoffTime * 2
+			if backoffTime > maxBackoffTime {
+				backoffTime = maxBackoffTime
+			}
+
 			// retry with the same pair
 			err := he.process(pair)
 			if err == nil {
@@ -184,19 +191,13 @@ func (he *headersExecutor) handleProcessError(ctx context.Context, pair cache.He
 					"retry_count", retryCount)
 				return
 			}
+
 			retryCount++
 			log.Warn("headersExecutor.handleProcessError - retry failed",
 				"nonce", pair.Header.GetNonce(),
 				"retry_count", retryCount,
 				"max_retries", maxRetryAttempts,
 				"err", err)
-
-			// Exponential backoff with maximum limit
-			time.Sleep(backoffTime)
-			backoffTime = backoffTime * 2
-			if backoffTime > maxBackoffTime {
-				backoffTime = maxBackoffTime
-			}
 		}
 	}
 

--- a/process/asyncExecution/headersExecutor_test.go
+++ b/process/asyncExecution/headersExecutor_test.go
@@ -451,7 +451,7 @@ func TestHeadersExecutor_ProcessBlock(t *testing.T) {
 		require.Equal(t, 1, countAddResult)
 	})
 
-	t.Run("block processing error, pop header for queue with the same nonce", func(t *testing.T) {
+	t.Run("block processing error, should retry until the max retries is reached", func(t *testing.T) {
 		t.Parallel()
 
 		args := createMockArgs()

--- a/process/asyncExecution/headersExecutor_test.go
+++ b/process/asyncExecution/headersExecutor_test.go
@@ -451,7 +451,7 @@ func TestHeadersExecutor_ProcessBlock(t *testing.T) {
 		require.Equal(t, 1, countAddResult)
 	})
 
-	t.Run("block processing error, should retry until the max retries is reached", func(t *testing.T) {
+	t.Run("block processing error, different hash should early exit", func(t *testing.T) {
 		t.Parallel()
 
 		args := createMockArgs()


### PR DESCRIPTION
## Reasoning behind the pull request
- although the audit finding pointed out that the backoff does not apply when same header is popped, the analysis suggested that the retry never actually happens
  
## Proposed changes
- fix the early exit condition

## Testing procedure
- with feat

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
