### PR TITLE
Reset tracked blocks when OnProposedBlock validation fails

### DIFF
--- a/txcache/selectionTracker.go
+++ b/txcache/selectionTracker.go
@@ -125,7 +125,8 @@ func (st *selectionTracker) OnProposedBlock(
 
 	lastNoncePerSender, err := st.validateTrackedBlocksAndCompileBreadcrumbsNoLock(blockBody, tBlock, accountsProvider, latestExecutedHash)
 	if err != nil {
-		log.Debug("selectionTracker.OnProposedBlock: error validating the tracked blocks", "err", err)
+		log.Debug("selectionTracker.OnProposedBlock: error validating the tracked blocks, resetting tracked state", "err", err)
+		st.resetTrackedBlocksNoLock()
 		return err
 	}
 
@@ -428,7 +429,11 @@ func (st *selectionTracker) ResetTrackedBlocks() {
 	st.mutTracker.Lock()
 	defer st.mutTracker.Unlock()
 
-	log.Debug("selectionTracker.ResetTrackedBlocks removing all tracked blocks",
+	st.resetTrackedBlocksNoLock()
+}
+
+func (st *selectionTracker) resetTrackedBlocksNoLock() {
+	log.Debug("selectionTracker.resetTrackedBlocksNoLock removing all tracked blocks",
 		"len(trackedBlocks)", len(st.blocks),
 	)
 


### PR DESCRIPTION
## Summary

- Fix infinite stuck loop in `selectionTracker.OnProposedBlock` when breadcrumb validation fails
- When `validateTrackedBlocksAndCompileBreadcrumbsNoLock` returns an error (e.g. `errDiscontinuousBreadcrumbs`), stale tracked blocks remain in `st.blocks`
- Every subsequent `OnProposedBlock` re-discovers the same stale block via `getChainOfTrackedPendingBlocks`, re-validates it, and fails with the same error
- The only cleanup paths (`OnExecutedBlock`, `ResetTrackedBlocks`) are never triggered during normal consensus/sync flow, causing both validators and observers to get permanently stuck
- Fix: call `resetTrackedBlocksNoLock()` on validation failure so the next `OnProposedBlock` starts clean

## Root cause

An account with `accountNonce=0` in state had a tracked block breadcrumb with `firstNonce=52`. The continuity check `breadcrumb.firstNonce.Value == sessionNonce` failed permanently. Since the stale block at nonce N-1 is never cleaned (only blocks at nonce >= N are replaced by `addNewTrackedBlockNoLock`), every new proposed block that references it as `prevHash` hits the same validation failure.

## Test plan

- [ ] Existing `TestSelectionTracker_OnProposedBlock*` tests pass
- [ ] Verify that after a breadcrumb validation failure, the next `OnProposedBlock` succeeds with a clean tracker state
- [ ] Confirm observers no longer get permanently stuck on discontinuous breadcrumbs

🤖 Generated with [Claude Code](https://claude.com/claude-code)