### PR TITLE
Cache header gas data

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -48,6 +48,11 @@ func PrepareOrderedTxHashesKey(headerHash []byte) []byte {
 	return append([]byte("execution"), headerHash...)
 }
 
+// PrepareHeaderGasDataKey will prepare header gas data key for cacher
+func PrepareHeaderGasDataKey(headerHash []byte) []byte {
+	return append([]byte("gas"), headerHash...)
+}
+
 // PrepareUnexecutableTxHashesKey will prepare unexecutable transaction hashes key for cacher
 func PrepareUnexecutableTxHashesKey(headerHash []byte) []byte {
 	return append([]byte("unexecutable"), headerHash...)

--- a/common/commonCachedData.go
+++ b/common/commonCachedData.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/data/outport"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	logger "github.com/multiversx/mx-chain-logger-go"
 
@@ -125,4 +126,20 @@ func GetCachedBody(cache storage.Cacher, marshaller marshal.Marshalizer, baseExe
 	}
 
 	return &block.Body{MiniBlocks: miniBlocks}, nil
+}
+
+// GetCacheHeaderGasData will return the cached header gas data from the provided cache
+func GetCacheHeaderGasData(cache storage.Cacher, headerHash []byte) (*outport.HeaderGasConsumption, error) {
+	cacheHeaderGasDataI, ok := cache.Get(PrepareHeaderGasDataKey(headerHash))
+	if !ok {
+		log.Warn("header gas data not found in dataPool", "hash", headerHash)
+		return nil, fmt.Errorf("%w for header %s", ErrMissingHeaderGasData, hex.EncodeToString(headerHash))
+	}
+
+	cacheHeaderGasData, ok := cacheHeaderGasDataI.(*outport.HeaderGasConsumption)
+	if !ok {
+		return nil, fmt.Errorf("%w for GetCacheHeaderGasData", ErrWrongTypeAssertion)
+	}
+
+	return cacheHeaderGasData, nil
 }

--- a/common/commonCachedData_test.go
+++ b/common/commonCachedData_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/data/outport"
 	"github.com/multiversx/mx-chain-core-go/data/receipt"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
@@ -338,4 +339,43 @@ func TestGetCachedUnexecutableTxHashes(t *testing.T) {
 		require.Equal(t, hashes, res)
 	})
 
+}
+
+func TestGetCachedHeaderGasData(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cannot find in cache should error", func(t *testing.T) {
+		t.Parallel()
+
+		cacher := cache.NewCacherMock()
+
+		headerHash := []byte("h")
+
+		_, err := GetCacheHeaderGasData(cacher, headerHash)
+		require.True(t, errors.Is(err, ErrMissingHeaderGasData))
+	})
+
+	t.Run("wrong type in cache should error", func(t *testing.T) {
+		cacher := cache.NewCacherMock()
+
+		headerHash := []byte("h")
+		cacher.Put(PrepareHeaderGasDataKey(headerHash), []byte("a"), 0)
+
+		_, err := GetCacheHeaderGasData(cacher, headerHash)
+		require.True(t, errors.Is(err, ErrWrongTypeAssertion))
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		cacher := cache.NewCacherMock()
+
+		headerHash := []byte("h")
+		headerGasData := &outport.HeaderGasConsumption{
+			GasRefunded: 100,
+		}
+		cacher.Put(PrepareHeaderGasDataKey(headerHash), headerGasData, 0)
+
+		res, err := GetCacheHeaderGasData(cacher, headerHash)
+		require.Nil(t, err)
+		require.Equal(t, headerGasData, res)
+	})
 }

--- a/common/errors.go
+++ b/common/errors.go
@@ -73,3 +73,6 @@ var ErrInvalidHeader = errors.New("invalid header")
 
 // ErrMissingUnexecutableTxHash signals that unexecutable tx hashes are missing
 var ErrMissingUnexecutableTxHash = errors.New("missing unexecutable tx hash")
