### PR TITLE
Add ntp sync cooldown

### DIFF
--- a/ntp/export_test.go
+++ b/ntp/export_test.go
@@ -43,3 +43,13 @@ func (s *syncTime) GetMedianOffset(clockOffsets []time.Duration) (time.Duration,
 func (s *syncTime) GetSleepTime() time.Duration {
 	return s.getSleepTime()
 }
+
+// SetLastSyncTime -
+func (s *syncTime) SetLastSyncTime(t time.Time) {
+	s.mut.Lock()
+	s.lastSyncTime = t
+	s.mut.Unlock()
+}
+
+// SyncCooldownDuration -
+var SyncCooldownDuration = syncCooldown

--- a/ntp/syncTime.go
+++ b/ntp/syncTime.go
@@ -160,12 +160,7 @@ func (s *syncTime) getSleepTime() time.Duration {
 // ForceSync will trigger ntp sync and does not wait for completion
 // it will not trigger if sync already in progress or if the cooldown period has not elapsed
 func (s *syncTime) ForceSync() {
-	s.mut.RLock()
-	elapsed := time.Since(s.lastSyncTime)
-	s.mut.RUnlock()
-
-	if elapsed < syncCooldown {
-		log.Debug("ForceSync ignored: cooldown active", "remaining", syncCooldown-elapsed)
+	if s.isCooldown() {
 		return
 	}
 
@@ -184,12 +179,7 @@ func (s *syncTime) ForceSync() {
 // triggerSync will trigger sync and waits for completion
 // this is called periodically in the ntp sync loop
 func (s *syncTime) triggerSync() {
-	s.mut.RLock()
-	elapsed := time.Since(s.lastSyncTime)
-	s.mut.RUnlock()
-
-	if elapsed < syncCooldown {
-		log.Debug("triggerSync ignored: cooldown active", "remaining", syncCooldown-elapsed)
+	if s.isCooldown() {
 		return
 	}
 
@@ -199,6 +189,19 @@ func (s *syncTime) triggerSync() {
 	})
 
 	<-ch
+}
+
+func (s *syncTime) isCooldown() bool {
+	s.mut.RLock()
+	elapsed := time.Since(s.lastSyncTime)
+	s.mut.RUnlock()
+
+	if elapsed < syncCooldown {
+		log.Debug("sync trigger ignored: cooldown active", "remaining", syncCooldown-elapsed)
+		return true
+	}
+
+	return false
 }
 
 // sync method does the time synchronization and sets the median offset difference between local time

--- a/ntp/syncTime.go
+++ b/ntp/syncTime.go
@@ -44,6 +44,10 @@ const maxAllowedNTPQueryResponseTimeMS = 200
 
 const syncKey = "ntp-sync"
 
+// syncCooldown represents the minimum time between two consecutive syncs.
+// This prevents excessive NTP queries when ForceSync is called frequently.
+const syncCooldown = 10 * time.Minute
+
 // NTPOptions defines configuration options for a NTP query
 type NTPOptions struct {
 	Hosts        []string
@@ -93,6 +97,7 @@ type syncTime struct {
 	query                func(options NTPOptions, hostIndex int) (*ntp.Response, error)
 	cancelFunc           func()
 	outOfBoundsThreshold time.Duration
+	lastSyncTime         time.Time
 
 	sf singleflight.Group
 }
@@ -153,8 +158,17 @@ func (s *syncTime) getSleepTime() time.Duration {
 }
 
 // ForceSync will trigger ntp sync and does not wait for completion
-// it will not trigger if sync already in progress
+// it will not trigger if sync already in progress or if the cooldown period has not elapsed
 func (s *syncTime) ForceSync() {
+	s.mut.RLock()
+	elapsed := time.Since(s.lastSyncTime)
+	s.mut.RUnlock()
+
+	if elapsed < syncCooldown {
+		log.Debug("ForceSync ignored: cooldown active", "remaining", syncCooldown-elapsed)
+		return
+	}
+
 	ch := s.sf.DoChan(syncKey, func() (any, error) {
 		s.sync()
 		return nil, nil
@@ -170,6 +184,15 @@ func (s *syncTime) ForceSync() {
 // triggerSync will trigger sync and waits for completion
 // this is called periodically in the ntp sync loop
 func (s *syncTime) triggerSync() {
+	s.mut.RLock()
+	elapsed := time.Since(s.lastSyncTime)
+	s.mut.RUnlock()
+
+	if elapsed < syncCooldown {
+		log.Debug("triggerSync ignored: cooldown active", "remaining", syncCooldown-elapsed)
+		return
+	}
+
 	ch := s.sf.DoChan(syncKey, func() (any, error) {
 		s.sync()
 		return nil, nil
@@ -244,6 +267,10 @@ func (s *syncTime) sync() {
 	}
 
 	s.setClockOffset(clockOffset)
+
+	s.mut.Lock()
+	s.lastSyncTime = time.Now()
+	s.mut.Unlock()
 
 	log.Debug("sync.setClockOffset done",
 		"num clock offsets", len(clockOffsets),

--- a/ntp/syncTime_test.go
+++ b/ntp/syncTime_test.go
@@ -611,10 +611,41 @@ func TestSyncTime_ForceSync(t *testing.T) {
 		// set lastSyncTime to now, so cooldown is active
 		st.SetLastSyncTime(time.Now())
 
-		// triggerSync should still work regardless of cooldown
+		// triggerSync should still skip during cooldown
 		st.TriggerSync()
 
 		require.Equal(t, uint32(0), numCalls.Load())
+	})
+
+	t.Run("ForceSync followed by TriggerSync within cooldown should result in a single sync", func(t *testing.T) {
+		t.Parallel()
+
+		numCalls := &atomic.Uint32{}
+
+		st := ntp.NewSyncTime(
+			config.NTPConfig{
+				SyncPeriodSeconds:    3600,
+				Hosts:                []string{"host1"},
+				OutOfBoundsThreshold: 2,
+			},
+
+			func(options ntp.NTPOptions, hostIndex int) (*beevikNtp.Response, error) {
+				numCalls.Add(1)
+				return &beevikNtp.Response{
+					ClockOffset: 1 * time.Millisecond,
+				}, nil
+			},
+		)
+
+		// call ForceSync to perform a sync and start cooldown
+		st.ForceSync()
+		time.Sleep(50 * time.Millisecond)
+
+		st.TriggerSync()
+		time.Sleep(50 * time.Millisecond)
+
+		// only one sync operation should have been performed
+		require.Equal(t, uint32(ntp.NumRequestsFromHost), numCalls.Load())
 	})
 }
 

--- a/ntp/syncTime_test.go
+++ b/ntp/syncTime_test.go
@@ -457,7 +457,7 @@ func TestSyncTime_ForceSync(t *testing.T) {
 		require.Equal(t, ntp.NumRequestsFromHost, numCalls)
 	})
 
-	t.Run("TriggerSync should trigger multiple times", func(t *testing.T) {
+	t.Run("TriggerSync should not trigger multiple times", func(t *testing.T) {
 		t.Parallel()
 
 		numCalls := &atomic.Uint32{}
@@ -491,7 +491,8 @@ func TestSyncTime_ForceSync(t *testing.T) {
 		expClockOffset := 1 * time.Millisecond
 		assert.Equal(t, expClockOffset, st.ClockOffset())
 
-		require.Equal(t, ntp.NumRequestsFromHost*4, int(numCalls.Load()))
+		// should not trigger multiple times due to cooldown
+		require.Equal(t, ntp.NumRequestsFromHost, int(numCalls.Load()))
 	})
 
 	t.Run("direct trigger should not trigger if already in progress", func(t *testing.T) {
@@ -525,6 +526,95 @@ func TestSyncTime_ForceSync(t *testing.T) {
 		time.Sleep(time.Duration(ntp.NumRequestsFromHost*10+10) * time.Millisecond)
 
 		require.Equal(t, ntp.NumRequestsFromHost, int(numCalls.Load()))
+	})
+
+	t.Run("ForceSync should skip during cooldown", func(t *testing.T) {
+		t.Parallel()
+
+		numCalls := &atomic.Uint32{}
+
+		st := ntp.NewSyncTime(
+			config.NTPConfig{
+				SyncPeriodSeconds:    3600,
+				Hosts:                []string{"host1"},
+				OutOfBoundsThreshold: 2,
+			},
+			func(options ntp.NTPOptions, hostIndex int) (*beevikNtp.Response, error) {
+				numCalls.Add(1)
+
+				return &beevikNtp.Response{
+					ClockOffset: 1 * time.Millisecond,
+				}, nil
+			},
+		)
+
+		// set lastSyncTime to now, so cooldown is active
+		st.SetLastSyncTime(time.Now())
+
+		st.ForceSync()
+
+		time.Sleep(50 * time.Millisecond)
+
+		require.Equal(t, uint32(0), numCalls.Load())
+	})
+
+	t.Run("ForceSync should work after cooldown expires", func(t *testing.T) {
+		t.Parallel()
+
+		numCalls := &atomic.Uint32{}
+
+		st := ntp.NewSyncTime(
+			config.NTPConfig{
+				SyncPeriodSeconds:    3600,
+				Hosts:                []string{"host1"},
+				OutOfBoundsThreshold: 2,
+			},
+			func(options ntp.NTPOptions, hostIndex int) (*beevikNtp.Response, error) {
+				numCalls.Add(1)
+
+				return &beevikNtp.Response{
+					ClockOffset: 1 * time.Millisecond,
+				}, nil
+			},
+		)
+
+		// set lastSyncTime in the past, so cooldown has expired
+		st.SetLastSyncTime(time.Now().Add(-ntp.SyncCooldownDuration - time.Second))
+
+		st.ForceSync()
+
+		time.Sleep(50 * time.Millisecond)
+
+		require.Equal(t, uint32(ntp.NumRequestsFromHost), numCalls.Load())
+	})
+
+	t.Run("triggerSync should skip during cooldown", func(t *testing.T) {
+		t.Parallel()
+
+		numCalls := &atomic.Uint32{}
+
+		st := ntp.NewSyncTime(
+			config.NTPConfig{
+				SyncPeriodSeconds:    3600,
+				Hosts:                []string{"host1"},
+				OutOfBoundsThreshold: 2,
+			},
+			func(options ntp.NTPOptions, hostIndex int) (*beevikNtp.Response, error) {
+				numCalls.Add(1)
+
+				return &beevikNtp.Response{
+					ClockOffset: 1 * time.Millisecond,
+				}, nil
+			},
+		)
+
+		// set lastSyncTime to now, so cooldown is active
+		st.SetLastSyncTime(time.Now())
+
+		// triggerSync should still work regardless of cooldown
+		st.TriggerSync()
+
+		require.Equal(t, uint32(0), numCalls.Load())
 	})
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request
- There are 2 ways in which ntp sync mechanism can be triggered
    - at specific intervals based on config
    - by force sync triggered based on round controller in consensus
  
## Proposed changes
- Add cooldown mechanism in ntp syncer to avoid excesive NTP queries calls

## Testing procedure
- System testing with induced ntp clock offsets

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
