### PR TITLE
PR action cancel if a new push arrives

### DIFF
--- a/.github/workflows/build_and_run_chain_simulator_and_execute_system_test.yml
+++ b/.github/workflows/build_and_run_chain_simulator_and_execute_system_test.yml
@@ -7,6 +7,10 @@ on:
       - 'master'
       - 'rc/*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   issues: write
   pull-requests: write

--- a/.github/workflows/build_and_test_on_macos.yml
+++ b/.github/workflows/build_and_test_on_macos.yml
@@ -5,6 +5,10 @@ on:
     branches: [master, rc/*]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Reasoning behind the pull request
- Each new push starts a new actions without closing current running actions
- 
- 
  
## Proposed changes
- Added concurrency block that groups runs by workflow name + branch ref and cancels any in-progress run when a new push arrives on the same branch
- 
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
