### PR TITLE
save pruningEnabled flag in AccountsDB

### DIFF
--- a/factory/state/stateComponents.go
+++ b/factory/state/stateComponents.go
@@ -261,6 +261,7 @@ func (scf *stateComponentsFactory) createAccountsAdapters(triesContainer common.
 		AddressConverter:       scf.core.AddressPubKeyConverter(),
 		SnapshotsManager:       snapshotsManager,
 		StateAccessesCollector: StateAccessesCollector,
+		PruningEnabled:         scf.config.StateTriesConfig.AccountsStatePruningEnabled,
 	}
 	accountsAdapter, err := state.NewAccountsDB(argsProcessingAccountsDB)
 	if err != nil {
@@ -364,6 +365,7 @@ func (scf *stateComponentsFactory) createPeerAdapter(triesContainer common.Tries
 		AddressConverter:       scf.core.AddressPubKeyConverter(),
 		SnapshotsManager:       snapshotManager,
 		StateAccessesCollector: disabled.NewDisabledStateAccessesCollector(),
+		PruningEnabled:         scf.config.StateTriesConfig.PeerStatePruningEnabled,
 	}
 	peerAdapter, err := state.NewPeerAccountsDB(argsProcessingPeerAccountsDB)
 	if err != nil {

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -499,6 +499,7 @@ func CreateAccountsDBWithEnableEpochsHandler(
 		AddressConverter:       &testscommon.PubkeyConverterMock{},
 		SnapshotsManager:       snapshotsManager,
 		StateAccessesCollector: disabled.NewDisabledStateAccessesCollector(),
+		PruningEnabled:         trieStorageManager.IsPruningEnabled(),
 	}
 	adb, _ := state.NewAccountsDB(args)
 

--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -89,6 +89,7 @@ type AccountsDB struct {
 	mutOp                  sync.RWMutex
 	loadCodeMeasurements   *loadingMeasurements
 	addressConverter       core.PubkeyConverter
+	pruningEnabled         bool
 
 	stackDebug []byte
 }
@@ -105,6 +106,7 @@ type ArgsAccountsDB struct {
 	AddressConverter       core.PubkeyConverter
 	SnapshotsManager       SnapshotsManager
 	StateAccessesCollector StateAccessesCollector
+	PruningEnabled         bool
 }
 
 // NewAccountsDB creates a new account manager
@@ -134,6 +136,7 @@ func createAccountsDb(args ArgsAccountsDB) *AccountsDB {
 		addressConverter:       args.AddressConverter,
 		snapshotsManger:        args.SnapshotsManager,
 		stateAccessesCollector: args.StateAccessesCollector,
+		pruningEnabled:         args.PruningEnabled,
 	}
 }
 
@@ -971,7 +974,7 @@ func (adb *AccountsDB) markForEviction(
 	oldHashes common.ModifiedHashes,
 	newHashes common.ModifiedHashes,
 ) error {
-	if !adb.mainTrie.GetStorageManager().IsPruningEnabled() {
+	if !adb.pruningEnabled {
 		return nil
 	}
 
@@ -985,7 +988,7 @@ func (adb *AccountsDB) markForEviction(
 }
 
 func (adb *AccountsDB) commitTrie(tr common.Trie, oldHashes common.ModifiedHashes, newHashes common.ModifiedHashes) error {
-	if adb.mainTrie.GetStorageManager().IsPruningEnabled() {
+	if adb.pruningEnabled {
 		oldTrieHashes := tr.GetObsoleteHashes()
 		newTrieHashes, err := tr.GetDirtyHashes()
 		if err != nil {
@@ -1256,7 +1259,7 @@ func emptyErrChanReturningHadContained(errChan chan error) bool {
 
 // IsPruningEnabled returns true if state pruning is enabled
 func (adb *AccountsDB) IsPruningEnabled() bool {
-	return adb.getMainTrie().GetStorageManager().IsPruningEnabled()
+	return adb.pruningEnabled
 }
 
 // GetAllLeaves returns all the leaves from a given rootHash

--- a/state/accountsDB_test.go
+++ b/state/accountsDB_test.go
@@ -181,6 +181,7 @@ func getDefaultStateComponents(
 		AddressConverter:       &testscommon.PubkeyConverterMock{},
 		SnapshotsManager:       snapshotsManager,
 		StateAccessesCollector: collector,
+		PruningEnabled:         true,
 	}
 	adb, _ := state.NewAccountsDB(argsAccountsDB)
 
@@ -1657,19 +1658,16 @@ func TestAccountsDB_SnapshotStateCallsRemoveFromAllActiveEpochs(t *testing.T) {
 func TestAccountsDB_IsPruningEnabled(t *testing.T) {
 	t.Parallel()
 
-	trieStub := &trieMock.TrieStub{
-		GetStorageManagerCalled: func() common.StorageManager {
-			return &storageManager.StorageManagerStub{
-				IsPruningEnabledCalled: func() bool {
-					return true
-				},
-			}
-		},
-	}
-	adb := generateAccountDBFromTrie(trieStub)
-	res := adb.IsPruningEnabled()
+	args := createMockAccountsDBArgs()
+	args.PruningEnabled = true
+	adb, err := state.NewAccountsDB(args)
+	assert.Nil(t, err)
+	assert.True(t, adb.IsPruningEnabled())
 
-	assert.Equal(t, true, res)
+	args.PruningEnabled = false
+	adb, err = state.NewAccountsDB(args)
+	assert.Nil(t, err)
+	assert.False(t, adb.IsPruningEnabled())
 }
 
 func TestAccountsDB_RevertToSnapshotOutOfBounds(t *testing.T) {
@@ -2135,6 +2133,7 @@ func TestAccountsDB_MainTrieAutomaticallyMarksCodeUpdatesForEviction(t *testing.
 	spm, _ := storagePruningManager.NewStoragePruningManager(ewl, 5)
 
 	argsAccountsDB := createMockAccountsDBArgs()
+	argsAccountsDB.PruningEnabled = true
 	argsAccountsDB.Trie = tr
 	argsAccountsDB.Hasher = hasher
 	argsAccountsDB.Marshaller = marshaller
@@ -2217,6 +2216,7 @@ func TestAccountsDB_RemoveAccountMarksObsoleteHashesForEviction(t *testing.T) {
 	spm, _ := storagePruningManager.NewStoragePruningManager(ewl, 5)
 
 	argsAccountsDB := createMockAccountsDBArgs()
+	argsAccountsDB.PruningEnabled = true
 	argsAccountsDB.Trie = tr
 	argsAccountsDB.Hasher = hasher
 	argsAccountsDB.Marshaller = marshaller
@@ -3200,6 +3200,7 @@ func TestAccountsDB_RevertTxWhichMigratesDataRemovesMigratedData(t *testing.T) {
 	tr, _ := trie.NewTrie(tsm, marshaller, hasher, enableEpochsHandler, uint(5))
 	spm := &stateMock.StoragePruningManagerStub{}
 	argsAccountsDB := createMockAccountsDBArgs()
+	argsAccountsDB.PruningEnabled = true
 	argsAccountsDB.Trie = tr
 	argsAccountsDB.Hasher = hasher
 	argsAccountsDB.Marshaller = marshaller


### PR DESCRIPTION
## Reasoning behind the pull request
- Avoid waiting for accountsDB mutex while checking if pruning is enabled
  
## Proposed changes
- Save a flag for pruningEnabled on accounts db. This flag is only read, so no mutex protection is needed

## Testing procedure
- Normal test

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
