### PR TITLE
Fix round index timestamp

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -14,10 +14,10 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-go/errors"
 	logger "github.com/multiversx/mx-chain-logger-go"
 
 	"github.com/multiversx/mx-chain-go/config"
-	"github.com/multiversx/mx-chain-go/errors"
 )
 
 const (
@@ -268,16 +268,20 @@ func GetHeaderTimestamps(
 	if check.IfNil(header) {
 		return 0, 0, ErrNilHeaderHandler
 	}
+
+	headerTimestamp := header.GetTimeStamp()
+	return PrepareTimestampBasedOnHeaderData(headerTimestamp, header.GetEpoch(), enableEpochsHandler)
+}
+
+// PrepareTimestampBasedOnHeaderData will prepare timestamp based on the provided data
+func PrepareTimestampBasedOnHeaderData(headerTimestamp uint64, headerEpoch uint32, enableEpochsHandler EnableEpochsHandler) (uint64, uint64, error) {
 	if check.IfNil(enableEpochsHandler) {
 		return 0, 0, errors.ErrNilEnableEpochsHandler
 	}
-
-	headerTimestamp := header.GetTimeStamp()
-
 	timestampSec := headerTimestamp
 	timestampMs := headerTimestamp
 
-	if !enableEpochsHandler.IsFlagEnabledInEpoch(SupernovaFlag, header.GetEpoch()) {
+	if !enableEpochsHandler.IsFlagEnabledInEpoch(SupernovaFlag, headerEpoch) {
 		timestampMs = ConvertTimeStampSecToMs(headerTimestamp)
 		return timestampSec, timestampMs, nil
 	}

--- a/consensus/spos/bls/v2/subroundStartRound.go
+++ b/consensus/spos/bls/v2/subroundStartRound.go
@@ -283,13 +283,21 @@ func (sr *subroundStartRound) indexRoundIfNeeded(pubKeys []string) {
 
 	round := sr.RoundHandler().Index()
 
+	headerTimestamp := sr.GetUnixTimestampForHeader(epoch)
+	timestampSec, timestampMs, err := common.PrepareTimestampBasedOnHeaderData(headerTimestamp, epoch, sr.EnableEpochsHandler())
+	if err != nil {
+		log.Debug("subroundStartRound.indexRoundIfNeeded cannot prepare timestamp", "error", err.Error(), "epoch", epoch, "round", round)
+		return
+	}
+
 	roundInfo := &outportcore.RoundInfo{
 		Round:            uint64(round),
 		SignersIndexes:   make([]uint64, 0),
 		BlockWasProposed: false,
 		ShardId:          shardId,
 		Epoch:            epoch,
-		Timestamp:        sr.GetUnixTimestampForHeader(epoch),
+		Timestamp:        timestampSec,
+		TimestampMs:      timestampMs,
 	}
 	roundsInfo := &outportcore.RoundsInfo{
 		ShardID:    shardId,


### PR DESCRIPTION
## Reasoning behind the pull request
- Fixes `RoundInfo` structure that is used in `OutportDriver`
- `timestampMs` field is not populated for the case when a block is not produced in a round 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
