### PR TITLE
Skip intra shard mbs indexing for header v3

### DIFF
--- a/outport/process/outportDataProvider.go
+++ b/outport/process/outportDataProvider.go
@@ -153,7 +153,7 @@ func (odp *outportDataProvider) PrepareOutportSaveBlockData(arg ArgPrepareOutpor
 		return nil, err
 	}
 
-	intraMiniBlocks, err := odp.getIntraShardMiniBlocks(arg.Body)
+	intraMiniBlocks, err := odp.getIntraShardMiniBlocks(arg.Body, arg.Header)
 	if err != nil {
 		return nil, err
 	}
@@ -704,7 +704,13 @@ func (odp *outportDataProvider) IsInterfaceNil() bool {
 	return odp == nil
 }
 
-func (odp *outportDataProvider) getIntraShardMiniBlocks(bodyHandler data.BodyHandler) ([]*block.MiniBlock, error) {
+func (odp *outportDataProvider) getIntraShardMiniBlocks(bodyHandler data.BodyHandler, headerHandler data.HeaderHandler) ([]*block.MiniBlock, error) {
+	if headerHandler.IsHeaderV3() {
+		// skip intra-shard miniblocks.
+		// they are returned later when this block’s execution result is included in a future block.
+		return []*block.MiniBlock{}, nil
+	}
+
 	body, err := outportcore.GetBody(bodyHandler)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Reasoning behind the pull request
- Skip indexing of the intra shard minbiblocks, these miniblocks will be saved later when the execution result is included in a future block
## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