+
+// ErrMissingHeaderGasData signal that header gas data is missing
+var ErrMissingHeaderGasData = errors.New("missing header gas data")

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/multiversx/mx-chain-communication-go v1.3.0
 	github.com/multiversx/mx-chain-core-go v1.4.2-0.20260219091525-015123fd1603
 	github.com/multiversx/mx-chain-crypto-go v1.3.1-0.20260130144701-dfa5fd3ea5d7
-	github.com/multiversx/mx-chain-es-indexer-go v1.9.4-0.20260212143150-525a629d966f
+	github.com/multiversx/mx-chain-es-indexer-go v1.9.4-0.20260219114236-37624897dc3a
 	github.com/multiversx/mx-chain-logger-go v1.1.0
 	github.com/multiversx/mx-chain-scenario-go v1.6.0
 	github.com/multiversx/mx-chain-storage-go v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.13.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiversx/mx-chain-communication-go v1.3.0
-	github.com/multiversx/mx-chain-core-go v1.4.2-0.20260210121034-184d4fbfa371
+	github.com/multiversx/mx-chain-core-go v1.4.2-0.20260219091525-015123fd1603
 	github.com/multiversx/mx-chain-crypto-go v1.3.1-0.20260130144701-dfa5fd3ea5d7
 	github.com/multiversx/mx-chain-es-indexer-go v1.9.4-0.20260212143150-525a629d966f
 	github.com/multiversx/mx-chain-logger-go v1.1.0
@@ -36,6 +36,7 @@ require (
 	github.com/urfave/cli v1.22.16
 	golang.org/x/crypto v0.35.0
 	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c
+	golang.org/x/sync v0.11.0
 	gopkg.in/go-playground/validator.v8 v8.18.2
 )
 
