### PR TITLE
add concurrent waitgroup ops

### DIFF
--- a/consensus/spos/bls/v2/subroundBlock.go
+++ b/consensus/spos/bls/v2/subroundBlock.go
@@ -396,16 +396,26 @@ func (sr *subroundBlock) triggerCreateSignaturesForManagedKeys(
 		return
 	}
 
+	keys := sr.getManagedKeysByIndex()
+	if len(keys) == 0 {
+		// nothing to wait for: the already-closed done channel published at round reset stays in place
+		return
+	}
+
 	timeLeft := sr.RoundHandler().RemainingTime(sr.RoundHandler().TimeStamp(), sigSubroundEndTime)
 	sigCtx, cancel := context.WithTimeout(ctx, timeLeft)
 	sr.SetSignaturesCtxCancelFunc(cancel)
 
-	keys := sr.getManagedKeysByIndex()
-	if len(keys) == 0 {
-		return
-	}
+	wg := &sync.WaitGroup{}
+	wg.Add(len(keys))
 
-	wg := sr.SignaturesWaitGroupAdd(len(keys))
+	done := make(chan struct{})
+	sr.SetSignaturesDone(done)
+
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
 
 	go func() {
 		triggered := 0
@@ -787,6 +797,8 @@ func (sr *subroundBlock) receivedBlockHeader(headerHandler data.HeaderHandler) {
 	ctx, cancel := context.WithTimeout(context.Background(), sr.RoundHandler().TimeDuration())
 	defer cancel()
 
+	sr.triggerCreateSignaturesForManagedKeys(ctx, headerHash, headerHandler)
+
 	_ = sr.processReceivedBlock(ctx, int64(headerHandler.GetRound()), []byte(sr.Leader()))
 	sr.PeerHonestyHandler().ChangeScore(
 		sr.Leader(),
@@ -882,8 +894,6 @@ func (sr *subroundBlock) processReceivedBlock(
 	if !sr.shouldProcessBlock(string(senderPK)) {
 		return false
 	}
-
-	sr.triggerCreateSignaturesForManagedKeys(ctx, sr.GetData(), sr.GetHeader())
 
 	sw.Start("processBlock")
 	ok := sr.processBlock(ctx, round, senderPK)

--- a/consensus/spos/bls/v2/subroundBlock.go
+++ b/consensus/spos/bls/v2/subroundBlock.go
@@ -398,7 +398,6 @@ func (sr *subroundBlock) triggerCreateSignaturesForManagedKeys(
 
 	keys := sr.getManagedKeysByIndex()
 	if len(keys) == 0 {
-		// nothing to wait for: the already-closed done channel published at round reset stays in place
 		return
 	}
 

--- a/consensus/spos/bls/v2/subroundBlock.go
+++ b/consensus/spos/bls/v2/subroundBlock.go
@@ -793,10 +793,10 @@ func (sr *subroundBlock) receivedBlockHeader(headerHandler data.HeaderHandler) {
 
 	sr.AddReceivedHeader(headerHandler)
 
+	sr.triggerCreateSignaturesForManagedKeys(context.Background(), headerHash, headerHandler)
+
 	ctx, cancel := context.WithTimeout(context.Background(), sr.RoundHandler().TimeDuration())
 	defer cancel()
-
-	sr.triggerCreateSignaturesForManagedKeys(ctx, headerHash, headerHandler)
 
 	_ = sr.processReceivedBlock(ctx, int64(headerHandler.GetRound()), []byte(sr.Leader()))
 	sr.PeerHonestyHandler().ChangeScore(

--- a/consensus/spos/bls/v2/subroundBlock.go
+++ b/consensus/spos/bls/v2/subroundBlock.go
@@ -403,8 +403,7 @@ func (sr *subroundBlock) triggerCreateSignaturesForManagedKeys(
 		return
 	}
 
-	wg := sr.SignaturesWaitGroup()
-	wg.Add(len(keys))
+	wg := sr.SignaturesWaitGroupAdd(len(keys))
 
 	go func() {
 		triggered := 0
@@ -756,7 +755,10 @@ func (sr *subroundBlock) receivedBlockHeader(headerHandler data.HeaderHandler) {
 		return
 	}
 
-	sr.SetData(headerHash)
+	if !sr.SetDataIfNotSet(headerHash) {
+		log.Debug("subroundBlock.receivedBlockHeader - consensus data already set")
+		return
+	}
 	sr.SetHeader(headerHandler)
 
 	log.Debug("step 1: block header has been received",

--- a/consensus/spos/bls/v2/subroundBlock.go
+++ b/consensus/spos/bls/v2/subroundBlock.go
@@ -793,6 +793,7 @@ func (sr *subroundBlock) receivedBlockHeader(headerHandler data.HeaderHandler) {
 
 	sr.AddReceivedHeader(headerHandler)
 
+	// the context here should not be related to processing context from below
 	sr.triggerCreateSignaturesForManagedKeys(context.Background(), headerHash, headerHandler)
 
 	ctx, cancel := context.WithTimeout(context.Background(), sr.RoundHandler().TimeDuration())

--- a/consensus/spos/bls/v2/subroundBlock.go
+++ b/consensus/spos/bls/v2/subroundBlock.go
@@ -769,8 +769,6 @@ func (sr *subroundBlock) receivedBlockHeader(headerHandler data.HeaderHandler) {
 
 	sr.AddReceivedHeader(headerHandler)
 
-	sr.triggerCreateSignaturesForManagedKeys(context.Background(), headerHash, headerHandler)
-
 	ctx, cancel := context.WithTimeout(context.Background(), sr.RoundHandler().TimeDuration())
 	defer cancel()
 
@@ -869,6 +867,8 @@ func (sr *subroundBlock) processReceivedBlock(
 	if !sr.shouldProcessBlock(string(senderPK)) {
 		return false
 	}
+
+	sr.triggerCreateSignaturesForManagedKeys(ctx, sr.GetData(), sr.GetHeader())
 
 	sw.Start("processBlock")
 	ok := sr.processBlock(ctx, round, senderPK)

--- a/consensus/spos/bls/v2/subroundBlock_test.go
+++ b/consensus/spos/bls/v2/subroundBlock_test.go
@@ -1942,7 +1942,7 @@ func TestSubroundBlock_TriggerCreateSignaturesForManagedKeys(t *testing.T) {
 
 		srBlock.TriggerCreateSignaturesForManagedKeys(context.TODO(), []byte("headerHash"), &block.Header{Epoch: currEpoch})
 
-		srBlock.SignaturesWaitGroup().Wait()
+		srBlock.SignaturesWaitGroupWait()
 
 		assert.Equal(t, int32(9), atomic.LoadInt32(&numMultiKeysSignaturesCreated)) // there are 9 keys in default consensus group config
 	})
@@ -2090,7 +2090,7 @@ func TestSubroundBlock_TriggerCreateSignaturesForManagedKeys(t *testing.T) {
 		cancel()
 		srBlock.TriggerCreateSignaturesForManagedKeys(ctx, []byte("headerHash"), nil)
 
-		srBlock.SignaturesWaitGroup().Wait()
+		srBlock.SignaturesWaitGroupWait()
 
 		assert.Equal(t, int32(0), atomic.LoadInt32(&numMultiKeysSignaturesCreated))
 	})
@@ -2165,7 +2165,7 @@ func TestSubroundBlock_TriggerCreateSignaturesForManagedKeys(t *testing.T) {
 
 		srBlock.TriggerCreateSignaturesForManagedKeys(context.TODO(), []byte("headerHash"), &block.Header{})
 
-		srBlock.SignaturesWaitGroup().Wait()
+		srBlock.SignaturesWaitGroupWait()
 
 		assert.Equal(t, int32(9), atomic.LoadInt32(&numMultiKeysSignaturesCreated)) // there are 9 keys in default consensus group config
 	})

--- a/consensus/spos/bls/v2/subroundBlock_test.go
+++ b/consensus/spos/bls/v2/subroundBlock_test.go
@@ -1942,7 +1942,7 @@ func TestSubroundBlock_TriggerCreateSignaturesForManagedKeys(t *testing.T) {
 
 		srBlock.TriggerCreateSignaturesForManagedKeys(context.TODO(), []byte("headerHash"), &block.Header{Epoch: currEpoch})
 
-		srBlock.SignaturesWaitGroupWait()
+		<-srBlock.SignaturesDone()
 
 		assert.Equal(t, int32(9), atomic.LoadInt32(&numMultiKeysSignaturesCreated)) // there are 9 keys in default consensus group config
 	})
@@ -2090,7 +2090,7 @@ func TestSubroundBlock_TriggerCreateSignaturesForManagedKeys(t *testing.T) {
 		cancel()
 		srBlock.TriggerCreateSignaturesForManagedKeys(ctx, []byte("headerHash"), nil)
 
-		srBlock.SignaturesWaitGroupWait()
+		<-srBlock.SignaturesDone()
 
 		assert.Equal(t, int32(0), atomic.LoadInt32(&numMultiKeysSignaturesCreated))
 	})
@@ -2165,7 +2165,7 @@ func TestSubroundBlock_TriggerCreateSignaturesForManagedKeys(t *testing.T) {
 
 		srBlock.TriggerCreateSignaturesForManagedKeys(context.TODO(), []byte("headerHash"), &block.Header{})
 
-		srBlock.SignaturesWaitGroupWait()
+		<-srBlock.SignaturesDone()
 
 		assert.Equal(t, int32(9), atomic.LoadInt32(&numMultiKeysSignaturesCreated)) // there are 9 keys in default consensus group config
 	})

--- a/consensus/spos/bls/v2/subroundSignature.go
+++ b/consensus/spos/bls/v2/subroundSignature.go
@@ -230,17 +230,13 @@ func (sr *subroundSignature) waitForSignatures(
 		return false
 	}
 
-	done := make(chan struct{})
-	go func() {
-		sr.SignaturesWaitGroupWait()
-		close(done)
-	}()
-
 	timer := time.NewTimer(timeLeft)
 	defer timer.Stop()
 
+	// Wait only on the done channel published by the trigger. It is closed when the optimistic-signatures
+	// creation finishes (or is already closed when no optimistic signatures were triggered this round).
 	select {
-	case <-done:
+	case <-sr.SignaturesDone():
 		sr.SignaturesCtxCancel()
 		return true
 	case <-timer.C:

--- a/consensus/spos/bls/v2/subroundSignature.go
+++ b/consensus/spos/bls/v2/subroundSignature.go
@@ -220,11 +220,6 @@ func (sr *subroundSignature) doSignatureConsensusCheck() bool {
 func (sr *subroundSignature) waitForSingatures(
 	timeLeft time.Duration,
 ) {
-	wg := sr.SignaturesWaitGroup()
-	if wg == nil {
-		return
-	}
-
 	if timeLeft <= 0 {
 		sr.SignaturesCtxCancel()
 		return
@@ -232,7 +227,7 @@ func (sr *subroundSignature) waitForSingatures(
 
 	done := make(chan struct{})
 	go func() {
-		wg.Wait()
+		sr.SignaturesWaitGroupWait()
 		close(done)
 	}()
 

--- a/consensus/spos/bls/v2/subroundSignature.go
+++ b/consensus/spos/bls/v2/subroundSignature.go
@@ -233,8 +233,6 @@ func (sr *subroundSignature) waitForSignatures(
 	timer := time.NewTimer(timeLeft)
 	defer timer.Stop()
 
-	// Wait only on the done channel published by the trigger. It is closed when the optimistic-signatures
-	// creation finishes (or is already closed when no optimistic signatures were triggered this round).
 	select {
 	case <-sr.SignaturesDone():
 		sr.SignaturesCtxCancel()

--- a/consensus/spos/consensusState.go
+++ b/consensus/spos/consensusState.go
@@ -572,10 +572,7 @@ func (cns *ConsensusState) SignaturesWaitGroup() *sync.WaitGroup {
 }
 
 // SignaturesWaitGroupAdd adds delta to the current round's optimistic-signatures wait group and returns the
-// exact wait group instance the delta was applied to. The pointer read and the Add are performed atomically
-// under mutState, so a round-boundary swap can no longer land between them. Returning the instance lets the
-// caller pair its Done calls to the same wait group even if a swap happens afterwards, preventing orphaned
-// Done calls or a negative-counter panic.
+// exact wait group instance the delta was applied to.
 func (cns *ConsensusState) SignaturesWaitGroupAdd(delta int) *sync.WaitGroup {
 	cns.mutState.Lock()
 	defer cns.mutState.Unlock()

--- a/consensus/spos/consensusState.go
+++ b/consensus/spos/consensusState.go
@@ -47,7 +47,7 @@ type ConsensusState struct {
 	processingBlock    bool
 	mutProcessingBlock sync.RWMutex
 
-	signaturesWaitGroup        *sync.WaitGroup
+	signaturesDone             chan struct{}
 	signaturesTimeoutCtxCancel context.CancelFunc
 
 	*roundConsensus
@@ -85,7 +85,10 @@ func (cns *ConsensusState) ResetConsensusRoundState() {
 	cns.roundCanceled = false
 	cns.extendedCalled = false
 	cns.waitingAllSignaturesTimeOut = false
-	cns.signaturesWaitGroup = &sync.WaitGroup{}
+	// Start each round with an already-closed done channel, so a signature subround that runs without any
+	// optimistic-signatures trigger (e.g. no managed keys) waits on it and returns immediately.
+	cns.signaturesDone = newClosedChannel()
+	cns.signaturesTimeoutCtxCancel = nil
 	cns.mutState.Unlock()
 	cns.ResetRoundStatus()
 	cns.ResetRoundState()
@@ -118,6 +121,12 @@ func (cns *ConsensusState) initReceivedMessagesWithSig() {
 // SignatureMessageKey scopes a signature evidence message to the header hash it signs.
 func SignatureMessageKey(headerHash []byte, pubKey string) string {
 	return string(headerHash) + pubKey
+}
+
+func newClosedChannel() chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
 }
 
 // AddReceivedHeader append the provided header to the inner received headers list
@@ -561,24 +570,23 @@ func (cns *ConsensusState) SetWaitingAllSignaturesTimeOut(waitingAllSignaturesTi
 	cns.waitingAllSignaturesTimeOut = waitingAllSignaturesTimeOut
 }
 
-// SignaturesWaitGroupWait blocks signatures wait group until wait counter is zero
-func (cns *ConsensusState) SignaturesWaitGroupWait() {
-	cns.mutState.Lock()
-	defer cns.mutState.Unlock()
+// SignaturesDone returns the channel that is closed once the optimistic-signatures creation for the current
+// round has finished. When no optimistic signatures were triggered for the round, the returned channel is
+// already closed.
+func (cns *ConsensusState) SignaturesDone() chan struct{} {
+	cns.mutState.RLock()
+	defer cns.mutState.RUnlock()
 
-	cns.signaturesWaitGroup.Wait()
+	return cns.signaturesDone
 }
 
-// SignaturesWaitGroupAdd adds delta to the current round's optimistic-signatures wait group and returns the
-// exact wait group instance the delta was applied to.
-func (cns *ConsensusState) SignaturesWaitGroupAdd(delta int) *sync.WaitGroup {
+// SetSignaturesDone publishes the done channel for the current round's optimistic-signatures creation. The
+// channel is owned by the trigger (subroundBlock) and is closed when the per-trigger local WaitGroup drains.
+func (cns *ConsensusState) SetSignaturesDone(done chan struct{}) {
 	cns.mutState.Lock()
 	defer cns.mutState.Unlock()
 
-	wg := cns.signaturesWaitGroup
-	wg.Add(delta)
-
-	return wg
+	cns.signaturesDone = done
 }
 
 // SetSignaturesCtxCancelFunc will set signatures context cancel function

--- a/consensus/spos/consensusState.go
+++ b/consensus/spos/consensusState.go
@@ -580,8 +580,7 @@ func (cns *ConsensusState) SignaturesDone() chan struct{} {
 	return cns.signaturesDone
 }
 
-// SetSignaturesDone publishes the done channel for the current round's optimistic-signatures creation. The
-// channel is owned by the trigger (subroundBlock) and is closed when the per-trigger local WaitGroup drains.
+// SetSignaturesDone sets the done channel for the optimistic-signatures creation
 func (cns *ConsensusState) SetSignaturesDone(done chan struct{}) {
 	cns.mutState.Lock()
 	defer cns.mutState.Unlock()

--- a/consensus/spos/consensusState.go
+++ b/consensus/spos/consensusState.go
@@ -47,7 +47,7 @@ type ConsensusState struct {
 	processingBlock    bool
 	mutProcessingBlock sync.RWMutex
 
-	signaturesDone             chan struct{}
+	signaturesDone             <-chan struct{}
 	signaturesTimeoutCtxCancel context.CancelFunc
 
 	*roundConsensus
@@ -88,7 +88,12 @@ func (cns *ConsensusState) ResetConsensusRoundState() {
 	// Start each round with an already-closed done channel, so a signature subround that runs without any
 	// optimistic-signatures trigger (e.g. no managed keys) waits on it and returns immediately.
 	cns.signaturesDone = newClosedChannel()
-	cns.signaturesTimeoutCtxCancel = nil
+
+	if cns.signaturesTimeoutCtxCancel != nil {
+		cns.signaturesTimeoutCtxCancel()
+		cns.signaturesTimeoutCtxCancel = nil
+	}
+
 	cns.mutState.Unlock()
 	cns.ResetRoundStatus()
 	cns.ResetRoundState()
@@ -573,7 +578,7 @@ func (cns *ConsensusState) SetWaitingAllSignaturesTimeOut(waitingAllSignaturesTi
 // SignaturesDone returns the channel that is closed once the optimistic-signatures creation for the current
 // round has finished. When no optimistic signatures were triggered for the round, the returned channel is
 // already closed.
-func (cns *ConsensusState) SignaturesDone() chan struct{} {
+func (cns *ConsensusState) SignaturesDone() <-chan struct{} {
 	cns.mutState.RLock()
 	defer cns.mutState.RUnlock()
 
@@ -581,7 +586,7 @@ func (cns *ConsensusState) SignaturesDone() chan struct{} {
 }
 
 // SetSignaturesDone sets the done channel for the optimistic-signatures creation
-func (cns *ConsensusState) SetSignaturesDone(done chan struct{}) {
+func (cns *ConsensusState) SetSignaturesDone(done <-chan struct{}) {
 	cns.mutState.Lock()
 	defer cns.mutState.Unlock()
 

--- a/consensus/spos/consensusState.go
+++ b/consensus/spos/consensusState.go
@@ -561,14 +561,12 @@ func (cns *ConsensusState) SetWaitingAllSignaturesTimeOut(waitingAllSignaturesTi
 	cns.waitingAllSignaturesTimeOut = waitingAllSignaturesTimeOut
 }
 
-// SignaturesWaitGroup returns wait group for optimistic signatures handling.
-// The pointer is read under mutState so it is consistent with the round-boundary swap done in
-// ResetConsensusRoundState.
-func (cns *ConsensusState) SignaturesWaitGroup() *sync.WaitGroup {
+// SignaturesWaitGroupWait blocks signatures wait group until wait counter is zero
+func (cns *ConsensusState) SignaturesWaitGroupWait() {
 	cns.mutState.Lock()
 	defer cns.mutState.Unlock()
 
-	return cns.signaturesWaitGroup
+	cns.signaturesWaitGroup.Wait()
 }
 
 // SignaturesWaitGroupAdd adds delta to the current round's optimistic-signatures wait group and returns the

--- a/consensus/spos/consensusState.go
+++ b/consensus/spos/consensusState.go
@@ -371,6 +371,19 @@ func (cns *ConsensusState) SetData(data []byte) {
 	cns.mutData.Unlock()
 }
 
+// SetDataIfNotSet atomically sets the consensus data only if it is not already set for the current round.
+func (cns *ConsensusState) SetDataIfNotSet(data []byte) bool {
+	cns.mutData.Lock()
+	defer cns.mutData.Unlock()
+
+	if cns.data != nil {
+		return false
+	}
+
+	cns.data = data
+	return true
+}
+
 // IsMultiKeyLeaderInCurrentRound method checks if one of the nodes which are controlled by this instance
 // is leader in the current round
 func (cns *ConsensusState) IsMultiKeyLeaderInCurrentRound() bool {
@@ -548,12 +561,29 @@ func (cns *ConsensusState) SetWaitingAllSignaturesTimeOut(waitingAllSignaturesTi
 	cns.waitingAllSignaturesTimeOut = waitingAllSignaturesTimeOut
 }
 
-// SignaturesWaitGroup returns wait group for optimistic signatures handling
+// SignaturesWaitGroup returns wait group for optimistic signatures handling.
+// The pointer is read under mutState so it is consistent with the round-boundary swap done in
+// ResetConsensusRoundState.
 func (cns *ConsensusState) SignaturesWaitGroup() *sync.WaitGroup {
 	cns.mutState.Lock()
 	defer cns.mutState.Unlock()
 
 	return cns.signaturesWaitGroup
+}
+
+// SignaturesWaitGroupAdd adds delta to the current round's optimistic-signatures wait group and returns the
+// exact wait group instance the delta was applied to. The pointer read and the Add are performed atomically
+// under mutState, so a round-boundary swap can no longer land between them. Returning the instance lets the
+// caller pair its Done calls to the same wait group even if a swap happens afterwards, preventing orphaned
+// Done calls or a negative-counter panic.
+func (cns *ConsensusState) SignaturesWaitGroupAdd(delta int) *sync.WaitGroup {
+	cns.mutState.Lock()
+	defer cns.mutState.Unlock()
+
+	wg := cns.signaturesWaitGroup
+	wg.Add(delta)
+
+	return wg
 }
 
 // SetSignaturesCtxCancelFunc will set signatures context cancel function

--- a/consensus/spos/consensusState_test.go
+++ b/consensus/spos/consensusState_test.go
@@ -267,31 +267,88 @@ func TestConsensusState_SetDataIfNotSet(t *testing.T) {
 	})
 }
 
-func TestConsensusState_SignaturesWaitGroupAdd(t *testing.T) {
+func TestConsensusState_SignaturesDone(t *testing.T) {
 	t.Parallel()
 
-	t.Run("should work", func(t *testing.T) {
+	t.Run("defaults to an already-closed channel after round reset", func(t *testing.T) {
+		t.Parallel()
+
+		cns := internalInitConsensusState()
+		cns.ResetConsensusRoundState()
+
+		select {
+		case <-cns.SignaturesDone():
+		case <-time.After(time.Second):
+			t.Fatal("SignaturesDone should be closed by default when no optimistic signatures were triggered")
+		}
+	})
+	t.Run("published done channel gates the wait until closed", func(t *testing.T) {
 		t.Parallel()
 
 		cns := internalInitConsensusState()
 
-		wg := cns.SignaturesWaitGroupAdd(2)
-		require.NotNil(t, wg)
-
 		done := make(chan struct{})
-		go func() {
-			wg.Wait()
-			close(done)
-		}()
+		cns.SetSignaturesDone(done)
 
-		wg.Done()
-		wg.Done()
+		require.True(t, done == cns.SignaturesDone(), "SignaturesDone should return the exact published channel")
 
 		select {
-		case <-done:
-		case <-time.After(time.Second):
-			t.Fatal("Wait did not return after the added deltas were Done")
+		case <-cns.SignaturesDone():
+			t.Fatal("SignaturesDone must block until the published channel is closed")
+		case <-time.After(20 * time.Millisecond):
 		}
+
+		close(done)
+
+		select {
+		case <-cns.SignaturesDone():
+		case <-time.After(time.Second):
+			t.Fatal("SignaturesDone must return once the published channel is closed")
+		}
+	})
+	t.Run("concurrent publish, wait and round reset are race free", func(t *testing.T) {
+		t.Parallel()
+
+		cns := internalInitConsensusState()
+
+		numIterations := 200
+		wg := sync.WaitGroup{}
+
+		// publisher: mimics subroundBlock triggering and closing the done channel
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < numIterations; i++ {
+				done := make(chan struct{})
+				cns.SetSignaturesDone(done)
+				close(done)
+			}
+		}()
+
+		// waiter: mimics the signature subround reading and waiting on the done channel
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < numIterations; i++ {
+				select {
+				case <-cns.SignaturesDone():
+				case <-time.After(time.Second):
+					t.Error("SignaturesDone should not block forever")
+					return
+				}
+			}
+		}()
+
+		// round advancer: mimics ResetConsensusRoundState swapping the round state
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < numIterations; i++ {
+				cns.ResetConsensusRoundState()
+			}
+		}()
+
+		wg.Wait()
 	})
 }
 

--- a/consensus/spos/consensusState_test.go
+++ b/consensus/spos/consensusState_test.go
@@ -270,14 +270,13 @@ func TestConsensusState_SetDataIfNotSet(t *testing.T) {
 func TestConsensusState_SignaturesWaitGroupAdd(t *testing.T) {
 	t.Parallel()
 
-	t.Run("adds the delta and returns the same instance the delta was applied to", func(t *testing.T) {
+	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
 		cns := internalInitConsensusState()
 
 		wg := cns.SignaturesWaitGroupAdd(2)
 		require.NotNil(t, wg)
-		require.Equal(t, cns.SignaturesWaitGroup(), wg)
 
 		done := make(chan struct{})
 		go func() {

--- a/consensus/spos/consensusState_test.go
+++ b/consensus/spos/consensusState_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -210,6 +211,90 @@ func TestConsensusState_IsConsensusDataSetShouldReturnFalse(t *testing.T) {
 	cns.SetData(nil)
 
 	assert.False(t, cns.IsConsensusDataSet())
+}
+
+func TestConsensusState_SetDataIfNotSet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sets data and returns true when not previously set", func(t *testing.T) {
+		t.Parallel()
+
+		cns := internalInitConsensusState()
+		cns.SetData(nil)
+
+		data := []byte("header hash")
+		didSet := cns.SetDataIfNotSet(data)
+
+		assert.True(t, didSet)
+		assert.Equal(t, data, cns.GetData())
+	})
+
+	t.Run("returns false and keeps existing data when already set", func(t *testing.T) {
+		t.Parallel()
+
+		cns := internalInitConsensusState()
+		first := []byte("first hash")
+		cns.SetData(first)
+
+		didSet := cns.SetDataIfNotSet([]byte("second hash"))
+
+		assert.False(t, didSet)
+		assert.Equal(t, first, cns.GetData(), "existing data must not be overwritten")
+	})
+
+	t.Run("concurrent callers should not set twice", func(t *testing.T) {
+		t.Parallel()
+
+		cns := internalInitConsensusState()
+		cns.SetData(nil)
+
+		numGoroutines := 50
+		wg := sync.WaitGroup{}
+		wg.Add(numGoroutines)
+		winners := int32(0)
+		for i := 0; i < numGoroutines; i++ {
+			go func() {
+				defer wg.Done()
+				if cns.SetDataIfNotSet([]byte("the winning hash")) {
+					atomic.AddInt32(&winners, 1)
+				}
+			}()
+		}
+		wg.Wait()
+
+		assert.Equal(t, int32(1), atomic.LoadInt32(&winners), "only one concurrent caller may win the set")
+		assert.Equal(t, []byte("the winning hash"), cns.GetData())
+	})
+}
+
+func TestConsensusState_SignaturesWaitGroupAdd(t *testing.T) {
+	t.Parallel()
+
+	t.Run("adds the delta and returns the same instance the delta was applied to", func(t *testing.T) {
+		t.Parallel()
+
+		cns := internalInitConsensusState()
+
+		wg := cns.SignaturesWaitGroupAdd(2)
+		require.NotNil(t, wg)
+		// the returned instance must be the current wait group, so Done calls on it release Wait
+		assert.Same(t, cns.SignaturesWaitGroup(), wg)
+
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		wg.Done()
+		wg.Done()
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("Wait did not return after the added deltas were Done")
+		}
+	})
 }
 
 func TestConsensusState_IsConsensusDataEqualShouldReturnTrue(t *testing.T) {

--- a/consensus/spos/consensusState_test.go
+++ b/consensus/spos/consensusState_test.go
@@ -222,7 +222,7 @@ func TestConsensusState_SetDataIfNotSet(t *testing.T) {
 		cns := internalInitConsensusState()
 		cns.SetData(nil)
 
-		data := []byte("header hash")
+		data := []byte("hash")
 		didSet := cns.SetDataIfNotSet(data)
 
 		assert.True(t, didSet)
@@ -233,13 +233,13 @@ func TestConsensusState_SetDataIfNotSet(t *testing.T) {
 		t.Parallel()
 
 		cns := internalInitConsensusState()
-		first := []byte("first hash")
+		first := []byte("firstHash")
 		cns.SetData(first)
 
-		didSet := cns.SetDataIfNotSet([]byte("second hash"))
+		didSet := cns.SetDataIfNotSet([]byte("secondHash"))
 
 		assert.False(t, didSet)
-		assert.Equal(t, first, cns.GetData(), "existing data must not be overwritten")
+		assert.Equal(t, first, cns.GetData())
 	})
 
 	t.Run("concurrent callers should not set twice", func(t *testing.T) {
@@ -255,15 +255,15 @@ func TestConsensusState_SetDataIfNotSet(t *testing.T) {
 		for i := 0; i < numGoroutines; i++ {
 			go func() {
 				defer wg.Done()
-				if cns.SetDataIfNotSet([]byte("the winning hash")) {
+				if cns.SetDataIfNotSet([]byte("hash")) {
 					atomic.AddInt32(&winners, 1)
 				}
 			}()
 		}
 		wg.Wait()
 
-		assert.Equal(t, int32(1), atomic.LoadInt32(&winners), "only one concurrent caller may win the set")
-		assert.Equal(t, []byte("the winning hash"), cns.GetData())
+		assert.Equal(t, int32(1), atomic.LoadInt32(&winners))
+		assert.Equal(t, []byte("hash"), cns.GetData())
 	})
 }
 
@@ -277,8 +277,7 @@ func TestConsensusState_SignaturesWaitGroupAdd(t *testing.T) {
 
 		wg := cns.SignaturesWaitGroupAdd(2)
 		require.NotNil(t, wg)
-		// the returned instance must be the current wait group, so Done calls on it release Wait
-		assert.Same(t, cns.SignaturesWaitGroup(), wg)
+		require.Equal(t, cns.SignaturesWaitGroup(), wg)
 
 		done := make(chan struct{})
 		go func() {

--- a/consensus/spos/consensusState_test.go
+++ b/consensus/spos/consensusState_test.go
@@ -282,6 +282,7 @@ func TestConsensusState_SignaturesDone(t *testing.T) {
 			t.Fatal("SignaturesDone should be closed by default when no optimistic signatures were triggered")
 		}
 	})
+
 	t.Run("published done channel gates the wait until closed", func(t *testing.T) {
 		t.Parallel()
 
@@ -290,7 +291,7 @@ func TestConsensusState_SignaturesDone(t *testing.T) {
 		done := make(chan struct{})
 		cns.SetSignaturesDone(done)
 
-		require.True(t, done == cns.SignaturesDone(), "SignaturesDone should return the exact published channel")
+		require.True(t, done == cns.SignaturesDone())
 
 		select {
 		case <-cns.SignaturesDone():
@@ -306,6 +307,7 @@ func TestConsensusState_SignaturesDone(t *testing.T) {
 			t.Fatal("SignaturesDone must return once the published channel is closed")
 		}
 	})
+
 	t.Run("concurrent publish, wait and round reset are race free", func(t *testing.T) {
 		t.Parallel()
 
@@ -314,7 +316,6 @@ func TestConsensusState_SignaturesDone(t *testing.T) {
 		numIterations := 200
 		wg := sync.WaitGroup{}
 
-		// publisher: mimics subroundBlock triggering and closing the done channel
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -325,7 +326,6 @@ func TestConsensusState_SignaturesDone(t *testing.T) {
 			}
 		}()
 
-		// waiter: mimics the signature subround reading and waiting on the done channel
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -339,7 +339,6 @@ func TestConsensusState_SignaturesDone(t *testing.T) {
 			}
 		}()
 
-		// round advancer: mimics ResetConsensusRoundState swapping the round state
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/consensus/spos/interface.go
+++ b/consensus/spos/interface.go
@@ -231,9 +231,11 @@ type ConsensusStateHandler interface {
 	SetBody(body data.BodyHandler)
 	GetHeader() data.HeaderHandler
 	SetHeader(header data.HeaderHandler)
+	SetDataIfNotSet(data []byte) bool
 	GetWaitingAllSignaturesTimeOut() bool
 	SetWaitingAllSignaturesTimeOut(bool)
 	SignaturesWaitGroup() *sync.WaitGroup
+	SignaturesWaitGroupAdd(delta int) *sync.WaitGroup
 	SetSignaturesCtxCancelFunc(cancelFunc context.CancelFunc)
 	SignaturesCtxCancel()
 	RoundConsensusHandler

--- a/consensus/spos/interface.go
+++ b/consensus/spos/interface.go
@@ -234,7 +234,7 @@ type ConsensusStateHandler interface {
 	SetDataIfNotSet(data []byte) bool
 	GetWaitingAllSignaturesTimeOut() bool
 	SetWaitingAllSignaturesTimeOut(bool)
-	SignaturesWaitGroup() *sync.WaitGroup
+	SignaturesWaitGroupWait()
 	SignaturesWaitGroupAdd(delta int) *sync.WaitGroup
 	SetSignaturesCtxCancelFunc(cancelFunc context.CancelFunc)
 	SignaturesCtxCancel()

--- a/consensus/spos/interface.go
+++ b/consensus/spos/interface.go
@@ -233,8 +233,8 @@ type ConsensusStateHandler interface {
 	SetDataIfNotSet(data []byte) bool
 	GetWaitingAllSignaturesTimeOut() bool
 	SetWaitingAllSignaturesTimeOut(bool)
-	SignaturesDone() chan struct{}
-	SetSignaturesDone(done chan struct{})
+	SignaturesDone() <-chan struct{}
+	SetSignaturesDone(done <-chan struct{})
 	SetSignaturesCtxCancelFunc(cancelFunc context.CancelFunc)
 	SignaturesCtxCancel()
 	RoundConsensusHandler

--- a/consensus/spos/interface.go
+++ b/consensus/spos/interface.go
@@ -2,7 +2,6 @@ package spos
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/multiversx/mx-chain-core-go/core"
@@ -234,8 +233,8 @@ type ConsensusStateHandler interface {
 	SetDataIfNotSet(data []byte) bool
 	GetWaitingAllSignaturesTimeOut() bool
 	SetWaitingAllSignaturesTimeOut(bool)
-	SignaturesWaitGroupWait()
-	SignaturesWaitGroupAdd(delta int) *sync.WaitGroup
+	SignaturesDone() chan struct{}
+	SetSignaturesDone(done chan struct{})
 	SetSignaturesCtxCancelFunc(cancelFunc context.CancelFunc)
 	SignaturesCtxCancel()
 	RoundConsensusHandler

--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"strconv"
 	"sync"
 	"time"
@@ -375,7 +376,10 @@ func (wrk *Worker) convertHeaderToConsensusMessage(header data.HeaderHandler) (*
 func (wrk *Worker) ReceivedHeader(headerHandler data.HeaderHandler, _ []byte) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Error("recovered from panic in Worker.ReceivedHeader", "panic", r)
+			log.Error("recovered from panic in Worker.ReceivedHeader",
+				"panic", r,
+				"stack", string(debug.Stack()),
+			)
 		}
 	}()
 

--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -373,6 +373,12 @@ func (wrk *Worker) convertHeaderToConsensusMessage(header data.HeaderHandler) (*
 
 // ReceivedHeader process the received header, calling each received header handler registered in worker instance
 func (wrk *Worker) ReceivedHeader(headerHandler data.HeaderHandler, _ []byte) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("recovered from panic in Worker.ReceivedHeader", "panic", r)
+		}
+	}()
+
 	if check.IfNil(headerHandler) {
 		log.Trace("ReceivedHeader: nil header handler")
 		return

--- a/testscommon/consensus/consensusStateMock.go
+++ b/testscommon/consensus/consensusStateMock.go
@@ -676,7 +676,7 @@ func (cnsm *ConsensusStateMock) SignaturesWaitGroupAdd(delta int) *sync.WaitGrou
 		return cnsm.SignaturesWaitGroupAddCalled(delta)
 	}
 
-	return nil
+	return &sync.WaitGroup{}
 }
 
 // SetDataIfNotSet -

--- a/testscommon/consensus/consensusStateMock.go
+++ b/testscommon/consensus/consensusStateMock.go
@@ -87,8 +87,8 @@ type ConsensusStateMock struct {
 	FallbackThresholdCalled                      func(subroundId int) int
 	SetFallbackThresholdCalled                   func(subroundId int, threshold int)
 	ResetConsensusRoundStateCalled               func()
-	SignaturesDoneCalled                         func() chan struct{}
-	SetSignaturesDoneCalled                      func(done chan struct{})
+	SignaturesDoneCalled                         func() <-chan struct{}
+	SetSignaturesDoneCalled                      func(done <-chan struct{})
 	SetDataIfNotSetCalled                        func(data []byte) bool
 	SetSignaturesCtxCancelFuncCalled             func(cancelFunc context.CancelFunc)
 	SignaturesCtxCancelCalled                    func()
@@ -661,7 +661,7 @@ func (cnsm *ConsensusStateMock) SetThreshold(subroundId int, threshold int) {
 }
 
 // SignaturesDone -
-func (cnsm *ConsensusStateMock) SignaturesDone() chan struct{} {
+func (cnsm *ConsensusStateMock) SignaturesDone() <-chan struct{} {
 	if cnsm.SignaturesDoneCalled != nil {
 		return cnsm.SignaturesDoneCalled()
 	}
@@ -673,7 +673,7 @@ func (cnsm *ConsensusStateMock) SignaturesDone() chan struct{} {
 }
 
 // SetSignaturesDone -
-func (cnsm *ConsensusStateMock) SetSignaturesDone(done chan struct{}) {
+func (cnsm *ConsensusStateMock) SetSignaturesDone(done <-chan struct{}) {
 	if cnsm.SetSignaturesDoneCalled != nil {
 		cnsm.SetSignaturesDoneCalled(done)
 	}

--- a/testscommon/consensus/consensusStateMock.go
+++ b/testscommon/consensus/consensusStateMock.go
@@ -2,7 +2,6 @@ package consensus
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/multiversx/mx-chain-core-go/core"
@@ -88,8 +87,8 @@ type ConsensusStateMock struct {
 	FallbackThresholdCalled                      func(subroundId int) int
 	SetFallbackThresholdCalled                   func(subroundId int, threshold int)
 	ResetConsensusRoundStateCalled               func()
-	SignaturesWaitGroupWaitCalled                func()
-	SignaturesWaitGroupAddCalled                 func(delta int) *sync.WaitGroup
+	SignaturesDoneCalled                         func() chan struct{}
+	SetSignaturesDoneCalled                      func(done chan struct{})
 	SetDataIfNotSetCalled                        func(data []byte) bool
 	SetSignaturesCtxCancelFuncCalled             func(cancelFunc context.CancelFunc)
 	SignaturesCtxCancelCalled                    func()
@@ -661,20 +660,23 @@ func (cnsm *ConsensusStateMock) SetThreshold(subroundId int, threshold int) {
 	}
 }
 
-// SignaturesWaitGroupWait -
-func (cnsm *ConsensusStateMock) SignaturesWaitGroupWait() {
-	if cnsm.SignaturesWaitGroupWaitCalled != nil {
-		cnsm.SignaturesWaitGroupWaitCalled()
+// SignaturesDone -
+func (cnsm *ConsensusStateMock) SignaturesDone() chan struct{} {
+	if cnsm.SignaturesDoneCalled != nil {
+		return cnsm.SignaturesDoneCalled()
 	}
+
+	// default to an already-closed channel so a wait on it returns immediately
+	ch := make(chan struct{})
+	close(ch)
+	return ch
 }
 
-// SignaturesWaitGroupAdd -
-func (cnsm *ConsensusStateMock) SignaturesWaitGroupAdd(delta int) *sync.WaitGroup {
-	if cnsm.SignaturesWaitGroupAddCalled != nil {
-		return cnsm.SignaturesWaitGroupAddCalled(delta)
+// SetSignaturesDone -
+func (cnsm *ConsensusStateMock) SetSignaturesDone(done chan struct{}) {
+	if cnsm.SetSignaturesDoneCalled != nil {
+		cnsm.SetSignaturesDoneCalled(done)
 	}
-
-	return &sync.WaitGroup{}
 }
 
 // SetDataIfNotSet -

--- a/testscommon/consensus/consensusStateMock.go
+++ b/testscommon/consensus/consensusStateMock.go
@@ -88,7 +88,7 @@ type ConsensusStateMock struct {
 	FallbackThresholdCalled                      func(subroundId int) int
 	SetFallbackThresholdCalled                   func(subroundId int, threshold int)
 	ResetConsensusRoundStateCalled               func()
-	SignaturesWaitGroupCalled                    func() *sync.WaitGroup
+	SignaturesWaitGroupWaitCalled                func()
 	SignaturesWaitGroupAddCalled                 func(delta int) *sync.WaitGroup
 	SetDataIfNotSetCalled                        func(data []byte) bool
 	SetSignaturesCtxCancelFuncCalled             func(cancelFunc context.CancelFunc)
@@ -661,13 +661,11 @@ func (cnsm *ConsensusStateMock) SetThreshold(subroundId int, threshold int) {
 	}
 }
 
-// SignaturesWaitGroup -
-func (cnsm *ConsensusStateMock) SignaturesWaitGroup() *sync.WaitGroup {
-	if cnsm.SignaturesWaitGroupCalled != nil {
-		return cnsm.SignaturesWaitGroupCalled()
+// SignaturesWaitGroupWait -
+func (cnsm *ConsensusStateMock) SignaturesWaitGroupWait() {
+	if cnsm.SignaturesWaitGroupWaitCalled != nil {
+		cnsm.SignaturesWaitGroupWaitCalled()
 	}
-
-	return nil
 }
 
 // SignaturesWaitGroupAdd -

--- a/testscommon/consensus/consensusStateMock.go
+++ b/testscommon/consensus/consensusStateMock.go
@@ -89,6 +89,8 @@ type ConsensusStateMock struct {
 	SetFallbackThresholdCalled                   func(subroundId int, threshold int)
 	ResetConsensusRoundStateCalled               func()
 	SignaturesWaitGroupCalled                    func() *sync.WaitGroup
+	SignaturesWaitGroupAddCalled                 func(delta int) *sync.WaitGroup
+	SetDataIfNotSetCalled                        func(data []byte) bool
 	SetSignaturesCtxCancelFuncCalled             func(cancelFunc context.CancelFunc)
 	SignaturesCtxCancelCalled                    func()
 }
@@ -666,6 +668,24 @@ func (cnsm *ConsensusStateMock) SignaturesWaitGroup() *sync.WaitGroup {
 	}
 
 	return nil
+}
+
+// SignaturesWaitGroupAdd -
+func (cnsm *ConsensusStateMock) SignaturesWaitGroupAdd(delta int) *sync.WaitGroup {
+	if cnsm.SignaturesWaitGroupAddCalled != nil {
+		return cnsm.SignaturesWaitGroupAddCalled(delta)
+	}
+
+	return nil
+}
+
+// SetDataIfNotSet -
+func (cnsm *ConsensusStateMock) SetDataIfNotSet(data []byte) bool {
+	if cnsm.SetDataIfNotSetCalled != nil {
+		return cnsm.SetDataIfNotSetCalled(data)
+	}
+
+	return true
 }
 
 // SetSignaturesCtxCancelFunc -


### PR DESCRIPTION
## Reasoning behind the pull request
- Add atomic operations for managing wait group
- Make data set in consensus atomically safer

## Testing procedure
- Standard system test

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
