### PR TITLE
Fix revert on worker extend

### DIFF
--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -60,6 +60,7 @@ type Worker struct {
 	headerIntegrityVerifier process.HeaderIntegrityVerifier
 	appStatusHandler        core.AppStatusHandler
 	enableEpochsHandler     common.EnableEpochsHandler
+	enableRoundsHandler     common.EnableRoundsHandler
 
 	networkShardingCollector consensus.NetworkShardingCollector
 
@@ -123,6 +124,7 @@ type WorkerArgs struct {
 	PeerBlacklistHandler     consensus.PeerBlacklistHandler
 	EnableEpochsHandler      common.EnableEpochsHandler
 	InvalidSignersCache      InvalidSignersCache
+	EnableRoundsHandler      common.EnableRoundsHandler
 }
 
 // NewWorker creates a new Worker object
@@ -180,6 +182,7 @@ func NewWorker(args *WorkerArgs) (*Worker, error) {
 		peerBlacklistHandler:     args.PeerBlacklistHandler,
 		closer:                   closing.NewSafeChanCloser(),
 		enableEpochsHandler:      args.EnableEpochsHandler,
+		enableRoundsHandler:      args.EnableRoundsHandler,
 		invalidSignersCache:      args.InvalidSignersCache,
 		consensusMetrics:         consensusMetrics,
 	}
@@ -868,18 +871,21 @@ func (wrk *Worker) Extend(subroundId int) {
 
 	log.Debug("current block is reverted")
 
-	header := wrk.consensusState.GetHeader()
-	if check.IfNil(header) {
-		return
-	}
-
-	isHeaderV3 := header.IsHeaderV3()
-	if !isHeaderV3 {
+	if !wrk.isAsyncExecEnabled() {
 		wrk.scheduledProcessor.ForceStopScheduledExecutionBlocking()
 		wrk.blockProcessor.RevertCurrentBlock()
 	}
 
 	wrk.removeConsensusHeaderFromPool()
+}
+
+func (wrk *Worker) isAsyncExecEnabled() bool {
+	header := wrk.consensusState.GetHeader()
+	if !check.IfNil(header) {
+		return header.IsHeaderV3()
+	}
+
+	return wrk.enableRoundsHandler.IsFlagEnabled(common.SupernovaRoundFlag)
 }
 
 func (wrk *Worker) removeConsensusHeaderFromPool() {

--- a/consensus/spos/worker_test.go
+++ b/consensus/spos/worker_test.go
@@ -124,6 +124,7 @@ func createDefaultWorkerArgs(appStatusHandler core.AppStatusHandler) *spos.Worke
 		NodeRedundancyHandler:    &mock.NodeRedundancyHandlerStub{},
 		PeerBlacklistHandler:     &mock.PeerBlacklistHandlerStub{},
 		EnableEpochsHandler:      &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
+		EnableRoundsHandler:      &testscommon.EnableRoundsHandlerStub{},
 		InvalidSignersCache:      &consensusMocks.InvalidSignersCacheMock{},
 	}
 

--- a/factory/consensus/consensusComponents.go
+++ b/factory/consensus/consensusComponents.go
@@ -222,6 +222,7 @@ func (ccf *consensusComponentsFactory) Create() (*consensusComponents, error) {
 		NodeRedundancyHandler:    ccf.processComponents.NodeRedundancyHandler(),
 		PeerBlacklistHandler:     cc.peerBlacklistHandler,
 		EnableEpochsHandler:      ccf.coreComponents.EnableEpochsHandler(),
+		EnableRoundsHandler:      ccf.coreComponents.EnableRoundsHandler(),
 		InvalidSignersCache:      invalidSignersCache,
 	}
 


### PR DESCRIPTION
## Reasoning behind the pull request
- In case header was not set, there was no revert called due to nil check
  
## Proposed changes
- Exclude nil check on worker extend

## Testing procedure
- Standard system test

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
