### PR TITLE
Default round duration

### DIFF
--- a/epochStart/metachain/economics.go
+++ b/epochStart/metachain/economics.go
@@ -492,19 +492,30 @@ func (e *economics) adjustRewardsPerBlockWithLeaderPercentage(
 
 // compute inflation rate from genesisTotalSupply and economics settings for that year
 func (e *economics) computeInflationBeforeSupernova(currentRound uint64, epoch uint32) float64 {
-	roundDurationInSec := e.roundTime.TimeDuration().Seconds()
+	roundDurationInSec := uint64(e.roundTime.TimeDuration().Seconds())
 	if roundDurationInSec <= 0 {
 		// this means that round duration is sub-seconds
-		// set it to 1 second
+		// set it to default number of seconds
 		log.Error("computeInflationBeforeSupernova: sub second round time before supernova activation")
-		roundDurationInSec = 1
+		roundDurationInSec = e.getDefaultRoundDuration()
 	}
 
-	roundsPerDay := numberOfSecondsInDay / uint64(roundDurationInSec)
+	roundsPerDay := numberOfSecondsInDay / roundDurationInSec
 	roundsPerYear := numberOfDaysInYear * roundsPerDay
 	yearsIndex := uint32(currentRound/roundsPerYear) + 1
 
 	return e.rewardsHandler.MaxInflationRate(yearsIndex, epoch)
+}
+
+func (e *economics) getDefaultRoundDuration() uint64 {
+	defaultRoundDuration := uint64(6) // seconds
+	chainParameters, err := e.chainParamsHandler.ChainParametersForEpoch(0)
+	if err != nil {
+		// this should not happen, chain parameter configs is checked at init
+		return defaultRoundDuration
+	}
+
+	return chainParameters.RoundDuration
 }
 
 func (e *economics) computeInflationRate(


### PR DESCRIPTION
## Reasoning behind the pull request
- Default round duration before supernova was set to 1
  
## Proposed changes
- Set it to round duration from epoch 0, in case of edge case inflation calculation

## Testing procedure
- Standard system test

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
