### PR TITLE
Fix round index timestamp

### DIFF
--- a/process/block/metrics.go
+++ b/process/block/metrics.go
@@ -194,6 +194,7 @@ func indexRoundInfo(
 
 	roundsInfo := make([]*outportcore.RoundInfo, 0)
 	roundsInfo = append(roundsInfo, roundInfo)
+	epoch := header.GetEpoch()
 	for i := lastBlockRound + 1; i < currentBlockRound; i++ {
 		var ok bool
 		signersIndexes, ok = getSignersIndices(header, enableEpochsHandler, lastHeader, i, nodesCoordinator)
@@ -202,15 +203,18 @@ func indexRoundInfo(
 		}
 
 		roundTimestamp := uint64(time.Duration(header.GetTimeStamp() - ((currentBlockRound - i) * roundDuration)))
-		roundTimestampMs := common.ConvertTimeStampSecToMs(roundTimestamp)
+		roundTimestampSec, roundTimestampMs, errP := common.PrepareTimestampBasedOnHeaderData(roundTimestamp, epoch, enableEpochsHandler)
+		if errP != nil {
+			continue
+		}
 
 		roundInfo = &outportcore.RoundInfo{
 			Round:            i,
 			SignersIndexes:   signersIndexes,
 			BlockWasProposed: false,
 			ShardId:          shardId,
-			Epoch:            header.GetEpoch(),
-			Timestamp:        roundTimestamp,
+			Epoch:            epoch,
+			Timestamp:        roundTimestampSec,
 			TimestampMs:      roundTimestampMs,
 		}
 

--- a/process/block/metrics_test.go
+++ b/process/block/metrics_test.go
@@ -4,10 +4,16 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	outportcore "github.com/multiversx/mx-chain-core-go/data/outport"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
+	outportStub "github.com/multiversx/mx-chain-go/testscommon/outport"
 	"github.com/multiversx/mx-chain-go/testscommon/shardingMocks"
 	statusHandlerMock "github.com/multiversx/mx-chain-go/testscommon/statusHandler"
 )
@@ -79,4 +85,55 @@ func TestMetrics_IncrementMetricCountConsensusAcceptedBlocks(t *testing.T) {
 		incrementMetricCountConsensusAcceptedBlocks(&block.MetaBlock{}, 0, nodesCoord, statusHandler, managedPeersHolder)
 		assert.Equal(t, 2, cntIncrement) // main key + managed key
 	})
+}
+
+func TestMetrics_IndexRoundInfoShouldKeepSyntheticRoundTimestampsSplitByUnitsAfterSupernova(t *testing.T) {
+	t.Parallel()
+
+	var savedRoundsInfo *outportcore.RoundsInfo
+	outportHandler := &outportStub.OutportStub{
+		SaveRoundsInfoCalled: func(roundsInfo *outportcore.RoundsInfo) {
+			savedRoundsInfo = roundsInfo
+		},
+	}
+	enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+		IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+			return flag == common.SupernovaFlag && epoch == 7
+		},
+	}
+	header := &testscommon.HeaderHandlerStub{
+		EpochField:        7,
+		RoundField:        10,
+		TimestampField:    1774864086000,
+		GetRandSeedCalled: func() []byte { return []byte("rand-seed") },
+	}
+	lastHeader := &testscommon.HeaderHandlerStub{
+		EpochField:        7,
+		RoundField:        8,
+		TimestampField:    1774864080000,
+		GetRandSeedCalled: func() []byte { return []byte("rand-seed") },
+	}
+	nodesCoordinator := &shardingMocks.NodesCoordinatorStub{
+		GetValidatorsPublicKeysCalled: func(_ []byte, _ uint64, _ uint32, _ uint32) (string, []string, error) {
+			return "leader", []string{"pk1"}, nil
+		},
+		GetValidatorsIndexesCalled: func(_ []string, _ uint32) ([]uint64, error) {
+			return []uint64{11}, nil
+		},
+	}
+
+	indexRoundInfo(outportHandler, nodesCoordinator, 1, header, lastHeader, []uint64{22}, enableEpochsHandler)
+
+	require.NotNil(t, savedRoundsInfo)
+	require.Len(t, savedRoundsInfo.RoundsInfo, 2)
+
+	currentRoundInfo := savedRoundsInfo.RoundsInfo[0]
+	assert.Equal(t, uint64(1774864086), currentRoundInfo.Timestamp)
+	assert.Equal(t, uint64(1774864086000), currentRoundInfo.TimestampMs)
+
+	syntheticRoundInfo := savedRoundsInfo.RoundsInfo[1]
+	assert.Equal(t, uint64(9), syntheticRoundInfo.Round)
+	assert.Equal(t, uint64(1774864083), syntheticRoundInfo.Timestamp)
+	assert.Equal(t, uint64(1774864083000), syntheticRoundInfo.TimestampMs)
+	assert.Equal(t, []uint64{11}, syntheticRoundInfo.SignersIndexes)
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- Fixes timestampMs field for rounds index

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
