### PR TITLE
MEDIUM-014: Unexecutable-transaction cache keys are not removed after cleanup

### DIFF
--- a/process/block/baseProcessHeaderV3_test.go
+++ b/process/block/baseProcessHeaderV3_test.go
@@ -784,11 +784,13 @@ func TestBaseProcessor_cleanPostProcessCache(t *testing.T) {
 			"hash1",
 			"executionhash1",
 			"logshash1",
+			"unexecutablehash1",
 			"hash1",
 			"mb1",
 			"hash2",
 			"executionhash2",
 			"logshash2",
+			"unexecutablehash2",
 			"hash2",
 			"mb2",
 		}

--- a/process/common.go
+++ b/process/common.go
@@ -1384,6 +1384,8 @@ func CleanCachesForExecutionResult(
 	postProcessTxsCache.Remove(common.PrepareOrderedTxHashesKey(headerHash))
 	// remove cached log events
 	postProcessTxsCache.Remove(common.PrepareLogEventsKey(headerHash))
+	// remove cached unexecutable txs
+	postProcessTxsCache.Remove(common.PrepareUnexecutableTxHashesKey(headerHash))
 
 	// remove headerHash from executed mini blocks
 	executedMbs.Remove(headerHash)

--- a/process/common_test.go
+++ b/process/common_test.go
@@ -3669,13 +3669,14 @@ func TestCleanCachesForExecutionResult(t *testing.T) {
 			string(headerHash),
 			string(common.PrepareOrderedTxHashesKey(headerHash)),
 			string(common.PrepareLogEventsKey(headerHash)),
+			string(common.PrepareUnexecutableTxHashesKey(headerHash)),
 		}
 
 		for _, key := range expectedPostProcessKeys {
 			_, found := postProcessRemovedKeys[key]
 			require.True(t, found, fmt.Sprintf("key %s should have been removed from postProcessTxsCache", key))
 		}
-		require.Equal(t, 3, len(postProcessRemovedKeys))
+		require.Equal(t, 4, len(postProcessRemovedKeys))
 
 		// Verify headerHash was removed from executedMbs
 		_, found := executedMbsRemovedKeys[string(headerHash)]
@@ -3724,13 +3725,14 @@ func TestCleanCachesForExecutionResult(t *testing.T) {
 			string(headerHash),
 			string(common.PrepareOrderedTxHashesKey(headerHash)),
 			string(common.PrepareLogEventsKey(headerHash)),
+			string(common.PrepareUnexecutableTxHashesKey(headerHash)),
 		}
 
 		for _, key := range expectedPostProcessKeys {
 			_, found := postProcessRemovedKeys[key]
 			require.True(t, found, fmt.Sprintf("key %s should have been removed from postProcessTxsCache", key))
 		}
-		require.Equal(t, 3, len(postProcessRemovedKeys))
+		require.Equal(t, 4, len(postProcessRemovedKeys))
 
 		// Verify all miniblock headers and headerHash were removed from executedMbs
 		expectedExecutedMbsKeys := []string{
@@ -3788,13 +3790,14 @@ func TestCleanCachesForExecutionResult(t *testing.T) {
 			string(headerHash),
 			string(common.PrepareOrderedTxHashesKey(headerHash)),
 			string(common.PrepareLogEventsKey(headerHash)),
+			string(common.PrepareUnexecutableTxHashesKey(headerHash)),
 		}
 
 		for _, key := range expectedPostProcessKeys {
 			_, found := postProcessRemovedKeys[key]
 			require.True(t, found, fmt.Sprintf("key %s should have been removed from postProcessTxsCache", key))
 		}
-		require.Equal(t, 3, len(postProcessRemovedKeys))
+		require.Equal(t, 4, len(postProcessRemovedKeys))
 
 		// Verify headerHash and miniblock hashes were removed from executedMbs
 		expectedExecutedMbsKeys := []string{


### PR DESCRIPTION
## Reasoning behind the pull request
- missing cache cleanup
  
## Proposed changes
- clean cache for unexecutable

## Testing procedure
- with feat branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
