### PR TITLE
MEDIUM-013: V3 timeout extension skips stale-header cleanup in pool/fork detector

### DIFF
--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -873,12 +873,11 @@ func (wrk *Worker) Extend(subroundId int) {
 	}
 
 	isHeaderV3 := header.IsHeaderV3()
-	if isHeaderV3 {
-		return
+	if !isHeaderV3 {
+		wrk.scheduledProcessor.ForceStopScheduledExecutionBlocking()
+		wrk.blockProcessor.RevertCurrentBlock()
 	}
 
-	wrk.scheduledProcessor.ForceStopScheduledExecutionBlocking()
-	wrk.blockProcessor.RevertCurrentBlock()
 	wrk.removeConsensusHeaderFromPool()
 }
 

--- a/process/asyncExecution/executionManager/executionManager_test.go
+++ b/process/asyncExecution/executionManager/executionManager_test.go
@@ -902,7 +902,7 @@ func TestExecutionManager_RemoveAtNonceAndHigher(t *testing.T) {
 				return []data.BaseExecutionResultHandler{pendingExecResult}, nil
 			},
 		}
-		args.BlocksQueue = &processMocks.BlocksQueueMock{
+		args.BlocksCache = &processMocks.BlocksCacheMock{
 			RemoveAtNonceAndHigherCalled: func(nonce uint64) []uint64 {
 				require.Equal(t, uint64(10), nonce)
 				// Block was still in cache but was already processed by headersExecutor


### PR DESCRIPTION
## Reasoning behind the pull request
- 
- 
- 
  
## Proposed changes
- 
- 
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
