### PR TITLE
End wait for signatures on proof received

### DIFF
--- a/consensus/spos/bls/v2/subroundEndRound.go
+++ b/consensus/spos/bls/v2/subroundEndRound.go
@@ -14,6 +14,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/display"
+
 	commonConsensus "github.com/multiversx/mx-chain-go/common/consensus"
 
 	"github.com/multiversx/mx-chain-go/common"
@@ -804,7 +805,7 @@ func (sr *subroundEndRound) waitForSignalSync() bool {
 		return true
 	}
 
-	if sr.checkReceivedSignatures() {
+	if sr.checkReceivedSignaturesOrProof() {
 		return true
 	}
 
@@ -824,7 +825,7 @@ func (sr *subroundEndRound) waitForSignalSync() bool {
 				return true
 			}
 
-			if sr.checkReceivedSignatures() {
+			if sr.checkReceivedSignaturesOrProof() {
 				return true
 			}
 			timerBetweenStatusChecks.Reset(timeBetweenSignaturesChecks)
@@ -936,7 +937,7 @@ func (sr *subroundEndRound) getThreshold() int {
 			threshold = core.GetPBFTFallbackThreshold(sr.ConsensusGroupSize())
 		}
 
-		log.Warn("subroundEndRound.checkReceivedSignatures: fallback validation has been applied",
+		log.Warn("subroundEndRound.checkReceivedSignaturesOrProof: fallback validation has been applied",
 			"minimum number of signatures required", threshold,
 			"actual number of signatures received", sr.getNumOfSignaturesCollected(),
 		)
@@ -945,13 +946,14 @@ func (sr *subroundEndRound) getThreshold() int {
 	return threshold
 }
 
-func (sr *subroundEndRound) checkReceivedSignatures() bool {
+func (sr *subroundEndRound) checkReceivedSignaturesOrProof() bool {
 	threshold := sr.getThreshold()
 
 	areSignaturesCollected, numSigs := sr.areSignaturesCollected(threshold)
 	areAllSignaturesCollected := numSigs == sr.ConsensusGroupSize()
+	isProofReceived := sr.EquivalentProofsPool().HasProof(sr.ShardCoordinator().SelfId(), sr.GetData())
 
-	isSignatureCollectionDone := areAllSignaturesCollected || (areSignaturesCollected && sr.GetWaitingAllSignaturesTimeOut())
+	isSignatureCollectionDone := isProofReceived || areAllSignaturesCollected || (areSignaturesCollected && sr.GetWaitingAllSignaturesTimeOut())
 
 	isSelfJobDone := sr.IsSelfJobDone(bls.SrSignature)
 
@@ -960,6 +962,7 @@ func (sr *subroundEndRound) checkReceivedSignatures() bool {
 		log.Debug("step 2: signatures collection done",
 			"subround", sr.Name(),
 			"signatures received", numSigs,
+			"is proof received", isProofReceived,
 			"total signatures", len(sr.ConsensusGroup()),
 			"threshold", threshold)
 

--- a/consensus/spos/bls/v2/subroundEndRound_test.go
+++ b/consensus/spos/bls/v2/subroundEndRound_test.go
@@ -1272,7 +1272,7 @@ func TestSubroundEndRound_DoEndRoundJobByNode(t *testing.T) {
 		numCalls := 0
 		container.SetEquivalentProofsPool(&dataRetriever.ProofsPoolMock{
 			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
-				if numCalls <= 2 {
+				if numCalls <= 9 {
 					numCalls++
 					return false
 				}

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -1872,6 +1872,7 @@ func (pcf *processComponentsFactory) newForkDetector(
 			pcf.data.Datapool().Proofs(),
 			pcf.coreData.ChainParametersHandler(),
 			pcf.coreData.ProcessConfigsHandler(),
+			shardCoordinator.SelfId(),
 		)
 	}
 	if shardCoordinator.SelfId() == core.MetachainShardId {

--- a/integrationTests/testConsensusNode.go
+++ b/integrationTests/testConsensusNode.go
@@ -427,6 +427,7 @@ func (tcn *TestConsensusNode) initNode(args ArgsTestConsensusNode) {
 		dataPool.Proofs(),
 		tcn.ChainParametersHandler,
 		tcn.ProcessConfigsHandler,
+		tcn.ShardCoordinator.SelfId(),
 	)
 
 	processComponents := GetDefaultProcessComponents()

--- a/integrationTests/testFullNode.go
+++ b/integrationTests/testFullNode.go
@@ -687,6 +687,7 @@ func (tfn *TestFullNode) createForkDetector(
 			tfn.DataPool.Proofs(),
 			tfn.ChainParametersHandler,
 			tfn.ProcessConfigsHandler,
+			tfn.ShardCoordinator.SelfId(),
 		)
 	} else {
 		forkDetector, err = processSync.NewMetaForkDetector(

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -2481,6 +2481,7 @@ func (tpn *TestProcessorNode) initBlockProcessor() {
 			tpn.DataPool.Proofs(),
 			tpn.ChainParametersHandler,
 			tpn.ProcessConfigsHandler,
+			tpn.ShardCoordinator.SelfId(),
 		)
 	} else {
 		tpn.ForkDetector, _ = processSync.NewMetaForkDetector(

--- a/integrationTests/testSyncNode.go
+++ b/integrationTests/testSyncNode.go
@@ -291,6 +291,7 @@ func (tpn *TestProcessorNode) initBlockProcessorWithSync() {
 			tpn.DataPool.Proofs(),
 			tpn.ChainParametersHandler,
 			tpn.ProcessConfigsHandler,
+			tpn.ShardCoordinator.SelfId(),
 		)
 		argumentsBase.ForkDetector = tpn.ForkDetector
 		argumentsBase.BlockChainHook = tpn.BlockchainHook

--- a/process/sync/baseForkDetector.go
+++ b/process/sync/baseForkDetector.go
@@ -46,6 +46,7 @@ type baseForkDetector struct {
 	fork       forkInfo
 	mutFork    sync.RWMutex
 
+	shardID                uint32
 	blackListHandler       process.TimeCacher
 	genesisTime            int64
 	supernovaGenesisTime   int64
@@ -230,6 +231,14 @@ func (bfd *baseForkDetector) RemoveHeader(nonce uint64, hash []byte) {
 	if nonce <= finalCheckpointNonce {
 		log.Debug("baseForkDetector.RemoveHeader: given nonce is lower or equal than final checkpoint",
 			"nonce", nonce,
+			"final checkpoint nonce", finalCheckpointNonce)
+		return
+	}
+
+	if bfd.proofsPool.HasProof(bfd.shardID, hash) {
+		log.Debug("baseForkDetector.RemoveHeader: proof available for the given header, skipping removal",
+			"nonce", nonce,
+			"hash", hash,
 			"final checkpoint nonce", finalCheckpointNonce)
 		return
 	}

--- a/process/sync/baseForkDetector_test.go
+++ b/process/sync/baseForkDetector_test.go
@@ -37,6 +37,7 @@ func TestNewBasicForkDetector_ShouldErrNilRoundHandler(t *testing.T) {
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	assert.Equal(t, process.ErrNilRoundHandler, err)
 	assert.Nil(t, bfd)
@@ -57,6 +58,7 @@ func TestNewBasicForkDetector_ShouldErrNilBlackListHandler(t *testing.T) {
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	assert.Equal(t, process.ErrNilBlackListCacher, err)
 	assert.Nil(t, bfd)
@@ -77,6 +79,7 @@ func TestNewBasicForkDetector_ShouldErrNilBlockTracker(t *testing.T) {
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	assert.Equal(t, process.ErrNilBlockTracker, err)
 	assert.Nil(t, bfd)
@@ -97,6 +100,7 @@ func TestNewBasicForkDetector_ShouldErrNilEnableEpochsHandler(t *testing.T) {
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	assert.Equal(t, process.ErrNilEnableEpochsHandler, err)
 	assert.Nil(t, bfd)
@@ -117,6 +121,7 @@ func TestNewBasicForkDetector_ShouldErrNilProofsPool(t *testing.T) {
 		nil,
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	assert.Equal(t, process.ErrNilProofsPool, err)
 	assert.Nil(t, bfd)
@@ -137,6 +142,7 @@ func TestNewBasicForkDetector_ShouldWork(t *testing.T) {
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	assert.Nil(t, err)
 	assert.NotNil(t, bfd)
@@ -162,6 +168,7 @@ func TestBasicForkDetector_CheckBlockValidityShouldErrGenesisTimeMissmatch(t *te
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 
 	err := bfd.CheckBlockValidity(&block.Header{Nonce: 1, Round: round, TimeStamp: incorrectTimeStamp}, []byte("hash"))
@@ -186,6 +193,7 @@ func TestBasicForkDetector_CheckBlockValidityShouldErrLowerRoundInBlock(t *testi
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	bfd.SetFinalCheckpoint(1, 1, nil)
 	err := bfd.CheckBlockValidity(&block.Header{PubKeysBitmap: []byte("X")}, []byte("hash"))
@@ -207,6 +215,7 @@ func TestBasicForkDetector_CheckBlockValidityShouldErrLowerNonceInBlock(t *testi
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	bfd.SetFinalCheckpoint(2, 2, nil)
 	err := bfd.CheckBlockValidity(&block.Header{Nonce: 1, Round: 3, PubKeysBitmap: []byte("X")}, []byte("hash"))
@@ -228,6 +237,7 @@ func TestBasicForkDetector_CheckBlockValidityShouldErrHigherRoundInBlock(t *test
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	err := bfd.CheckBlockValidity(&block.Header{Nonce: 1, Round: 2, PubKeysBitmap: []byte("X")}, []byte("hash"))
 	assert.Equal(t, sync.ErrHigherRoundInBlock, err)
@@ -248,6 +258,7 @@ func TestBasicForkDetector_CheckBlockValidityShouldErrHigherNonceInBlock(t *test
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	err := bfd.CheckBlockValidity(&block.Header{Nonce: 2, Round: 1, PubKeysBitmap: []byte("X")}, []byte("hash"))
 	assert.Equal(t, sync.ErrHigherNonceInBlock, err)
@@ -268,6 +279,7 @@ func TestBasicForkDetector_CheckBlockValidityShouldWork(t *testing.T) {
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	err := bfd.CheckBlockValidity(&block.Header{Nonce: 1, Round: 1, PubKeysBitmap: []byte("X")}, []byte("hash"))
 	assert.Nil(t, err)
@@ -292,6 +304,7 @@ func TestBasicForkDetector_RemoveHeadersShouldWork(t *testing.T) {
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 
 	roundHandlerMock.RoundIndex = 1
@@ -329,6 +342,7 @@ func TestBasicForkDetector_CheckForkOnlyOneShardHeaderOnANonceShouldReturnFalse(
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	_ = bfd.AddHeader(
 		&block.Header{Nonce: 0, PubKeysBitmap: []byte("X")},
@@ -363,6 +377,7 @@ func TestBasicForkDetector_CheckForkOnlyReceivedHeadersShouldReturnFalse(t *test
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	_ = bfd.AddHeader(
 		&block.Header{Nonce: 0, PubKeysBitmap: []byte("X")},
@@ -399,6 +414,7 @@ func TestBasicForkDetector_CheckForkOnlyOneShardHeaderOnANonceReceivedAndProcess
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	_ = bfd.AddHeader(
 		&block.Header{Nonce: 0, PubKeysBitmap: []byte("X")},
@@ -568,6 +584,7 @@ func TestBasicForkDetector_CheckForkShardHeaderProcessedShouldReturnTrueWhenEqua
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 
 	hdr1 := &block.Header{Nonce: 1, Round: 4, PubKeysBitmap: []byte("X")}
@@ -686,6 +703,7 @@ func TestBasicForkDetector_CheckForkShardHeaderProcessedShouldReturnTrueWhenEqua
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 
 	hdr1 := &block.Header{Nonce: 1, Round: 4, PubKeysBitmap: []byte("X")}
@@ -895,6 +913,7 @@ func TestBasicForkDetector_RemovePastHeadersShouldWork(t *testing.T) {
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	_ = bfd.AddHeader(hdr1, hash1, process.BHReceived, nil, nil)
 	_ = bfd.AddHeader(hdr2, hash2, process.BHReceived, nil, nil)
@@ -935,6 +954,7 @@ func TestBasicForkDetector_RemoveInvalidReceivedHeadersShouldWork(t *testing.T) 
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	roundHandlerMock.RoundIndex = 11
 	_ = bfd.AddHeader(hdr0, hash0, process.BHReceived, nil, nil)
@@ -979,6 +999,7 @@ func TestBasicForkDetector_RemoveCheckpointHeaderNonceShouldResetCheckpoint(t *t
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 
 	_ = bfd.AddHeader(hdr1, hash1, process.BHProcessed, nil, nil)
@@ -1114,6 +1135,7 @@ func TestShardForkDetector_ShouldAddBlockInForkDetectorShouldWork(t *testing.T) 
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 
 	hdr := &block.Header{Nonce: 1, Round: 1}
@@ -1143,6 +1165,7 @@ func TestShardForkDetector_ShouldAddBlockInForkDetectorShouldErrLowerRoundInBloc
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	hdr := &block.Header{Nonce: 1, Round: 1}
 
@@ -1218,6 +1241,7 @@ func TestShardForkDetector_AddNotarizedHeadersShouldNotChangeTheFinalCheckpoint(
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	hdr1 := &block.Header{Nonce: 3, Round: 3}
 	hash1 := []byte("hash1")
@@ -1275,6 +1299,7 @@ func TestBaseForkDetector_IsConsensusStuckNotSyncingShouldReturnFalse(t *testing
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 
 	bfd.SetProbableHighestNonce(1)
@@ -1397,6 +1422,7 @@ func TestShardForkDetector_RemoveHeaderShouldComputeFinalCheckpoint(t *testing.T
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	hdr1 := &block.Header{Nonce: 3, Round: 3}
 	hash1 := []byte("hash1")
@@ -1701,6 +1727,7 @@ func TestBaseForkDetector_ReceivedProofForBlockHeaderShouldSetProof(t *testing.T
 		&dataRetriever.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 
 	hdrInfo := &sync.HeaderInfo{

--- a/process/sync/metaForkDetector.go
+++ b/process/sync/metaForkDetector.go
@@ -76,6 +76,7 @@ func NewMetaForkDetector(
 		proofsPool:             proofsPool,
 		chainParametersHandler: chainParametersHandler,
 		processConfigsHandler:  processConfigsHandler,
+		shardID:                core.MetachainShardId,
 	}
 
 	bfd.headers = make(map[uint64][]*headerInfo)

--- a/process/sync/shardForkDetector.go
+++ b/process/sync/shardForkDetector.go
@@ -32,6 +32,7 @@ func NewShardForkDetector(
 	proofsPool process.ProofsPool,
 	chainParametersHandler common.ChainParametersHandler,
 	processConfigsHandler common.ProcessConfigsHandler,
+	shardID uint32,
 ) (*shardForkDetector, error) {
 	if check.IfNil(roundHandler) {
 		return nil, process.ErrNilRoundHandler
@@ -77,6 +78,7 @@ func NewShardForkDetector(
 		proofsPool:             proofsPool,
 		chainParametersHandler: chainParametersHandler,
 		processConfigsHandler:  processConfigsHandler,
+		shardID:                shardID,
 	}
 
 	bfd.headers = make(map[uint64][]*headerInfo)

--- a/process/sync/shardForkDetector_test.go
+++ b/process/sync/shardForkDetector_test.go
@@ -36,6 +36,7 @@ func TestNewShardForkDetector_NilRoundHandlerShouldErr(t *testing.T) {
 		&dataRetrieverMock.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	assert.True(t, check.IfNil(sfd))
 	assert.Equal(t, process.ErrNilRoundHandler, err)
@@ -55,6 +56,7 @@ func TestNewShardForkDetector_NilBlackListShouldErr(t *testing.T) {
 		&dataRetrieverMock.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	assert.True(t, check.IfNil(sfd))
 	assert.Equal(t, process.ErrNilBlackListCacher, err)
@@ -74,6 +76,7 @@ func TestNewShardForkDetector_NilBlockTrackerShouldErr(t *testing.T) {
 		&dataRetrieverMock.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	assert.True(t, check.IfNil(sfd))
 	assert.Equal(t, process.ErrNilBlockTracker, err)
@@ -93,6 +96,7 @@ func TestNewShardForkDetector_NilEnableEpochsHandlerShouldErr(t *testing.T) {
 		&dataRetrieverMock.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	assert.True(t, check.IfNil(sfd))
 	assert.Equal(t, process.ErrNilEnableEpochsHandler, err)
@@ -112,6 +116,7 @@ func TestNewShardForkDetector_NilEnableRoundsHandlerShouldErr(t *testing.T) {
 		&dataRetrieverMock.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	assert.True(t, check.IfNil(sfd))
 	assert.Equal(t, process.ErrNilEnableRoundsHandler, err)
@@ -131,6 +136,7 @@ func TestNewShardForkDetector_NilProofsPoolShouldErr(t *testing.T) {
 		nil,
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	assert.True(t, check.IfNil(sfd))
 	assert.Equal(t, process.ErrNilProofsPool, err)
@@ -150,6 +156,7 @@ func TestNewShardForkDetector_OkParamsShouldWork(t *testing.T) {
 		&dataRetrieverMock.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	assert.Nil(t, err)
 	assert.False(t, check.IfNil(sfd))
@@ -175,6 +182,7 @@ func TestShardForkDetector_AddHeaderNilHeaderShouldErr(t *testing.T) {
 		&dataRetrieverMock.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	err := bfd.AddHeader(nil, make([]byte, 0), process.BHProcessed, nil, nil)
 	assert.Equal(t, sync.ErrNilHeader, err)
@@ -195,6 +203,7 @@ func TestShardForkDetector_AddHeaderNilHashShouldErr(t *testing.T) {
 		&dataRetrieverMock.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	err := bfd.AddHeader(&block.Header{}, nil, process.BHProcessed, nil, nil)
 	assert.Equal(t, sync.ErrNilHash, err)
@@ -217,6 +226,7 @@ func TestShardForkDetector_AddHeaderNotPresentShouldWork(t *testing.T) {
 		&dataRetrieverMock.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	err := bfd.AddHeader(hdr, hash, process.BHProcessed, nil, nil)
 	assert.Nil(t, err)
@@ -245,6 +255,7 @@ func TestShardForkDetector_AddHeaderPresentShouldAppend(t *testing.T) {
 		&dataRetrieverMock.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	_ = bfd.AddHeader(hdr1, hash1, process.BHProcessed, nil, nil)
 	err := bfd.AddHeader(hdr2, hash2, process.BHProcessed, nil, nil)
@@ -273,6 +284,7 @@ func TestShardForkDetector_AddHeaderWithProcessedBlockShouldSetCheckpoint(t *tes
 		&dataRetrieverMock.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	_ = bfd.AddHeader(hdr1, hash1, process.BHProcessed, nil, nil)
 	assert.Equal(t, hdr1.Nonce, bfd.LastCheckpointNonce())
@@ -296,6 +308,7 @@ func TestShardForkDetector_AddHeaderPresentShouldNotRewriteState(t *testing.T) {
 		&dataRetrieverMock.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	_ = bfd.AddHeader(hdr1, hash, process.BHReceived, nil, nil)
 	err := bfd.AddHeader(hdr2, hash, process.BHProcessed, nil, nil)
@@ -323,6 +336,7 @@ func TestShardForkDetector_AddHeaderHigherNonceThanRoundShouldErr(t *testing.T) 
 		&dataRetrieverMock.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 	err := bfd.AddHeader(
 		&block.Header{Nonce: 1, Round: 0, PubKeysBitmap: []byte("X")}, []byte("hash1"), process.BHProcessed, nil, nil)
@@ -362,6 +376,7 @@ func TestShardForkDetector_ComputeGenesisTimeFromHeader(t *testing.T) {
 				},
 			},
 			testscommon.GetDefaultProcessConfigsHandler(),
+			0,
 		)
 
 		hdr1 := &block.Header{Nonce: 1, Round: hdrRound, PubKeysBitmap: []byte("X"), TimeStamp: hdrTimeStamp}
@@ -439,6 +454,7 @@ func TestShardForkDetector_ComputeGenesisTimeFromHeader(t *testing.T) {
 				},
 			},
 			testscommon.GetDefaultProcessConfigsHandler(),
+			0,
 		)
 
 		hdr1 := &block.Header{
@@ -484,6 +500,7 @@ func TestShardForkDetector_ComputeGenesisTimeFromHeader(t *testing.T) {
 				},
 			},
 			testscommon.GetDefaultProcessConfigsHandler(),
+			0,
 		)
 
 		hdr1 := &block.Header{Nonce: 1, Round: hdrRound, Epoch: 2, PubKeysBitmap: []byte("X"), TimeStamp: hdrTimeStamp}
@@ -533,6 +550,7 @@ func TestShardForkDetector_ComputeGenesisTimeFromHeader(t *testing.T) {
 				},
 			},
 			testscommon.GetDefaultProcessConfigsHandler(),
+			0,
 		)
 
 		hdr1 := &block.Header{Nonce: 1, Round: hdrRound, PubKeysBitmap: []byte("X"), TimeStamp: hdrTimeStamp}

--- a/process/sync/shardblock_test.go
+++ b/process/sync/shardblock_test.go
@@ -1307,6 +1307,7 @@ func TestBootstrap_GetNodeStateShouldReturnNotSynchronizedWhenForkIsDetectedAndI
 		&dataRetrieverMock.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 
 	bs, _ := sync.NewShardBootstrap(args)
@@ -1388,6 +1389,7 @@ func TestBootstrap_GetNodeStateShouldReturnSynchronizedWhenForkIsDetectedAndItRe
 		&dataRetrieverMock.ProofsPoolMock{},
 		&chainParameters.ChainParametersHandlerStub{},
 		testscommon.GetDefaultProcessConfigsHandler(),
+		0,
 	)
 
 	bs, _ := sync.NewShardBootstrap(args)


### PR DESCRIPTION
## Reasoning behind the pull request
This PR implements an optimization to end the wait for consensus signatures when an equivalent proof is received from another node. The changes add a shardID parameter to fork detector constructors and modify the consensus mechanism to check for proof availability as an alternative to collecting all signatures
  
## Proposed changes
- Added shardID field to baseForkDetector struct and updated all fork detector constructors to accept/set this parameter
- Modified consensus end-round logic to exit signature waiting early when proof is received via checkReceivedSignaturesOrProof()
- Updated RemoveHeader in fork detector to skip removal if a proof exists for the header 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
