### PR TITLE
Num header to request in advance to config

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -77,7 +77,8 @@
             # MaxRoundsOfInactivityAccepted defines the number of rounds missed by a main or higher level backup machine before
             # the current machine will take over and propose/sign blocks. Used in both single-key and multi-key modes.
             MaxRoundsOfInactivityAccepted = 3,
-            MaxBlockProcessingTimeMs = 3000
+            MaxBlockProcessingTimeMs = 3000,
+            NumHeadersToRequestInAdvance = 10
         },
         {
             EnableRound = 440,
@@ -89,7 +90,8 @@
             MaxRoundsToKeepUnprocessedTransactions = 3000,
             MaxConsecutiveRoundsOfRatingDecrease = 6000,
             MaxRoundsOfInactivityAccepted = 30,
-            MaxBlockProcessingTimeMs = 3000
+            MaxBlockProcessingTimeMs = 3000,
+            NumHeadersToRequestInAdvance = 10
         }
     ]
 

--- a/common/configs/consts.go
+++ b/common/configs/consts.go
@@ -18,4 +18,5 @@ const (
 	defaultMaxConsecutiveRoundsOfRatingDecrease   = 600
 	defaultMaxRoundsOfInactivityAccepted          = 3
 	defaultMaxBlockProcessingTimeMs               = 100
+	defaultNumHeadersToRequestInAdvance           = 10
 )

--- a/common/configs/processConfigs.go
+++ b/common/configs/processConfigs.go
@@ -275,6 +275,18 @@ func (pce *processConfigsByEpoch) GetMaxBlockProcessingTime(round uint64) time.D
 	)
 }
 
+// GetNumHeadersToRequestInAdvance returns the number of headers to request in advance based on round
+func (pce *processConfigsByEpoch) GetNumHeadersToRequestInAdvance(round uint64) uint64 {
+	return getConfigValueByRound(
+		pce.orderedConfigByRound,
+		round,
+		func(cfg config.ProcessConfigByRound) uint64 {
+			return cfg.NumHeadersToRequestInAdvance
+		},
+		defaultNumHeadersToRequestInAdvance,
+	)
+}
+
 // GetValue returns the value of the provided variable for the current round
 func (pce *processConfigsByEpoch) GetValue(variable dto.ConfigVariable) uint64 {
 	return pce.getValueByRound(variable, pce.roundNotifier.CurrentRound())

--- a/common/interface.go
+++ b/common/interface.go
@@ -494,6 +494,7 @@ type ProcessConfigsHandler interface {
 	GetMaxRoundsToKeepUnprocessedTransactions(round uint64) uint64
 	GetMaxRoundsToKeepUnprocessedMiniBlocks(round uint64) uint64
 	GetMaxBlockProcessingTime(round uint64) time.Duration
+	GetNumHeadersToRequestInAdvance(round uint64) uint64
 
 	GetValue(variable dto.ConfigVariable) uint64
 

--- a/config/config.go
+++ b/config/config.go
@@ -413,6 +413,7 @@ type ProcessConfigByRound struct {
 	MaxConsecutiveRoundsOfRatingDecrease uint64
 	MaxRoundsOfInactivityAccepted        uint64
 	MaxBlockProcessingTimeMs             uint32
+	NumHeadersToRequestInAdvance         uint64
 }
 
 // GeneralSettingsConfig will hold the general settings for a node

--- a/config/tomlConfig_test.go
+++ b/config/tomlConfig_test.go
@@ -74,6 +74,7 @@ func TestTomlParser(t *testing.T) {
 					MaxConsecutiveRoundsOfRatingDecrease:   11,
 					MaxRoundsOfInactivityAccepted:          12,
 					MaxBlockProcessingTimeMs:               13,
+					NumHeadersToRequestInAdvance:           14,
 				},
 			},
 		},
@@ -381,7 +382,8 @@ func TestTomlParser(t *testing.T) {
         MaxRoundsToKeepUnprocessedTransactions = 7,
         MaxConsecutiveRoundsOfRatingDecrease = 11,
         MaxRoundsOfInactivityAccepted = 12,
-		MaxBlockProcessingTimeMs = 13
+		MaxBlockProcessingTimeMs = 13,
+        NumHeadersToRequestInAdvance = 14
         }
     ]
 

