### PR TITLE
sync all needed intermediate blocks

### DIFF
--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -815,7 +815,7 @@ func (e *epochStartBootstrap) syncEpochStartDataInfo(
 
 	// sync last notarized meta header references by epoch start header for shard
 	// this will sync based on the meta block hashes references on header and based on the provided LastFinishedMetaBlock
-	err = e.syncLastNotarizedMetaForEpochStartData(syncedHeaders, syncedHeader)
+	lastNotarizedMetaForShard, err := e.syncLastNotarizedMetaForEpochStartData(syncedHeaders, syncedHeader)
 	if err != nil {
 		return err
 	}
@@ -830,20 +830,36 @@ func (e *epochStartBootstrap) syncEpochStartDataInfo(
 		return process.ErrMissingHeader
 	}
 
-	// sync meta blocks from epoch start meta blocks up to last finished metablock referenced on shard
-	return e.syncIntermediateBlocksIfNeeded(syncedHeaders, epochStartMeta, lastFinishedMetaBlockForShard.GetNonce())
+	// Sync the complete meta chain needed by the shard. The last notarized meta can be older than
+	// LastFinishedMetaBlock; using only the latter as the lower bound would leave a gap between them.
+	lowestMetaNonceToSync := core.MinUint64(
+		lastNotarizedMetaForShard.GetNonce(),
+		lastFinishedMetaBlockForShard.GetNonce(),
+	)
+
+	return e.syncIntermediateBlocksIfNeeded(syncedHeaders, epochStartMeta, lowestMetaNonceToSync)
 }
 
 func (e *epochStartBootstrap) syncLastNotarizedMetaForEpochStartData(
 	syncedHeaders map[string]data.HeaderHandler,
 	header data.HeaderHandler,
-) error {
+) (data.HeaderHandler, error) {
 	lastReferencedMetaHash, err := getLastReferencedMetaHash(syncedHeaders, e.syncPrevShardHeaderHandler, header)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return e.syncOneHeader(syncedHeaders, lastReferencedMetaHash, core.MetachainShardId)
+	err = e.syncOneHeader(syncedHeaders, lastReferencedMetaHash, core.MetachainShardId)
+	if err != nil {
+		return nil, err
+	}
+
+	lastReferencedMeta, ok := syncedHeaders[string(lastReferencedMetaHash)]
+	if !ok {
+		return nil, epochStart.ErrMissingHeader
+	}
+
+	return lastReferencedMeta, nil
 }
 
 func getLastReferencedMetaHash(

--- a/epochStart/bootstrap/process_test.go
+++ b/epochStart/bootstrap/process_test.go
@@ -3869,6 +3869,76 @@ func TestEpochStartBoostrap_SyncHeadersV3FromMeta(t *testing.T) {
 	})
 }
 
+func TestEpochStartBootstrap_SyncEpochStartDataInfoShouldSyncFullMetaRange(t *testing.T) {
+	t.Parallel()
+
+	shardHeader12Hash := []byte("shard-header-12")
+	shardHeader11Hash := []byte("shard-header-11")
+	shardHeader10Hash := []byte("shard-header-10")
+	meta196Hash := []byte("meta-196")
+	meta195Hash := []byte("meta-195")
+	meta194Hash := []byte("meta-194")
+	meta193Hash := []byte("meta-193")
+	meta192Hash := []byte("meta-192")
+	meta191Hash := []byte("meta-191")
+	meta190Hash := []byte("meta-190")
+
+	availableHeaders := map[string]data.HeaderHandler{
+		string(shardHeader12Hash): &block.HeaderV3{
+			Nonce:    12,
+			PrevHash: shardHeader11Hash,
+			LastExecutionResult: &block.ExecutionResultInfo{
+				ExecutionResult: &block.BaseExecutionResult{
+					HeaderNonce: 10,
+					HeaderHash:  shardHeader10Hash,
+				},
+			},
+		},
+		string(shardHeader11Hash): &block.HeaderV3{Nonce: 11, PrevHash: shardHeader10Hash},
+		string(shardHeader10Hash): &block.HeaderV3{Nonce: 10, MetaBlockHashes: [][]byte{meta190Hash}},
+		string(meta196Hash):       &block.MetaBlockV3{Nonce: 196, PrevHash: meta195Hash},
+		string(meta195Hash):       &block.MetaBlockV3{Nonce: 195, PrevHash: meta194Hash},
+		string(meta194Hash):       &block.MetaBlockV3{Nonce: 194, PrevHash: meta193Hash},
+		string(meta193Hash):       &block.MetaBlockV3{Nonce: 193, PrevHash: meta192Hash},
+		string(meta192Hash):       &block.MetaBlockV3{Nonce: 192, PrevHash: meta191Hash},
+		string(meta191Hash):       &block.MetaBlockV3{Nonce: 191, PrevHash: meta190Hash},
+		string(meta190Hash):       &block.MetaBlockV3{Nonce: 190},
+	}
+
+	requestedHeaders := make(map[string]bool)
+	var requestedHash []byte
+	coreComp, cryptoComp := createComponentsForEpochStart()
+	args := createMockEpochStartBootstrapArgs(coreComp, cryptoComp)
+	epochStartProvider, _ := NewEpochStartBootstrap(args)
+	epochStartProvider.headersSyncer = &epochStartMocks.HeadersByHashSyncerStub{
+		SyncMissingHeadersByHashCalled: func(_ []uint32, hashes [][]byte, _ context.Context) error {
+			require.Len(t, hashes, 1)
+			requestedHash = hashes[0]
+			requestedHeaders[string(requestedHash)] = true
+			return nil
+		},
+		GetHeadersCalled: func() (map[string]data.HeaderHandler, error) {
+			header, ok := availableHeaders[string(requestedHash)]
+			require.True(t, ok, "unexpected requested hash %q", requestedHash)
+			return map[string]data.HeaderHandler{string(requestedHash): header}, nil
+		},
+	}
+
+	epochStartMeta := &block.MetaBlockV3{Nonce: 197, PrevHash: meta196Hash}
+	epochStartData := &block.EpochStartShardData{
+		HeaderHash:            shardHeader12Hash,
+		ShardID:               0,
+		LastFinishedMetaBlock: meta192Hash,
+	}
+	syncedHeaders := make(map[string]data.HeaderHandler)
+
+	err := epochStartProvider.syncEpochStartDataInfo(epochStartMeta, epochStartData, syncedHeaders)
+
+	require.NoError(t, err)
+	require.True(t, requestedHeaders[string(meta191Hash)])
+	require.Contains(t, syncedHeaders, string(meta191Hash))
+}
+
 func TestGetStartOfEpochRootHashFromExecutionResults(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Reasoning behind the pull request
- During epoch-start bootstrap, meta headers were synchronized only down to the shard's LastFinishedMetaBlock. When the last notarized meta header was older, this could leave missing intermediate meta headers between the two references.
  
## Proposed changes
- Use the oldest nonce between the last notarized and last finished meta headers as the synchronization boundary.
- Ensure the complete required meta-header chain is available during bootstrap.

## Testing procedure
- Added a targeted epoch-start bootstrap test for the missing intermediate range.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
