### PR TITLE
Add fallback validation check on aggregation sig check

### DIFF
--- a/consensus/spos/bls/v2/subroundEndRound.go
+++ b/consensus/spos/bls/v2/subroundEndRound.go
@@ -585,7 +585,7 @@ func (sr *subroundEndRound) handleInvalidSignersOnAggSigFail(sender string) ([]b
 }
 
 func (sr *subroundEndRound) computeAggSigOnValidNodes() ([]byte, []byte, error) {
-	threshold := sr.Threshold(bls.SrSignature)
+	threshold := sr.getThreshold()
 	numValidSigShares := sr.ComputeSize(bls.SrSignature)
 
 	if check.IfNil(sr.GetHeader()) {
@@ -922,7 +922,7 @@ func (sr *subroundEndRound) receivedSignature(_ context.Context, cnsDta *consens
 	return true
 }
 
-func (sr *subroundEndRound) checkReceivedSignatures() bool {
+func (sr *subroundEndRound) getThreshold() int {
 	isTransitionBlock := common.IsEpochChangeBlockForFlagActivation(sr.GetHeader(), sr.EnableEpochsHandler(), common.AndromedaFlag)
 
 	threshold := sr.Threshold(bls.SrSignature)
@@ -941,6 +941,12 @@ func (sr *subroundEndRound) checkReceivedSignatures() bool {
 			"actual number of signatures received", sr.getNumOfSignaturesCollected(),
 		)
 	}
+
+	return threshold
+}
+
+func (sr *subroundEndRound) checkReceivedSignatures() bool {
+	threshold := sr.getThreshold()
 
 	areSignaturesCollected, numSigs := sr.areSignaturesCollected(threshold)
 	areAllSignaturesCollected := numSigs == sr.ConsensusGroupSize()

--- a/consensus/spos/bls/v2/subroundEndRound_test.go
+++ b/consensus/spos/bls/v2/subroundEndRound_test.go
@@ -1119,6 +1119,24 @@ func TestComputeAddSigOnValidNodes(t *testing.T) {
 		require.True(t, errors.Is(err, spos.ErrInvalidNumSigShares))
 	})
 
+	t.Run("invalid number of valid sig shares, with fallback validation", func(t *testing.T) {
+		t.Parallel()
+
+		container := consensusMocks.InitConsensusCore()
+		container.SetFallbackHeaderValidator(&testscommon.FallBackHeaderValidatorStub{
+			ShouldApplyFallbackValidationCalled: func(headerHandler data.HeaderHandler) bool {
+				return true
+			},
+		})
+
+		sr := initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
+		sr.SetHeader(&block.Header{})
+		sr.SetFallbackThreshold(bls.SrEndRound, 2)
+
+		_, _, err := sr.ComputeAggSigOnValidNodes()
+		require.True(t, errors.Is(err, spos.ErrInvalidNumSigShares))
+	})
+
 	t.Run("fail to created aggregated sig", func(t *testing.T) {
 		t.Parallel()
 

--- a/consensus/spos/bls/v2/subroundEndRound_test.go
+++ b/consensus/spos/bls/v2/subroundEndRound_test.go
@@ -1113,7 +1113,7 @@ func TestComputeAddSigOnValidNodes(t *testing.T) {
 		container := consensusMocks.InitConsensusCore()
 		sr := initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
 		sr.SetHeader(&block.Header{})
-		sr.SetThreshold(bls.SrEndRound, 2)
+		sr.SetThreshold(bls.SrSignature, 2)
 
 		_, _, err := sr.ComputeAggSigOnValidNodes()
 		require.True(t, errors.Is(err, spos.ErrInvalidNumSigShares))
@@ -1131,7 +1131,7 @@ func TestComputeAddSigOnValidNodes(t *testing.T) {
 
 		sr := initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
 		sr.SetHeader(&block.Header{})
-		sr.SetFallbackThreshold(bls.SrEndRound, 2)
+		sr.SetFallbackThreshold(bls.SrSignature, 2)
 
 		_, _, err := sr.ComputeAggSigOnValidNodes()
 		require.True(t, errors.Is(err, spos.ErrInvalidNumSigShares))


### PR DESCRIPTION
## Reasoning behind the pull request
- There is a fallback mechanism on number of signatures to check in consensus flow
- It was applied when waiting for signatures, but not in case aggregation signatures fail and all valid individual signatures were collected and aggregated again
  
## Proposed changes
- Add fallback validation check on signatures aggregation handling
 
## Testing procedure
- With feat branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
