### PR TITLE
Update round per epoch supernova

### DIFF
--- a/integrationTests/chainSimulator/mempool/testutils_test.go
+++ b/integrationTests/chainSimulator/mempool/testutils_test.go
@@ -63,7 +63,7 @@ func startChainSimulator(t *testing.T, alterConfigsFunction func(cfg *config.Con
 		},
 		SupernovaRoundsPerEpoch: core.OptionalUint64{
 			HasValue: true,
-			Value:    100,
+			Value:    10,
 		},
 		ApiInterface:             api.NewNoApiInterface(),
 		MinNodesPerShard:         1,

--- a/integrationTests/chainSimulator/relayedTx/relayedTx_test.go
+++ b/integrationTests/chainSimulator/relayedTx/relayedTx_test.go
@@ -1331,7 +1331,7 @@ func startChainSimulator(
 	}
 	supernovaRoundsPerEpochOpt := core.OptionalUint64{
 		HasValue: true,
-		Value:    roundsPerEpoch * 10,
+		Value:    roundsPerEpoch,
 	}
 
 	cs, err := chainSimulator.NewChainSimulator(chainSimulator.ArgsChainSimulator{

--- a/integrationTests/chainSimulator/simulate/simulate_test.go
+++ b/integrationTests/chainSimulator/simulate/simulate_test.go
@@ -39,7 +39,7 @@ func TestCostScDeploy(t *testing.T) {
 	}
 	supernovaRoundsPerEpochOpt := core.OptionalUint64{
 		HasValue: true,
-		Value:    200,
+		Value:    20,
 	}
 
 	cs, err := chainSimulator.NewChainSimulator(chainSimulator.ArgsChainSimulator{
@@ -113,7 +113,7 @@ func TestSimulateIntraShardTxWithGuardian(t *testing.T) {
 	}
 	supernovaRoundsPerEpochOpt := core.OptionalUint64{
 		HasValue: true,
-		Value:    200,
+		Value:    20,
 	}
 
 	cs, err := chainSimulator.NewChainSimulator(chainSimulator.ArgsChainSimulator{

--- a/integrationTests/chainSimulator/staking/jail/jail_test.go
+++ b/integrationTests/chainSimulator/staking/jail/jail_test.go
@@ -62,7 +62,7 @@ func testChainSimulatorJailAndUnJail(t *testing.T, targetEpoch int32, nodeStatus
 	}
 	supernovaRoundsPerEpochOpt := core.OptionalUint64{
 		HasValue: true,
-		Value:    200,
+		Value:    20,
 	}
 
 	numOfShards := uint32(3)
@@ -171,7 +171,7 @@ func TestChainSimulator_FromQueueToAuctionList(t *testing.T) {
 	}
 	supernovaRoundsPerEpochOpt := core.OptionalUint64{
 		HasValue: true,
-		Value:    400,
+		Value:    40,
 	}
 
 	numOfShards := uint32(3)

--- a/integrationTests/chainSimulator/staking/stake/simpleStake/simpleStake_test.go
+++ b/integrationTests/chainSimulator/staking/stake/simpleStake/simpleStake_test.go
@@ -62,7 +62,7 @@ func testChainSimulatorSimpleStake(t *testing.T, targetEpoch int32, nodesStatus 
 	}
 	supernovaRoundsPerEpochOpt := core.OptionalUint64{
 		HasValue: true,
-		Value:    200,
+		Value:    20,
 	}
 
 	numOfShards := uint32(3)

--- a/integrationTests/chainSimulator/staking/stakingProvider/delegation_test.go
+++ b/integrationTests/chainSimulator/staking/stakingProvider/delegation_test.go
@@ -52,7 +52,7 @@ var (
 	}
 	supernovaRoundsPerEpoch = core.OptionalUint64{
 		HasValue: true,
-		Value:    300,
+		Value:    30,
 	}
 )
 

--- a/integrationTests/chainSimulator/vm/common.go
+++ b/integrationTests/chainSimulator/vm/common.go
@@ -41,7 +41,7 @@ var (
 	}
 	SupernovaRoundsPerEpoch = core.OptionalUint64{
 		HasValue: true,
-		Value:    200,
+		Value:    20,
 	}
 
 	OneEGLD = big.NewInt(1000000000000000000)


### PR DESCRIPTION
## Reasoning behind the pull request
- Changed the number of rounds per epoch for supernova in chain simulator integration tests

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
