### PR TITLE
added minimum block count check

### DIFF
--- a/epochStart/metachain/trigger.go
+++ b/epochStart/metachain/trigger.go
@@ -33,7 +33,7 @@ var _ process.EpochStartTriggerHandler = (*trigger)(nil)
 var _ process.EpochBootstrapper = (*trigger)(nil)
 var _ closing.Closer = (*trigger)(nil)
 
-const minimumNonceToStartEpoch = 4
+const minimumBlocksPerEpoch = 4
 const disabledRoundForForceEpochStart = math.MaxUint64
 
 // ArgsNewMetaEpochStartTrigger defines struct needed to create a new start of epoch trigger
@@ -251,10 +251,11 @@ func (t *trigger) GetEpochChangeProposed() bool {
 }
 
 func (t *trigger) shouldTriggerEpochStart(currentRound uint64, currentNonce uint64) bool {
-	isZeroEpochEdgeCase := currentNonce < minimumNonceToStartEpoch
+	epochStartNonce := t.epochStartMeta.GetNonce()
+	hasMinBlocksInEpoch := currentNonce >= epochStartNonce+minimumBlocksPerEpoch
 	isNormalEpochStart := currentRound > t.currEpochStartRound+t.getRoundsPerEpoch(t.epoch)-t.getOffsetPerEpoch(t.epoch)
 	isWithEarlyEndOfEpoch := currentRound >= t.nextEpochStartRound
-	shouldTriggerEpochStart := (isNormalEpochStart || isWithEarlyEndOfEpoch) && !isZeroEpochEdgeCase
+	shouldTriggerEpochStart := (isNormalEpochStart || isWithEarlyEndOfEpoch) && hasMinBlocksInEpoch
 
 	return shouldTriggerEpochStart
 }

--- a/epochStart/metachain/trigger_test.go
+++ b/epochStart/metachain/trigger_test.go
@@ -304,10 +304,91 @@ func TestTrigger_ForceEpochStartShouldOk(t *testing.T) {
 
 	assert.Equal(t, expectedRound, epochStartTrigger.nextEpochStartRound)
 
-	epochStartTrigger.Update(expectedRound, minimumNonceToStartEpoch)
+	epochStartTrigger.Update(expectedRound, minimumBlocksPerEpoch)
 
 	isEpochStart := epochStartTrigger.IsEpochStart()
 	assert.True(t, isEpochStart)
+}
+
+func TestTrigger_ForceEpochStartShouldWaitMinimumNonceEvenWhenForced(t *testing.T) {
+	t.Parallel()
+
+	arguments := createMockEpochStartTriggerArguments()
+	arguments.ChainParametersHandler = &chainParameters.ChainParametersHandlerStub{
+		ChainParametersForEpochCalled: func(epoch uint32) (config.ChainParametersByEpochConfig, error) {
+			return config.ChainParametersByEpochConfig{
+				MinRoundsBetweenEpochs: 20,
+				RoundsPerEpoch:         200,
+			}, nil
+		},
+	}
+
+	epochStartTrigger, err := NewEpochStartTrigger(arguments)
+	require.Nil(t, err)
+
+	forcedRound := uint64(60)
+	epochStartTrigger.ForceEpochStart(forcedRound)
+
+	// forced round reached but fewer than minimumNonceToStartEpoch blocks produced
+	epochStartTrigger.Update(forcedRound, minimumBlocksPerEpoch-1)
+	assert.False(t, epochStartTrigger.IsEpochStart())
+
+	// minimum block count reached — epoch should now trigger
+	epochStartTrigger.Update(forcedRound, minimumBlocksPerEpoch)
+	assert.True(t, epochStartTrigger.IsEpochStart())
+}
+
+func TestTrigger_UpdateShouldWaitMinimumNonceFromPreviousEpochStart(t *testing.T) {
+	t.Parallel()
+
+	arguments := createMockEpochStartTriggerArguments()
+	epochStartTrigger, err := NewEpochStartTrigger(arguments)
+	require.Nil(t, err)
+
+	epochStartNonce := uint64(100)
+	epochStartTrigger.epochStartMeta = &block.MetaBlock{Nonce: epochStartNonce}
+
+	round := uint64(3)
+	epochStartTrigger.Update(round, epochStartNonce+minimumBlocksPerEpoch-1)
+	assert.False(t, epochStartTrigger.IsEpochStart())
+
+	epochStartTrigger.Update(round, epochStartNonce+minimumBlocksPerEpoch)
+	assert.True(t, epochStartTrigger.IsEpochStart())
+}
+
+func TestTrigger_UpdateShouldEnforceMinBlocksAfterEpochTransition(t *testing.T) {
+	t.Parallel()
+
+	arguments := createMockEpochStartTriggerArguments()
+	epochStartTrigger, err := NewEpochStartTrigger(arguments)
+	require.Nil(t, err)
+
+	// default mock: RoundsPerEpoch=2, currEpochStartRound=0
+	// round 3 > 0+2 satisfies isNormalEpochStart; nonce 4 satisfies hasMinBlocksInEpoch (4 >= 0+4)
+	epochStartTrigger.Update(3, minimumBlocksPerEpoch)
+	assert.True(t, epochStartTrigger.IsEpochStart())
+
+	// SetProcessed moves epochStartMeta to the epoch-1-start block at nonce 500
+	// this resets the baseline: next epoch needs currentNonce >= 500+4
+	epochOneStartNonce := uint64(500)
+	epochStartTrigger.SetProcessed(&block.MetaBlock{
+		Round: 3,
+		Nonce: epochOneStartNonce,
+		Epoch: 1,
+		EpochStart: block.EpochStart{
+			LastFinalizedHeaders: []block.EpochStartShardData{{RootHash: []byte("root")}},
+		},
+	}, nil)
+	assert.False(t, epochStartTrigger.IsEpochStart())
+
+	// round 6 > 3+2 satisfies isNormalEpochStart for epoch 2
+	// but only 3 blocks since epoch 1 start — hasMinBlocksInEpoch must block it
+	epochStartTrigger.Update(6, epochOneStartNonce+minimumBlocksPerEpoch-1)
+	assert.False(t, epochStartTrigger.IsEpochStart())
+
+	// 4th block since epoch 1 start — guard satisfied
+	epochStartTrigger.Update(6, epochOneStartNonce+minimumBlocksPerEpoch)
+	assert.True(t, epochStartTrigger.IsEpochStart())
 }
 
 func TestTrigger_ForceEpochStartShouldWorkForSupernovaEpoch(t *testing.T) {


### PR DESCRIPTION
## Reasoning behind the pull request
- the block after the start of epoch block is treated differently and should not be a start of epoch block in any circumstances
  
## Proposed changes
- set a min blocks per epoch so that the next block after a start of epoch blocks is never a start of epoch block

## Testing procedure
- allow a start of epoch block to be created and shut down the nodes until the next epoch should start... start the network again and see that at least 4 blocks are in the epoch  

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