@@ -196,7 +197,6 @@ require (
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
-	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/tools v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.3.0 h1:ziNM1dRuiR/7al2L/jGEA/a/hjurtJ/HEqgazHNt9P8=
 github.com/multiversx/mx-chain-communication-go v1.3.0/go.mod h1:gDVWn6zUW6aCN1YOm/FbbT5MUmhgn/L1Rmpl8EoH3Yg=
-github.com/multiversx/mx-chain-core-go v1.4.2-0.20260210121034-184d4fbfa371 h1:5a94TjX7IG7K4zKO87SF3D4gzfNiy56RCAM+Qw9M4TY=
-github.com/multiversx/mx-chain-core-go v1.4.2-0.20260210121034-184d4fbfa371/go.mod h1:IO+vspNan+gT0WOHnJ95uvWygiziHZvfXpff6KnxV7g=
+github.com/multiversx/mx-chain-core-go v1.4.2-0.20260219091525-015123fd1603 h1:PhvZUz2zHo3cjx/zySG02enKgvY4r0Vy39l0FKxc+D4=
+github.com/multiversx/mx-chain-core-go v1.4.2-0.20260219091525-015123fd1603/go.mod h1:IO+vspNan+gT0WOHnJ95uvWygiziHZvfXpff6KnxV7g=
 github.com/multiversx/mx-chain-crypto-go v1.3.1-0.20260130144701-dfa5fd3ea5d7 h1:3cJf1poYPhurIenMd3GYCEh0npaEchodVzcdmHxJrY4=
 github.com/multiversx/mx-chain-crypto-go v1.3.1-0.20260130144701-dfa5fd3ea5d7/go.mod h1:nPIkxxzyTP8IquWKds+22Q2OJ9W7LtusC7cAosz7ojM=
 github.com/multiversx/mx-chain-es-indexer-go v1.9.4-0.20260212143150-525a629d966f h1:/MECgVU12IBH0kMX4ykXDH3EnzO0OIW3RFE4ZhSvIGo=

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/multiversx/mx-chain-core-go v1.4.2-0.20260219091525-015123fd1603 h1:P
 github.com/multiversx/mx-chain-core-go v1.4.2-0.20260219091525-015123fd1603/go.mod h1:IO+vspNan+gT0WOHnJ95uvWygiziHZvfXpff6KnxV7g=
 github.com/multiversx/mx-chain-crypto-go v1.3.1-0.20260130144701-dfa5fd3ea5d7 h1:3cJf1poYPhurIenMd3GYCEh0npaEchodVzcdmHxJrY4=
 github.com/multiversx/mx-chain-crypto-go v1.3.1-0.20260130144701-dfa5fd3ea5d7/go.mod h1:nPIkxxzyTP8IquWKds+22Q2OJ9W7LtusC7cAosz7ojM=
-github.com/multiversx/mx-chain-es-indexer-go v1.9.4-0.20260212143150-525a629d966f h1:/MECgVU12IBH0kMX4ykXDH3EnzO0OIW3RFE4ZhSvIGo=
-github.com/multiversx/mx-chain-es-indexer-go v1.9.4-0.20260212143150-525a629d966f/go.mod h1:w0ATzIaXcbfjzY/RhTAVyHV0j4ZRIRY3/Ws/UOA/ivg=
+github.com/multiversx/mx-chain-es-indexer-go v1.9.4-0.20260219114236-37624897dc3a h1:4ExtYUKB8Hd+IlvxscVpAHjO6hMSYlL2yFfsKBUAzgY=
+github.com/multiversx/mx-chain-es-indexer-go v1.9.4-0.20260219114236-37624897dc3a/go.mod h1:aPHgLkELJWxCDXBFF9+tbYaXJH2GIRk723YOaTejYWc=
 github.com/multiversx/mx-chain-logger-go v1.1.0 h1:97x84A6L4RfCa6YOx1HpAFxZp1cf/WI0Qh112whgZNM=
 github.com/multiversx/mx-chain-logger-go v1.1.0/go.mod h1:K9XgiohLwOsNACETMNL0LItJMREuEvTH6NsoXWXWg7g=
 github.com/multiversx/mx-chain-scenario-go v1.6.0 h1:cwDFuS1pSc4YXnfiKKDTEb+QDY4fulPQaiRgIebnKxI=

--- a/outport/process/outportDataProvider.go
+++ b/outport/process/outportDataProvider.go
@@ -166,15 +166,9 @@ func (odp *outportDataProvider) PrepareOutportSaveBlockData(arg ArgPrepareOutpor
 	stateAccessesForBlock, stateAccessesDeprecated := odp.getStateAccesses(arg.Header, arg.HeaderHash, arg.ScheduledRootHash)
 	outportBlock := &outportcore.OutportBlockWithHeaderAndBody{
 		OutportBlock: &outportcore.OutportBlock{
-			ShardID:         odp.shardID,
-			BlockData:       nil, // this will be filled with specific data for each driver
-			TransactionPool: pool,
-			HeaderGasConsumption: &outportcore.HeaderGasConsumption{
-				GasProvided:    odp.gasConsumedProvider.TotalGasProvidedWithScheduled(),
-				GasRefunded:    odp.gasConsumedProvider.TotalGasRefunded(),
-				GasPenalized:   odp.gasConsumedProvider.TotalGasPenalized(),
-				MaxGasPerBlock: odp.economicsData.MaxGasLimitPerBlock(odp.shardID),
-			},
+			ShardID:                odp.shardID,
+			BlockData:              nil, // this will be filled with specific data for each driver
+			TransactionPool:        pool,
 			StateAccesses:          stateAccessesDeprecated,
 			StateAccessesForBlock:  stateAccessesForBlock,
 			AlteredAccounts:        alteredAccounts,
@@ -194,6 +188,15 @@ func (odp *outportDataProvider) PrepareOutportSaveBlockData(arg ArgPrepareOutpor
 			IntraShardMiniBlocks: intraMiniBlocks,
 			Results:              results,
 		},
+	}
+
+	if !arg.Header.IsHeaderV3() {
+		outportBlock.OutportBlock.HeaderGasConsumption = &outportcore.HeaderGasConsumption{
+			GasProvided:    odp.gasConsumedProvider.TotalGasProvidedWithScheduled(),
+			GasRefunded:    odp.gasConsumedProvider.TotalGasRefunded(),
+			GasPenalized:   odp.gasConsumedProvider.TotalGasPenalized(),
+			MaxGasPerBlock: odp.economicsData.MaxGasLimitPerBlock(odp.shardID),
+		}
 	}
 
 	if odp.enableEpochsHandler.IsFlagEnabledInEpoch(common.AndromedaFlag, arg.Header.GetEpoch()) {
@@ -305,6 +308,11 @@ func (odp *outportDataProvider) prepareExecutionResultsData(args ArgPrepareOutpo
 			return nil, fmt.Errorf("alteredAccountsProvider.ExtractAlteredAccountsFromPool %w", err)
 		}
 
+		headerGasData, err := common.GetCacheHeaderGasData(odp.dataPool.PostProcessTransactions(), headerHash)
+		if err != nil {
+			return nil, err
+		}
+
 		encodedHash := hex.EncodeToString(headerHash)
 		executionResultData := &outportcore.ExecutionResultData{
 			HeaderNonce:          executionResult.GetHeaderNonce(),
@@ -313,6 +321,7 @@ func (odp *outportDataProvider) prepareExecutionResultsData(args ArgPrepareOutpo
 			TransactionPool:      pool,
 			AlteredAccounts:      alteredAccounts,
 			TimestampMs:          odp.roundHandler.GetTimeStampForRound(executionResult.GetHeaderRound()),
+			HeaderGasConsumption: headerGasData,
 		}
 
 		results[encodedHash] = executionResultData

--- a/outport/process/outportDataProvider_test.go
+++ b/outport/process/outportDataProvider_test.go
@@ -860,6 +860,52 @@ func TestPrepareExecutionResultsData(t *testing.T) {
 		require.Len(t, results, 0)
 	})
 
+	t.Run("cannot get header gas data should err", func(t *testing.T) {
+		arg := createArgOutportDataProvider()
+		arg.DataPool = dataRetriever.NewPoolsHolderMock()
+		arg.AlteredAccountsProvider = &testscommon.AlteredAccountsProviderStub{
+			ExtractAlteredAccountsFromPoolCalled: func(txPool *outportcore.TransactionPool, options shared.AlteredAccountsOptions) (map[string]*alteredAccount.AlteredAccount, error) {
+				return map[string]*alteredAccount.AlteredAccount{
+					"s": {},
+				}, nil
+			},
+		}
+
+		headerHash := []byte("hash")
+		intraMbs := make([]*block.MiniBlock, 0)
+		intraMbs = append(intraMbs, &block.MiniBlock{})
+		arg.DataPool.ExecutedMiniBlocks().Put(headerHash, intraMbs, 0)
+
+		logsKey := common.PrepareLogEventsKey(headerHash)
+		logsSlice := make([]data.LogDataHandler, 0)
+		arg.DataPool.PostProcessTransactions().Put(logsKey, logsSlice, 0)
+		arg.DataPool.PostProcessTransactions().Put(common.PrepareUnexecutableTxHashesKey(headerHash), make([][]byte, 0), 0)
+
+		cachedTxs := make(map[block.Type]map[string]data.TransactionHandler)
+		cachedTxs[block.TxBlock] = make(map[string]data.TransactionHandler)
+		arg.DataPool.PostProcessTransactions().Put(headerHash, cachedTxs, 1)
+
+		key := common.PrepareOrderedTxHashesKey(headerHash)
+		arg.DataPool.PostProcessTransactions().Put(key, [][]byte{[]byte("a")}, 1)
+
+		outportDataP, _ := NewOutportDataProvider(arg)
+
+		results, err := outportDataP.prepareExecutionResultsData(ArgPrepareOutportSaveBlockData{
+			Header: &block.HeaderV3{
+				ExecutionResults: []*block.ExecutionResult{
+					{
+						BaseExecutionResult: &block.BaseExecutionResult{
+							HeaderHash:  headerHash,
+							HeaderNonce: 10,
+						},
+					},
+				},
+			},
+		})
+		require.True(t, errors.Is(err, common.ErrMissingHeaderGasData))
+		require.Len(t, results, 0)
+	})
+
 	t.Run("should work", func(t *testing.T) {
 		arg := createArgOutportDataProvider()
 		arg.DataPool = dataRetriever.NewPoolsHolderMock()
@@ -884,6 +930,7 @@ func TestPrepareExecutionResultsData(t *testing.T) {
 		cachedTxs := make(map[block.Type]map[string]data.TransactionHandler)
 		cachedTxs[block.TxBlock] = make(map[string]data.TransactionHandler)
 		arg.DataPool.PostProcessTransactions().Put(headerHash, cachedTxs, 1)
+		arg.DataPool.PostProcessTransactions().Put(common.PrepareHeaderGasDataKey(headerHash), &outportcore.HeaderGasConsumption{}, 0)
 
 		key := common.PrepareOrderedTxHashesKey(headerHash)
 		arg.DataPool.PostProcessTransactions().Put(key, [][]byte{[]byte("a")}, 1)
@@ -1020,6 +1067,7 @@ func TestOutportDataProvider_GetRewards(t *testing.T) {
 	key := common.PrepareOrderedTxHashesKey(headerHash)
 	arg.DataPool.PostProcessTransactions().Put(key, [][]byte{[]byte("a")}, 1)
 	arg.DataPool.PostProcessTransactions().Put(common.PrepareUnexecutableTxHashesKey(headerHash), make([][]byte, 0), 0)
+	arg.DataPool.PostProcessTransactions().Put(common.PrepareHeaderGasDataKey(headerHash), &outportcore.HeaderGasConsumption{}, 0)
 
 	outportDataP, _ := NewOutportDataProvider(arg)
 

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -3820,6 +3820,18 @@ func (bp *baseProcessor) cacheOrderedTxHashes(headerHash []byte) {
 	bp.dataPool.PostProcessTransactions().Put(executionOrderKey, items, size)
 }
 
+func (bp *baseProcessor) cacheHeaderGasData(headerHash []byte) {
+	headerGasData := &outportcore.HeaderGasConsumption{
+		GasProvided:    bp.gasConsumedProvider.TotalGasProvidedWithScheduled(),
+		GasPenalized:   bp.gasConsumedProvider.TotalGasPenalized(),
+		GasRefunded:    bp.gasConsumedProvider.TotalGasRefunded(),
+		MaxGasPerBlock: bp.economicsData.MaxGasLimitPerBlock(bp.shardCoordinator.SelfId()),
+	}
+
+	key := common.PrepareHeaderGasDataKey(headerHash)
+	bp.dataPool.PostProcessTransactions().Put(key, headerGasData, headerGasData.Size())
+}
+
 func (bp *baseProcessor) cacheUnexecutableTxHashes(headerHash []byte) {
 	unexecutableTxHashes := bp.txCoordinator.GetUnExecutableTransactions()
 

--- a/process/block/baseProcessHeaderV3_test.go
+++ b/process/block/baseProcessHeaderV3_test.go
@@ -784,11 +784,13 @@ func TestBaseProcessor_cleanPostProcessCache(t *testing.T) {
 			"hash1",
 			"executionhash1",
 			"logshash1",
+			"gashash1",
 			"hash1",
 			"mb1",
 			"hash2",
 			"executionhash2",
 			"logshash2",
+			"gashash2",
 			"hash2",
 			"mb2",
 		}

--- a/process/block/metablockProposal.go
+++ b/process/block/metablockProposal.go
@@ -737,6 +737,7 @@ func (mp *metaProcessor) createExecutionResult(
 
 	mp.cacheOrderedTxHashes(headerHash)
 	mp.cacheUnexecutableTxHashes(headerHash)
+	mp.cacheHeaderGasData(headerHash)
 
 	return executionResult, nil
 }

--- a/process/block/shardblockProposal.go
+++ b/process/block/shardblockProposal.go
@@ -866,6 +866,7 @@ func (sp *shardProcessor) collectExecutionResults(headerHash []byte, header data
 
 	sp.cacheOrderedTxHashes(headerHash)
 	sp.cacheUnexecutableTxHashes(headerHash)
+	sp.cacheHeaderGasData(headerHash)
 
 	return executionResult, nil
 }

--- a/process/block/shardblockProposal_test.go
+++ b/process/block/shardblockProposal_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-go/storage"
 	"github.com/multiversx/mx-chain-go/testscommon/cache"
+	"github.com/multiversx/mx-chain-go/testscommon/economicsmocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -4543,6 +4544,7 @@ func createSubComponentsForCollectExecutionResultsTest() (map[string]interface{}
 		"dataPool":                initDataPool(),
 		"accountsDB":              accounts,
 		"txExecutionOrderHandler": &commonMocks.TxExecutionOrderHandlerStub{},
+		"economicsData":           &economicsmocks.EconomicsHandlerMock{},
 	}
 
 	header, body := createHeaderAndBodyForTestingProcessBlockProposal()

--- a/process/common.go
+++ b/process/common.go
@@ -1384,6 +1384,8 @@ func CleanCachesForExecutionResult(
 	postProcessTxsCache.Remove(common.PrepareOrderedTxHashesKey(headerHash))
 	// remove cached log events
 	postProcessTxsCache.Remove(common.PrepareLogEventsKey(headerHash))
+	// remove header gas data
+	postProcessTxsCache.Remove(common.PrepareHeaderGasDataKey(headerHash))
 
 	// remove headerHash from executed mini blocks
 	executedMbs.Remove(headerHash)

--- a/process/common_test.go
+++ b/process/common_test.go
@@ -3675,7 +3675,7 @@ func TestCleanCachesForExecutionResult(t *testing.T) {
 			_, found := postProcessRemovedKeys[key]
 			require.True(t, found, fmt.Sprintf("key %s should have been removed from postProcessTxsCache", key))
 		}
-		require.Equal(t, 3, len(postProcessRemovedKeys))
+		require.Equal(t, 4, len(postProcessRemovedKeys))
 
 		// Verify headerHash was removed from executedMbs
 		_, found := executedMbsRemovedKeys[string(headerHash)]
@@ -3724,13 +3724,14 @@ func TestCleanCachesForExecutionResult(t *testing.T) {
 			string(headerHash),
 			string(common.PrepareOrderedTxHashesKey(headerHash)),
 			string(common.PrepareLogEventsKey(headerHash)),
+			string(common.PrepareHeaderGasDataKey(headerHash)),
 		}
 
 		for _, key := range expectedPostProcessKeys {
 			_, found := postProcessRemovedKeys[key]
 			require.True(t, found, fmt.Sprintf("key %s should have been removed from postProcessTxsCache", key))
 		}
-		require.Equal(t, 3, len(postProcessRemovedKeys))
+		require.Equal(t, 4, len(postProcessRemovedKeys))
 
 		// Verify all miniblock headers and headerHash were removed from executedMbs
 		expectedExecutedMbsKeys := []string{
@@ -3788,13 +3789,14 @@ func TestCleanCachesForExecutionResult(t *testing.T) {
 			string(headerHash),
 			string(common.PrepareOrderedTxHashesKey(headerHash)),
 			string(common.PrepareLogEventsKey(headerHash)),
+			string(common.PrepareHeaderGasDataKey(headerHash)),
 		}
 
 		for _, key := range expectedPostProcessKeys {
 			_, found := postProcessRemovedKeys[key]
 			require.True(t, found, fmt.Sprintf("key %s should have been removed from postProcessTxsCache", key))
 		}
-		require.Equal(t, 3, len(postProcessRemovedKeys))
+		require.Equal(t, 4, len(postProcessRemovedKeys))
 
 		// Verify headerHash and miniblock hashes were removed from executedMbs
 		expectedExecutedMbsKeys := []string{


### PR DESCRIPTION
## Reasoning behind the pull request
- Fix how fields for header gas data are populated in outport data provider
- Changed the version of mx-chain-core-go: https://github.com/multiversx/mx-chain-core-go/pull/432
- New indexer version: https://github.com/multiversx/mx-chain-es-indexer-go/pull/373

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
