### PR TITLE
reduce allocations in validator consensus hot paths

### DIFF
--- a/consensus/spos/bls/v2/subroundBlock.go
+++ b/consensus/spos/bls/v2/subroundBlock.go
@@ -10,6 +10,8 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
 
+	logger "github.com/multiversx/mx-chain-logger-go"
+
 	"github.com/multiversx/mx-chain-go/common"
 	commonConsensus "github.com/multiversx/mx-chain-go/common/consensus"
 	"github.com/multiversx/mx-chain-go/consensus"
@@ -653,10 +655,13 @@ func (sr *subroundBlock) receivedBlockHeader(headerHandler data.HeaderHandler) {
 		spos.LeaderPeerHonestyIncreaseFactor,
 	)
 
-	// log the header output for debugging purposes
-	headerOutput, err := common.PrettifyStruct(headerHandler)
-	if err == nil {
-		log.Debug("proposed header received", "header", headerOutput)
+	// log the header output for debugging purposes — PrettifyStruct uses reflection + JSON
+	// marshal which is expensive; guard with log level check to avoid the cost when debug is disabled
+	if log.GetLevel() <= logger.LogDebug {
+		headerOutput, err := common.PrettifyStruct(headerHandler)
+		if err == nil {
+			log.Debug("proposed header received", "header", headerOutput)
+		}
 	}
 }
 

--- a/dataRetriever/dataPool/proofsCache/proofsPool.go
+++ b/dataRetriever/dataPool/proofsCache/proofsPool.go
@@ -171,10 +171,15 @@ func (pp *proofsPool) GetProof(
 	if headerHash == nil {
 		return nil, fmt.Errorf("nil header hash")
 	}
-	log.Trace("trying to get proof",
-		"headerHash", headerHash,
-		"shardID", shardID,
-	)
+
+	// Guard log.Trace to avoid variadic slice allocation when trace logging is disabled.
+	// This is called from HasProof in hot polling loops (~300 times per consensus round).
+	if log.GetLevel() <= logger.LogTrace {
+		log.Trace("trying to get proof",
+			"headerHash", headerHash,
+			"shardID", shardID,
+		)
+	}
 
 	pp.mutCache.RLock()
 	proofsPerShard, ok := pp.cache[shardID]
@@ -188,10 +193,12 @@ func (pp *proofsPool) GetProof(
 
 // GetProofByNonce will get the proof from pool for the provided header nonce, searching through all shards
 func (pp *proofsPool) GetProofByNonce(headerNonce uint64, shardID uint32) (data.HeaderProofHandler, error) {
-	log.Trace("trying to get proof",
-		"headerNonce", headerNonce,
-		"shardID", shardID,
-	)
+	if log.GetLevel() <= logger.LogTrace {
+		log.Trace("trying to get proof",
+			"headerNonce", headerNonce,
+			"shardID", shardID,
+		)
+	}
 
 	pp.mutCache.RLock()
 	proofsPerShard, ok := pp.cache[shardID]


### PR DESCRIPTION
## Summary

Two fixes targeting the validator's per-round consensus critical path: proof cache log guards and header debug logging guard.

## Changes

### 1. Guard `log.Trace` in `GetProof` / `GetProofByNonce` with log level check
**File:** `dataRetriever/dataPool/proofsCache/proofsPool.go`

`log.Trace(...)` allocates a variadic `[]interface{}` slice even when trace logging is disabled. Since `HasProof` delegates to `GetProof` and is called ~300 times per round in the `waitForProof` polling loop, this creates ~300 unnecessary allocations per round. Guard with `log.GetLevel() <= logger.LogTrace` — same pattern used elsewhere in the codebase (`epochStart/bootstrap/shardStorageHandler.go:507`, `epochStart/metachain/auctionListDisplayer.go:72`).

Logs are preserved, not bypassed. When trace logging is enabled, behavior is identical to before.

### 2. Guard `PrettifyStruct` with log level check in `receivedBlockHeader`
**File:** `consensus/spos/bls/v2/subroundBlock.go`

`PrettifyStruct` uses reflection to walk the entire header struct + JSON marshal, called unconditionally on every received block by every validator. Guard with `log.GetLevel() <= logger.LogDebug` to skip the work when debug logging is disabled (the default in production).


## Test plan
- [x] `go test ./dataRetriever/dataPool/proofsCache/` — PASS
- [x] `go test ./consensus/spos/bls/v2/` — PASS
- [x] `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)