--- a/node/chainSimulator/components/coreComponents_test.go
+++ b/node/chainSimulator/components/coreComponents_test.go
@@ -76,6 +76,7 @@ func createArgsCoreComponentsHolder() ArgsCoreComponentsHolder {
 						NumFloodingRoundsOutOfSpecs:            40,
 						MaxConsecutiveRoundsOfRatingDecrease:   600,
 						MaxBlockProcessingTimeMs:               1000,
+						NumHeadersToRequestInAdvance:           10,
 					},
 				},
 				EpochStartConfigsByEpoch: []config.EpochStartConfigByEpoch{

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -3483,7 +3483,7 @@ func (bp *baseProcessor) requestHeadersFromHeaderIfNeeded(
 	}
 
 	fromNonce := lastHeader.GetNonce() + 1
-	toNonce := fromNonce + numHeadersToRequestInAdvance
+	toNonce := fromNonce + bp.processConfigsHandler.GetNumHeadersToRequestInAdvance(lastRound)
 
 	for nonce := fromNonce; nonce <= toNonce; nonce++ {
 		bp.requestHeaderIfNeeded(nonce, shardID)

--- a/process/block/metablockProposal.go
+++ b/process/block/metablockProposal.go
@@ -17,8 +17,6 @@ import (
 	"github.com/multiversx/mx-chain-go/state"
 )
 
-const numHeadersToRequestInAdvance = 10
-
 // usedShardHeadersInfo holds the used shard headers information
 type usedShardHeadersInfo struct {
 	headersPerShard          map[uint32][]ShardHeaderInfo

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -328,6 +328,7 @@ func GetNetworkFactoryArgs() networkComp.NetworkComponentsFactoryArgs {
 					NumFloodingRoundsOutOfSpecs:            40,
 					MaxConsecutiveRoundsOfRatingDecrease:   600,
 					MaxBlockProcessingTimeMs:               1000,
+					NumHeadersToRequestInAdvance:           10,
 				},
 			},
 		},

--- a/testscommon/components/configs.go
+++ b/testscommon/components/configs.go
@@ -187,6 +187,7 @@ func GetGeneralConfig() config.Config {
 					NumFloodingRoundsSlowReacting:          20,
 					MaxConsecutiveRoundsOfRatingDecrease:   600,
 					MaxBlockProcessingTimeMs:               1000,
+					NumHeadersToRequestInAdvance:           10,
 				},
 			},
 			EpochStartConfigsByEpoch: []config.EpochStartConfigByEpoch{

--- a/testscommon/generalConfig.go
+++ b/testscommon/generalConfig.go
@@ -91,6 +91,7 @@ func GetGeneralConfig() config.Config {
 					NumFloodingRoundsOutOfSpecs:            40,
 					MaxConsecutiveRoundsOfRatingDecrease:   2000,
 					MaxBlockProcessingTimeMs:               1000,
+					NumHeadersToRequestInAdvance:           10,
 				},
 			},
 			EpochStartConfigsByEpoch: []config.EpochStartConfigByEpoch{

--- a/testscommon/processConfigsHandlerStub.go
+++ b/testscommon/processConfigsHandlerStub.go
@@ -32,6 +32,7 @@ func GetDefaultProcessConfigsHandler() common.ProcessConfigsHandler {
 				NumFloodingRoundsOutOfSpecs:            40,
 				MaxConsecutiveRoundsOfRatingDecrease:   600,
 				MaxBlockProcessingTimeMs:               1000,
+				NumHeadersToRequestInAdvance:           10,
 			},
 		},
 		&epochNotifier.RoundNotifierStub{},
@@ -53,6 +54,7 @@ type ProcessConfigsHandlerStub struct {
 	GetMaxRoundsToKeepUnprocessedMiniBlocksCalled     func(round uint64) uint64
 	GetValueCalled                                    func(variable dto.ConfigVariable) uint64
 	GetMaxBlockProcessingTimeCalled                   func(round uint64) time.Duration
+	GetNumHeadersToRequestInAdvanceCalled             func(round uint64) uint64
 }
 
 // GetMaxMetaNoncesBehindByEpoch -
@@ -151,6 +153,15 @@ func (p *ProcessConfigsHandlerStub) GetMaxBlockProcessingTime(round uint64) time
 	}
 
 	return time.Millisecond
+}
+
+// GetNumHeadersToRequestInAdvance -
+func (p *ProcessConfigsHandlerStub) GetNumHeadersToRequestInAdvance(round uint64) uint64 {
+	if p.GetNumHeadersToRequestInAdvanceCalled != nil {
+		return p.GetNumHeadersToRequestInAdvanceCalled(round)
+	}
+
+	return 10
 }
 
 // IsInterfaceNil -


### PR DESCRIPTION
## Reasoning behind the pull request
- There was a constant for num headers to request in advance if needed
  
## Proposed changes
- Add const to config by round

## Testing procedure
- Standard system test

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
