### PR TITLE
Separate mutex for state accesses per block

### DIFF
--- a/state/stateAccesses/collector.go
+++ b/state/stateAccesses/collector.go
@@ -22,14 +22,16 @@ const maxNumBlocksInMemory = 20
 type stateAccessesForTxs map[string]*data.StateAccesses
 
 type collector struct {
-	collectRead           bool
-	collectWrite          bool
-	withAccountChanges    bool
-	stateAccesses         []*data.StateAccess
-	stateAccessesForTxs   stateAccessesForTxs
-	stateAccessesForBlock map[string]stateAccessesForTxs
-	storer                state.StateAccessesStorer
-	stateAccessesMut      sync.RWMutex
+	collectRead              bool
+	collectWrite             bool
+	withAccountChanges       bool
+	stateAccesses            []*data.StateAccess
+	stateAccessesForTxs      stateAccessesForTxs
+	stateAccessesForBlock    map[string]stateAccessesForTxs
+	stateAccessesForBlockMut sync.RWMutex
+
+	storer           state.StateAccessesStorer
+	stateAccessesMut sync.RWMutex
 
 	lastCollectedRootHash     []byte
 	lastCommitHasStateChanges bool
@@ -86,27 +88,30 @@ func (c *collector) GetAccountChanges(oldAccount, account vmcommon.AccountHandle
 // Reset resets the state accesses collector
 func (c *collector) Reset() {
 	c.stateAccessesMut.Lock()
-	defer c.stateAccessesMut.Unlock()
 
 	c.stateAccesses = make([]*data.StateAccess, 0)
 	c.stateAccessesForTxs = make(map[string]*data.StateAccesses)
 
 	if c.lastCommitHasStateChanges {
-		delete(c.stateAccessesForBlock, string(c.lastCollectedRootHash))
+		c.removeStateAccessesForRootHash(c.lastCollectedRootHash)
 		log.Trace("removed last collected root hash from stateAccessesForBlock", "rootHash", c.lastCollectedRootHash)
 	}
+	c.stateAccessesMut.Unlock()
+
+	c.stateAccessesForBlockMut.RLock()
 	if len(c.stateAccessesForBlock) > maxNumBlocksInMemory {
 		// TODO remove oldest entries instead of logging a warning
 		log.Warn("max number of blocks in memory exceeded", "numBlocksInMemory", len(c.stateAccessesForBlock))
 	}
 
 	log.Trace("reset state accesses collector", "num state accesses for block", len(c.stateAccessesForBlock))
+	c.stateAccessesForBlockMut.RUnlock()
 }
 
 // GetStateAccessesForRootHash will return the collected state accesses
 func (c *collector) GetStateAccessesForRootHash(rootHash []byte) map[string]*data.StateAccesses {
-	c.stateAccessesMut.RLock()
-	defer c.stateAccessesMut.RUnlock()
+	c.stateAccessesForBlockMut.RLock()
+	defer c.stateAccessesForBlockMut.RUnlock()
 
 	stateAccessesForRootHash, ok := c.stateAccessesForBlock[string(rootHash)]
 	if !ok {
@@ -119,8 +124,12 @@ func (c *collector) GetStateAccessesForRootHash(rootHash []byte) map[string]*dat
 
 // RemoveStateAccessesForRootHash will remove the collected state accesses for the given root hash
 func (c *collector) RemoveStateAccessesForRootHash(rootHash []byte) {
-	c.stateAccessesMut.Lock()
-	defer c.stateAccessesMut.Unlock()
+	c.removeStateAccessesForRootHash(rootHash)
+}
+
+func (c *collector) removeStateAccessesForRootHash(rootHash []byte) {
+	c.stateAccessesForBlockMut.Lock()
+	defer c.stateAccessesForBlockMut.Unlock()
 
 	delete(c.stateAccessesForBlock, string(rootHash))
 	log.Trace("removed stateAccessesForRootHash from stateAccessesForBlock", "rootHash", rootHash)
@@ -224,13 +233,15 @@ func stateAccessToString(stateAccess *data.StateAccess) string {
 // CommitCollectedAccesses will call the Store method of the underlying storer, giving it the collected state accesses.
 func (c *collector) CommitCollectedAccesses(rootHash []byte) error {
 	c.stateAccessesMut.Lock()
-	defer c.stateAccessesMut.Unlock()
 
 	collectedStateAccesses := c.getStateAccessesForTxs()
 	if len(collectedStateAccesses) == 0 {
 		c.lastCollectedRootHash = rootHash
 		c.lastCommitHasStateChanges = false
+		c.stateAccessesMut.Unlock()
+
 		log.Trace("no state accesses collected, skipping commit", "rootHash", rootHash)
+
 		return nil
 	}
 
@@ -239,12 +250,16 @@ func (c *collector) CommitCollectedAccesses(rootHash []byte) error {
 
 	c.lastCollectedRootHash = rootHash
 	c.lastCommitHasStateChanges = true
+	c.stateAccessesMut.Unlock()
+
+	c.stateAccessesForBlockMut.Lock()
 	c.stateAccessesForBlock[string(rootHash)] = collectedStateAccesses
 	log.Trace("state accesses collected", "numStateAccesses", len(collectedStateAccesses), "rootHash", rootHash)
 
 	if len(c.stateAccessesForBlock) > maxNumBlocksInMemory {
 		log.Warn("max number of blocks in memory exceeded", "numBlocksInMemory", len(c.stateAccessesForBlock))
 	}
+	c.stateAccessesForBlockMut.Unlock()
 
 	return c.storer.Store(collectedStateAccesses)
 }

--- a/state/stateAccesses/collector_test.go
+++ b/state/stateAccesses/collector_test.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"math/rand"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core"
@@ -959,4 +961,48 @@ func TestStateAccessesCollector_RemoveStateAccessesSForRootHash(t *testing.T) {
 
 	c.RemoveStateAccessesForRootHash(rootHash)
 	assert.Equal(t, 0, len(c.stateAccessesForBlock))
+}
+
+func TestStateAccessesCollector_Concurrency(t *testing.T) {
+	t.Parallel()
+
+	c, _ := NewCollector(disabled.NewDisabledStateAccessesStorer(), WithCollectRead(), WithCollectWrite())
+
+	numOperations := 1000
+
+	wg := sync.WaitGroup{}
+	wg.Add(numOperations)
+
+	for i := 0; i < numOperations; i++ {
+		go func(idx int) {
+			switch idx % 10 {
+			case 0:
+				c.AddStateAccess(getWriteStateAccess())
+			case 1:
+				c.AddStateAccess(getReadStateAccess())
+			case 2:
+				c.AddTxHashToCollectedStateAccesses([]byte("txHash" + fmt.Sprintf("%d", rand.Intn(100))))
+			case 3:
+				c.CommitCollectedAccesses([]byte("rootHash"))
+			case 4:
+				c.GetAccountChanges(&mockState.UserAccountStub{}, &mockState.UserAccountStub{})
+			case 5:
+				c.GetStateAccessesForRootHash([]byte("rootHash"))
+			case 6:
+				c.RemoveStateAccessesForRootHash([]byte("rootHash"))
+			case 7:
+				c.Reset()
+			case 8:
+				_ = c.RevertToIndex(rand.Intn(10))
+			case 9:
+				c.SetIndexToLatestStateAccesses(rand.Intn(10))
+			default:
+				assert.Fail(t, "should have not beed called")
+			}
+
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
 }

--- a/state/stateAccesses/collector_test.go
+++ b/state/stateAccesses/collector_test.go
@@ -997,7 +997,7 @@ func TestStateAccessesCollector_Concurrency(t *testing.T) {
 			case 9:
 				c.SetIndexToLatestStateAccesses(rand.Intn(10))
 			default:
-				assert.Fail(t, "should have not beed called")
+				assert.Fail(t, "should have not been called")
 			}
 
 			wg.Done()


### PR DESCRIPTION
## Reasoning behind the pull request
- State accesses collector component is used in both processing and consensus flow
    - processing flow: for each executed transactions
    - consensus flow: when fetching state accesses per block in outport driver
 - This can create locking when operations might collide
  
## Proposed changes
- Add separate mutex for state accesses per block

## Testing procedure
- System test with outport driver and state accesses enabled

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
